### PR TITLE
feat: versioned Postgres migration runner, and cancelled as a real session state

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,7 +41,6 @@
       "Edit(./**/Identity/**)",
       "Edit(./**/Security/**)",
       "Edit(./**/SecurityAttributes/**)",
-      "Edit(./**/Migrations/**)",
       "Edit(./infra/**)"
     ],
     "deny": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,14 @@ jobs:
         with:
           dotnet-version: '10.x'
 
-      # The schema scripts are normally applied by docker-entrypoint-initdb.d, which is
-      # unavailable to GitHub Actions service containers. Apply them in lexical order via
-      # psql once the service is healthy so the observability tables exist before tests run.
-      - name: Apply observability schema
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-client
-          for f in Dashboards/init-db/*.sql; do
-            echo "Applying $f"
-            PGPASSWORD=observability psql -h localhost -p 5432 -U observability -d observability -v ON_ERROR_STOP=1 -f "$f"
-          done
-
+      # No schema step. There used to be one here that replayed Dashboards/init-db/*.sql through
+      # psql, and it is the reason #301 stayed invisible for as long as it did: it rebuilt the
+      # schema from scratch on a fresh database every run, so CI could prove a schema change worked
+      # for a new installation while nothing on earth could deliver that change to a database that
+      # already held data.
+      #
+      # PostgresFixture now applies the real migration runner instead, which means every CI run
+      # exercises the actual delivery path rather than a parallel one that only CI ever used.
       - name: Restore
         run: dotnet restore src/AgenticHarness.slnx
 

--- a/Dashboards/Grafana Dashboards/sessions.json
+++ b/Dashboards/Grafana Dashboards/sessions.json
@@ -464,6 +464,11 @@
                         "color": "blue",
                         "index": 2,
                         "text": "active"
+                      },
+                      "cancelled": {
+                        "color": "orange",
+                        "index": 3,
+                        "text": "cancelled"
                       }
                     }
                   }
@@ -722,9 +727,14 @@
             "selected": false,
             "text": "error",
             "value": "error"
+          },
+          {
+            "selected": false,
+            "text": "cancelled",
+            "value": "cancelled"
           }
         ],
-        "query": "All,active,completed,error",
+        "query": "All,active,completed,error,cancelled",
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"

--- a/Dashboards/docker-compose.yml
+++ b/Dashboards/docker-compose.yml
@@ -48,7 +48,18 @@ services:
 
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - ./init-db:/docker-entrypoint-initdb.d:ro
+      # Cluster bootstrap only — the grafana_reader role and its default
+      # privileges. The observability SCHEMA is no longer delivered here.
+      #
+      # It used to be: ./init-db held the tables, and Postgres runs everything in
+      # this directory exactly once, when it initialises an empty data directory.
+      # That made a schema change undeliverable to any database that already held
+      # data — a consumer running the harness for a month could not receive one at
+      # all, and CI could not see the problem because it built a fresh database
+      # every run (#301). Tables, columns and constraints now come from the
+      # application's migration runner, which records what it has applied and can
+      # therefore bring an existing database forward.
+      - ./postgres-bootstrap:/docker-entrypoint-initdb.d:ro
 
     ports:
       - "127.0.0.1:5432:5432"

--- a/Dashboards/postgres-bootstrap/00-grafana-reader.sql
+++ b/Dashboards/postgres-bootstrap/00-grafana-reader.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- Cluster bootstrap: the read-only role Grafana connects as.
+--
+-- This is NOT schema, and it is deliberately the only thing still fed to
+-- /docker-entrypoint-initdb.d. Tables, columns and constraints now come from the
+-- application's migration runner (see Infrastructure.Observability/Migrations),
+-- because they change over the life of an installation and have to reach a
+-- database that already holds data.
+--
+-- A role does not: it is created once when the cluster is created, and it lives
+-- in the cluster rather than in the database. It also cannot come from the
+-- application, because CREATE ROLE requires the CREATEROLE privilege and no
+-- least-privilege application account should hold it. An enterprise consumer
+-- pointing the harness at a managed Postgres runs this once, by hand or from
+-- their provisioning tooling, and never again.
+--
+-- The password below is a local-development default for a role with SELECT and
+-- nothing else. Change it — along with Grafana's datasource configuration —
+-- before pointing this at anything that is not a laptop.
+-- =============================================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'grafana_reader') THEN
+        CREATE ROLE grafana_reader LOGIN PASSWORD 'grafana_readonly';
+    END IF;
+END
+$$;
+
+-- current_database() rather than a hardcoded name: POSTGRES_DB is configurable
+-- in docker-compose.yml, and the previous version of this statement named
+-- 'observability' literally, so it broke for anyone who changed it.
+DO $$
+BEGIN
+    EXECUTE format('GRANT CONNECT ON DATABASE %I TO grafana_reader', current_database());
+END
+$$;
+
+GRANT USAGE ON SCHEMA public TO grafana_reader;
+
+-- Retroactive, for a database that already has tables.
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafana_reader;
+
+-- Prospective, and the important one. Every table the migration runner creates
+-- from here on is readable by Grafana without any migration having to grant it —
+-- which is what lets the migrations stay pure schema and stay runnable against a
+-- database where this role was never provisioned at all.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafana_reader;

--- a/Dashboards/postgres-bootstrap/00-grafana-reader.sql
+++ b/Dashboards/postgres-bootstrap/00-grafana-reader.sql
@@ -41,8 +41,24 @@ GRANT USAGE ON SCHEMA public TO grafana_reader;
 -- Retroactive, for a database that already has tables.
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafana_reader;
 
--- Prospective, and the important one. Every table the migration runner creates
--- from here on is readable by Grafana without any migration having to grant it —
--- which is what lets the migrations stay pure schema and stay runnable against a
+-- Prospective, and the important one: tables the migration runner creates from
+-- here on are readable by Grafana without any migration having to grant it, which
+-- is what lets the migrations stay pure schema and stay runnable against a
 -- database where this role was never provisioned at all.
+--
+-- READ THIS BEFORE ADAPTING THE FILE. Default privileges attach to the role that
+-- GRANTS them, not to the schema. Written without FOR ROLE, the statement below
+-- covers only tables created by whoever runs this script. On the docker-compose
+-- path that is the same account the harness connects as, so it just works. On a
+-- managed Postgres — where the header above tells you to run this yourself — you
+-- will typically run it as an admin while the harness connects as something else,
+-- and then it silently covers nothing, because every migration-created table is
+-- owned by the app role instead. Name that role explicitly:
+--
+--   ALTER DEFAULT PRIVILEGES FOR ROLE <role the harness connects as>
+--       IN SCHEMA public GRANT SELECT ON TABLES TO grafana_reader;
+--
+-- The symptom of getting this wrong is Grafana reporting "permission denied" on
+-- tables that plainly exist, which reads like a broken dashboard rather than a
+-- missing grant.
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafana_reader;

--- a/documentation/onboarding/10-observability.html
+++ b/documentation/onboarding/10-observability.html
@@ -183,13 +183,32 @@ docker run -d --name jaeger \
                         and <code>SessionTimeline</code> ("view full →" link → <code>/sessions/:id/files/:messageId</code>).
                     </p>
                     <p>
-                        Schema migration: existing observability databases need
-                        <code>psql -f Dashboards/init-db/03-message-and-tool-bodies.sql</code> to add the
-                        <code>content_full</code>, <code>call_id</code>, <code>args</code>, and
-                        <code>stdout</code> columns. Fresh installs pick the schema up automatically via the
-                        alphabetical Docker entrypoint order. Rows recorded before the migration return
+                        Schema migration: nothing to run by hand. The
+                        <code>content_full</code>, <code>call_id</code>, <code>args</code> and
+                        <code>stdout</code> columns arrive from migration
+                        <code>004_message_and_tool_bodies.sql</code>, which the harness applies itself on the
+                        first database connection it opens. Rows recorded before that migration ran return
                         <code>contentFull: null</code>; the dashboard renders a banner explaining the preview
                         fallback in that case.
+                    </p>
+                    <p>
+                        This page previously told you to apply that file yourself with <code>psql</code>, because
+                        the schema used to be delivered by SQL mounted into the Postgres container — and Postgres
+                        runs those scripts <em>only</em> when it first creates an empty data directory. A database
+                        that already held data could not receive a schema change at all, so hand-applying was the
+                        only route. That is fixed: schema now ships as numbered migrations embedded in the
+                        application, applied under a lock, with a ledger table recording what has already run, so
+                        an installation that has been live for months picks up exactly the changes it is missing.
+                    </p>
+                    <p>
+                        Two things worth knowing if you are adapting this for your own deployment. To add a schema
+                        change, drop a numbered <code>.sql</code> file into
+                        <code>Infrastructure.Observability/Migrations/</code> — it is embedded automatically and
+                        applied in numeric order; write it to be safely re-runnable. And
+                        <code>Dashboards/postgres-bootstrap/</code> is a separate, once-per-cluster step that
+                        creates the read-only role Grafana connects as. That one is <em>not</em> applied by the
+                        application, because creating a role needs a privilege no least-privilege application
+                        account should hold — against a managed Postgres you run it yourself, once.
                     </p>
 
                     <hr />

--- a/src/AgenticHarness.slnx
+++ b/src/AgenticHarness.slnx
@@ -122,6 +122,11 @@
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
     </Project>
+    <Project Path="Content/Infrastructure/Infrastructure.Postgres/Infrastructure.Postgres.csproj">
+      <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
+    </Project>
   </Folder>
   <Folder Name="/Presentation/">
     <Project Path="Content/Presentation/Presentation.AgentHub/Presentation.AgentHub.csproj">
@@ -265,6 +270,7 @@
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
     </Project>
+    <Project Path="Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj" />
     <Project Path="Content/Tests/Infrastructure.Observability.Tests/Infrastructure.Observability.Tests.csproj">
       <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -459,11 +459,12 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 			// is rethrown rather than turned into a failed result: a caller that walked away is not a run
 			// that failed.
 			//
-			// It nevertheless closes as Error. This path is where the string "cancelled" came from; see
-			// SessionStatus for what the database did with it, and why cancellation is carried in the
-			// reason rather than given a state of its own. The visible cost is local and worth naming
-			// here: a cancelled run is counted among the errors on the dashboard.
-			await EndRunSessionAsync(SessionStatus.Error, "conversation.cancelled");
+			// It closes as Cancelled, a state of its own again as of #301. This path is where the
+			// string "cancelled" came from: the schema rejected the word, the store logged and
+			// swallowed the rejected write, and the session was never ended at all. It then spent a
+			// release closing as Error — counted among the failures on every dashboard — because
+			// nothing could deliver a widened constraint to a database that already held data.
+			await EndRunSessionAsync(SessionStatus.Cancelled, "conversation.cancelled");
 			throw;
 		}
 		catch (Exception ex)

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -453,7 +453,13 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 				Governance = governanceTraces.Count > 0 ? GovernanceTrace.Merge(governanceTraces) : null
 			};
 		}
-		catch (OperationCanceledException)
+		// The filter is load-bearing, not decoration. TaskCanceledException derives from
+		// OperationCanceledException and is what an HTTP client throws when a request exceeds its
+		// timeout — with nobody having cancelled anything. Catching the base type unfiltered would
+		// file a model call that timed out as a deliberate stop: absent from the error rate, and
+		// silent, because only the general handler below logs. Asking the token whether cancellation
+		// was actually requested is what separates "the caller walked away" from "the call failed".
+		catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
 		{
 			// Caller cancellation (e.g. client disconnect) is routine, not exceptional, and the exception
 			// is rethrown rather than turned into a failed result: a caller that walked away is not a run

--- a/src/Content/Domain/Domain.AI/Observability/Models/SessionStatus.cs
+++ b/src/Content/Domain/Domain.AI/Observability/Models/SessionStatus.cs
@@ -47,9 +47,16 @@ public enum SessionStatus
     /// token — before it could finish.
     /// </summary>
     /// <remarks>
-    /// Distinct from <see cref="Error"/> because it is not a failure, and counting it as one is
-    /// visible: the dashboards' error-rate panel is <c>status = 'error'</c>, so every cancelled run
-    /// used to be reported as something going wrong.
+    /// Distinct from <see cref="Error"/> because it is not a failure, and the distinction is visible:
+    /// this value is what the sessions list and the Grafana <c>$status</c> filter show an operator,
+    /// so while cancellations were written as <see cref="Error"/> every ordinary disconnect read as
+    /// something having gone wrong.
+    /// </remarks>
+    /// <remarks>
+    /// It does <em>not</em> move any error-rate number, and an earlier version of this comment said
+    /// it did. No panel in <c>Dashboards/</c> computes a rate from <c>status = 'error'</c> — the
+    /// error-rate tiles are Prometheus counters over tool errors. The claim was repeated in five
+    /// places, which is how an unchecked justification becomes something everyone assumes was checked.
     /// </remarks>
     Cancelled,
 }

--- a/src/Content/Domain/Domain.AI/Observability/Models/SessionStatus.cs
+++ b/src/Content/Domain/Domain.AI/Observability/Models/SessionStatus.cs
@@ -21,13 +21,14 @@ namespace Domain.AI.Observability.Models;
 /// apart again.
 /// </para>
 /// <para>
-/// <strong>Cancellation is deliberately not a member.</strong> The schema has no word for it, and the
-/// template has no way to migrate an existing database — <c>Dashboards/init-db/*.sql</c> is applied by
-/// Postgres only when the data volume is first created, so widening the constraint would reach CI and
-/// fresh installs while leaving every database that already holds data rejecting the new value exactly
-/// as before. A cancelled run is therefore recorded as <see cref="Error"/> with its reason string
-/// naming the cancellation, which overstates failures on the dashboard and is the known cost of the
-/// choice. Giving cancellation its own state is tracked with the missing migration runner in #301.
+/// <strong>Cancellation is a state of its own again (#301).</strong> It could not be, for a while:
+/// the schema had no word for it and the template had no way to change the shape of a database that
+/// already held data, so widening the constraint would have reached CI and fresh installs while
+/// leaving every real installation rejecting the new value exactly as before. A cancelled run was
+/// recorded as <see cref="Error"/> instead, which overstated the failure rate on every dashboard.
+/// A versioned migration runner now delivers schema changes to existing databases, so
+/// <see cref="Cancelled"/> is carried by migration <c>005_sessions_status_cancelled.sql</c> and the
+/// compromise is retired.
 /// </para>
 /// </remarks>
 public enum SessionStatus
@@ -38,8 +39,19 @@ public enum SessionStatus
     /// <summary>The session finished normally.</summary>
     Completed,
 
-    /// <summary>The session stopped because of a failure, or because it was cancelled.</summary>
+    /// <summary>The session stopped because of a failure.</summary>
     Error,
+
+    /// <summary>
+    /// The session was stopped on purpose — by the caller, by a disconnect, or by a cancellation
+    /// token — before it could finish.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="Error"/> because it is not a failure, and counting it as one is
+    /// visible: the dashboards' error-rate panel is <c>status = 'error'</c>, so every cancelled run
+    /// used to be reported as something going wrong.
+    /// </remarks>
+    Cancelled,
 }
 
 /// <summary>Converts <see cref="SessionStatus"/> to the literal the observability schema stores.</summary>
@@ -49,7 +61,7 @@ public static class SessionStatusExtensions
     /// Returns the exact text the <c>sessions.status</c> CHECK constraint accepts for this state.
     /// </summary>
     /// <param name="status">The state to write.</param>
-    /// <returns>One of <c>active</c>, <c>completed</c>, or <c>error</c>.</returns>
+    /// <returns>One of <c>active</c>, <c>completed</c>, <c>error</c>, or <c>cancelled</c>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when a member is added to <see cref="SessionStatus"/> without a literal here. Failing
     /// loudly is the point: a silent fallback would reintroduce the swallowed write this type exists to
@@ -60,6 +72,7 @@ public static class SessionStatusExtensions
         SessionStatus.Active => "active",
         SessionStatus.Completed => "completed",
         SessionStatus.Error => "error",
+        SessionStatus.Cancelled => "cancelled",
         _ => throw new ArgumentOutOfRangeException(
             nameof(status), status, "No schema literal is defined for this session status."),
     };

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Infrastructure.AI.KnowledgeGraph.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Infrastructure.AI.KnowledgeGraph.csproj
@@ -17,6 +17,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
+    <ProjectReference Include="..\Infrastructure.Postgres\Infrastructure.Postgres.csproj" />
+  </ItemGroup>
+
+  <!-- Explicit LogicalName; see the note in Infrastructure.Observability.csproj. -->
+  <ItemGroup>
+    <EmbeddedResource Include="Migrations\*.sql">
+      <LogicalName>Migrations.%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Migrations/001_baseline_kg_schema.sql
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Migrations/001_baseline_kg_schema.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- Knowledge graph baseline — nodes and edges with their isolation and temporal
+-- columns.
+--
+-- This was previously a string constant inside PostgreSqlGraphStore, executed on
+-- first connection. That could create the tables but could never change them: a
+-- consumer whose database already held a graph would keep the old shape forever,
+-- the same dead end #301 fixed for the observability schema. It is a migration
+-- now so the next column can actually reach them.
+--
+-- Idempotent, because a database created by the old inline DDL already has these
+-- tables and no ledger row saying so.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS kg_nodes (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    properties  JSONB,
+    chunk_ids   TEXT[],
+    provenance  JSONB,
+    owner_id    TEXT,
+    tenant_id   TEXT,
+    created_at  TIMESTAMPTZ,
+    expires_at  TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS kg_edges (
+    id              TEXT PRIMARY KEY,
+    source_node_id  TEXT NOT NULL,
+    target_node_id  TEXT NOT NULL,
+    predicate       TEXT NOT NULL,
+    properties      JSONB,
+    chunk_id        TEXT,
+    provenance      JSONB,
+    owner_id        TEXT,
+    tenant_id       TEXT,
+    created_at      TIMESTAMPTZ,
+    expires_at      TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_kg_nodes_owner ON kg_nodes (owner_id);
+CREATE INDEX IF NOT EXISTS idx_kg_nodes_tenant ON kg_nodes (tenant_id);

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/KnowledgeGraphMigrations.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/KnowledgeGraphMigrations.cs
@@ -1,0 +1,47 @@
+using Infrastructure.Postgres.Migrations;
+
+namespace Infrastructure.AI.KnowledgeGraph.PostgreSql;
+
+/// <summary>
+/// The knowledge-graph schema's migration set: where its ledger lives, and how to load its scripts.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The counterpart to <c>ObservabilityMigrations</c>, and named publicly for the same reason: anything
+/// that needs to bring a knowledge-graph database up to date — the store, an integration fixture, a
+/// consumer's own provisioning step — must do it through one definition, or a test database and a
+/// production database end up migrated by two different sets of rules. That divergence is the exact
+/// shape of the defect #301 was filed about.
+/// </para>
+/// <para>
+/// This started life as a private field and an inline load inside <c>PostgreSqlGraphStore</c>, which
+/// meant nothing outside that class could name the set. The observability side had already learned
+/// otherwise; the two are now at the same altitude, so whichever a future author reads first teaches
+/// them the same pattern.
+/// </para>
+/// </remarks>
+public static class KnowledgeGraphMigrations
+{
+    /// <summary>
+    /// Ledger table and advisory lock key for this migration set.
+    /// </summary>
+    /// <remarks>
+    /// The key is unchanged from when <c>PostgreSqlGraphStore</c> held its DDL inline and took this
+    /// lock by hand, so a rolling deployment where both versions are briefly live still serializes
+    /// their schema work against each other. The ledger name is prefixed rather than the bare
+    /// <c>schema_migrations</c> that Rails, Flyway and Django all use, so pointing the harness at a
+    /// database a consumer's own application already owns cannot collide with their ledger.
+    /// </remarks>
+    public static PostgresMigrationOptions Options { get; } =
+        new("kg_schema_migrations", 0x6B675F736368656DL);
+
+    /// <summary>Loads the knowledge-graph migration set in apply order.</summary>
+    /// <returns>The migration scripts, ordered by their numeric file-name prefix.</returns>
+    /// <remarks>
+    /// Read once and reused; <see cref="MigrationScript"/> is immutable, so one instance is shareable.
+    /// </remarks>
+    public static IReadOnlyList<MigrationScript> Load() => Scripts;
+
+    private static readonly IReadOnlyList<MigrationScript> Scripts =
+        EmbeddedSqlMigrationSource.Load(typeof(KnowledgeGraphMigrations).Assembly);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.Reflection;
 using System.Text.Json;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
+using Infrastructure.Postgres.Migrations;
 using Domain.AI.KnowledgeGraph.Models;
 using Domain.AI.KnowledgeGraph.Scoping;
 using Microsoft.Extensions.Logging;
@@ -32,40 +34,17 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     private static readonly ActivitySource ActivitySource = new("Infrastructure.AI.KnowledgeGraph.PostgreSql");
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-    private const string SchemaDdl = """
-        CREATE TABLE IF NOT EXISTS kg_nodes (
-            id          TEXT PRIMARY KEY,
-            name        TEXT NOT NULL,
-            type        TEXT NOT NULL,
-            properties  JSONB,
-            chunk_ids   TEXT[],
-            provenance  JSONB,
-            owner_id    TEXT,
-            tenant_id   TEXT,
-            created_at  TIMESTAMPTZ,
-            expires_at  TIMESTAMPTZ
-        );
-        CREATE TABLE IF NOT EXISTS kg_edges (
-            id              TEXT PRIMARY KEY,
-            source_node_id  TEXT NOT NULL,
-            target_node_id  TEXT NOT NULL,
-            predicate       TEXT NOT NULL,
-            properties      JSONB,
-            chunk_id        TEXT,
-            provenance      JSONB,
-            owner_id        TEXT,
-            tenant_id       TEXT,
-            created_at      TIMESTAMPTZ,
-            expires_at      TIMESTAMPTZ
-        );
-        CREATE INDEX IF NOT EXISTS idx_kg_nodes_owner ON kg_nodes (owner_id);
-        CREATE INDEX IF NOT EXISTS idx_kg_nodes_tenant ON kg_nodes (tenant_id);
-        """;
+    /// <summary>
+    /// Ledger table and advisory lock key for the knowledge-graph migration set. The key is
+    /// unchanged from when this class held its DDL inline, so a rolling deployment where both
+    /// versions are briefly live still serializes their schema work against each other.
+    /// </summary>
+    private static readonly PostgresMigrationOptions MigrationOptions =
+        new("kg_schema_migrations", 0x6B675F736368656DL);
 
     private readonly string _connectionString;
     private readonly ILogger<PostgreSqlGraphStore> _logger;
-    private readonly SemaphoreSlim _schemaLock = new(1, 1);
-    private volatile bool _schemaReady;
+    private readonly PostgresSchemaGate _schema;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PostgreSqlGraphStore"/> class.
@@ -83,6 +62,11 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
             ?? throw new InvalidOperationException(
                 "GraphRag.ConnectionString must be configured when using the 'postgresql' graph provider.");
         _logger = logger;
+
+        _schema = new PostgresSchemaGate(new PostgresMigrationRunner(
+            MigrationOptions,
+            EmbeddedSqlMigrationSource.Load(Assembly.GetExecutingAssembly()),
+            logger));
     }
 
     /// <inheritdoc />
@@ -452,40 +436,19 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     }
 
     /// <summary>
-    /// Creates the <c>kg_nodes</c>/<c>kg_edges</c> tables (with the full isolation/temporal column
-    /// set) if they do not already exist. Runs once per store instance — the backend is a singleton —
-    /// guarded so concurrent callers initialize the schema exactly once.
+    /// Brings the <c>kg_nodes</c>/<c>kg_edges</c> schema up to date on first use, then does nothing.
     /// </summary>
-    private async Task EnsureSchemaAsync(NpgsqlConnection conn, CancellationToken ct)
-    {
-        if (_schemaReady) return;
-        await _schemaLock.WaitAsync(ct);
-        try
-        {
-            if (_schemaReady) return;
-
-            // Serialize DDL across processes/replicas: concurrent CREATE TABLE/INDEX IF NOT EXISTS
-            // on a fresh database can race and throw ("tuple concurrently updated" / duplicate
-            // object). A transaction-scoped advisory lock (auto-released on commit) makes first-use
-            // safe in a scaled-out deployment; the in-process semaphore + flag handle the common case.
-            await using var tx = await conn.BeginTransactionAsync(ct);
-            await using (var lockCmd = new NpgsqlCommand("SELECT pg_advisory_xact_lock(@key)", conn, tx))
-            {
-                lockCmd.Parameters.AddWithValue("key", 0x6B675F736368656DL); // "kg_schem"
-                await lockCmd.ExecuteNonQueryAsync(ct);
-            }
-            await using (var cmd = new NpgsqlCommand(SchemaDdl, conn, tx))
-            {
-                await cmd.ExecuteNonQueryAsync(ct);
-            }
-            await tx.CommitAsync(ct);
-            _schemaReady = true;
-        }
-        finally
-        {
-            _schemaLock.Release();
-        }
-    }
+    /// <remarks>
+    /// This used to execute a DDL string constant held in this class, which could create the tables
+    /// but could never change them: a consumer whose database already held a graph would keep the
+    /// original shape forever. The DDL is now migration <c>001_baseline_kg_schema.sql</c> behind a
+    /// versioned runner, so the next column can actually reach an existing installation. The
+    /// advisory-lock and lazy-once behaviour it had is unchanged — it moved into
+    /// <see cref="PostgresSchemaGate"/> and <see cref="PostgresMigrationRunner"/>, which the
+    /// observability store shares.
+    /// </remarks>
+    private Task EnsureSchemaAsync(NpgsqlConnection conn, CancellationToken ct) =>
+        _schema.EnsureAsync(conn, ct);
 
     private static GraphNode ReadNode(NpgsqlDataReader reader) => ReadNodeAt(reader, 0);
 

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Reflection;
 using System.Text.Json;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Infrastructure.Postgres.Migrations;
@@ -63,10 +62,10 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
                 "GraphRag.ConnectionString must be configured when using the 'postgresql' graph provider.");
         _logger = logger;
 
-        _schema = new PostgresSchemaGate(new PostgresMigrationRunner(
+        _schema = new PostgresSchemaGate(
             MigrationOptions,
-            EmbeddedSqlMigrationSource.Load(Assembly.GetExecutingAssembly()),
-            logger));
+            EmbeddedSqlMigrationSource.Load(typeof(PostgreSqlGraphStore).Assembly),
+            logger);
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/PostgreSql/PostgreSqlGraphStore.cs
@@ -33,14 +33,6 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     private static readonly ActivitySource ActivitySource = new("Infrastructure.AI.KnowledgeGraph.PostgreSql");
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-    /// <summary>
-    /// Ledger table and advisory lock key for the knowledge-graph migration set. The key is
-    /// unchanged from when this class held its DDL inline, so a rolling deployment where both
-    /// versions are briefly live still serializes their schema work against each other.
-    /// </summary>
-    private static readonly PostgresMigrationOptions MigrationOptions =
-        new("kg_schema_migrations", 0x6B675F736368656DL);
-
     private readonly string _connectionString;
     private readonly ILogger<PostgreSqlGraphStore> _logger;
     private readonly PostgresSchemaGate _schema;
@@ -63,8 +55,8 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
         _logger = logger;
 
         _schema = new PostgresSchemaGate(
-            MigrationOptions,
-            EmbeddedSqlMigrationSource.Load(typeof(PostgreSqlGraphStore).Assembly),
+            KnowledgeGraphMigrations.Options,
+            KnowledgeGraphMigrations.Load(),
             logger);
     }
 
@@ -430,24 +422,17 @@ public sealed class PostgreSqlGraphStore : IKnowledgeGraphStore
     {
         var conn = new NpgsqlConnection(_connectionString);
         await conn.OpenAsync(ct);
-        await EnsureSchemaAsync(conn, ct);
+        // Brings kg_nodes/kg_edges up to date on the first connection, then costs a bool read. This
+        // used to be a DDL string constant executed here, which could create the tables but never
+        // change them: a consumer whose database already held a graph kept the original shape for
+        // ever. The DDL is now 001_baseline_kg_schema.sql behind a versioned runner, so the next
+        // column can actually reach an existing installation. The advisory-lock and lazy-once
+        // behaviour is unchanged — it moved into PostgresSchemaGate, which the observability store
+        // shares. (There was a private one-line wrapper here holding this note. It read as a policy
+        // hook and was not one.)
+        await _schema.EnsureAsync(conn, ct);
         return conn;
     }
-
-    /// <summary>
-    /// Brings the <c>kg_nodes</c>/<c>kg_edges</c> schema up to date on first use, then does nothing.
-    /// </summary>
-    /// <remarks>
-    /// This used to execute a DDL string constant held in this class, which could create the tables
-    /// but could never change them: a consumer whose database already held a graph would keep the
-    /// original shape forever. The DDL is now migration <c>001_baseline_kg_schema.sql</c> behind a
-    /// versioned runner, so the next column can actually reach an existing installation. The
-    /// advisory-lock and lazy-once behaviour it had is unchanged — it moved into
-    /// <see cref="PostgresSchemaGate"/> and <see cref="PostgresMigrationRunner"/>, which the
-    /// observability store shares.
-    /// </remarks>
-    private Task EnsureSchemaAsync(NpgsqlConnection conn, CancellationToken ct) =>
-        _schema.EnsureAsync(conn, ct);
 
     private static GraphNode ReadNode(NpgsqlDataReader reader) => ReadNodeAt(reader, 0);
 

--- a/src/Content/Infrastructure/Infrastructure.Observability/Infrastructure.Observability.csproj
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Infrastructure.Observability.csproj
@@ -22,6 +22,20 @@
     <ProjectReference Include="..\..\Application\Application.Common\Application.Common.csproj" />
     <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
     <ProjectReference Include="..\..\Domain\Domain.AI\Domain.AI.csproj" />
+    <ProjectReference Include="..\Infrastructure.Postgres\Infrastructure.Postgres.csproj" />
+  </ItemGroup>
+
+  <!--
+    LogicalName is set explicitly so the resource names are exactly
+    "Migrations.<file>.sql". MSBuild's default naming derives from the root
+    namespace and folder path and rewrites characters it considers invalid, which
+    would make the name something to be verified rather than known — and a
+    migration set that silently resolves to empty reads as "schema is up to date".
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="Migrations\*.sql">
+      <LogicalName>Migrations.%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Content/Infrastructure/Infrastructure.Observability/Migrations/001_baseline_schema.sql
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Migrations/001_baseline_schema.sql
@@ -1,21 +1,26 @@
 -- =============================================================================
--- Agentic Harness Observability Schema
--- PostgreSQL 16 — initialized via docker-entrypoint-initdb.d
+-- Agentic Harness Observability Schema — baseline
+-- PostgreSQL 16. Applied by PostgresMigrationRunner, not by the Docker entrypoint.
+--
+-- Every statement here is idempotent, and that is load-bearing rather than
+-- tidiness. A database that predates the migration runner already has these
+-- tables but has no ledger recording them, so the runner will try to apply this
+-- script against it. IF NOT EXISTS makes that a no-op and lets the later
+-- migrations do the real work, which is simpler and more forgiving of drift than
+-- trying to detect an existing installation and mark the baseline as applied.
+--
+-- The grafana_reader role and its grants are NOT here. Creating a role is a
+-- cluster-level operation needing CREATEROLE, which no least-privilege
+-- application account should hold; it lives in Dashboards/postgres-bootstrap/
+-- and runs once when the cluster is created. That file also sets ALTER DEFAULT
+-- PRIVILEGES, so every table created by a migration below is readable by Grafana
+-- without any migration having to grant it.
 -- =============================================================================
-
--- Read-only user for Grafana datasource
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'grafana_reader') THEN
-        CREATE ROLE grafana_reader LOGIN PASSWORD 'grafana_readonly';
-    END IF;
-END
-$$;
 
 -- ---------------------------------------------------------------------------
 -- Sessions: one row per agent conversation
 -- ---------------------------------------------------------------------------
-CREATE TABLE sessions (
+CREATE TABLE IF NOT EXISTS sessions (
     id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     conversation_id       TEXT NOT NULL UNIQUE,
     agent_name            TEXT NOT NULL,
@@ -32,20 +37,24 @@ CREATE TABLE sessions (
     total_cache_write     INTEGER NOT NULL DEFAULT 0,
     total_cost_usd        NUMERIC(10,6) NOT NULL DEFAULT 0,
     cache_hit_rate        NUMERIC(5,4) NOT NULL DEFAULT 0,
-    status                TEXT NOT NULL DEFAULT 'active'
-                          CHECK (status IN ('active','completed','error')),
+    status                TEXT NOT NULL DEFAULT 'active',
     error_message         TEXT,
-    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Named explicitly. Postgres would name an inline column CHECK for us, but
+    -- the generated name is a convention to be looked up rather than a fact to
+    -- be relied on, and migration 005 has to drop this constraint by name.
+    CONSTRAINT sessions_status_check CHECK (status IN ('active','completed','error'))
 );
 
-CREATE INDEX idx_sessions_started   ON sessions (started_at);
-CREATE INDEX idx_sessions_agent     ON sessions (agent_name, started_at);
-CREATE INDEX idx_sessions_status    ON sessions (status);
+CREATE INDEX IF NOT EXISTS idx_sessions_started   ON sessions (started_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_agent     ON sessions (agent_name, started_at);
+CREATE INDEX IF NOT EXISTS idx_sessions_status    ON sessions (status);
 
 -- ---------------------------------------------------------------------------
 -- Session messages: one row per turn
 -- ---------------------------------------------------------------------------
-CREATE TABLE session_messages (
+CREATE TABLE IF NOT EXISTS session_messages (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     session_id      UUID NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
     turn_index      INTEGER NOT NULL,
@@ -72,13 +81,13 @@ CREATE TABLE session_messages (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_messages_session ON session_messages (session_id, turn_index);
-CREATE INDEX idx_messages_created ON session_messages (created_at);
+CREATE INDEX IF NOT EXISTS idx_messages_session ON session_messages (session_id, turn_index);
+CREATE INDEX IF NOT EXISTS idx_messages_created ON session_messages (created_at);
 
 -- ---------------------------------------------------------------------------
 -- Tool executions: one row per tool call
 -- ---------------------------------------------------------------------------
-CREATE TABLE tool_executions (
+CREATE TABLE IF NOT EXISTS tool_executions (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     session_id      UUID NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
     message_id      UUID REFERENCES session_messages (id) ON DELETE SET NULL,
@@ -104,14 +113,14 @@ CREATE TABLE tool_executions (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_tools_session ON tool_executions (session_id);
-CREATE INDEX idx_tools_name    ON tool_executions (tool_name, created_at);
-CREATE INDEX idx_tools_status  ON tool_executions (status) WHERE status != 'success';
+CREATE INDEX IF NOT EXISTS idx_tools_session ON tool_executions (session_id);
+CREATE INDEX IF NOT EXISTS idx_tools_name    ON tool_executions (tool_name, created_at);
+CREATE INDEX IF NOT EXISTS idx_tools_status  ON tool_executions (status) WHERE status != 'success';
 
 -- ---------------------------------------------------------------------------
 -- Content safety evaluations
 -- ---------------------------------------------------------------------------
-CREATE TABLE safety_events (
+CREATE TABLE IF NOT EXISTS safety_events (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     session_id      UUID NOT NULL REFERENCES sessions (id) ON DELETE CASCADE,
     phase           TEXT NOT NULL CHECK (phase IN ('prompt','response')),
@@ -122,13 +131,13 @@ CREATE TABLE safety_events (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_safety_session ON safety_events (session_id);
-CREATE INDEX idx_safety_outcome ON safety_events (outcome) WHERE outcome != 'pass';
+CREATE INDEX IF NOT EXISTS idx_safety_session ON safety_events (session_id);
+CREATE INDEX IF NOT EXISTS idx_safety_outcome ON safety_events (outcome) WHERE outcome != 'pass';
 
 -- ---------------------------------------------------------------------------
 -- Budget configurations
 -- ---------------------------------------------------------------------------
-CREATE TABLE budget_configs (
+CREATE TABLE IF NOT EXISTS budget_configs (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name            TEXT NOT NULL UNIQUE,
     period          TEXT NOT NULL CHECK (period IN ('daily','weekly','monthly')),
@@ -145,7 +154,7 @@ CREATE TABLE budget_configs (
 -- ---------------------------------------------------------------------------
 -- Budget state (current period)
 -- ---------------------------------------------------------------------------
-CREATE TABLE budget_state (
+CREATE TABLE IF NOT EXISTS budget_state (
     config_id       UUID PRIMARY KEY REFERENCES budget_configs (id) ON DELETE CASCADE,
     status          TEXT NOT NULL DEFAULT 'clear'
                     CHECK (status IN ('clear','warning','critical')),
@@ -158,7 +167,7 @@ CREATE TABLE budget_state (
 -- ---------------------------------------------------------------------------
 -- Budget alert transitions (history)
 -- ---------------------------------------------------------------------------
-CREATE TABLE budget_events (
+CREATE TABLE IF NOT EXISTS budget_events (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     config_id       UUID NOT NULL REFERENCES budget_configs (id) ON DELETE CASCADE,
     prev_status     TEXT CHECK (prev_status IN ('clear','warning','critical')),
@@ -168,12 +177,12 @@ CREATE TABLE budget_events (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_budget_events_config ON budget_events (config_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_budget_events_config ON budget_events (config_id, created_at);
 
 -- ---------------------------------------------------------------------------
 -- Audit log
 -- ---------------------------------------------------------------------------
-CREATE TABLE audit_log (
+CREATE TABLE IF NOT EXISTS audit_log (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     operation       TEXT NOT NULL,
     source          TEXT NOT NULL CHECK (source IN ('harness','api','system')),
@@ -182,13 +191,13 @@ CREATE TABLE audit_log (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-CREATE INDEX idx_audit_created   ON audit_log (created_at);
-CREATE INDEX idx_audit_operation ON audit_log (operation);
+CREATE INDEX IF NOT EXISTS idx_audit_created   ON audit_log (created_at);
+CREATE INDEX IF NOT EXISTS idx_audit_operation ON audit_log (operation);
 
 -- ---------------------------------------------------------------------------
 -- Model pricing reference (seed data)
 -- ---------------------------------------------------------------------------
-CREATE TABLE model_pricing (
+CREATE TABLE IF NOT EXISTS model_pricing (
     model_name              TEXT PRIMARY KEY,
     input_per_million       NUMERIC(10,4) NOT NULL,
     output_per_million      NUMERIC(10,4) NOT NULL,
@@ -211,7 +220,7 @@ ON CONFLICT (model_name) DO NOTHING;
 -- ---------------------------------------------------------------------------
 -- Materialized view: daily cost summary
 -- ---------------------------------------------------------------------------
-CREATE MATERIALIZED VIEW daily_cost_summary AS
+CREATE MATERIALIZED VIEW IF NOT EXISTS daily_cost_summary AS
 SELECT
     DATE_TRUNC('day', started_at)   AS day,
     agent_name,
@@ -228,7 +237,7 @@ FROM sessions
 WHERE ended_at IS NOT NULL
 GROUP BY DATE_TRUNC('day', started_at), agent_name, model;
 
-CREATE UNIQUE INDEX idx_daily_cost ON daily_cost_summary (day, agent_name, model);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_cost ON daily_cost_summary (day, agent_name, model);
 
 -- ---------------------------------------------------------------------------
 -- Seed budget configurations
@@ -247,11 +256,3 @@ INSERT INTO budget_state (config_id, status, current_spend, period_start)
 SELECT id, 'clear', 0, DATE_TRUNC('month', NOW())
 FROM budget_configs WHERE period = 'monthly'
 ON CONFLICT (config_id) DO NOTHING;
-
--- ---------------------------------------------------------------------------
--- Grant read-only access to Grafana user
--- ---------------------------------------------------------------------------
-GRANT CONNECT ON DATABASE observability TO grafana_reader;
-GRANT USAGE ON SCHEMA public TO grafana_reader;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO grafana_reader;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafana_reader;

--- a/src/Content/Infrastructure/Infrastructure.Observability/Migrations/002_context_snapshots.sql
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Migrations/002_context_snapshots.sql
@@ -1,8 +1,8 @@
 -- =============================================================================
 -- Foresight context snapshots — one row per turn per conversation.
--- Loaded after 01-schema.sql via the alphabetical Docker entrypoint order, so
--- the table is available in fresh deployments. For an existing observability
--- database, apply this file manually:  psql -d observability -f 02-context-snapshots.sql
+-- Applied by PostgresMigrationRunner after 001_baseline_schema.sql. The manual
+-- "apply this file yourself with psql" instruction this header used to carry is
+-- gone: that workaround is the thing the migration runner replaced.
 -- =============================================================================
 
 CREATE TABLE IF NOT EXISTS context_snapshots (
@@ -39,4 +39,7 @@ CREATE INDEX IF NOT EXISTS idx_context_snapshots_conv
 CREATE INDEX IF NOT EXISTS idx_context_snapshots_captured
     ON context_snapshots (captured_at DESC);
 
-GRANT SELECT ON context_snapshots TO grafana_reader;
+-- No GRANT here. Dashboards/postgres-bootstrap/ sets ALTER DEFAULT PRIVILEGES
+-- for grafana_reader, so every table a migration creates is readable already. A
+-- grant in a migration would also fail outright on a database where that role
+-- was never provisioned, taking the whole schema upgrade down with it.

--- a/src/Content/Infrastructure/Infrastructure.Observability/Migrations/003_loaded_bodies.sql
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Migrations/003_loaded_bodies.sql
@@ -7,9 +7,12 @@
 -- carries metadata + token counts only, keeping SignalR / HTTP wire payloads
 -- small.
 --
--- Loaded after 02-context-snapshots.sql via the alphabetical Docker entrypoint
--- order. For an existing observability database, apply manually:
---   psql -d observability -f 03-loaded-bodies.sql
+-- Applied by PostgresMigrationRunner after 002_context_snapshots.sql.
+--
+-- This and 004 both used to be numbered 03-, so their order was decided by the
+-- shell glob that fed them to the Docker entrypoint. They are independent — this
+-- one creates a new table, 004 alters tables from 001 — so the split is safe;
+-- the numbering exists so nobody has to establish that again.
 -- =============================================================================
 
 CREATE TABLE IF NOT EXISTS context_snapshot_loaded_bodies (
@@ -29,4 +32,4 @@ CREATE TABLE IF NOT EXISTS context_snapshot_loaded_bodies (
 CREATE INDEX IF NOT EXISTS idx_loaded_bodies_conv_turn
     ON context_snapshot_loaded_bodies (conversation_id, turn_index);
 
-GRANT SELECT ON context_snapshot_loaded_bodies TO grafana_reader;
+-- No GRANT here; see the note in 002_context_snapshots.sql.

--- a/src/Content/Infrastructure/Infrastructure.Observability/Migrations/004_message_and_tool_bodies.sql
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Migrations/004_message_and_tool_bodies.sql
@@ -1,10 +1,10 @@
 -- =============================================================================
 -- Foresight message + tool-execution body capture — adds the full-content
 -- columns the file-body and per-invocation deep-link endpoints read.
--- Loaded after 02-context-snapshots.sql via the alphabetical Docker entrypoint
--- order. For an existing observability database, apply manually:
---   psql -d observability -f 03-message-and-tool-bodies.sql
--- All ADDs are guarded with IF NOT EXISTS so re-applying is a no-op.
+-- Applied by PostgresMigrationRunner. All ADDs are guarded with IF NOT EXISTS so
+-- re-applying is a no-op — which is also why this script is safe to run against a
+-- database created before the migration ledger existed, where 001 finds every
+-- table already present and these columns may or may not be.
 -- =============================================================================
 
 ALTER TABLE session_messages

--- a/src/Content/Infrastructure/Infrastructure.Observability/Migrations/005_sessions_status_cancelled.sql
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Migrations/005_sessions_status_cancelled.sql
@@ -8,11 +8,27 @@
 -- because the only delivery mechanism reached databases being created for the
 -- first time.
 --
--- The old constraint is dropped by DISCOVERED name, not by assumed name. A
--- database created by 001 has 'sessions_status_check' because 001 says so, but a
--- database created before 001 was rewritten has whatever Postgres generated for
--- an inline column CHECK. Those happen to be the same string today; relying on
--- that would be assuming the very kind of thing this issue punished.
+-- The old constraint is dropped by DISCOVERED name rather than assumed name.
+--
+-- Be honest about how much that buys, because an earlier draft of this comment
+-- was not: for the two databases this template actually produces, the assumed
+-- name would have worked. A database created by 001 is named
+-- 'sessions_status_check' because 001 says so, and on a pre-#301 database
+-- Postgres's generated name for an inline column CHECK is '<table>_<column>_check'
+-- — the same string. Mutation-testing this proved it: replacing the lookup below
+-- with a hardcoded DROP ... IF EXISTS left every test green.
+--
+-- What the lookup covers is the database this template did not produce: one whose
+-- schema was hand-applied, adapted, or restored in a way that named the constraint
+-- something else, which is exactly the population #301 exists to reach and the one
+-- nobody can enumerate. There a hardcoded DROP silently matches nothing and the ADD
+-- then SUCCEEDS, because it declares a name nothing is using yet. Nothing errors,
+-- nothing rolls back, and the table is left carrying two status constraints — the
+-- old narrow one still refusing 'cancelled'. A silent half-upgrade that reports
+-- success is the exact failure shape #301 was filed about, which is why six lines
+-- to not depend on a naming convention are worth it. The control is the test named
+-- ...HandNamedConstraint...; with the lookup replaced by a hardcoded DROP it fails,
+-- and it is the only test here that does.
 -- =============================================================================
 
 DO $$

--- a/src/Content/Infrastructure/Infrastructure.Observability/Migrations/005_sessions_status_cancelled.sql
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Migrations/005_sessions_status_cancelled.sql
@@ -1,0 +1,43 @@
+-- =============================================================================
+-- Add 'cancelled' to the sessions.status vocabulary.
+--
+-- This is the change #301 existed to make possible. A cancelled run is a real
+-- outcome and is not a failure; before there was a migration runner it had to be
+-- recorded as 'error' with the reason 'conversation.cancelled', which overstated
+-- the failure rate on every dashboard. Widening the constraint was impossible
+-- because the only delivery mechanism reached databases being created for the
+-- first time.
+--
+-- The old constraint is dropped by DISCOVERED name, not by assumed name. A
+-- database created by 001 has 'sessions_status_check' because 001 says so, but a
+-- database created before 001 was rewritten has whatever Postgres generated for
+-- an inline column CHECK. Those happen to be the same string today; relying on
+-- that would be assuming the very kind of thing this issue punished.
+-- =============================================================================
+
+DO $$
+DECLARE
+    constraint_name TEXT;
+BEGIN
+    -- Every CHECK constraint on sessions whose definition mentions the status
+    -- column. There is exactly one; looping rather than selecting into a scalar
+    -- means a database that somehow grew a second one is cleaned up instead of
+    -- raising "more than one row returned".
+    FOR constraint_name IN
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+        WHERE rel.relname = 'sessions'
+          AND nsp.nspname = current_schema()
+          AND con.contype = 'c'
+          AND pg_get_constraintdef(con.oid) ILIKE '%status%'
+    LOOP
+        EXECUTE format('ALTER TABLE sessions DROP CONSTRAINT %I', constraint_name);
+    END LOOP;
+
+    ALTER TABLE sessions
+        ADD CONSTRAINT sessions_status_check
+        CHECK (status IN ('active','completed','error','cancelled'));
+END
+$$;

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/ObservabilityMigrations.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/ObservabilityMigrations.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using Infrastructure.Postgres.Migrations;
 
 namespace Infrastructure.Observability.Persistence;
@@ -20,14 +19,18 @@ public static class ObservabilityMigrations
     /// <c>obs_migr</c>, chosen only so it is unlikely to collide with a key another subsystem picks
     /// in a shared database.
     /// </summary>
+    /// <remarks>
+    /// The ledger is <c>obs_schema_migrations</c>, not <c>schema_migrations</c>. The bare name is
+    /// what Rails, Flyway and Django all use verbatim, so a consumer pointing the harness at a
+    /// database their application already owns would have collided with a ledger that is not ours:
+    /// the runner reads someone else's table, finds none of its own ids there, and applies its entire
+    /// baseline. Prefixing costs nothing and the knowledge-graph set already did it.
+    /// </remarks>
     public static PostgresMigrationOptions Options { get; } =
-        new("schema_migrations", 0x6F62735F6D696772L);
-
-    /// <summary>The assembly carrying the embedded observability migration scripts.</summary>
-    public static Assembly ScriptAssembly => typeof(ObservabilityMigrations).Assembly;
+        new("obs_schema_migrations", 0x6F62735F6D696772L);
 
     /// <summary>Loads the observability migration set in apply order.</summary>
     /// <returns>The migration scripts, ordered by their numeric file-name prefix.</returns>
     public static IReadOnlyList<MigrationScript> Load() =>
-        EmbeddedSqlMigrationSource.Load(ScriptAssembly);
+        EmbeddedSqlMigrationSource.Load(typeof(ObservabilityMigrations).Assembly);
 }

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/ObservabilityMigrations.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/ObservabilityMigrations.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Infrastructure.Postgres.Migrations;
+
+namespace Infrastructure.Observability.Persistence;
+
+/// <summary>
+/// The observability schema's migration set: where its ledger lives, and how to load its scripts.
+/// </summary>
+/// <remarks>
+/// Public, and named once, because more than the store needs it. The integration test fixture brings
+/// its database up to date through this same definition, so a test database and a production database
+/// cannot end up being migrated by two different sets of rules — which was exactly the shape of the
+/// defect this schema had before #301: CI applied the SQL one way, real installations another, and
+/// only the CI path was ever exercised.
+/// </remarks>
+public static class ObservabilityMigrations
+{
+    /// <summary>
+    /// Ledger table and advisory lock key for this migration set. The key is the ASCII bytes of
+    /// <c>obs_migr</c>, chosen only so it is unlikely to collide with a key another subsystem picks
+    /// in a shared database.
+    /// </summary>
+    public static PostgresMigrationOptions Options { get; } =
+        new("schema_migrations", 0x6F62735F6D696772L);
+
+    /// <summary>The assembly carrying the embedded observability migration scripts.</summary>
+    public static Assembly ScriptAssembly => typeof(ObservabilityMigrations).Assembly;
+
+    /// <summary>Loads the observability migration set in apply order.</summary>
+    /// <returns>The migration scripts, ordered by their numeric file-name prefix.</returns>
+    public static IReadOnlyList<MigrationScript> Load() =>
+        EmbeddedSqlMigrationSource.Load(ScriptAssembly);
+}

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/ObservabilityMigrations.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/ObservabilityMigrations.cs
@@ -31,6 +31,15 @@ public static class ObservabilityMigrations
 
     /// <summary>Loads the observability migration set in apply order.</summary>
     /// <returns>The migration scripts, ordered by their numeric file-name prefix.</returns>
-    public static IReadOnlyList<MigrationScript> Load() =>
+    /// <remarks>
+    /// Read once and reused, matching <see cref="Options"/> directly above. It was a method that
+    /// re-enumerated every resource in the assembly and re-read all five scripts on each call, which
+    /// is invisible in production — the store is a singleton — but made callers reason about whether
+    /// calling it twice was wasteful, and at least one assertion pair had already called it twice in
+    /// consecutive lines. <see cref="MigrationScript"/> is immutable, so one instance is shareable.
+    /// </remarks>
+    public static IReadOnlyList<MigrationScript> Load() => Scripts;
+
+    private static readonly IReadOnlyList<MigrationScript> Scripts =
         EmbeddedSqlMigrationSource.Load(typeof(ObservabilityMigrations).Assembly);
 }

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.Context.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.Context.cs
@@ -7,7 +7,8 @@ namespace Infrastructure.Observability.Persistence;
 
 /// <summary>
 /// Foresight context-snapshot persistence. Schema lives in
-/// <c>Dashboards/init-db/02-context-snapshots.sql</c>.
+/// <c>Migrations/002_context_snapshots.sql</c>, embedded in this assembly and applied by the
+/// migration runner.
 /// </summary>
 public sealed partial class PostgresObservabilityStore
 {

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.LoadedBodies.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.LoadedBodies.cs
@@ -5,7 +5,8 @@ namespace Infrastructure.Observability.Persistence;
 
 /// <summary>
 /// Foresight loaded-item body persistence — sidecar to <c>context_snapshots</c>.
-/// Schema lives in <c>Dashboards/init-db/03-loaded-bodies.sql</c>.
+/// Schema lives in <c>Migrations/003_loaded_bodies.sql</c>, embedded in this assembly and applied
+/// by the migration runner.
 /// </summary>
 public sealed partial class PostgresObservabilityStore
 {

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Infrastructure.Postgres.Migrations;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
@@ -10,17 +11,72 @@ namespace Infrastructure.Observability.Persistence;
 /// for non-critical writes (audit, safety) to avoid blocking agent turns.
 /// Read methods return empty collections on failure to maintain resilience.
 /// </summary>
+/// <remarks>
+/// The schema is owned by this assembly and applied by <see cref="PostgresMigrationRunner"/> on the
+/// first physical connection this store opens. It used to arrive from SQL files mounted into the
+/// Postgres container, which the server runs only when it creates an empty data directory — so a
+/// schema change could never reach a database that already held data.
+/// </remarks>
 public sealed partial class PostgresObservabilityStore : IObservabilityStore, IDisposable
 {
     private readonly NpgsqlDataSource _dataSource;
+    private readonly PostgresSchemaGate _schema;
     private readonly ILogger<PostgresObservabilityStore> _logger;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgresObservabilityStore"/> class.
+    /// </summary>
+    /// <param name="connectionString">Connection string for the observability database.</param>
+    /// <param name="logger">Logger for write failures and schema migration.</param>
     public PostgresObservabilityStore(
         string connectionString,
         ILogger<PostgresObservabilityStore> logger)
     {
-        _dataSource = NpgsqlDataSource.Create(connectionString);
         _logger = logger;
+
+        _schema = new PostgresSchemaGate(new PostgresMigrationRunner(
+            ObservabilityMigrations.Options,
+            ObservabilityMigrations.Load(),
+            logger));
+
+        var builder = new NpgsqlDataSourceBuilder(connectionString);
+
+        // The one place every query in this store passes through. Eighteen call sites take commands
+        // straight off the data source, so hooking the physical connection is what lets the schema be
+        // guaranteed current without threading an "ensure schema" call through all of them — and it
+        // happens before the first query rather than racing it.
+        builder.UsePhysicalConnectionInitializer(
+            _ => throw new NotSupportedException(
+                "The observability store opens connections asynchronously only. A synchronous Open() " +
+                "would skip the schema migration this initializer performs."),
+            EnsureSchemaAsync);
+
+        _dataSource = builder.Build();
+    }
+
+    /// <summary>
+    /// Brings the schema up to date on the first physical connection, then does nothing.
+    /// </summary>
+    /// <remarks>
+    /// The failure is logged here, at Error, as well as thrown. Callers on the write path
+    /// deliberately swallow exceptions so telemetry can never fail the agent turn that produced it,
+    /// which would otherwise reduce a failed schema upgrade to a warning about one query. Logging at
+    /// the point of failure keeps the real cause visible whatever the caller does with it.
+    /// </remarks>
+    private async Task EnsureSchemaAsync(NpgsqlConnection connection)
+    {
+        try
+        {
+            await _schema.EnsureAsync(connection);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Observability schema migration failed. Session, message and tool data cannot be " +
+                "persisted until the database is brought up to date.");
+            throw;
+        }
     }
 
     private async Task ExecuteNonQuerySafe(
@@ -41,5 +97,9 @@ public sealed partial class PostgresObservabilityStore : IObservabilityStore, ID
     }
 
     /// <inheritdoc />
-    public void Dispose() => _dataSource.Dispose();
+    public void Dispose()
+    {
+        _dataSource.Dispose();
+        _schema.Dispose();
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.cs
@@ -34,10 +34,8 @@ public sealed partial class PostgresObservabilityStore : IObservabilityStore, ID
     {
         _logger = logger;
 
-        _schema = new PostgresSchemaGate(new PostgresMigrationRunner(
-            ObservabilityMigrations.Options,
-            ObservabilityMigrations.Load(),
-            logger));
+        _schema = new PostgresSchemaGate(
+            ObservabilityMigrations.Options, ObservabilityMigrations.Load(), logger);
 
         var builder = new NpgsqlDataSourceBuilder(connectionString);
 
@@ -97,9 +95,5 @@ public sealed partial class PostgresObservabilityStore : IObservabilityStore, ID
     }
 
     /// <inheritdoc />
-    public void Dispose()
-    {
-        _dataSource.Dispose();
-        _schema.Dispose();
-    }
+    public void Dispose() => _dataSource.Dispose();
 }

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Infrastructure.Postgres.csproj
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Infrastructure.Postgres.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Infrastructure.Postgres</RootNamespace>
+    <Configurations>Debug;Release;Debug-AgentHub-All;Debug-AgentHub-WebUI;Debug-AgentHub-Dashboard</Configurations>
+  </PropertyGroup>
+
+  <!--
+    Deliberately narrow. This project is plumbing shared by every Postgres-backed store, so it
+    references Npgsql and logging and nothing else. Infrastructure.Common would have been the
+    obvious home, but it carries a FrameworkReference to Microsoft.AspNetCore.App: referencing it
+    would drag ASP.NET Core into Infrastructure.Observability and Infrastructure.AI.KnowledgeGraph,
+    both of which are currently framework-free and should stay that way.
+  -->
+  <ItemGroup>
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/EmbeddedSqlMigrationSource.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/EmbeddedSqlMigrationSource.cs
@@ -1,0 +1,109 @@
+using System.Globalization;
+using System.Reflection;
+
+namespace Infrastructure.Postgres.Migrations;
+
+/// <summary>
+/// Loads an ordered migration set from <c>.sql</c> files embedded in an assembly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Migrations ship inside the assembly rather than beside it because a deployed harness has no
+/// repository on disk. A consumer's published output contains DLLs; it does not contain
+/// <c>Dashboards/init-db</c>, which is precisely why the previous mechanism could only ever reach a
+/// database being created for the first time.
+/// </para>
+/// <para>
+/// Resource names are pinned by an explicit <c>LogicalName</c> in each consuming project file, so
+/// they are exactly <c>Migrations.&lt;file name&gt;</c>. That is deliberate: MSBuild's default
+/// resource naming derives from the root namespace and folder path and rewrites characters it
+/// considers invalid, which makes the name something you would have to verify rather than know.
+/// </para>
+/// </remarks>
+public static class EmbeddedSqlMigrationSource
+{
+    /// <summary>
+    /// Reads every embedded <c>.sql</c> resource under <paramref name="resourcePrefix"/> and returns
+    /// them ordered by the numeric prefix of their file names.
+    /// </summary>
+    /// <param name="assembly">The assembly carrying the migration resources.</param>
+    /// <param name="resourcePrefix">
+    /// The logical-name prefix the scripts were embedded under, without a trailing dot — normally
+    /// <c>Migrations</c>.
+    /// </param>
+    /// <returns>The migration set, in apply order.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// No scripts were found, a file name lacks a numeric prefix, or two scripts share an ordinal.
+    /// Each of these is thrown rather than tolerated because the failure they would otherwise cause
+    /// is invisible: an empty set means "schema is up to date", and a duplicate ordinal means the
+    /// apply order is whatever the sort happened to pick. The live folder this replaced had two
+    /// files numbered <c>03-</c>, ordered only by shell glob luck.
+    /// </exception>
+    public static IReadOnlyList<MigrationScript> Load(Assembly assembly, string resourcePrefix = "Migrations")
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourcePrefix);
+
+        var prefix = resourcePrefix + ".";
+        var names = assembly.GetManifestResourceNames()
+            .Where(n => n.StartsWith(prefix, StringComparison.Ordinal)
+                        && n.EndsWith(".sql", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        if (names.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"No embedded migration scripts found under '{prefix}' in assembly " +
+                $"'{assembly.GetName().Name}'. Check that the project file embeds Migrations\\*.sql " +
+                "with an explicit LogicalName.");
+        }
+
+        var scripts = new List<MigrationScript>(names.Length);
+        var seen = new Dictionary<int, string>(names.Length);
+
+        foreach (var name in names)
+        {
+            var id = name[prefix.Length..^".sql".Length];
+            var ordinal = ParseOrdinal(id, assembly);
+
+            if (seen.TryGetValue(ordinal, out var clash))
+            {
+                throw new InvalidOperationException(
+                    $"Migrations '{clash}' and '{id}' share ordinal {ordinal} in assembly " +
+                    $"'{assembly.GetName().Name}'. Two scripts with the same ordinal have no " +
+                    "defined order between them; renumber one of them.");
+            }
+
+            seen[ordinal] = id;
+            scripts.Add(new MigrationScript(ordinal, id, ReadResource(assembly, name)));
+        }
+
+        return scripts.OrderBy(s => s.Ordinal).ToArray();
+    }
+
+    private static int ParseOrdinal(string id, Assembly assembly)
+    {
+        var digits = 0;
+        while (digits < id.Length && char.IsAsciiDigit(id[digits])) digits++;
+
+        if (digits == 0)
+        {
+            throw new InvalidOperationException(
+                $"Migration '{id}' in assembly '{assembly.GetName().Name}' does not start with a " +
+                "number. Apply order is determined by that prefix, so it is required — name the " +
+                "file like '001_baseline_schema.sql'.");
+        }
+
+        return int.Parse(id[..digits], CultureInfo.InvariantCulture);
+    }
+
+    private static string ReadResource(Assembly assembly, string name)
+    {
+        using var stream = assembly.GetManifestResourceStream(name)
+            ?? throw new InvalidOperationException(
+                $"Embedded resource '{name}' was listed by the assembly but could not be opened.");
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/EmbeddedSqlMigrationSource.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/EmbeddedSqlMigrationSource.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Reflection;
 
 namespace Infrastructure.Postgres.Migrations;
@@ -64,37 +63,36 @@ public static class EmbeddedSqlMigrationSource
         foreach (var name in names)
         {
             var id = name[prefix.Length..^".sql".Length];
-            var ordinal = ParseOrdinal(id, assembly);
 
-            if (seen.TryGetValue(ordinal, out var clash))
+            // The ordinal is parsed by MigrationScript itself, which throws if the name has no
+            // numeric prefix. Rethrown here with the assembly named, because "migration 'schema'
+            // does not start with a number" is a good deal easier to act on when you know which
+            // assembly's Migrations folder to go and look in.
+            MigrationScript script;
+            try
+            {
+                script = new MigrationScript(id, ReadResource(assembly, name));
+            }
+            catch (ArgumentException ex)
             {
                 throw new InvalidOperationException(
-                    $"Migrations '{clash}' and '{id}' share ordinal {ordinal} in assembly " +
+                    $"Migration '{id}' in assembly '{assembly.GetName().Name}' is not usable: {ex.Message}",
+                    ex);
+            }
+
+            if (seen.TryGetValue(script.Ordinal, out var clash))
+            {
+                throw new InvalidOperationException(
+                    $"Migrations '{clash}' and '{id}' share ordinal {script.Ordinal} in assembly " +
                     $"'{assembly.GetName().Name}'. Two scripts with the same ordinal have no " +
                     "defined order between them; renumber one of them.");
             }
 
-            seen[ordinal] = id;
-            scripts.Add(new MigrationScript(ordinal, id, ReadResource(assembly, name)));
+            seen[script.Ordinal] = id;
+            scripts.Add(script);
         }
 
         return scripts.OrderBy(s => s.Ordinal).ToArray();
-    }
-
-    private static int ParseOrdinal(string id, Assembly assembly)
-    {
-        var digits = 0;
-        while (digits < id.Length && char.IsAsciiDigit(id[digits])) digits++;
-
-        if (digits == 0)
-        {
-            throw new InvalidOperationException(
-                $"Migration '{id}' in assembly '{assembly.GetName().Name}' does not start with a " +
-                "number. Apply order is determined by that prefix, so it is required — name the " +
-                "file like '001_baseline_schema.sql'.");
-        }
-
-        return int.Parse(id[..digits], CultureInfo.InvariantCulture);
     }
 
     private static string ReadResource(Assembly assembly, string name)

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/MigrationScript.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/MigrationScript.cs
@@ -1,0 +1,18 @@
+namespace Infrastructure.Postgres.Migrations;
+
+/// <summary>
+/// One ordered schema change, ready to apply.
+/// </summary>
+/// <param name="Ordinal">
+/// The numeric prefix parsed from the script's file name, used only to sort the set. Ordinals need
+/// not be contiguous — gaps are expected once a migration is abandoned before release — but they
+/// must be unique, because two scripts sharing an ordinal have no defined order between them.
+/// </param>
+/// <param name="Id">
+/// The script's file name without its extension, and the key recorded in the applied-migrations
+/// ledger. Renaming a released script therefore makes it look unapplied and it will run again,
+/// which is safe only because every script in this repo is written to be idempotent — but it is
+/// still a rename you should not make. Add a new script instead.
+/// </param>
+/// <param name="Sql">The script body, applied verbatim as a single command.</param>
+public sealed record MigrationScript(int Ordinal, string Id, string Sql);

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/MigrationScript.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/MigrationScript.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Infrastructure.Postgres.Migrations;
 
@@ -30,6 +32,44 @@ public sealed record MigrationScript(string Id, string Sql)
     /// </para>
     /// </remarks>
     public int Ordinal { get; } = ParseOrdinal(Id);
+
+    /// <summary>
+    /// A fingerprint of <see cref="Sql"/>, recorded alongside the id so an edit to an already-applied
+    /// script is caught instead of silently splitting the installed base in two.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Without this, editing a released migration is a no-op on every database that already ran it and
+    /// a full apply on every database created afterwards. The two populations then diverge for good,
+    /// nothing reports it, and it is found by hand-diffing a live schema — structurally the same
+    /// failure this whole subsystem was built to end. Flyway and Liquibase both keep a checksum for
+    /// exactly this reason, and the answer is not an approval prompt at authoring time: the mistake
+    /// does its damage at apply time, so that is where it has to be caught.
+    /// </para>
+    /// <para>
+    /// Line endings are normalized before hashing, and that is not cosmetic. These scripts are
+    /// embedded resources, so the bytes are whatever git checked out — CRLF on a Windows developer's
+    /// machine, LF in Linux CI. Hashing raw bytes would make every database look tampered with the
+    /// moment it met the other platform, which is a false alarm loud enough that the first fix anyone
+    /// reaches for is to switch the check off.
+    /// </para>
+    /// </remarks>
+    public string Checksum { get; } = ComputeChecksum(Sql);
+
+    /// <summary>
+    /// Hashes a script body, insensitive to the line endings the file happened to be checked out with.
+    /// </summary>
+    /// <param name="sql">The script body.</param>
+    /// <returns>The lowercase hex SHA-256 of the normalized text.</returns>
+    private static string ComputeChecksum(string sql)
+    {
+        ArgumentNullException.ThrowIfNull(sql);
+
+        var normalized = sql.Replace("\r\n", "\n", StringComparison.Ordinal)
+                            .Replace("\r", "\n", StringComparison.Ordinal);
+
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
+    }
 
     /// <summary>
     /// Reads the leading digits of a migration id.

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/MigrationScript.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/MigrationScript.cs
@@ -1,18 +1,61 @@
+using System.Globalization;
+
 namespace Infrastructure.Postgres.Migrations;
 
 /// <summary>
 /// One ordered schema change, ready to apply.
 /// </summary>
-/// <param name="Ordinal">
-/// The numeric prefix parsed from the script's file name, used only to sort the set. Ordinals need
-/// not be contiguous — gaps are expected once a migration is abandoned before release — but they
-/// must be unique, because two scripts sharing an ordinal have no defined order between them.
-/// </param>
 /// <param name="Id">
-/// The script's file name without its extension, and the key recorded in the applied-migrations
-/// ledger. Renaming a released script therefore makes it look unapplied and it will run again,
-/// which is safe only because every script in this repo is written to be idempotent — but it is
-/// still a rename you should not make. Add a new script instead.
+/// The script's file name without its extension — <c>001_baseline_schema</c> — and the key recorded
+/// in the applied-migrations ledger. Renaming a released script therefore makes it look unapplied and
+/// it will run again, which is safe only because every script in this repo is written to be
+/// idempotent; it is still a rename you should not make. Add a new script instead.
 /// </param>
 /// <param name="Sql">The script body, applied verbatim as a single command.</param>
-public sealed record MigrationScript(int Ordinal, string Id, string Sql);
+public sealed record MigrationScript(string Id, string Sql)
+{
+    /// <summary>
+    /// The numeric prefix of <see cref="Id"/>, used to sort the set.
+    /// </summary>
+    /// <remarks>
+    /// Computed rather than supplied. It was briefly a third constructor parameter, which let a
+    /// caller hand over an ordinal that disagreed with the id it sat next to — a state that cannot
+    /// exist in reality, since both come from one file name, but that nothing validated. The test
+    /// helpers were already doing it: one assigned the ordinal from array position while the id
+    /// carried its own prefix, and they agreed only by the author's care.
+    /// <para>
+    /// Ordinals need not be contiguous — gaps are expected once a migration is abandoned before
+    /// release — but they must be unique, because two scripts sharing one have no defined order
+    /// between them. <see cref="EmbeddedSqlMigrationSource"/> enforces that.
+    /// </para>
+    /// </remarks>
+    public int Ordinal { get; } = ParseOrdinal(Id);
+
+    /// <summary>
+    /// Reads the leading digits of a migration id.
+    /// </summary>
+    /// <param name="id">The migration id.</param>
+    /// <returns>The numeric prefix.</returns>
+    /// <exception cref="ArgumentException">
+    /// The id does not start with a number, so its place in the apply order is undefined. Thrown
+    /// rather than defaulted: a script that silently sorted to position zero would run before the
+    /// baseline that creates the tables it alters.
+    /// </exception>
+    private static int ParseOrdinal(string id)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+
+        var digits = 0;
+        while (digits < id.Length && char.IsAsciiDigit(id[digits])) digits++;
+
+        if (digits == 0)
+        {
+            throw new ArgumentException(
+                $"Migration '{id}' does not start with a number. Apply order is determined by that " +
+                "prefix, so it is required — name the file like '001_baseline_schema.sql'.",
+                nameof(id));
+        }
+
+        return int.Parse(id[..digits], CultureInfo.InvariantCulture);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationException.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationException.cs
@@ -1,0 +1,26 @@
+namespace Infrastructure.Postgres.Migrations;
+
+/// <summary>
+/// Thrown when a schema migration fails. The run is transactional, so the database is left at the
+/// version it held before the attempt.
+/// </summary>
+/// <remarks>
+/// A distinct type rather than a rethrow so callers can tell "the schema could not be brought up to
+/// date" apart from an ordinary query failure against a database that is already correct. The
+/// migration's id is on the exception because the inner Postgres error names a table or constraint,
+/// not the script that tried to change it.
+/// </remarks>
+public sealed class PostgresMigrationException : Exception
+{
+    /// <summary>Initializes a new instance of the <see cref="PostgresMigrationException"/> class.</summary>
+    /// <param name="migrationId">The id of the migration that failed.</param>
+    /// <param name="innerException">The underlying failure.</param>
+    public PostgresMigrationException(string migrationId, Exception innerException)
+        : base($"Schema migration '{migrationId}' failed; no migrations were applied.", innerException)
+    {
+        MigrationId = migrationId;
+    }
+
+    /// <summary>The id of the migration that failed.</summary>
+    public string MigrationId { get; }
+}

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationException.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationException.cs
@@ -21,6 +21,20 @@ public sealed class PostgresMigrationException : Exception
         MigrationId = migrationId;
     }
 
+    /// <summary>Initializes a new instance of the <see cref="PostgresMigrationException"/> class.</summary>
+    /// <param name="migrationId">The id of the migration the run refused to proceed past.</param>
+    /// <param name="message">Why the run was refused.</param>
+    /// <remarks>
+    /// For refusals decided before any SQL is sent — a script whose text no longer matches what this
+    /// database recorded, for instance. There is no inner exception because nothing failed: the run
+    /// was stopped on purpose.
+    /// </remarks>
+    public PostgresMigrationException(string migrationId, string message)
+        : base(message)
+    {
+        MigrationId = migrationId;
+    }
+
     /// <summary>The id of the migration that failed.</summary>
     public string MigrationId { get; }
 }

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationOptions.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationOptions.cs
@@ -8,7 +8,14 @@ namespace Infrastructure.Postgres.Migrations;
 /// Unqualified name of the table recording which scripts have been applied. It is interpolated into
 /// DDL rather than parameterized — Postgres does not accept a parameter where an identifier belongs
 /// — so the value must be a literal chosen by the harness, never anything derived from user input.
-/// <see cref="Validate"/> enforces that.
+/// The constructor enforces that it is a bare lower-case identifier.
+/// <para>
+/// Prefix it with the subsystem, as <c>obs_schema_migrations</c> and <c>kg_schema_migrations</c> do.
+/// A bare <c>schema_migrations</c> is the name Rails, Flyway and Django all use verbatim, so a
+/// consumer who points the harness at an existing application database would collide with a ledger
+/// that is not ours — the runner would read someone else's table, find none of its ids, and apply
+/// its whole baseline.
+/// </para>
 /// </param>
 /// <param name="AdvisoryLockKey">
 /// The key passed to <c>pg_advisory_xact_lock</c> to serialize migration runs across processes.
@@ -18,27 +25,36 @@ namespace Infrastructure.Postgres.Migrations;
 public sealed record PostgresMigrationOptions(string LedgerTable, long AdvisoryLockKey)
 {
     /// <summary>
-    /// Throws if <see cref="LedgerTable"/> is anything other than a plain lower-case identifier.
+    /// The ledger table name, guaranteed to be a bare lower-case identifier.
     /// </summary>
     /// <remarks>
-    /// The name reaches Postgres by string interpolation, which is ordinarily how SQL injection
-    /// arrives. It cannot be parameterized, so the defence has to be that the value is not
-    /// attacker-reachable — and this check is what makes that claim checkable rather than assumed.
+    /// Checked here rather than in a separate <c>Validate()</c> the caller had to remember. That is
+    /// how it was written first, and the giveaway was the test that had to exist to document the
+    /// seam: a record that can hold an invalid value plus one constructor that happens to check it is
+    /// strictly worse than a record that cannot hold one. The name reaches Postgres by string
+    /// interpolation, which is ordinarily how SQL injection arrives; the defence is that the value
+    /// cannot be attacker-reachable, and this is what makes that claim checkable rather than assumed.
     /// </remarks>
-    /// <exception cref="ArgumentException">The ledger table name is empty or not a bare identifier.</exception>
-    public void Validate()
-    {
-        if (string.IsNullOrWhiteSpace(LedgerTable))
-            throw new ArgumentException("A migration ledger table name is required.", nameof(LedgerTable));
+    /// <exception cref="ArgumentException">
+    /// The name is empty or contains anything other than lower-case letters, digits and underscores.
+    /// </exception>
+    public string LedgerTable { get; } = ValidateLedgerTable(LedgerTable);
 
-        foreach (var c in LedgerTable)
+    private static string ValidateLedgerTable(string ledgerTable)
+    {
+        if (string.IsNullOrWhiteSpace(ledgerTable))
+            throw new ArgumentException("A migration ledger table name is required.", nameof(ledgerTable));
+
+        foreach (var c in ledgerTable)
         {
             if (c is (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_') continue;
 
             throw new ArgumentException(
-                $"Ledger table '{LedgerTable}' must contain only lower-case letters, digits and " +
+                $"Ledger table '{ledgerTable}' must contain only lower-case letters, digits and " +
                 "underscores. The name is interpolated into DDL and cannot be parameterized.",
-                nameof(LedgerTable));
+                nameof(ledgerTable));
         }
+
+        return ledgerTable;
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationOptions.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationOptions.cs
@@ -1,0 +1,44 @@
+namespace Infrastructure.Postgres.Migrations;
+
+/// <summary>
+/// Identifies one migration set within a database, so that independent subsystems sharing a
+/// Postgres instance keep separate ledgers and do not serialize behind each other.
+/// </summary>
+/// <param name="LedgerTable">
+/// Unqualified name of the table recording which scripts have been applied. It is interpolated into
+/// DDL rather than parameterized — Postgres does not accept a parameter where an identifier belongs
+/// — so the value must be a literal chosen by the harness, never anything derived from user input.
+/// <see cref="Validate"/> enforces that.
+/// </param>
+/// <param name="AdvisoryLockKey">
+/// The key passed to <c>pg_advisory_xact_lock</c> to serialize migration runs across processes.
+/// Two migration sets must not share a key: they would block each other for no reason. Two hosts
+/// running the <em>same</em> set must share one, or they can both decide a script is unapplied.
+/// </param>
+public sealed record PostgresMigrationOptions(string LedgerTable, long AdvisoryLockKey)
+{
+    /// <summary>
+    /// Throws if <see cref="LedgerTable"/> is anything other than a plain lower-case identifier.
+    /// </summary>
+    /// <remarks>
+    /// The name reaches Postgres by string interpolation, which is ordinarily how SQL injection
+    /// arrives. It cannot be parameterized, so the defence has to be that the value is not
+    /// attacker-reachable — and this check is what makes that claim checkable rather than assumed.
+    /// </remarks>
+    /// <exception cref="ArgumentException">The ledger table name is empty or not a bare identifier.</exception>
+    public void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(LedgerTable))
+            throw new ArgumentException("A migration ledger table name is required.", nameof(LedgerTable));
+
+        foreach (var c in LedgerTable)
+        {
+            if (c is (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_') continue;
+
+            throw new ArgumentException(
+                $"Ledger table '{LedgerTable}' must contain only lower-case letters, digits and " +
+                "underscores. The name is interpolated into DDL and cannot be parameterized.",
+                nameof(LedgerTable));
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationRunner.cs
@@ -29,6 +29,24 @@ namespace Infrastructure.Postgres.Migrations;
 /// here: a schema failure that reports success is exactly how the original defect stayed invisible
 /// for as long as it did.
 /// </para>
+/// <para>
+/// <strong>An applied migration is history.</strong> The ledger records a checksum of each script
+/// alongside its id, and a script whose text has changed since this database ran it stops the run.
+/// Without that, editing a released migration is a no-op here and a full apply on every database
+/// created afterwards — the installed base splits in two and nothing says so. See
+/// <see cref="MigrationScript.Checksum"/>.
+/// </para>
+/// <para>
+/// <strong>Postgres only. SQLite is not migrated by this and should not be.</strong> The EF Core
+/// subsystems reconcile their SQLite schema through <c>SchemaInitializer&lt;TContext&gt;</c>, which
+/// diffs the live database against the EF model and adds what is missing. The two are different
+/// mechanisms for different problems, kept apart on purpose: the reconciler is model-driven and
+/// additive-only, which suits a store whose shape is defined by entity classes, while ordered
+/// hand-written DDL is the only way to express a constraint being widened or a table rewritten —
+/// operations SQLite largely cannot perform in place anyway, and which have no representation in an
+/// EF model. Neither is redundant, and extending either to cover the other's job would make it worse
+/// at its own.
+/// </para>
 /// </remarks>
 public sealed class PostgresMigrationRunner
 {
@@ -97,7 +115,9 @@ public sealed class PostgresMigrationRunner
         await EnsureLedgerAsync(connection, transaction, cancellationToken);
         var applied = await ReadAppliedAsync(connection, transaction, cancellationToken);
 
-        var pending = _scripts.Where(s => !applied.Contains(s.Id)).ToArray();
+        await VerifyAppliedScriptsAreUnchangedAsync(connection, transaction, applied, cancellationToken);
+
+        var pending = _scripts.Where(s => !applied.ContainsKey(s.Id)).ToArray();
 
         // No early return for the up-to-date case. It existed only to log at Debug instead of
         // Information, and it bought that with a second CommitAsync and a second exit from the one
@@ -112,8 +132,10 @@ public sealed class PostgresMigrationRunner
                 await command.ExecuteNonQueryAsync(cancellationToken);
 
                 await using var record = new NpgsqlCommand(
-                    $"INSERT INTO {_options.LedgerTable} (id) VALUES (@id)", connection, transaction);
+                    $"INSERT INTO {_options.LedgerTable} (id, checksum) VALUES (@id, @checksum)",
+                    connection, transaction);
                 record.Parameters.AddWithValue("id", script.Id);
+                record.Parameters.AddWithValue("checksum", script.Checksum);
                 await record.ExecuteNonQueryAsync(cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -143,29 +165,91 @@ public sealed class PostgresMigrationRunner
     private async Task EnsureLedgerAsync(
         NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
     {
+        // The ledger reconciles itself. ADD COLUMN IF NOT EXISTS is not redundant next to CREATE
+        // TABLE IF NOT EXISTS: a database whose ledger was created before checksums existed keeps
+        // that older two-column table for ever, because CREATE TABLE IF NOT EXISTS looks only at the
+        // name. The ledger is the one table in this system that cannot be evolved by a migration —
+        // it is what decides which migrations have run — so it evolves here or not at all.
+        //
+        // checksum is nullable on purpose. NULL means "recorded before this database knew about
+        // checksums", which is a real state, not a broken one; see the verification below.
         await using var command = new NpgsqlCommand(
             $"""
             CREATE TABLE IF NOT EXISTS {_options.LedgerTable} (
                 id         TEXT PRIMARY KEY,
                 applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
-            )
+            );
+            ALTER TABLE {_options.LedgerTable} ADD COLUMN IF NOT EXISTS checksum TEXT;
             """,
             connection, transaction);
 
         await command.ExecuteNonQueryAsync(cancellationToken);
     }
 
-    private async Task<HashSet<string>> ReadAppliedAsync(
+    /// <summary>
+    /// Refuses the run if a script this database already applied no longer says what it said then,
+    /// and adopts a checksum for rows recorded before the ledger carried one.
+    /// </summary>
+    private async Task VerifyAppliedScriptsAreUnchangedAsync(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        IReadOnlyDictionary<string, string?> applied,
+        CancellationToken cancellationToken)
+    {
+        foreach (var script in _scripts)
+        {
+            if (!applied.TryGetValue(script.Id, out var recorded))
+                continue;
+
+            if (recorded is null)
+            {
+                // Adopt, do not accuse. There is nothing to compare against, so the only available
+                // assumption is that the file has not changed since it ran — the same assumption
+                // Flyway's baseline makes. Recording it now means the NEXT edit is caught, which is
+                // the whole point; refusing to start instead would strand every database this branch
+                // migrated before the column existed.
+                await using var backfill = new NpgsqlCommand(
+                    $"UPDATE {_options.LedgerTable} SET checksum = @checksum WHERE id = @id",
+                    connection, transaction);
+                backfill.Parameters.AddWithValue("checksum", script.Checksum);
+                backfill.Parameters.AddWithValue("id", script.Id);
+                await backfill.ExecuteNonQueryAsync(cancellationToken);
+
+                _logger.LogInformation(
+                    "Adopted a checksum for migration {Migration} in ledger {Ledger}; it was applied "
+                        + "before this ledger recorded one.",
+                    script.Id, _options.LedgerTable);
+                continue;
+            }
+
+            if (string.Equals(recorded, script.Checksum, StringComparison.Ordinal))
+                continue;
+
+            // Fatal, and deliberately so. Carrying on would apply nothing — the id is in the ledger —
+            // so this database would keep the old shape while every database created from here on
+            // gets the new one, and no test, log line or dashboard would ever say so.
+            throw new PostgresMigrationException(
+                script.Id,
+                $"Migration '{script.Id}' has changed since this database applied it "
+                    + $"(recorded {recorded}, now {script.Checksum}). An applied migration is history "
+                    + "and cannot be edited: databases that already ran it would keep the old schema "
+                    + "while new ones get the new one. Add a further migration instead. If the "
+                    + "change is genuinely cosmetic and you are certain the schema is unaffected, "
+                    + $"update {_options.LedgerTable}.checksum for this row by hand.");
+        }
+    }
+
+    private async Task<Dictionary<string, string?>> ReadAppliedAsync(
         NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
     {
-        var applied = new HashSet<string>(StringComparer.Ordinal);
+        var applied = new Dictionary<string, string?>(StringComparer.Ordinal);
 
         await using var command = new NpgsqlCommand(
-            $"SELECT id FROM {_options.LedgerTable}", connection, transaction);
+            $"SELECT id, checksum FROM {_options.LedgerTable}", connection, transaction);
         await using var reader = await command.ExecuteReaderAsync(cancellationToken);
 
         while (await reader.ReadAsync(cancellationToken))
-            applied.Add(reader.GetString(0));
+            applied.Add(reader.GetString(0), reader.IsDBNull(1) ? null : reader.GetString(1));
 
         return applied;
     }

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationRunner.cs
@@ -52,8 +52,6 @@ public sealed class PostgresMigrationRunner
         ArgumentNullException.ThrowIfNull(scripts);
         ArgumentNullException.ThrowIfNull(logger);
 
-        options.Validate();
-
         _options = options;
 
         // Sorted here rather than trusted from the caller. EmbeddedSqlMigrationSource already returns
@@ -100,15 +98,12 @@ public sealed class PostgresMigrationRunner
         var applied = await ReadAppliedAsync(connection, transaction, cancellationToken);
 
         var pending = _scripts.Where(s => !applied.Contains(s.Id)).ToArray();
-        if (pending.Length == 0)
-        {
-            await transaction.CommitAsync(cancellationToken);
-            _logger.LogDebug(
-                "Schema is current: {Total} migration(s) already applied in ledger {Ledger}.",
-                _scripts.Count, _options.LedgerTable);
-            return 0;
-        }
 
+        // No early return for the up-to-date case. It existed only to log at Debug instead of
+        // Information, and it bought that with a second CommitAsync and a second exit from the one
+        // block whose entire contract is "did the transaction close" — the shape where a later edit
+        // most easily lands on one branch and not the other. The loop is already a no-op when
+        // nothing is pending, so the commit stays in one place and the logging branches after it.
         foreach (var script in pending)
         {
             try
@@ -129,9 +124,18 @@ public sealed class PostgresMigrationRunner
 
         await transaction.CommitAsync(cancellationToken);
 
-        _logger.LogInformation(
-            "Applied {Count} schema migration(s) to ledger {Ledger}: {Migrations}.",
-            pending.Length, _options.LedgerTable, string.Join(", ", pending.Select(s => s.Id)));
+        if (pending.Length == 0)
+        {
+            _logger.LogDebug(
+                "Schema is current: {Total} migration(s) already applied in ledger {Ledger}.",
+                _scripts.Count, _options.LedgerTable);
+        }
+        else
+        {
+            _logger.LogInformation(
+                "Applied {Count} schema migration(s) to ledger {Ledger}: {Migrations}.",
+                pending.Length, _options.LedgerTable, string.Join(", ", pending.Select(s => s.Id)));
+        }
 
         return pending.Length;
     }

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresMigrationRunner.cs
@@ -1,0 +1,168 @@
+using Microsoft.Extensions.Logging;
+using Npgsql;
+
+namespace Infrastructure.Postgres.Migrations;
+
+/// <summary>
+/// Applies an ordered set of SQL migrations to a Postgres database, recording what it has applied so
+/// that a database which already holds data receives only the changes it is missing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists because the template previously had no way to change the shape of a database that was
+/// already in use. The observability schema was delivered by files mounted at
+/// <c>/docker-entrypoint-initdb.d</c>, which Postgres runs exactly once — when it initialises an
+/// empty data directory — and never again. A consumer who had been running the harness for a month
+/// could not receive a schema change at all, and CI could not see the problem because it built a
+/// fresh database on every run.
+/// </para>
+/// <para>
+/// <strong>The whole run is one transaction.</strong> Postgres applies DDL transactionally, so either
+/// every outstanding migration lands or none does. That is a deliberate choice over the more common
+/// per-migration transaction: a database left half-upgraded is a state nothing else in this system
+/// knows how to reason about, whereas a database left at its previous version is simply the state it
+/// was already in, and the throw makes it loud.
+/// </para>
+/// <para>
+/// <strong>Failure is fatal by design.</strong> The observability store swallows and logs write
+/// failures so telemetry can never fail the agent turn that produced it. That rule must not extend
+/// here: a schema failure that reports success is exactly how the original defect stayed invisible
+/// for as long as it did.
+/// </para>
+/// </remarks>
+public sealed class PostgresMigrationRunner
+{
+    private readonly PostgresMigrationOptions _options;
+    private readonly IReadOnlyList<MigrationScript> _scripts;
+    private readonly ILogger _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PostgresMigrationRunner"/> class.
+    /// </summary>
+    /// <param name="options">Ledger table and advisory lock key identifying this migration set.</param>
+    /// <param name="scripts">The migration set, normally from <see cref="EmbeddedSqlMigrationSource"/>.</param>
+    /// <param name="logger">Logger recording which migrations were applied.</param>
+    /// <exception cref="ArgumentException">The ledger table name is not a bare identifier.</exception>
+    public PostgresMigrationRunner(
+        PostgresMigrationOptions options,
+        IReadOnlyList<MigrationScript> scripts,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(scripts);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        options.Validate();
+
+        _options = options;
+
+        // Sorted here rather than trusted from the caller. EmbeddedSqlMigrationSource already returns
+        // an ordered set, so this looks redundant — but "ordered" was a property of one particular
+        // caller, not of the runner, and a caller that built its list by hand got whatever order it
+        // happened to write. That failed exactly as you would expect and not at all when you would
+        // want: migration 002 ran before 001 and died on a table 001 had not created yet.
+        _scripts = scripts.OrderBy(s => s.Ordinal).ToArray();
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Applies every migration this database has not recorded, and returns how many ran.
+    /// </summary>
+    /// <param name="connection">An open connection to the target database.</param>
+    /// <param name="cancellationToken">Token to cancel the run.</param>
+    /// <returns>The number of migrations applied; zero when the database was already current.</returns>
+    /// <exception cref="PostgresMigrationException">
+    /// A migration failed. The transaction is rolled back, so the database is left at the version it
+    /// held before the run.
+    /// </exception>
+    public async Task<int> ApplyAsync(NpgsqlConnection connection, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        // Serialize across processes before reading the ledger. Order matters: a runner that read
+        // the ledger first could decide a script was unapplied, wait for the lock, and then apply it
+        // a second time on top of another host's work.
+        //
+        // The read below is correct only because Postgres defaults to READ COMMITTED, where each
+        // statement takes a fresh snapshot — so once this lock is granted, the ledger query sees the
+        // rows the previous holder committed. Under REPEATABLE READ it would not, and two hosts
+        // starting together would both run the full set.
+        await using (var lockCommand =
+            new NpgsqlCommand("SELECT pg_advisory_xact_lock(@key)", connection, transaction))
+        {
+            lockCommand.Parameters.AddWithValue("key", _options.AdvisoryLockKey);
+            await lockCommand.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        await EnsureLedgerAsync(connection, transaction, cancellationToken);
+        var applied = await ReadAppliedAsync(connection, transaction, cancellationToken);
+
+        var pending = _scripts.Where(s => !applied.Contains(s.Id)).ToArray();
+        if (pending.Length == 0)
+        {
+            await transaction.CommitAsync(cancellationToken);
+            _logger.LogDebug(
+                "Schema is current: {Total} migration(s) already applied in ledger {Ledger}.",
+                _scripts.Count, _options.LedgerTable);
+            return 0;
+        }
+
+        foreach (var script in pending)
+        {
+            try
+            {
+                await using var command = new NpgsqlCommand(script.Sql, connection, transaction);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+
+                await using var record = new NpgsqlCommand(
+                    $"INSERT INTO {_options.LedgerTable} (id) VALUES (@id)", connection, transaction);
+                record.Parameters.AddWithValue("id", script.Id);
+                await record.ExecuteNonQueryAsync(cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                throw new PostgresMigrationException(script.Id, ex);
+            }
+        }
+
+        await transaction.CommitAsync(cancellationToken);
+
+        _logger.LogInformation(
+            "Applied {Count} schema migration(s) to ledger {Ledger}: {Migrations}.",
+            pending.Length, _options.LedgerTable, string.Join(", ", pending.Select(s => s.Id)));
+
+        return pending.Length;
+    }
+
+    private async Task EnsureLedgerAsync(
+        NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
+    {
+        await using var command = new NpgsqlCommand(
+            $"""
+            CREATE TABLE IF NOT EXISTS {_options.LedgerTable} (
+                id         TEXT PRIMARY KEY,
+                applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """,
+            connection, transaction);
+
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private async Task<HashSet<string>> ReadAppliedAsync(
+        NpgsqlConnection connection, NpgsqlTransaction transaction, CancellationToken cancellationToken)
+    {
+        var applied = new HashSet<string>(StringComparer.Ordinal);
+
+        await using var command = new NpgsqlCommand(
+            $"SELECT id FROM {_options.LedgerTable}", connection, transaction);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+        while (await reader.ReadAsync(cancellationToken))
+            applied.Add(reader.GetString(0));
+
+        return applied;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
@@ -1,0 +1,62 @@
+using Npgsql;
+
+namespace Infrastructure.Postgres.Migrations;
+
+/// <summary>
+/// Runs a store's migrations at most once per process, on the first connection that needs them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Migrations run lazily on first use rather than at dependency-injection composition or from a
+/// hosted service. The harness has several hosts — console, agent hub, execution API, MCP server —
+/// and only some of them run hosted services; binding schema readiness to first use is the one point
+/// that is guaranteed to happen in all of them, and it happens before the first query rather than
+/// racing it.
+/// </para>
+/// <para>
+/// A failed attempt does not latch. Postgres being briefly unreachable while the host starts is
+/// ordinary, and a store that gave up permanently on the first refused connection would need a
+/// restart to recover from a condition that fixes itself.
+/// </para>
+/// </remarks>
+public sealed class PostgresSchemaGate : IDisposable
+{
+    private readonly PostgresMigrationRunner _runner;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private volatile bool _ready;
+
+    /// <summary>Initializes a new instance of the <see cref="PostgresSchemaGate"/> class.</summary>
+    /// <param name="runner">The migration runner to invoke once.</param>
+    public PostgresSchemaGate(PostgresMigrationRunner runner)
+    {
+        ArgumentNullException.ThrowIfNull(runner);
+        _runner = runner;
+    }
+
+    /// <summary>
+    /// Ensures the schema is current, running the migrations if this is the first caller to ask.
+    /// </summary>
+    /// <param name="connection">An open connection to the target database.</param>
+    /// <param name="cancellationToken">Token to cancel the run.</param>
+    /// <exception cref="PostgresMigrationException">A migration failed; the schema is unchanged.</exception>
+    public async Task EnsureAsync(NpgsqlConnection connection, CancellationToken cancellationToken = default)
+    {
+        if (_ready) return;
+
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            if (_ready) return;
+
+            await _runner.ApplyAsync(connection, cancellationToken);
+            _ready = true;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => _gate.Dispose();
+}

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Npgsql;
 
 namespace Infrastructure.Postgres.Migrations;
@@ -19,7 +20,17 @@ namespace Infrastructure.Postgres.Migrations;
 /// restart to recover from a condition that fixes itself.
 /// </para>
 /// </remarks>
-public sealed class PostgresSchemaGate : IDisposable
+/// <remarks>
+/// <para>
+/// Deliberately NOT <see cref="IDisposable"/>. It was, briefly, because it holds a
+/// <see cref="SemaphoreSlim"/> — and the ceremony was immediately skipped by one of its two
+/// consumers, which is the tell that it was never needed. A <see cref="SemaphoreSlim"/> only needs
+/// disposing if its <c>AvailableWaitHandle</c> has been touched, which allocates the underlying
+/// handle; nothing here touches it. Exporting a lifetime requirement that does not exist buys
+/// nothing and gives every consumer a decision it can get wrong.
+/// </para>
+/// </remarks>
+public sealed class PostgresSchemaGate
 {
     private readonly PostgresMigrationRunner _runner;
     private readonly SemaphoreSlim _gate = new(1, 1);
@@ -31,6 +42,24 @@ public sealed class PostgresSchemaGate : IDisposable
     {
         ArgumentNullException.ThrowIfNull(runner);
         _runner = runner;
+    }
+
+    /// <summary>
+    /// Initializes a new instance that builds its own runner — the shape both stores actually want.
+    /// </summary>
+    /// <param name="options">Ledger table and advisory lock key for this migration set.</param>
+    /// <param name="scripts">The migration set, in any order.</param>
+    /// <param name="logger">Logger recording which migrations were applied.</param>
+    /// <remarks>
+    /// Exists because both consumers were writing the same nested double-construction. The
+    /// runner-taking overload stays for the test fixture, which needs to hold the runner itself.
+    /// </remarks>
+    public PostgresSchemaGate(
+        PostgresMigrationOptions options,
+        IReadOnlyList<MigrationScript> scripts,
+        ILogger logger)
+        : this(new PostgresMigrationRunner(options, scripts, logger))
+    {
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
@@ -19,8 +19,6 @@ namespace Infrastructure.Postgres.Migrations;
 /// ordinary, and a store that gave up permanently on the first refused connection would need a
 /// restart to recover from a condition that fixes itself.
 /// </para>
-/// </remarks>
-/// <remarks>
 /// <para>
 /// Deliberately NOT <see cref="IDisposable"/>. It was, briefly, because it holds a
 /// <see cref="SemaphoreSlim"/> — and the ceremony was immediately skipped by one of its two
@@ -29,6 +27,13 @@ namespace Infrastructure.Postgres.Migrations;
 /// handle; nothing here touches it. Exporting a lifetime requirement that does not exist buys
 /// nothing and gives every consumer a decision it can get wrong.
 /// </para>
+/// <para>
+/// A public <c>Dispose</c> survived that removal for a while, on a type that no longer implements
+/// the interface — so nothing called it, and nothing could have noticed. Do not put it back. The
+/// observability store invokes this gate from its physical-connection initializer, so a consumer who
+/// found the method and called it would leave every subsequent connection unable to open, and the
+/// store would stop writing entirely.
+/// </para>
 /// </remarks>
 public sealed class PostgresSchemaGate
 {
@@ -36,30 +41,27 @@ public sealed class PostgresSchemaGate
     private readonly SemaphoreSlim _gate = new(1, 1);
     private volatile bool _ready;
 
-    /// <summary>Initializes a new instance of the <see cref="PostgresSchemaGate"/> class.</summary>
-    /// <param name="runner">The migration runner to invoke once.</param>
-    public PostgresSchemaGate(PostgresMigrationRunner runner)
-    {
-        ArgumentNullException.ThrowIfNull(runner);
-        _runner = runner;
-    }
-
     /// <summary>
-    /// Initializes a new instance that builds its own runner — the shape both stores actually want.
+    /// Initializes a new instance of the <see cref="PostgresSchemaGate"/> class.
     /// </summary>
     /// <param name="options">Ledger table and advisory lock key for this migration set.</param>
     /// <param name="scripts">The migration set, in any order.</param>
     /// <param name="logger">Logger recording which migrations were applied.</param>
     /// <remarks>
-    /// Exists because both consumers were writing the same nested double-construction. The
-    /// runner-taking overload stays for the test fixture, which needs to hold the runner itself.
+    /// The gate builds its own runner rather than taking one, because both consumers were otherwise
+    /// writing the same nested double-construction. There was briefly a second, runner-taking
+    /// constructor kept "for the test fixture, which needs to hold the runner itself" — no such
+    /// consumer ever existed, and the two fixtures that might have been it construct a
+    /// <see cref="PostgresMigrationRunner"/> directly and never touch this class. A documented seam
+    /// with no caller is worse than no seam: it survives refactors on the strength of a consumer
+    /// nobody can find.
     /// </remarks>
     public PostgresSchemaGate(
         PostgresMigrationOptions options,
         IReadOnlyList<MigrationScript> scripts,
         ILogger logger)
-        : this(new PostgresMigrationRunner(options, scripts, logger))
     {
+        _runner = new PostgresMigrationRunner(options, scripts, logger);
     }
 
     /// <summary>
@@ -85,7 +87,4 @@ public sealed class PostgresSchemaGate
             _gate.Release();
         }
     }
-
-    /// <inheritdoc />
-    public void Dispose() => _gate.Dispose();
 }

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/SessionsController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/SessionsController.cs
@@ -58,8 +58,13 @@ public sealed class SessionsController : ControllerBase
     /// <param name="limit">Maximum number of sessions to return (1-200, default 50).</param>
     /// <param name="offset">Number of sessions to skip for pagination (default 0).</param>
     /// <param name="status">
-    /// Optional status filter: <c>active</c>, <c>completed</c> or <c>error</c>, matched
-    /// case-insensitively. Any other word is a 400 — see the remarks on the 400 response.
+    /// Optional status filter: any member of <see cref="SessionStatus"/>, matched case-insensitively.
+    /// Any other word is a 400 — see the remarks on the 400 response.
+    /// <para>
+    /// Deliberately not an enumeration of the accepted words. The list was written out here once and
+    /// went stale the moment the vocabulary grew; the code below derives the accepted set from the
+    /// enum, so there is nothing here left to keep in sync.
+    /// </para>
     /// </param>
     /// <param name="since">Optional Unix epoch seconds lower bound on started_at.</param>
     /// <param name="until">Optional Unix epoch seconds upper bound on started_at.</param>

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -210,7 +210,18 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
 
         // This path is where the string "errored" came from; see SessionStatus for what the database
         // did with it and why the parameter is typed now.
-        var status = exception is null ? SessionStatus.Completed : SessionStatus.Error;
+        //
+        // A cancellation is separated out from the other exceptions rather than lumped in with them.
+        // An OperationCanceledException here means the connection went away deliberately — the client
+        // navigated, the host is shutting down — which is the single most common way a conversation
+        // ends and is not a failure. Counting it as one is not cosmetic: the dashboards' error-rate
+        // panel is literally `status = 'error'`, so every ordinary disconnect inflated it.
+        var status = exception switch
+        {
+            null => SessionStatus.Completed,
+            OperationCanceledException => SessionStatus.Cancelled,
+            _ => SessionStatus.Error,
+        };
 
         // The reason is a stable code, never the exception's own text, and fixing the status above is
         // exactly why that matters now: while the write was being rejected nothing reached the row, so
@@ -218,7 +229,7 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         // strings, tokens, internal paths — into sessions.error_message, which is read back out and
         // served to clients on the session list. The full exception goes to the log, where it belongs.
         // Same rule, and the same stable-code shape, as RunConversationCommandHandler's error path.
-        if (exception is not null)
+        if (status == SessionStatus.Error)
         {
             _logger.LogError(
                 exception,
@@ -227,12 +238,19 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
                 info.ConversationId);
         }
 
+        var reason = status switch
+        {
+            SessionStatus.Error => "connection.dropped_with_exception",
+            SessionStatus.Cancelled => "connection.cancelled",
+            _ => null,
+        };
+
         try
         {
             await _observabilityStore.EndSessionAsync(
                 info.ObservabilitySessionId,
                 status,
-                exception is null ? null : "connection.dropped_with_exception",
+                reason,
                 ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -213,20 +213,24 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         //
         // A deliberate stop is separated out from the other exceptions rather than lumped in with
         // them: a client that navigated away or a host shutting down is the single most common way a
-        // conversation ends and is not a failure. Counting it as one is not cosmetic — the dashboards'
-        // error-rate panel is literally `status = 'error'`, so every ordinary disconnect inflated it.
+        // conversation ends and is not a failure, and `status` is what the sessions list and the
+        // Grafana $status filter show an operator. (An earlier version of this comment justified the
+        // change by claiming the dashboards compute an error rate from `status = 'error'`. They do
+        // not — the error-rate tiles are Prometheus counters over tool errors, and no panel in
+        // Dashboards/ filters on that literal. The change stands on its own; the invented cost did
+        // not, and repeating it five times across this file and its tests did not make it true.)
         //
-        // The token check is what makes that split safe. TaskCanceledException derives from
-        // OperationCanceledException and is also what a keepalive or read timeout throws with nobody
-        // having cancelled anything, so matching on the type alone would quietly reclassify a broken
-        // transport as a tidy goodbye — and, given the logging below, stop recording it at all.
-        var deliberatelyStopped =
-            exception is OperationCanceledException && ct.IsCancellationRequested;
-
+        // On the token check: it is the same rule RunConversationCommandHandler applies, where it
+        // genuinely discriminates. Here it does not, and that is worth stating rather than implying
+        // otherwise — the only production caller is AgentTelemetryHub.OnDisconnectedAsync passing
+        // Context.ConnectionAborted, which SignalR has already cancelled before dispatching (see the
+        // note on the write below). So today this reduces to the type test. It is kept because the
+        // classification rule is "a stop that was asked for", not "an exception that looks like one",
+        // and because a caller that is not the hub would otherwise silently get the wrong answer.
         var status = exception switch
         {
             null => SessionStatus.Completed,
-            _ when deliberatelyStopped => SessionStatus.Cancelled,
+            OperationCanceledException when ct.IsCancellationRequested => SessionStatus.Cancelled,
             _ => SessionStatus.Error,
         };
 
@@ -244,12 +248,16 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
                     + "recorded as errored",
                 info.ConversationId);
         }
-        else if (exception is not null)
+        else if (status is SessionStatus.Cancelled)
         {
             // A deliberate stop still gets a record, at a level that does not cry wolf. Routing the
             // Error log through a status check alone would have made this branch log nothing at all
             // and drop the exception on the floor — trading an over-reported failure for an
             // unreported one, which is the worse of the two.
+            //
+            // Branching on `status` in both arms rather than on `exception is not null` here: the two
+            // are equivalent, since Cancelled is unreachable with a null exception, but only one of
+            // them makes that obvious without re-deriving it.
             _logger.LogDebug(
                 exception,
                 "Connection for conversation {ConversationId} was cancelled; the session is recorded "
@@ -266,11 +274,21 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
 
         try
         {
+            // CancellationToken.None, deliberately, and this is load-bearing: `ct` here is
+            // Context.ConnectionAborted, and SignalR aborts the connection BEFORE it dispatches
+            // disconnect ("Ensure the connection is aborted before firing disconnect", in its own
+            // source). So `ct` is already cancelled every single time this method runs. Passing it
+            // to the write meant the UPDATE was refused before it was sent — and because the
+            // observability store catches every exception on a telemetry write, cancellation
+            // included, and logs a warning, nothing surfaced. Every ordinary disconnect left its row
+            // status='active' with no ended_at, for ever. Choosing the right status word above is
+            // worth nothing if the write that carries it cannot run: cleanup after a cancellation is
+            // not itself cancellable. Same rule as RunConversationCommandHandler.EndRunSessionAsync.
             await _observabilityStore.EndSessionAsync(
                 info.ObservabilitySessionId,
                 status,
                 reason,
-                ct);
+                CancellationToken.None);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -211,15 +211,22 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         // This path is where the string "errored" came from; see SessionStatus for what the database
         // did with it and why the parameter is typed now.
         //
-        // A cancellation is separated out from the other exceptions rather than lumped in with them.
-        // An OperationCanceledException here means the connection went away deliberately — the client
-        // navigated, the host is shutting down — which is the single most common way a conversation
-        // ends and is not a failure. Counting it as one is not cosmetic: the dashboards' error-rate
-        // panel is literally `status = 'error'`, so every ordinary disconnect inflated it.
+        // A deliberate stop is separated out from the other exceptions rather than lumped in with
+        // them: a client that navigated away or a host shutting down is the single most common way a
+        // conversation ends and is not a failure. Counting it as one is not cosmetic — the dashboards'
+        // error-rate panel is literally `status = 'error'`, so every ordinary disconnect inflated it.
+        //
+        // The token check is what makes that split safe. TaskCanceledException derives from
+        // OperationCanceledException and is also what a keepalive or read timeout throws with nobody
+        // having cancelled anything, so matching on the type alone would quietly reclassify a broken
+        // transport as a tidy goodbye — and, given the logging below, stop recording it at all.
+        var deliberatelyStopped =
+            exception is OperationCanceledException && ct.IsCancellationRequested;
+
         var status = exception switch
         {
             null => SessionStatus.Completed,
-            OperationCanceledException => SessionStatus.Cancelled,
+            _ when deliberatelyStopped => SessionStatus.Cancelled,
             _ => SessionStatus.Error,
         };
 
@@ -235,6 +242,18 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
                 exception,
                 "Connection for conversation {ConversationId} dropped with an exception; the session is "
                     + "recorded as errored",
+                info.ConversationId);
+        }
+        else if (exception is not null)
+        {
+            // A deliberate stop still gets a record, at a level that does not cry wolf. Routing the
+            // Error log through a status check alone would have made this branch log nothing at all
+            // and drop the exception on the floor — trading an over-reported failure for an
+            // unreported one, which is the worse of the two.
+            _logger.LogDebug(
+                exception,
+                "Connection for conversation {ConversationId} was cancelled; the session is recorded "
+                    + "as cancelled rather than errored",
                 info.ConversationId);
         }
 

--- a/src/Content/Presentation/Presentation.Dashboard/package-lock.json
+++ b/src/Content/Presentation/Presentation.Dashboard/package-lock.json
@@ -7487,9 +7487,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/StatusBadge.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/StatusBadge.tsx
@@ -5,10 +5,17 @@ interface StatusBadgeProps {
   className?: string;
 }
 
+// Must cover every value of SessionStatus. A status with no entry here does not fail — it falls
+// through to the neutral "unknown" style below and looks like a rendering glitch rather than a
+// missing case, which is how 'cancelled' would have shipped looking broken.
+//
+// Slate rather than amber for cancelled: amber is taken by active, and the two must not read as
+// near-identical when a cancelled run is precisely the one that is NOT still going.
 const statusStyles: Record<string, string> = {
   completed: 'bg-emerald-500/15 text-emerald-400',
   error: 'bg-red-500/15 text-red-400',
   active: 'bg-amber-500/15 text-amber-400',
+  cancelled: 'bg-slate-500/15 text-slate-400',
 };
 
 export function StatusBadge({ status, className }: StatusBadgeProps) {

--- a/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/StatusBadge.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/routes/Sessions/StatusBadge.tsx
@@ -5,13 +5,20 @@ interface StatusBadgeProps {
   className?: string;
 }
 
-// Must cover every value of SessionStatus. A status with no entry here does not fail — it falls
-// through to the neutral "unknown" style below and looks like a rendering glitch rather than a
-// missing case, which is how 'cancelled' would have shipped looking broken.
+// Every value the API's SessionStatus can take. Keep this in step with the C# enum of the same name
+// and with the sessions.status CHECK constraint in Infrastructure.Observability/Migrations.
+export type SessionStatus = 'active' | 'completed' | 'error' | 'cancelled';
+
+// Keyed by SessionStatus, not by string, and that is the whole point: a value added to the union
+// with no style here is a compile error under `tsc --noEmit`, which the frontend CI runs. Typed as
+// Record<string, string> it was not — a missing entry fell through to the neutral style below and
+// rendered as a washed-out badge that reads like a CSS glitch rather than a missing case. The
+// previous version of this comment asked the reader to remember instead, on the one site in this
+// vocabulary where the type system was available to enforce it.
 //
 // Slate rather than amber for cancelled: amber is taken by active, and the two must not read as
 // near-identical when a cancelled run is precisely the one that is NOT still going.
-const statusStyles: Record<string, string> = {
+const statusStyles: Record<SessionStatus, string> = {
   completed: 'bg-emerald-500/15 text-emerald-400',
   error: 'bg-red-500/15 text-red-400',
   active: 'bg-amber-500/15 text-amber-400',
@@ -19,7 +26,11 @@ const statusStyles: Record<string, string> = {
 };
 
 export function StatusBadge({ status, className }: StatusBadgeProps) {
-  const style = statusStyles[status.toLowerCase()] ?? 'bg-muted text-muted-foreground';
+  // The runtime fallback stays. The Record type makes a status the UI forgot a build error, but the
+  // status arrives over HTTP from a server that may be a version ahead, and an unstyled badge beats
+  // a thrown render.
+  const style =
+    statusStyles[status.toLowerCase() as SessionStatus] ?? 'bg-muted text-muted-foreground';
   return (
     <span className={cn('inline-block rounded-full px-2 py-0.5 text-xs font-medium capitalize', style, className)}>
       {status}

--- a/src/Content/Presentation/Presentation.WebUI/package-lock.json
+++ b/src/Content/Presentation/Presentation.WebUI/package-lock.json
@@ -8324,9 +8324,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
@@ -115,6 +115,50 @@ public class RunConversationCommandHandlerSolutionReviewFixTests
             Times.Once);
     }
 
+    /// <summary>
+    /// A model call that times out is a failure, not a cancellation, even though it arrives as the
+    /// same exception type.
+    /// </summary>
+    /// <remarks>
+    /// <c>TaskCanceledException</c> derives from <c>OperationCanceledException</c> and is what an
+    /// HTTP client throws when a request exceeds its timeout — with nobody having cancelled anything.
+    /// While the cancellation arm caught the base type unfiltered, a timed-out turn closed as
+    /// <c>Cancelled</c>: absent from the error rate, and silent, because only the general handler
+    /// logs. That traded an over-reported failure for an unreported one. The token, not the exception
+    /// type, is what says whether a stop was asked for.
+    /// </remarks>
+    [Fact]
+    public async Task Handle_TurnTimesOutRatherThanBeingCancelled_EndsSessionAsErrorNotCancelled()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new TaskCanceledException("The request was canceled due to the configured " +
+                                                  "HttpClient.Timeout of 100 seconds elapsing."));
+
+        var command = new RunConversationCommand
+        {
+            AgentName = "TestAgent",
+            UserMessages = ["hello"]
+        };
+
+        // No cancellation requested — this is the whole point of the case.
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<TaskCanceledException>();
+
+        _observabilityStore.Verify(
+            s => s.EndSessionAsync(
+                SessionId, SessionStatus.Error, "conversation.unhandled_exception",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _observabilityStore.Verify(
+            s => s.EndSessionAsync(
+                It.IsAny<Guid>(), SessionStatus.Cancelled, It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     [Fact]
     public async Task Handle_Cancelled_EndsSessionWithAStatusTheSchemaAcceptsAndNamesTheCancellation()
     {

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
@@ -132,13 +132,16 @@ public class RunConversationCommandHandlerSolutionReviewFixTests
         // Act
         var act = () => _handler.Handle(command, new CancellationToken(canceled: true));
 
-        // Assert — this used to end the session with the literal "cancelled", which the sessions table
-        // does not accept; Postgres rejected the write, the store logged and swallowed it, and every
-        // cancelled run left its session open forever. The distinction survives in the reason instead.
+        // Assert — cancellation is its own terminal state again (#301). It has been three things:
+        // the raw literal "cancelled", which the sessions table rejected, so the store swallowed the
+        // write and the session stayed open forever; then Error, because no schema change could
+        // reach a database that already held data; and now Cancelled, delivered by the migration
+        // runner. Asserting the state and not just the reason is the point — the reason was never the
+        // thing the error-rate panel counted.
         await act.Should().ThrowAsync<OperationCanceledException>();
         _observabilityStore.Verify(
             s => s.EndSessionAsync(
-                SessionId, SessionStatus.Error, "conversation.cancelled", It.IsAny<CancellationToken>()),
+                SessionId, SessionStatus.Cancelled, "conversation.cancelled", It.IsAny<CancellationToken>()),
             Times.Once);
     }
 
@@ -164,7 +167,7 @@ public class RunConversationCommandHandlerSolutionReviewFixTests
         await act.Should().ThrowAsync<OperationCanceledException>();
         _observabilityStore.Verify(
             s => s.EndSessionAsync(
-                SessionId, SessionStatus.Error, It.IsAny<string?>(),
+                SessionId, SessionStatus.Cancelled, It.IsAny<string?>(),
                 It.Is<CancellationToken>(ct => !ct.IsCancellationRequested)),
             Times.Once);
     }

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
@@ -180,8 +180,9 @@ public class RunConversationCommandHandlerSolutionReviewFixTests
         // the raw literal "cancelled", which the sessions table rejected, so the store swallowed the
         // write and the session stayed open forever; then Error, because no schema change could
         // reach a database that already held data; and now Cancelled, delivered by the migration
-        // runner. Asserting the state and not just the reason is the point — the reason was never the
-        // thing the error-rate panel counted.
+        // runner. Asserting the state and not just the reason is the point: the reason is a free-text
+        // column nothing filters on, while the status is the column the sessions list and the Grafana
+        // $status variable both read.
         await act.Should().ThrowAsync<OperationCanceledException>();
         _observabilityStore.Verify(
             s => s.EndSessionAsync(

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixture.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixture.cs
@@ -1,4 +1,6 @@
 using System.Net.Sockets;
+using Infrastructure.Observability.Persistence;
+using Infrastructure.Postgres.Migrations;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -58,6 +60,32 @@ public sealed class PostgresFixture : IAsyncLifetime
             // OBSERVABILITY_TEST_CONN — treat as "not provisioned" so local dev runs can skip.
             IsAvailable = false;
         }
+
+        if (IsAvailable) await ApplyMigrationsAsync();
+    }
+
+    /// <summary>
+    /// Brings the test database up to the schema this assembly ships, using the same runner the
+    /// application uses.
+    /// </summary>
+    /// <remarks>
+    /// CI used to do this with a psql loop over <c>Dashboards/init-db/*.sql</c> against a database
+    /// created fresh each run. That is why #301 could hide: the one environment able to prove a
+    /// schema change worked was also the one environment that never had a database old enough to
+    /// need migrating. Going through <see cref="PostgresMigrationRunner"/> means the delivery path
+    /// under test is the delivery path that ships — and, on a developer's long-lived local database,
+    /// it is genuinely the upgrade path rather than the create path.
+    /// </remarks>
+    private async Task ApplyMigrationsAsync()
+    {
+        await using var connection = await DataSource.OpenConnectionAsync();
+
+        var runner = new PostgresMigrationRunner(
+            ObservabilityMigrations.Options,
+            ObservabilityMigrations.Load(),
+            NullLogger.Instance);
+
+        await runner.ApplyAsync(connection);
     }
 
     /// <summary>
@@ -148,18 +176,13 @@ public sealed class PostgresFixture : IAsyncLifetime
                 new NpgsqlParameter { Value = $"{RunTag}%" });
 
             // context_snapshots holds conversation_id by value (no FK) so it is
-            // not cascade-cleaned by the sessions delete above. Best-effort —
-            // table may not exist on older test databases.
-            try
-            {
-                await ExecuteAsync(
-                    "DELETE FROM context_snapshots WHERE conversation_id LIKE $1",
-                    new NpgsqlParameter { Value = $"{RunTag}%" });
-            }
-            catch
-            {
-                // Table doesn't exist on this database — skip.
-            }
+            // not cascade-cleaned by the sessions delete above. The "table may not
+            // exist on older test databases" guard that used to wrap this is gone:
+            // InitializeAsync now migrates the database, so an older one is brought
+            // forward rather than tolerated.
+            await ExecuteAsync(
+                "DELETE FROM context_snapshots WHERE conversation_id LIKE $1",
+                new NpgsqlParameter { Value = $"{RunTag}%" });
         }
         catch
         {

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixture.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixture.cs
@@ -81,9 +81,7 @@ public sealed class PostgresFixture : IAsyncLifetime
         await using var connection = await DataSource.OpenConnectionAsync();
 
         var runner = new PostgresMigrationRunner(
-            ObservabilityMigrations.Options,
-            ObservabilityMigrations.Load(),
-            NullLogger.Instance);
+            ObservabilityMigrations.Options, ObservabilityMigrations.Load(), NullLogger.Instance);
 
         await runner.ApplyAsync(connection);
     }

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusSchemaAgreementTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusSchemaAgreementTests.cs
@@ -84,6 +84,7 @@ public sealed class SessionStatusSchemaAgreementTests
     {
         var declaring = ObservabilityMigrations.Load()
             .Where(s => StatusCheckDeclaration.IsMatch(s.Sql))
+            .OrderBy(s => s.Ordinal)
             .ToArray();
 
         Assert.True(
@@ -92,7 +93,16 @@ public sealed class SessionStatusSchemaAgreementTests
             "that a later declaration overrides an earlier one. If the constraint has genuinely been " +
             "consolidated into the baseline, delete this test rather than relaxing it.");
 
-        Assert.Equal(declaring.OrderBy(s => s.Ordinal).Select(s => s.Id), declaring.Select(s => s.Id));
+        // Compare the EARLIEST declaration's values against what the reader returns. Asserting that a
+        // sorted list is sorted — which is what this did first — cannot fail: Load() already returns
+        // scripts in ordinal order and Where preserves it. The real claim is that the reader ignores
+        // the first declaration in favour of the last, and it is only checkable because the two
+        // genuinely differ.
+        var earliest = ParseValues(StatusCheckDeclaration.Match(declaring[0].Sql));
+        var effective = ReadAcceptedStatusesFromMigrations();
+
+        Assert.NotEqual(earliest, effective);
+        Assert.ProperSubset(effective, earliest);
     }
 
     private static HashSet<string> ReadAcceptedStatusesFromMigrations()
@@ -106,9 +116,12 @@ public sealed class SessionStatusSchemaAgreementTests
             declaration is not null,
             "No migration declares a CHECK constraint named 'sessions_status_check' on 'status'.");
 
-        return declaration!.Groups["values"].Value
+        return ParseValues(declaration!);
+    }
+
+    private static HashSet<string> ParseValues(Match declaration) =>
+        declaration.Groups["values"].Value
             .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(v => v.Trim('\''))
             .ToHashSet(StringComparer.Ordinal);
-    }
 }

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusSchemaAgreementTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusSchemaAgreementTests.cs
@@ -82,9 +82,11 @@ public sealed class SessionStatusSchemaAgreementTests
     [Fact]
     public void MoreThanOneMigrationDeclaresTheConstraint_AndTheLaterOneIsTheOneThatCounts()
     {
+        // No OrderBy: Load() returns ordinal order as a documented contract, enforced by
+        // EmbeddedSqlMigrationSource, and Where preserves it. Sorting again here implied the ordering
+        // was each caller's job to establish — while a comment eight lines below said the opposite.
         var declaring = ObservabilityMigrations.Load()
             .Where(s => StatusCheckDeclaration.IsMatch(s.Sql))
-            .OrderBy(s => s.Ordinal)
             .ToArray();
 
         Assert.True(
@@ -94,21 +96,25 @@ public sealed class SessionStatusSchemaAgreementTests
             "consolidated into the baseline, delete this test rather than relaxing it.");
 
         // Compare the EARLIEST declaration's values against what the reader returns. Asserting that a
-        // sorted list is sorted — which is what this did first — cannot fail: Load() already returns
-        // scripts in ordinal order and Where preserves it. The real claim is that the reader ignores
-        // the first declaration in favour of the last, and it is only checkable because the two
-        // genuinely differ.
+        // sorted list is sorted — which is what this did first — cannot fail. The real claim is that
+        // the reader ignores the first declaration in favour of the last, and it is only checkable
+        // because the two genuinely differ.
+        //
+        // ProperSubset alone: it already means subset AND not equal, so the NotEqual that used to sit
+        // beside it only made a reader stop and work out whether the two lines were saying different
+        // things.
         var earliest = ParseValues(StatusCheckDeclaration.Match(declaring[0].Sql));
         var effective = ReadAcceptedStatusesFromMigrations();
 
-        Assert.NotEqual(earliest, effective);
         Assert.ProperSubset(effective, earliest);
     }
 
     private static HashSet<string> ReadAcceptedStatusesFromMigrations()
     {
+        // "Last wins" is load-bearing here and rests entirely on Load() returning ordinal order, which
+        // it documents and EmbeddedSqlMigrationSource enforces. Stated rather than re-sorted, so there
+        // is one answer in this file to "whose job is the ordering".
         var declaration = ObservabilityMigrations.Load()
-            .OrderBy(s => s.Ordinal)
             .Select(s => StatusCheckDeclaration.Match(s.Sql))
             .LastOrDefault(m => m.Success);
 

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusSchemaAgreementTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusSchemaAgreementTests.cs
@@ -1,6 +1,6 @@
 using System.Text.RegularExpressions;
 using Domain.AI.Observability.Models;
-using Tests.Common;
+using Infrastructure.Observability.Persistence;
 using Xunit;
 
 namespace Infrastructure.Observability.Tests.Schema;
@@ -11,42 +11,49 @@ namespace Infrastructure.Observability.Tests.Schema;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This agreement is already proved against a live Postgres by
-/// <c>SessionWriteTests.EndSessionAsync_EveryStatusTheCodeCanExpress_IsAcceptedByTheSchema</c>. That
-/// test is a <c>SkippableFact</c>, so whenever Docker is not running it does not fail — it disappears,
-/// and with it the only evidence for the claim <see cref="SessionStatus"/> makes about itself: that the
-/// two sets "cannot drift apart again". Docker being down is the ordinary state of a developer machine,
-/// so the guarantee was absent exactly when someone was most likely to add a member.
+/// This agreement is also proved against a live Postgres, by
+/// <c>SessionWriteTests.EndSessionAsync_EveryStatusTheCodeCanExpress_IsAcceptedByTheSchema</c> and by
+/// <c>ObservabilitySchemaUpgradeTests</c>. Those are <c>SkippableFact</c>s, so whenever Docker is not
+/// running they do not fail — they disappear, and with them the only evidence for the claim
+/// <see cref="SessionStatus"/> makes about itself: that the two sets "cannot drift apart again".
+/// Docker being down is the ordinary state of a developer machine, so the guarantee was absent
+/// exactly when someone was most likely to add a member.
 /// </para>
 /// <para>
-/// Reading the constraint out of the checked-in DDL costs no container and cannot be skipped. It is a
-/// weaker proof — it shows the two literals agree, not that Postgres accepts them — which is why it
-/// sits alongside the integration test rather than replacing it.
+/// Reading the constraint out of the shipped migration set costs no container and cannot be skipped.
+/// It is a weaker proof — it shows the two literals agree, not that Postgres accepts them — which is
+/// why it sits alongside the integration tests rather than replacing them.
+/// </para>
+/// <para>
+/// <strong>It reads the last declaration, not the first.</strong> The baseline migration creates the
+/// constraint with three values and a later migration widens it; a reader that stopped at the
+/// <c>CREATE TABLE</c> would assert the schema of a release that no longer exists, and would have
+/// failed the moment #301 landed for the wrong reason.
 /// </para>
 /// </remarks>
 public sealed class SessionStatusSchemaAgreementTests
 {
     /// <summary>
-    /// Matches the <c>status</c> column's CHECK list inside the <c>sessions</c> table only.
+    /// Matches a declaration of the <c>sessions_status_check</c> constraint and captures its value
+    /// list, wherever in a migration it appears — inline in a <c>CREATE TABLE</c> or in a later
+    /// <c>ADD CONSTRAINT</c>.
     /// </summary>
     /// <remarks>
-    /// Anchored on <c>CREATE TABLE sessions</c> and stopped at the first <c>);</c>, because the file
-    /// declares five <c>CHECK (… IN (…))</c> constraints and three of them belong to other tables with
-    /// an unrelated status vocabulary (<c>success/failure/timeout</c>, <c>clear/warning/critical</c>).
-    /// A pattern that merely found "the status CHECK" would silently assert against the wrong table.
+    /// Anchoring on the constraint's own name rather than on the surrounding table block is what
+    /// makes this work across both forms, and is why migration 001 names the constraint explicitly
+    /// instead of letting Postgres generate a name. The file declares several
+    /// <c>CHECK (… IN (…))</c> constraints and most belong to other tables with an unrelated status
+    /// vocabulary (<c>success/failure/timeout</c>, <c>clear/warning/critical</c>); a pattern that
+    /// merely found "the status CHECK" would silently assert against the wrong one.
     /// </remarks>
-    private static readonly Regex SessionsStatusCheck = new(
-        @"CREATE\s+TABLE\s+sessions\b(?<body>.*?)\n\s*\);",
-        RegexOptions.Singleline | RegexOptions.IgnoreCase);
-
-    private static readonly Regex StatusCheckList = new(
-        @"CHECK\s*\(\s*status\s+IN\s*\((?<values>[^)]*)\)\s*\)",
+    private static readonly Regex StatusCheckDeclaration = new(
+        @"CONSTRAINT\s+sessions_status_check\s+CHECK\s*\(\s*status\s+IN\s*\((?<values>[^)]*)\)\s*\)",
         RegexOptions.Singleline | RegexOptions.IgnoreCase);
 
     [Fact]
     public void SessionsStatusCheckConstraint_AcceptsExactlyTheStatusesTheCodeCanWrite()
     {
-        var accepted = ReadAcceptedStatusesFromSchema();
+        var accepted = ReadAcceptedStatusesFromMigrations();
         var writable = Enum.GetValues<SessionStatus>().Select(s => s.ToDbValue()).ToHashSet(StringComparer.Ordinal);
 
         // Set equality in both directions on purpose. A missing schema literal is the #289 defect —
@@ -63,25 +70,43 @@ public sealed class SessionStatusSchemaAgreementTests
     /// must fail rather than quietly assert against an empty set.
     /// </summary>
     [Fact]
-    public void SchemaFile_DeclaresAStatusCheckOnTheSessionsTable()
+    public void TheMigrationSet_DeclaresAStatusCheckOnTheSessionsTable()
     {
-        Assert.NotEmpty(ReadAcceptedStatusesFromSchema());
+        Assert.NotEmpty(ReadAcceptedStatusesFromMigrations());
     }
 
-    private static HashSet<string> ReadAcceptedStatusesFromSchema()
+    /// <summary>
+    /// Guards the "last declaration wins" rule specifically, since it is invisible while only one
+    /// migration happens to declare the constraint.
+    /// </summary>
+    [Fact]
+    public void MoreThanOneMigrationDeclaresTheConstraint_AndTheLaterOneIsTheOneThatCounts()
     {
-        var schemaPath = RepoRoot.Combine("Dashboards", "init-db", "01-schema.sql");
-        Assert.True(File.Exists(schemaPath), $"Schema file not found at '{schemaPath}'.");
+        var declaring = ObservabilityMigrations.Load()
+            .Where(s => StatusCheckDeclaration.IsMatch(s.Sql))
+            .ToArray();
 
-        var sql = File.ReadAllText(schemaPath);
+        Assert.True(
+            declaring.Length > 1,
+            "Only one migration declares sessions_status_check, so this suite is no longer proving " +
+            "that a later declaration overrides an earlier one. If the constraint has genuinely been " +
+            "consolidated into the baseline, delete this test rather than relaxing it.");
 
-        var table = SessionsStatusCheck.Match(sql);
-        Assert.True(table.Success, "Could not locate the 'sessions' CREATE TABLE block in the schema file.");
+        Assert.Equal(declaring.OrderBy(s => s.Ordinal).Select(s => s.Id), declaring.Select(s => s.Id));
+    }
 
-        var check = StatusCheckList.Match(table.Groups["body"].Value);
-        Assert.True(check.Success, "The 'sessions' table declares no CHECK constraint on 'status'.");
+    private static HashSet<string> ReadAcceptedStatusesFromMigrations()
+    {
+        var declaration = ObservabilityMigrations.Load()
+            .OrderBy(s => s.Ordinal)
+            .Select(s => StatusCheckDeclaration.Match(s.Sql))
+            .LastOrDefault(m => m.Success);
 
-        return check.Groups["values"].Value
+        Assert.True(
+            declaration is not null,
+            "No migration declares a CHECK constraint named 'sessions_status_check' on 'status'.");
+
+        return declaration!.Groups["values"].Value
             .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
             .Select(v => v.Trim('\''))
             .ToHashSet(StringComparer.Ordinal);

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/EmbeddedSqlMigrationSourceTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/EmbeddedSqlMigrationSourceTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+using Infrastructure.Observability.Persistence;
+using Infrastructure.Postgres.Migrations;
+using Xunit;
+
+namespace Infrastructure.Postgres.Tests;
+
+/// <summary>
+/// Covers how a migration set is discovered and ordered — the part of the runner that needs no
+/// database and therefore cannot be skipped.
+/// </summary>
+/// <remarks>
+/// Every case here is a failure the old mechanism could not detect. Scripts were fed to Postgres by
+/// a shell glob over a directory, so an unreadable set was an empty apply, a badly named file was
+/// silently sorted somewhere, and two files sharing a number were ordered by whatever the glob
+/// returned. All three now throw.
+/// </remarks>
+public sealed class EmbeddedSqlMigrationSourceTests
+{
+    private static Assembly TestAssembly => typeof(EmbeddedSqlMigrationSourceTests).Assembly;
+
+    [Fact]
+    public void Load_ObservabilityAssembly_ReturnsTheShippedScriptsInAscendingOrdinalOrder()
+    {
+        var scripts = ObservabilityMigrations.Load();
+
+        // Asserting the exact ids, not just "some scripts were found". A prefix that silently
+        // stopped matching would otherwise surface as an empty set, and an empty set reads as
+        // "the schema is already up to date" — the quietest possible way for this to break.
+        Assert.Equal(
+            new[]
+            {
+                "001_baseline_schema",
+                "002_context_snapshots",
+                "003_loaded_bodies",
+                "004_message_and_tool_bodies",
+                "005_sessions_status_cancelled",
+            },
+            scripts.Select(s => s.Id));
+
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, scripts.Select(s => s.Ordinal));
+        Assert.All(scripts, s => Assert.False(string.IsNullOrWhiteSpace(s.Sql)));
+    }
+
+    [Fact]
+    public void Load_ScriptsOutOfNameOrder_StillOrdersByOrdinalRatherThanByResourceName()
+    {
+        var scripts = ObservabilityMigrations.Load();
+
+        // GetManifestResourceNames makes no ordering guarantee, so this asserts the sort actually
+        // happens rather than that the runtime happened to hand them over in a helpful order.
+        var ordinals = scripts.Select(s => s.Ordinal).ToArray();
+        Assert.Equal(ordinals.OrderBy(o => o), ordinals);
+    }
+
+    [Fact]
+    public void Load_NoScriptsUnderThePrefix_ThrowsRatherThanReturningAnEmptySet()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => EmbeddedSqlMigrationSource.Load(TestAssembly, "NoSuchPrefix"));
+
+        Assert.Contains("No embedded migration scripts found", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_TwoScriptsShareAnOrdinal_ThrowsAndNamesBoth()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => EmbeddedSqlMigrationSource.Load(TestAssembly, "DuplicateOrdinal"));
+
+        Assert.Contains("001_first", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("001_second", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("share ordinal", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_ScriptWithoutANumericPrefix_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => EmbeddedSqlMigrationSource.Load(TestAssembly, "Unnumbered"));
+
+        Assert.Contains("does not start with a number", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/Fixtures/DuplicateOrdinal.001_first.sql
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/Fixtures/DuplicateOrdinal.001_first.sql
@@ -1,0 +1,2 @@
+-- Fixture: one half of a deliberately duplicated ordinal. See DuplicateOrdinal.001_second.sql.
+SELECT 1;

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/Fixtures/DuplicateOrdinal.001_second.sql
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/Fixtures/DuplicateOrdinal.001_second.sql
@@ -1,0 +1,3 @@
+-- Fixture: the other half of the duplicated ordinal. This is the shape the real schema folder was
+-- in before #301 — two scripts numbered 03-, ordered only by whatever the shell glob returned.
+SELECT 1;

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/Fixtures/Unnumbered.schema.sql
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/Fixtures/Unnumbered.schema.sql
@@ -1,0 +1,2 @@
+-- Fixture: a migration with no numeric prefix, so its place in the apply order is undefined.
+SELECT 1;

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Npgsql" />
     <PackageReference Include="xunit" />

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Infrastructure.Postgres.Tests</RootNamespace>
+    <NuGetPackagePruning>false</NuGetPackagePruning>
+    <Configurations>Debug;Release;Debug-AgentHub-All;Debug-AgentHub-WebUI;Debug-AgentHub-Dashboard</Configurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Infrastructure/Infrastructure.Postgres/Infrastructure.Postgres.csproj" />
+    <!--
+      The observability assembly is referenced so the upgrade-path test can run the real shipped
+      migration set rather than a set written for the test. A test that invented its own scripts
+      would prove the runner works and prove nothing about whether this product's schema can
+      actually be delivered to an existing database, which is the claim #301 is about.
+    -->
+    <ProjectReference Include="../../Infrastructure/Infrastructure.Observability/Infrastructure.Observability.csproj" />
+  </ItemGroup>
+
+  <!--
+    Fixture scripts for the tests that need a deliberately malformed migration set. Each file name
+    carries its own resource prefix (e.g. "DuplicateOrdinal.001_first.sql"), so the logical name is
+    just the file name and a test can ask for one broken set without seeing the others.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="Fixtures\*.sql">
+      <LogicalName>%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+</Project>

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
@@ -32,20 +32,31 @@ public sealed class MigrationTestSchema : IAsyncDisposable
     private const string DefaultConnectionString =
         "Host=localhost;Port=5432;Database=observability;Username=observability;Password=observability";
 
-    /// <summary>Ledger table used by tests that do not care which ledger they write to.</summary>
-    private const string TestLedgerTable = "test_schema_migrations";
+    /// <summary>
+    /// Ledger table used by tests that do not care which ledger they write to.
+    /// </summary>
+    /// <remarks>
+    /// Public because <c>PostgresMigrationRunnerTests</c> queries this table directly to count applied
+    /// rows. With the name written out in both places, changing it here left those assertions reading
+    /// a table the runner never wrote to — <c>COUNT(*)</c> of nothing, still looking meaningful.
+    /// </remarks>
+    public const string TestLedgerTable = "test_schema_migrations";
 
     private MigrationTestSchema(NpgsqlDataSource dataSource, string schemaName)
     {
         DataSource = dataSource;
         SchemaName = schemaName;
+
+        // Computed once. As an expression-bodied property this re-hashed on every read, which reads
+        // as a constant and was not one.
+        AdvisoryLockKey = BitConverter.ToInt64(SHA256.HashData(Encoding.UTF8.GetBytes(schemaName)));
     }
 
     /// <summary>Data source whose connections resolve unqualified names to <see cref="SchemaName"/>.</summary>
-    public NpgsqlDataSource DataSource { get; }
+    private NpgsqlDataSource DataSource { get; }
 
     /// <summary>The throwaway schema this instance owns.</summary>
-    public string SchemaName { get; }
+    private string SchemaName { get; }
 
     /// <summary>
     /// An advisory lock key unique to this schema.
@@ -56,8 +67,7 @@ public sealed class MigrationTestSchema : IAsyncDisposable
     /// still proving nothing extra — the one test that genuinely needs two runners to contend simply
     /// uses the same schema, and therefore the same key.
     /// </remarks>
-    public long AdvisoryLockKey =>
-        BitConverter.ToInt64(SHA256.HashData(Encoding.UTF8.GetBytes(SchemaName)));
+    private long AdvisoryLockKey { get; }
 
     private static string ConnectionString =>
         Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN") ?? DefaultConnectionString;

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
@@ -1,4 +1,8 @@
 using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Text;
+using Infrastructure.Postgres.Migrations;
+using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using Xunit;
 
@@ -28,13 +32,16 @@ public sealed class MigrationTestSchema : IAsyncDisposable
     private const string DefaultConnectionString =
         "Host=localhost;Port=5432;Database=observability;Username=observability;Password=observability";
 
+    /// <summary>Ledger table used by tests that do not care which ledger they write to.</summary>
+    private const string TestLedgerTable = "test_schema_migrations";
+
     private MigrationTestSchema(NpgsqlDataSource dataSource, string schemaName)
     {
         DataSource = dataSource;
         SchemaName = schemaName;
     }
 
-    /// <summary>Data source whose connections already have <see cref="SchemaName"/> as search_path.</summary>
+    /// <summary>Data source whose connections resolve unqualified names to <see cref="SchemaName"/>.</summary>
     public NpgsqlDataSource DataSource { get; }
 
     /// <summary>The throwaway schema this instance owns.</summary>
@@ -49,8 +56,8 @@ public sealed class MigrationTestSchema : IAsyncDisposable
     /// still proving nothing extra — the one test that genuinely needs two runners to contend simply
     /// uses the same schema, and therefore the same key.
     /// </remarks>
-    public long AdvisoryLockKey => BitConverter.ToInt64(
-        System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(SchemaName)));
+    public long AdvisoryLockKey =>
+        BitConverter.ToInt64(SHA256.HashData(Encoding.UTF8.GetBytes(SchemaName)));
 
     private static string ConnectionString =>
         Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN") ?? DefaultConnectionString;
@@ -69,40 +76,81 @@ public sealed class MigrationTestSchema : IAsyncDisposable
         try
         {
             probe = NpgsqlDataSource.Create(ConnectionString);
+
             await using (var ping = probe.CreateCommand("SELECT 1"))
                 await ping.ExecuteScalarAsync();
+
+            var schemaName = $"mig_{Guid.NewGuid():N}";
+            await using (var create = probe.CreateCommand($"CREATE SCHEMA \"{schemaName}\""))
+                await create.ExecuteNonQueryAsync();
+
+            // Search Path belongs in the connection string, not in a physical-connection initializer.
+            // The initializer was the first thing tried and it silently did not hold: Npgsql resets a
+            // connection's session state when it goes back to the pool, and the initializer does not
+            // re-run when that physical connection is handed out again — so the first command after
+            // each physical open landed in the throwaway schema and every command after it landed in
+            // public. The tests still passed their early assertions and then failed on counts that had
+            // collected every other test's rows, which is a good deal more confusing than an error.
+            var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { SearchPath = schemaName };
+
+            return new MigrationTestSchema(NpgsqlDataSource.Create(builder.ConnectionString), schemaName);
         }
         catch (Exception ex) when (!IsConnectionExplicitlyConfigured && IsServerAbsent(ex))
         {
-            probe?.Dispose();
             Skip.If(true,
                 "Postgres is not provisioned for this run (set OBSERVABILITY_TEST_CONN or start a " +
                 "local Postgres on localhost:5432). The test is skipped rather than reported as a " +
                 "silent pass.");
             throw; // unreachable; Skip.If throws.
         }
+        finally
+        {
+            // In a finally, not on each exit path. It was written per-path first and leaked the probe
+            // whenever CREATE SCHEMA itself failed — a data source and its whole pool, per failure,
+            // for the life of the test process.
+            probe?.Dispose();
+        }
+    }
 
-        var schemaName = $"mig_{Guid.NewGuid():N}";
-        await using (var create = probe.CreateCommand($"CREATE SCHEMA \"{schemaName}\""))
-            await create.ExecuteNonQueryAsync();
+    /// <summary>
+    /// Applies a migration set to this schema and returns how many ran.
+    /// </summary>
+    /// <param name="scripts">The migrations to apply.</param>
+    /// <param name="ledgerTable">Ledger table to record them in; defaults to a test-owned name.</param>
+    /// <returns>The number of migrations applied.</returns>
+    public async Task<int> ApplyAsync(
+        IReadOnlyList<MigrationScript> scripts, string ledgerTable = TestLedgerTable)
+    {
+        var runner = new PostgresMigrationRunner(
+            new PostgresMigrationOptions(ledgerTable, AdvisoryLockKey),
+            scripts,
+            NullLogger.Instance);
 
-        probe.Dispose();
-
-        // Search Path belongs in the connection string, not in a physical-connection initializer.
-        // The initializer was the first thing tried and it silently did not hold: Npgsql resets a
-        // connection's session state when it goes back to the pool, and the initializer does not
-        // re-run when that physical connection is handed out again — so the first command after each
-        // physical open landed in the throwaway schema and every command after it landed in public.
-        // The tests still passed their early assertions and then failed on counts that had collected
-        // every other test's rows, which is a good deal more confusing than an outright error.
-        var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { SearchPath = schemaName };
-
-        return new MigrationTestSchema(NpgsqlDataSource.Create(builder.ConnectionString), schemaName);
+        await using var connection = await OpenAsync();
+        return await runner.ApplyAsync(connection);
     }
 
     /// <summary>Opens a connection already scoped to this schema.</summary>
     /// <returns>An open connection.</returns>
     public Task<NpgsqlConnection> OpenAsync() => DataSource.OpenConnectionAsync().AsTask();
+
+    /// <summary>Counts tables with the given name in this schema — 0 or 1.</summary>
+    /// <param name="tableName">Unqualified table name.</param>
+    /// <returns>1 if the table exists, otherwise 0.</returns>
+    public Task<int> CountTablesAsync(string tableName) =>
+        ScalarAsync<int>(
+            "SELECT COUNT(*) FROM information_schema.tables " +
+            $"WHERE table_schema = '{SchemaName}' AND table_name = '{tableName}'");
+
+    /// <summary>Counts columns with the given name on the given table in this schema — 0 or 1.</summary>
+    /// <param name="tableName">Unqualified table name.</param>
+    /// <param name="columnName">Column name.</param>
+    /// <returns>1 if the column exists, otherwise 0.</returns>
+    public Task<int> CountColumnsAsync(string tableName, string columnName) =>
+        ScalarAsync<int>(
+            "SELECT COUNT(*) FROM information_schema.columns " +
+            $"WHERE table_schema = '{SchemaName}' AND table_name = '{tableName}' " +
+            $"AND column_name = '{columnName}'");
 
     /// <summary>Runs a statement against this schema and returns the first column of the first row.</summary>
     /// <typeparam name="T">Expected scalar type.</typeparam>
@@ -113,14 +161,6 @@ public sealed class MigrationTestSchema : IAsyncDisposable
         await using var cmd = DataSource.CreateCommand(sql);
         var result = await cmd.ExecuteScalarAsync();
         return result is DBNull or null ? default : (T)Convert.ChangeType(result, typeof(T));
-    }
-
-    /// <summary>Runs a statement against this schema.</summary>
-    /// <param name="sql">The statement to run.</param>
-    public async Task ExecuteAsync(string sql)
-    {
-        await using var cmd = DataSource.CreateCommand(sql);
-        await cmd.ExecuteNonQueryAsync();
     }
 
     /// <summary>Runs a statement and returns the exception it raised, or null if it succeeded.</summary>
@@ -137,6 +177,14 @@ public sealed class MigrationTestSchema : IAsyncDisposable
         {
             return ex;
         }
+    }
+
+    /// <summary>Runs a statement against this schema.</summary>
+    /// <param name="sql">The statement to run.</param>
+    public async Task ExecuteAsync(string sql)
+    {
+        await using var cmd = DataSource.CreateCommand(sql);
+        await cmd.ExecuteNonQueryAsync();
     }
 
     private static bool IsServerAbsent(Exception ex)

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
@@ -1,0 +1,175 @@
+using System.Net.Sockets;
+using Npgsql;
+using Xunit;
+
+namespace Infrastructure.Postgres.Tests;
+
+/// <summary>
+/// Gives each test its own empty Postgres schema, so a migration set can be applied from nothing and
+/// inspected without any test seeing another's tables.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A schema rather than a database. Creating a database needs a connection to a different one and
+/// costs a template copy per test; a schema plus <c>search_path</c> is nearly free, and every
+/// migration in this repo names its objects unqualified, so they land in the right place with no
+/// changes. The cost is that <c>current_schema()</c> matters — migration 005 filters
+/// <c>pg_constraint</c> by it, which is correct here and correct in production for the same reason.
+/// </para>
+/// <para>
+/// Connectivity is treated exactly as <c>PostgresFixture</c> treats it: a server that is simply not
+/// listening means "not provisioned" and the tests skip; anything else is a real defect and is
+/// rethrown. Skipping is reported as a skip, never as a pass — a suite that goes green with zero
+/// assertions run is worse than one that goes red.
+/// </para>
+/// </remarks>
+public sealed class MigrationTestSchema : IAsyncDisposable
+{
+    private const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=observability;Username=observability;Password=observability";
+
+    private MigrationTestSchema(NpgsqlDataSource dataSource, string schemaName)
+    {
+        DataSource = dataSource;
+        SchemaName = schemaName;
+    }
+
+    /// <summary>Data source whose connections already have <see cref="SchemaName"/> as search_path.</summary>
+    public NpgsqlDataSource DataSource { get; }
+
+    /// <summary>The throwaway schema this instance owns.</summary>
+    public string SchemaName { get; }
+
+    /// <summary>
+    /// An advisory lock key unique to this schema.
+    /// </summary>
+    /// <remarks>
+    /// Postgres advisory locks are cluster-wide, not schema-scoped. Sharing one key across the suite
+    /// would make every test in every parallel class queue behind every other for no reason, while
+    /// still proving nothing extra — the one test that genuinely needs two runners to contend simply
+    /// uses the same schema, and therefore the same key.
+    /// </remarks>
+    public long AdvisoryLockKey => BitConverter.ToInt64(
+        System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(SchemaName)));
+
+    private static string ConnectionString =>
+        Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN") ?? DefaultConnectionString;
+
+    private static bool IsConnectionExplicitlyConfigured =>
+        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN"));
+
+    /// <summary>
+    /// Creates an empty schema and returns a data source scoped to it, or skips the calling test when
+    /// no Postgres is provisioned. Callers must be <c>[SkippableFact]</c>.
+    /// </summary>
+    /// <returns>The schema handle; dispose it to drop the schema.</returns>
+    public static async Task<MigrationTestSchema> CreateAsync()
+    {
+        NpgsqlDataSource? probe = null;
+        try
+        {
+            probe = NpgsqlDataSource.Create(ConnectionString);
+            await using (var ping = probe.CreateCommand("SELECT 1"))
+                await ping.ExecuteScalarAsync();
+        }
+        catch (Exception ex) when (!IsConnectionExplicitlyConfigured && IsServerAbsent(ex))
+        {
+            probe?.Dispose();
+            Skip.If(true,
+                "Postgres is not provisioned for this run (set OBSERVABILITY_TEST_CONN or start a " +
+                "local Postgres on localhost:5432). The test is skipped rather than reported as a " +
+                "silent pass.");
+            throw; // unreachable; Skip.If throws.
+        }
+
+        var schemaName = $"mig_{Guid.NewGuid():N}";
+        await using (var create = probe.CreateCommand($"CREATE SCHEMA \"{schemaName}\""))
+            await create.ExecuteNonQueryAsync();
+
+        probe.Dispose();
+
+        // Search Path belongs in the connection string, not in a physical-connection initializer.
+        // The initializer was the first thing tried and it silently did not hold: Npgsql resets a
+        // connection's session state when it goes back to the pool, and the initializer does not
+        // re-run when that physical connection is handed out again — so the first command after each
+        // physical open landed in the throwaway schema and every command after it landed in public.
+        // The tests still passed their early assertions and then failed on counts that had collected
+        // every other test's rows, which is a good deal more confusing than an outright error.
+        var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { SearchPath = schemaName };
+
+        return new MigrationTestSchema(NpgsqlDataSource.Create(builder.ConnectionString), schemaName);
+    }
+
+    /// <summary>Opens a connection already scoped to this schema.</summary>
+    /// <returns>An open connection.</returns>
+    public Task<NpgsqlConnection> OpenAsync() => DataSource.OpenConnectionAsync().AsTask();
+
+    /// <summary>Runs a statement against this schema and returns the first column of the first row.</summary>
+    /// <typeparam name="T">Expected scalar type.</typeparam>
+    /// <param name="sql">The statement to run.</param>
+    /// <returns>The scalar value, or <c>default</c> when the result is null or empty.</returns>
+    public async Task<T?> ScalarAsync<T>(string sql)
+    {
+        await using var cmd = DataSource.CreateCommand(sql);
+        var result = await cmd.ExecuteScalarAsync();
+        return result is DBNull or null ? default : (T)Convert.ChangeType(result, typeof(T));
+    }
+
+    /// <summary>Runs a statement against this schema.</summary>
+    /// <param name="sql">The statement to run.</param>
+    public async Task ExecuteAsync(string sql)
+    {
+        await using var cmd = DataSource.CreateCommand(sql);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    /// <summary>Runs a statement and returns the exception it raised, or null if it succeeded.</summary>
+    /// <param name="sql">The statement to run.</param>
+    /// <returns>The failure, or <c>null</c>.</returns>
+    public async Task<Exception?> TryExecuteAsync(string sql)
+    {
+        try
+        {
+            await ExecuteAsync(sql);
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+
+    private static bool IsServerAbsent(Exception ex)
+    {
+        for (var current = ex; current is not null; current = current.InnerException)
+        {
+            if (current is SocketException socket &&
+                socket.SocketErrorCode is SocketError.ConnectionRefused
+                    or SocketError.HostNotFound
+                    or SocketError.HostUnreachable
+                    or SocketError.NetworkUnreachable
+                    or SocketError.TimedOut)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await using var drop = DataSource.CreateCommand($"DROP SCHEMA IF EXISTS \"{SchemaName}\" CASCADE");
+            await drop.ExecuteNonQueryAsync();
+        }
+        catch
+        {
+            // Best-effort cleanup; a leaked test schema is noise, not a failure.
+        }
+
+        await DataSource.DisposeAsync();
+    }
+}

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
@@ -1,7 +1,5 @@
 using Domain.AI.Observability.Models;
 using Infrastructure.Observability.Persistence;
-using Infrastructure.Postgres.Migrations;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Infrastructure.Postgres.Tests;
@@ -13,23 +11,168 @@ namespace Infrastructure.Postgres.Tests;
 /// <remarks>
 /// <para>
 /// Structured as a control and a treatment, following <c>SchemaInitializerAddedColumnTests</c> on the
-/// SQLite side. The control is a database migrated to the <em>previous</em> release and asked to
-/// store the new value; it must be rejected. Without that step the treatment proves only that a
-/// freshly built database accepts <c>cancelled</c>, which the old mechanism could already do and
-/// which is exactly why nobody noticed the gap for so long.
+/// SQLite side. The control is a database on the <em>previous</em> release asked to store the new
+/// value; it must be rejected. Without that step the treatment proves only that a freshly built
+/// database accepts <c>cancelled</c>, which the old mechanism could already do and which is exactly
+/// why nobody noticed the gap for so long.
 /// </para>
 /// <para>
-/// <strong>If the control ever stops failing, this runner is dead weight — delete it, do not keep
+/// <strong>If a control ever stops failing, this runner is dead weight — delete it, do not keep
 /// it.</strong> A control that passes means the value is already accepted without migration 005,
 /// which would mean something else is delivering the schema and this machinery is redundant.
 /// </para>
 /// </remarks>
 public sealed class ObservabilitySchemaUpgradeTests
 {
+    private const string Ledger = "obs_schema_migrations";
+
     private const string InsertCancelledSession =
         """
         INSERT INTO sessions (conversation_id, agent_name, status)
         VALUES ('upgrade-probe', 'ProbeAgent', 'cancelled')
+        """;
+
+    /// <summary>
+    /// The `sessions` table exactly as a pre-#301 installation has it: created by the old
+    /// <c>init-db/01-schema.sql</c>, with the status CHECK written inline and therefore carrying
+    /// whatever name Postgres generated for it, and with no migration ledger anywhere.
+    /// </summary>
+    private const string PreMigrationRunnerSchema =
+        """
+        CREATE TABLE sessions (
+            id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            conversation_id       TEXT NOT NULL UNIQUE,
+            agent_name            TEXT NOT NULL,
+            model                 TEXT,
+            started_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            ended_at              TIMESTAMPTZ,
+            duration_ms           INTEGER,
+            turn_count            INTEGER NOT NULL DEFAULT 0,
+            tool_call_count       INTEGER NOT NULL DEFAULT 0,
+            subagent_count        INTEGER NOT NULL DEFAULT 0,
+            total_input_tokens    INTEGER NOT NULL DEFAULT 0,
+            total_output_tokens   INTEGER NOT NULL DEFAULT 0,
+            total_cache_read      INTEGER NOT NULL DEFAULT 0,
+            total_cache_write     INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd        NUMERIC(10,6) NOT NULL DEFAULT 0,
+            cache_hit_rate        NUMERIC(5,4) NOT NULL DEFAULT 0,
+            status                TEXT NOT NULL DEFAULT 'active'
+                                  CHECK (status IN ('active','completed','error')),
+            error_message         TEXT,
+            created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """;
+
+    /// <summary>
+    /// The case the whole idempotent-baseline strategy exists for, and the one every other test here
+    /// was missing: a database whose tables were created by the ORIGINAL init-db SQL, with no ledger.
+    /// </summary>
+    /// <remarks>
+    /// Every other case in this class builds its "old" database by running the migration runner with
+    /// a truncated script list — so a ledger always exists and migration 001 is never replayed
+    /// against tables that were already there. That is the interesting path: on a real consumer
+    /// database 001 finds <c>sessions</c> present, <c>CREATE TABLE IF NOT EXISTS</c> no-ops, and the
+    /// explicitly-named <c>sessions_status_check</c> that 001 declares is therefore never created.
+    /// The upgrade only works because migration 005 discovers the constraint's real name from
+    /// <c>pg_constraint</c> instead of assuming it. Nothing pinned that until this test.
+    /// </remarks>
+    [SkippableFact]
+    public async Task ADatabaseBuiltByTheOldInitDbSql_IsBroughtForwardWithoutALedger()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        // Arrange: not through the runner. This is the shape no ledger has ever seen.
+        await schema.ExecuteAsync(PreMigrationRunnerSchema);
+        Assert.Equal(0, await schema.CountTablesAsync(Ledger));
+
+        // Control: the old inline constraint is live and refuses the new word.
+        var rejected = await schema.TryExecuteAsync(InsertCancelledSession);
+        Assert.NotNull(rejected);
+
+        // Treatment: the full set, replayed over pre-existing tables.
+        var applied = await schema.ApplyAsync(ObservabilityMigrations.Load(), Ledger);
+        Assert.Equal(ObservabilityMigrations.Load().Count, applied);
+
+        Assert.Null(await schema.TryExecuteAsync(InsertCancelledSession));
+        Assert.Equal("cancelled", await schema.ScalarAsync<string>(
+            "SELECT status FROM sessions WHERE conversation_id = 'upgrade-probe'"));
+
+        // And the rest of the set landed too — 001 no-oped on sessions but the later scripts did
+        // real work on a database that had none of their objects.
+        Assert.Equal(1, await schema.CountTablesAsync("context_snapshots"));
+        Assert.Equal(1, await schema.CountColumnsAsync("session_messages", "content_full"));
+    }
+
+    /// <summary>
+    /// The control for migration 005's <c>pg_constraint</c> lookup — a database whose status CHECK
+    /// carries a name of the installation's own choosing rather than the one Postgres generates.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This was missing, and its absence made six lines of 005 indistinguishable from a comment.
+    /// Postgres names an inline column CHECK <c>&lt;table&gt;_&lt;column&gt;_check</c> — character for
+    /// character the name 005 declares — so for both databases this template itself produces, simply
+    /// assuming the name works. Mutation-testing proved it: replacing 005's lookup with a hardcoded
+    /// <c>DROP CONSTRAINT IF EXISTS sessions_status_check</c> left the entire suite green.
+    /// </para>
+    /// <para>
+    /// The population #301 exists to reach is the database this template did <em>not</em> produce:
+    /// one whose schema was hand-applied, adapted, or restored from a dump that named things
+    /// differently. There a hardcoded DROP matches nothing and the ADD then <em>succeeds</em>, since
+    /// the name it declares is not in use — so the migration reports success while the table ends up
+    /// with two status constraints, the old narrow one still refusing <c>cancelled</c>. Nothing
+    /// throws; the upgrade is simply a lie. This test is the only one here that can tell the lookup
+    /// from the assumption.
+    /// </para>
+    /// </remarks>
+    [SkippableFact]
+    public async Task ADatabaseWhoseStatusConstraintWasHandNamed_IsStillBroughtForward()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        const string generatedName = "CHECK (status IN ('active','completed','error'))";
+        const string handName =
+            "CONSTRAINT sessions_status_allowed CHECK (status IN ('active','completed','error'))";
+
+        var handNamed = PreMigrationRunnerSchema.Replace(generatedName, handName, StringComparison.Ordinal);
+
+        // The rewrite is the entire premise. If it silently matched nothing this would just be the
+        // test above wearing a more interesting name.
+        Assert.NotEqual(PreMigrationRunnerSchema, handNamed);
+
+        await schema.ExecuteAsync(handNamed);
+        Assert.Equal("sessions_status_allowed", await schema.ScalarAsync<string>(StatusConstraintName));
+
+        // Control: the hand-named constraint is live and refuses the new word, naming itself as it does.
+        var rejected = await schema.TryExecuteAsync(InsertCancelledSession);
+        Assert.NotNull(rejected);
+        Assert.Contains("sessions_status_allowed", rejected!.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        // Treatment: the runner finds the constraint by definition rather than by name.
+        await schema.ApplyAsync(ObservabilityMigrations.Load(), Ledger);
+
+        Assert.Null(await schema.TryExecuteAsync(InsertCancelledSession));
+
+        // Exactly one status constraint survives, and it is the one 005 declares — the old name was
+        // dropped, not merely worked around.
+        Assert.Equal("sessions_status_check", await schema.ScalarAsync<string>(StatusConstraintName));
+    }
+
+    /// <summary>
+    /// The name of the CHECK constraint governing <c>sessions.status</c>, whatever it happens to be.
+    /// Deliberately mirrors migration 005's own discovery query: a test that hardcoded the name could
+    /// not detect 005 hardcoding it too.
+    /// </summary>
+    private const string StatusConstraintName =
+        """
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+        WHERE rel.relname = 'sessions'
+          AND nsp.nspname = current_schema()
+          AND con.contype = 'c'
+          AND pg_get_constraintdef(con.oid) ILIKE '%status%'
         """;
 
     [SkippableFact]
@@ -42,7 +185,7 @@ public sealed class ObservabilitySchemaUpgradeTests
         Assert.Equal(4, previousRelease.Length);
 
         // ---- Arrange: a database as a consumer running last month's harness would have it.
-        await ApplyAsync(schema, previousRelease);
+        await schema.ApplyAsync(previousRelease, Ledger);
 
         // ---- Control. This must fail, with the same instrument the treatment uses.
         var rejected = await schema.TryExecuteAsync(InsertCancelledSession);
@@ -50,22 +193,19 @@ public sealed class ObservabilitySchemaUpgradeTests
         Assert.Contains("sessions_status_check", rejected!.ToString(), StringComparison.OrdinalIgnoreCase);
 
         // ---- Treatment: the same database, brought forward by the runner.
-        var applied = await ApplyAsync(schema, all);
+        var applied = await schema.ApplyAsync(all, Ledger);
         Assert.Equal(1, applied); // only 005 was outstanding
 
-        var accepted = await schema.TryExecuteAsync(InsertCancelledSession);
-        Assert.Null(accepted);
-
-        var stored = await schema.ScalarAsync<string>(
-            "SELECT status FROM sessions WHERE conversation_id = 'upgrade-probe'");
-        Assert.Equal("cancelled", stored);
+        Assert.Null(await schema.TryExecuteAsync(InsertCancelledSession));
+        Assert.Equal("cancelled", await schema.ScalarAsync<string>(
+            "SELECT status FROM sessions WHERE conversation_id = 'upgrade-probe'"));
     }
 
     [SkippableFact]
     public async Task TheWidenedConstraintStillRefusesAWordThatIsNotAStatus()
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
-        await ApplyAsync(schema, ObservabilityMigrations.Load());
+        await schema.ApplyAsync(ObservabilityMigrations.Load(), Ledger);
 
         // Migration 005 drops the old constraint before adding the new one. A version that dropped it
         // and failed to re-add would pass every assertion in the test above — the insert would
@@ -84,7 +224,7 @@ public sealed class ObservabilitySchemaUpgradeTests
     public async Task EveryStatusTheCodeCanExpress_IsAcceptedByTheMigratedSchema()
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
-        await ApplyAsync(schema, ObservabilityMigrations.Load());
+        await schema.ApplyAsync(ObservabilityMigrations.Load(), Ledger);
 
         // Enumerated from the enum rather than listed, so adding a member without a migration fails
         // here instead of at a customer's first write — which is the failure mode #289 described.
@@ -109,35 +249,14 @@ public sealed class ObservabilitySchemaUpgradeTests
         await using var schema = await MigrationTestSchema.CreateAsync();
         var all = ObservabilityMigrations.Load();
 
-        // The oldest thing that can exist: a database created by the very first schema file, with
-        // none of the columns or tables added since. This is the case that used to be unreachable.
-        await ApplyAsync(schema, all.Take(1).ToArray());
-        Assert.Equal(0, await CountTablesAsync(schema, "context_snapshots"));
+        // The oldest thing the runner itself can produce: only the baseline applied.
+        await schema.ApplyAsync(all.Take(1).ToArray(), Ledger);
+        Assert.Equal(0, await schema.CountTablesAsync("context_snapshots"));
 
-        var applied = await ApplyAsync(schema, all);
+        var applied = await schema.ApplyAsync(all, Ledger);
 
         Assert.Equal(all.Count - 1, applied);
-        Assert.Equal(1, await CountTablesAsync(schema, "context_snapshots"));
-        Assert.Equal(1, await schema.ScalarAsync<int>(
-            "SELECT COUNT(*) FROM information_schema.columns " +
-            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = 'session_messages' " +
-            "AND column_name = 'content_full'"));
+        Assert.Equal(1, await schema.CountTablesAsync("context_snapshots"));
+        Assert.Equal(1, await schema.CountColumnsAsync("session_messages", "content_full"));
     }
-
-    private static async Task<int> ApplyAsync(
-        MigrationTestSchema schema, IReadOnlyList<MigrationScript> scripts)
-    {
-        var runner = new PostgresMigrationRunner(
-            new PostgresMigrationOptions("schema_migrations", schema.AdvisoryLockKey),
-            scripts,
-            NullLogger.Instance);
-
-        await using var connection = await schema.OpenAsync();
-        return await runner.ApplyAsync(connection);
-    }
-
-    private static Task<int> CountTablesAsync(MigrationTestSchema schema, string tableName) =>
-        schema.ScalarAsync<int>(
-            "SELECT COUNT(*) FROM information_schema.tables " +
-            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = '{tableName}'");
 }

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
@@ -24,7 +24,9 @@ namespace Infrastructure.Postgres.Tests;
 /// </remarks>
 public sealed class ObservabilitySchemaUpgradeTests
 {
-    private const string Ledger = "obs_schema_migrations";
+    // Taken from the shipped options rather than re-typed. With a literal here, renaming the real
+    // ledger left these tests green while they quietly migrated a table the product no longer writes.
+    private static readonly string Ledger = ObservabilityMigrations.Options.LedgerTable;
 
     private const string InsertCancelledSession =
         """
@@ -90,8 +92,9 @@ public sealed class ObservabilitySchemaUpgradeTests
         Assert.NotNull(rejected);
 
         // Treatment: the full set, replayed over pre-existing tables.
-        var applied = await schema.ApplyAsync(ObservabilityMigrations.Load(), Ledger);
-        Assert.Equal(ObservabilityMigrations.Load().Count, applied);
+        var all = ObservabilityMigrations.Load();
+        var applied = await schema.ApplyAsync(all, Ledger);
+        Assert.Equal(all.Count, applied);
 
         Assert.Null(await schema.TryExecuteAsync(InsertCancelledSession));
         Assert.Equal("cancelled", await schema.ScalarAsync<string>(

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
@@ -1,0 +1,143 @@
+using Domain.AI.Observability.Models;
+using Infrastructure.Observability.Persistence;
+using Infrastructure.Postgres.Migrations;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.Postgres.Tests;
+
+/// <summary>
+/// The test this whole issue exists for: proving a schema change reaches a database that already
+/// holds data.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Structured as a control and a treatment, following <c>SchemaInitializerAddedColumnTests</c> on the
+/// SQLite side. The control is a database migrated to the <em>previous</em> release and asked to
+/// store the new value; it must be rejected. Without that step the treatment proves only that a
+/// freshly built database accepts <c>cancelled</c>, which the old mechanism could already do and
+/// which is exactly why nobody noticed the gap for so long.
+/// </para>
+/// <para>
+/// <strong>If the control ever stops failing, this runner is dead weight — delete it, do not keep
+/// it.</strong> A control that passes means the value is already accepted without migration 005,
+/// which would mean something else is delivering the schema and this machinery is redundant.
+/// </para>
+/// </remarks>
+public sealed class ObservabilitySchemaUpgradeTests
+{
+    private const string InsertCancelledSession =
+        """
+        INSERT INTO sessions (conversation_id, agent_name, status)
+        VALUES ('upgrade-probe', 'ProbeAgent', 'cancelled')
+        """;
+
+    [SkippableFact]
+    public async Task ADatabaseOnThePreviousRelease_RejectsCancelled_UntilTheMigrationRunnerReachesIt()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var all = ObservabilityMigrations.Load();
+        var previousRelease = all.Where(s => s.Ordinal < 5).ToArray();
+        Assert.Equal(4, previousRelease.Length);
+
+        // ---- Arrange: a database as a consumer running last month's harness would have it.
+        await ApplyAsync(schema, previousRelease);
+
+        // ---- Control. This must fail, with the same instrument the treatment uses.
+        var rejected = await schema.TryExecuteAsync(InsertCancelledSession);
+        Assert.NotNull(rejected);
+        Assert.Contains("sessions_status_check", rejected!.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        // ---- Treatment: the same database, brought forward by the runner.
+        var applied = await ApplyAsync(schema, all);
+        Assert.Equal(1, applied); // only 005 was outstanding
+
+        var accepted = await schema.TryExecuteAsync(InsertCancelledSession);
+        Assert.Null(accepted);
+
+        var stored = await schema.ScalarAsync<string>(
+            "SELECT status FROM sessions WHERE conversation_id = 'upgrade-probe'");
+        Assert.Equal("cancelled", stored);
+    }
+
+    [SkippableFact]
+    public async Task TheWidenedConstraintStillRefusesAWordThatIsNotAStatus()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+        await ApplyAsync(schema, ObservabilityMigrations.Load());
+
+        // Migration 005 drops the old constraint before adding the new one. A version that dropped it
+        // and failed to re-add would pass every assertion in the test above — the insert would
+        // succeed — while having quietly removed the guard from the column entirely.
+        var rejected = await schema.TryExecuteAsync(
+            """
+            INSERT INTO sessions (conversation_id, agent_name, status)
+            VALUES ('bad-status-probe', 'ProbeAgent', 'errored')
+            """);
+
+        Assert.NotNull(rejected);
+        Assert.Contains("sessions_status_check", rejected!.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public async Task EveryStatusTheCodeCanExpress_IsAcceptedByTheMigratedSchema()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+        await ApplyAsync(schema, ObservabilityMigrations.Load());
+
+        // Enumerated from the enum rather than listed, so adding a member without a migration fails
+        // here instead of at a customer's first write — which is the failure mode #289 described.
+        foreach (var status in Enum.GetValues<SessionStatus>())
+        {
+            var word = status.ToDbValue();
+            var failure = await schema.TryExecuteAsync(
+                $"""
+                INSERT INTO sessions (conversation_id, agent_name, status)
+                VALUES ('probe-{word}', 'ProbeAgent', '{word}')
+                """);
+
+            Assert.True(
+                failure is null,
+                $"The schema rejected '{word}', which SessionStatus.{status} can write: {failure}");
+        }
+    }
+
+    [SkippableFact]
+    public async Task ABaselineOnlyDatabase_IsBroughtAllTheWayForward()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+        var all = ObservabilityMigrations.Load();
+
+        // The oldest thing that can exist: a database created by the very first schema file, with
+        // none of the columns or tables added since. This is the case that used to be unreachable.
+        await ApplyAsync(schema, all.Take(1).ToArray());
+        Assert.Equal(0, await CountTablesAsync(schema, "context_snapshots"));
+
+        var applied = await ApplyAsync(schema, all);
+
+        Assert.Equal(all.Count - 1, applied);
+        Assert.Equal(1, await CountTablesAsync(schema, "context_snapshots"));
+        Assert.Equal(1, await schema.ScalarAsync<int>(
+            "SELECT COUNT(*) FROM information_schema.columns " +
+            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = 'session_messages' " +
+            "AND column_name = 'content_full'"));
+    }
+
+    private static async Task<int> ApplyAsync(
+        MigrationTestSchema schema, IReadOnlyList<MigrationScript> scripts)
+    {
+        var runner = new PostgresMigrationRunner(
+            new PostgresMigrationOptions("schema_migrations", schema.AdvisoryLockKey),
+            scripts,
+            NullLogger.Instance);
+
+        await using var connection = await schema.OpenAsync();
+        return await runner.ApplyAsync(connection);
+    }
+
+    private static Task<int> CountTablesAsync(MigrationTestSchema schema, string tableName) =>
+        schema.ScalarAsync<int>(
+            "SELECT COUNT(*) FROM information_schema.tables " +
+            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = '{tableName}'");
+}

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationOptionsTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationOptionsTests.cs
@@ -8,15 +8,21 @@ namespace Infrastructure.Postgres.Tests;
 /// accept a parameter where an identifier belongs, so this is the only thing standing between that
 /// interpolation and an injection — worth proving rather than asserting in a comment.
 /// </summary>
+/// <remarks>
+/// These target the constructor. They used to call a separate <c>Validate()</c>, alongside a third
+/// test whose whole job was to document that the record could be constructed invalid and that one
+/// caller remembered to check it. That test was the argument for deleting the seam: a record that
+/// cannot hold a bad value proves strictly more than a record plus a method someone must remember.
+/// </remarks>
 public sealed class PostgresMigrationOptionsTests
 {
     [Theory]
-    [InlineData("schema_migrations")]
+    [InlineData("obs_schema_migrations")]
     [InlineData("kg_schema_migrations")]
     [InlineData("m1")]
-    public void Validate_PlainLowerCaseIdentifier_IsAccepted(string table)
+    public void PlainLowerCaseIdentifier_IsAccepted(string table)
     {
-        new PostgresMigrationOptions(table, 1).Validate();
+        Assert.Equal(table, new PostgresMigrationOptions(table, 1).LedgerTable);
     }
 
     [Theory]
@@ -27,20 +33,19 @@ public sealed class PostgresMigrationOptionsTests
     [InlineData("schema-migrations")]
     [InlineData("schema_migrations; DROP TABLE sessions --")]
     [InlineData("\"schema_migrations\"")]
-    public void Validate_AnythingOtherThanABareIdentifier_Throws(string table)
+    public void AnythingOtherThanABareIdentifier_IsRefusedAtConstruction(string table)
     {
-        Assert.Throws<ArgumentException>(() => new PostgresMigrationOptions(table, 1).Validate());
+        Assert.Throws<ArgumentException>(() => new PostgresMigrationOptions(table, 1));
     }
 
     [Fact]
-    public void Constructor_IsNotWhereValidationHappens_SoTheRunnerMustCallValidate()
+    public void AnInvalidNameCannotReachTheRunnerAtAll()
     {
-        // Documenting the seam rather than the behaviour: the record accepts anything, and
-        // PostgresMigrationRunner's constructor is what refuses it. If validation ever moves into
-        // the record this test should be deleted, not made to pass by weakening the runner.
-        var options = new PostgresMigrationOptions("Not Valid", 1);
-
-        Assert.Throws<ArgumentException>(
-            () => new PostgresMigrationRunner(options, [], Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance));
+        // The runner no longer validates, because it no longer can be handed anything invalid.
+        // Constructing the options is where it fails, one frame earlier than it used to.
+        Assert.Throws<ArgumentException>(() => new PostgresMigrationRunner(
+            new PostgresMigrationOptions("Not Valid", 1),
+            [],
+            Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance));
     }
 }

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationOptionsTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationOptionsTests.cs
@@ -1,0 +1,46 @@
+using Infrastructure.Postgres.Migrations;
+using Xunit;
+
+namespace Infrastructure.Postgres.Tests;
+
+/// <summary>
+/// Covers the ledger-table name check. The name is interpolated into DDL because Postgres will not
+/// accept a parameter where an identifier belongs, so this is the only thing standing between that
+/// interpolation and an injection — worth proving rather than asserting in a comment.
+/// </summary>
+public sealed class PostgresMigrationOptionsTests
+{
+    [Theory]
+    [InlineData("schema_migrations")]
+    [InlineData("kg_schema_migrations")]
+    [InlineData("m1")]
+    public void Validate_PlainLowerCaseIdentifier_IsAccepted(string table)
+    {
+        new PostgresMigrationOptions(table, 1).Validate();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Schema_Migrations")]         // upper case would need quoting to round-trip
+    [InlineData("public.schema_migrations")]  // a dot is a second identifier, not part of this one
+    [InlineData("schema-migrations")]
+    [InlineData("schema_migrations; DROP TABLE sessions --")]
+    [InlineData("\"schema_migrations\"")]
+    public void Validate_AnythingOtherThanABareIdentifier_Throws(string table)
+    {
+        Assert.Throws<ArgumentException>(() => new PostgresMigrationOptions(table, 1).Validate());
+    }
+
+    [Fact]
+    public void Constructor_IsNotWhereValidationHappens_SoTheRunnerMustCallValidate()
+    {
+        // Documenting the seam rather than the behaviour: the record accepts anything, and
+        // PostgresMigrationRunner's constructor is what refuses it. If validation ever moves into
+        // the record this test should be deleted, not made to pass by weakening the runner.
+        var options = new PostgresMigrationOptions("Not Valid", 1);
+
+        Assert.Throws<ArgumentException>(
+            () => new PostgresMigrationRunner(options, [], Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance));
+    }
+}

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationRunnerTests.cs
@@ -9,7 +9,7 @@ namespace Infrastructure.Postgres.Tests;
 /// </summary>
 public sealed class PostgresMigrationRunnerTests
 {
-    private const string Ledger = "test_schema_migrations";
+    private const string Ledger = MigrationTestSchema.TestLedgerTable;
 
     [SkippableFact]
     public async Task ARunAgainstAnUpToDateDatabase_AppliesNothing()
@@ -27,10 +27,20 @@ public sealed class PostgresMigrationRunnerTests
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
 
-        await schema.ApplyAsync(Scripts(("001_a", "CREATE TABLE a (id INT)")));
+        // Deliberately NOT idempotent: re-running it raises "relation already exists". That is what
+        // makes the second call below evidence rather than a count — if 001 were re-applied the whole
+        // run would throw, so a clean result proves it was skipped, not merely tolerated.
+        //
+        // An earlier version of this test made that point by handing 001 a different body the second
+        // time ("SELECT 1/0"). The checksum guard now refuses exactly that, and rightly: same id,
+        // different text is the edit-an-applied-migration mistake, so the test was demonstrating its
+        // property with the one move the runner exists to forbid.
+        const string createA = "CREATE TABLE a (id INT)";
+
+        await schema.ApplyAsync(Scripts(("001_a", createA)));
 
         var applied = await schema.ApplyAsync(Scripts(
-            ("001_a", "SELECT 1/0"), // would throw if re-run; proves it is skipped, not merely tolerated
+            ("001_a", createA),
             ("002_b", "CREATE TABLE b (id INT)")));
 
         Assert.Equal(1, applied);
@@ -52,6 +62,92 @@ public sealed class PostgresMigrationRunnerTests
         await schema.ApplyAsync(outOfOrder);
 
         Assert.Equal(1, await schema.CountColumnsAsync("ordered", "label"));
+    }
+
+    /// <summary>
+    /// Editing a migration this database already ran stops the run, rather than doing nothing and
+    /// letting the installed base split in two.
+    /// </summary>
+    /// <remarks>
+    /// The failure this prevents is silent by construction: the id is in the ledger, so the edited
+    /// script is skipped here and applied in full on every database created afterwards. Nothing logs
+    /// it, no test goes red, and it is found by hand-diffing a live schema — the same shape as the
+    /// defect the whole subsystem exists to end. Note what the control below establishes: re-running
+    /// the *unedited* set is a clean no-op, so the throw is caused by the edit and not by the second
+    /// run.
+    /// </remarks>
+    [SkippableFact]
+    public async Task EditingAnAlreadyAppliedMigration_StopsTheRun()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var original = Scripts(("001_a", "CREATE TABLE a (id INT)"));
+        Assert.Equal(1, await schema.ApplyAsync(original));
+
+        // Control: unedited, the same set re-runs as a no-op.
+        Assert.Equal(0, await schema.ApplyAsync(original));
+
+        // Treatment: same id, different body.
+        var edited = Scripts(("001_a", "CREATE TABLE a (id INT, added TEXT)"));
+        var ex = await Assert.ThrowsAsync<PostgresMigrationException>(() => schema.ApplyAsync(edited));
+
+        Assert.Equal("001_a", ex.MigrationId);
+        Assert.Contains("has changed since this database applied it", ex.Message, StringComparison.Ordinal);
+
+        // The edit did not sneak in under the throw.
+        Assert.Equal(0, await schema.CountColumnsAsync("a", "added"));
+    }
+
+    /// <summary>
+    /// Only the line endings differing is not an edit.
+    /// </summary>
+    /// <remarks>
+    /// Migrations ship as embedded resources, so their bytes are whatever git checked out: CRLF on a
+    /// Windows developer's machine, LF in Linux CI. A checksum over raw bytes would call every
+    /// database tampered the moment it met the other platform — a false alarm loud enough that the
+    /// first fix anyone reaches for is switching the check off, which is worse than not having it.
+    /// </remarks>
+    [SkippableFact]
+    public async Task TheSameScriptCheckedOutWithWindowsLineEndings_IsNotTreatedAsAnEdit()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        const string unix = "CREATE TABLE crlf_probe (\n  id INT\n)";
+        var windows = unix.Replace("\n", "\r\n", StringComparison.Ordinal);
+        Assert.NotEqual(unix, windows); // the rewrite is the premise
+
+        Assert.Equal(1, await schema.ApplyAsync(Scripts(("001_a", unix))));
+        Assert.Equal(0, await schema.ApplyAsync(Scripts(("001_a", windows))));
+    }
+
+    /// <summary>
+    /// A database migrated before the ledger recorded checksums keeps working, and gains one.
+    /// </summary>
+    /// <remarks>
+    /// Adopt, do not accuse: there is nothing to compare a legacy row against, so refusing to start
+    /// would strand every database that this runner migrated before the column existed. Recording the
+    /// current text now is what makes the <em>next</em> edit catchable, which is the point.
+    /// </remarks>
+    [SkippableFact]
+    public async Task ALedgerRowWithNoChecksum_IsAdoptedRatherThanRefused()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var scripts = Scripts(("001_a", "CREATE TABLE a (id INT)"));
+        await schema.ApplyAsync(scripts);
+
+        // Rewind this database to the pre-checksum ledger shape.
+        await schema.ExecuteAsync($"UPDATE {Ledger} SET checksum = NULL");
+        Assert.Equal(1, await schema.ScalarAsync<int>(
+            $"SELECT COUNT(*) FROM {Ledger} WHERE checksum IS NULL"));
+
+        Assert.Equal(0, await schema.ApplyAsync(scripts));
+
+        // Adopted, so the next edit is caught rather than being a second free pass.
+        Assert.Equal(0, await schema.ScalarAsync<int>(
+            $"SELECT COUNT(*) FROM {Ledger} WHERE checksum IS NULL"));
+        await Assert.ThrowsAsync<PostgresMigrationException>(
+            () => schema.ApplyAsync(Scripts(("001_a", "CREATE TABLE a (id INT, added TEXT)"))));
     }
 
     [SkippableFact]

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationRunnerTests.cs
@@ -1,5 +1,4 @@
 using Infrastructure.Postgres.Migrations;
-using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Infrastructure.Postgres.Tests;
@@ -10,15 +9,17 @@ namespace Infrastructure.Postgres.Tests;
 /// </summary>
 public sealed class PostgresMigrationRunnerTests
 {
+    private const string Ledger = "test_schema_migrations";
+
     [SkippableFact]
     public async Task ARunAgainstAnUpToDateDatabase_AppliesNothing()
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
         var scripts = Scripts(("001_a", "CREATE TABLE a (id INT)"), ("002_b", "CREATE TABLE b (id INT)"));
 
-        Assert.Equal(2, await ApplyAsync(schema, scripts));
-        Assert.Equal(0, await ApplyAsync(schema, scripts));
-        Assert.Equal(2, await schema.ScalarAsync<int>("SELECT COUNT(*) FROM schema_migrations"));
+        Assert.Equal(2, await schema.ApplyAsync(scripts));
+        Assert.Equal(0, await schema.ApplyAsync(scripts));
+        Assert.Equal(2, await schema.ScalarAsync<int>($"SELECT COUNT(*) FROM {Ledger}"));
     }
 
     [SkippableFact]
@@ -26,14 +27,14 @@ public sealed class PostgresMigrationRunnerTests
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
 
-        await ApplyAsync(schema, Scripts(("001_a", "CREATE TABLE a (id INT)")));
+        await schema.ApplyAsync(Scripts(("001_a", "CREATE TABLE a (id INT)")));
 
-        var applied = await ApplyAsync(schema, Scripts(
+        var applied = await schema.ApplyAsync(Scripts(
             ("001_a", "SELECT 1/0"), // would throw if re-run; proves it is skipped, not merely tolerated
             ("002_b", "CREATE TABLE b (id INT)")));
 
         Assert.Equal(1, applied);
-        Assert.Equal(1, await CountTablesAsync(schema, "b"));
+        Assert.Equal(1, await schema.CountTablesAsync("b"));
     }
 
     [SkippableFact]
@@ -44,15 +45,13 @@ public sealed class PostgresMigrationRunnerTests
         // 002 depends on 001. Handed over backwards, so only the sort can save it.
         var outOfOrder = new[]
         {
-            new MigrationScript(2, "002_add_column", "ALTER TABLE ordered ADD COLUMN label TEXT"),
-            new MigrationScript(1, "001_create_table", "CREATE TABLE ordered (id INT)"),
+            new MigrationScript("002_add_column", "ALTER TABLE ordered ADD COLUMN label TEXT"),
+            new MigrationScript("001_create_table", "CREATE TABLE ordered (id INT)"),
         };
 
-        await ApplyAsync(schema, outOfOrder);
+        await schema.ApplyAsync(outOfOrder);
 
-        Assert.Equal(1, await schema.ScalarAsync<int>(
-            "SELECT COUNT(*) FROM information_schema.columns " +
-            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = 'ordered' AND column_name = 'label'"));
+        Assert.Equal(1, await schema.CountColumnsAsync("ordered", "label"));
     }
 
     [SkippableFact]
@@ -60,7 +59,7 @@ public sealed class PostgresMigrationRunnerTests
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
 
-        var ex = await Assert.ThrowsAsync<PostgresMigrationException>(() => ApplyAsync(schema, Scripts(
+        var ex = await Assert.ThrowsAsync<PostgresMigrationException>(() => schema.ApplyAsync(Scripts(
             ("001_good", "CREATE TABLE survivor (id INT)"),
             ("002_bad", "CREATE TABLE nonsense (id NOT_A_TYPE)"))));
 
@@ -69,9 +68,9 @@ public sealed class PostgresMigrationRunnerTests
         // All-or-nothing: 001 succeeded inside the transaction and is rolled back with 002. A
         // half-applied schema is a state nothing else in this system knows how to reason about,
         // whereas "still on the previous version" is the state it was already in.
-        Assert.Equal(0, await CountTablesAsync(schema, "survivor"));
-        Assert.Equal(0, await CountTablesAsync(schema, "nonsense"));
-        Assert.Equal(0, await CountTablesAsync(schema, "schema_migrations"));
+        Assert.Equal(0, await schema.CountTablesAsync("survivor"));
+        Assert.Equal(0, await schema.CountTablesAsync("nonsense"));
+        Assert.Equal(0, await schema.CountTablesAsync(Ledger));
     }
 
     [SkippableFact]
@@ -88,12 +87,12 @@ public sealed class PostgresMigrationRunnerTests
             ("002_b", "INSERT INTO raced (id) VALUES (1)"));
 
         var results = await Task.WhenAll(
-            Task.Run(() => ApplyAsync(schema, scripts)),
-            Task.Run(() => ApplyAsync(schema, scripts)));
+            Task.Run(() => schema.ApplyAsync(scripts)),
+            Task.Run(() => schema.ApplyAsync(scripts)));
 
         // One runner did all the work; the other found nothing to do. Which one is not determined.
         Assert.Equal([0, 2], results.OrderBy(r => r));
-        Assert.Equal(2, await schema.ScalarAsync<int>("SELECT COUNT(*) FROM schema_migrations"));
+        Assert.Equal(2, await schema.ScalarAsync<int>($"SELECT COUNT(*) FROM {Ledger}"));
         Assert.Equal(1, await schema.ScalarAsync<int>("SELECT COUNT(*) FROM raced"));
     }
 
@@ -101,30 +100,30 @@ public sealed class PostgresMigrationRunnerTests
     public async Task TheLedgerRecordsWhatWasAppliedAndWhen()
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
-        await ApplyAsync(schema, Scripts(("001_a", "CREATE TABLE a (id INT)")));
+        await schema.ApplyAsync(Scripts(("001_a", "CREATE TABLE a (id INT)")));
 
-        Assert.Equal("001_a", await schema.ScalarAsync<string>("SELECT id FROM schema_migrations"));
+        Assert.Equal("001_a", await schema.ScalarAsync<string>($"SELECT id FROM {Ledger}"));
         Assert.Equal(0, await schema.ScalarAsync<int>(
-            "SELECT COUNT(*) FROM schema_migrations WHERE applied_at IS NULL"));
+            $"SELECT COUNT(*) FROM {Ledger} WHERE applied_at IS NULL"));
     }
 
-    private static async Task<int> ApplyAsync(
-        MigrationTestSchema schema, IReadOnlyList<MigrationScript> scripts)
+    [SkippableFact]
+    public async Task TwoMigrationSetsInOneDatabase_KeepSeparateLedgersAndDoNotSeeEachOther()
     {
-        var runner = new PostgresMigrationRunner(
-            new PostgresMigrationOptions("schema_migrations", schema.AdvisoryLockKey),
-            scripts,
-            NullLogger.Instance);
+        await using var schema = await MigrationTestSchema.CreateAsync();
 
-        await using var connection = await schema.OpenAsync();
-        return await runner.ApplyAsync(connection);
+        await schema.ApplyAsync(Scripts(("001_a", "CREATE TABLE set_one (id INT)")), "ledger_one");
+        var applied = await schema.ApplyAsync(
+            Scripts(("001_a", "CREATE TABLE set_two (id INT)")), "ledger_two");
+
+        // Same migration id in both sets. If the ledger name were not part of the identity, the
+        // second set would find '001_a' already applied and silently skip its own table — which is
+        // the collision a bare 'schema_migrations' invites in a database shared with another product.
+        Assert.Equal(1, applied);
+        Assert.Equal(1, await schema.CountTablesAsync("set_one"));
+        Assert.Equal(1, await schema.CountTablesAsync("set_two"));
     }
-
-    private static Task<int> CountTablesAsync(MigrationTestSchema schema, string tableName) =>
-        schema.ScalarAsync<int>(
-            "SELECT COUNT(*) FROM information_schema.tables " +
-            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = '{tableName}'");
 
     private static MigrationScript[] Scripts(params (string Id, string Sql)[] scripts) =>
-        scripts.Select((s, i) => new MigrationScript(i + 1, s.Id, s.Sql)).ToArray();
+        scripts.Select(s => new MigrationScript(s.Id, s.Sql)).ToArray();
 }

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresMigrationRunnerTests.cs
@@ -1,0 +1,130 @@
+using Infrastructure.Postgres.Migrations;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.Postgres.Tests;
+
+/// <summary>
+/// The runner's own guarantees: apply once, apply in order, never half-apply, and stay correct when
+/// two hosts start at the same moment.
+/// </summary>
+public sealed class PostgresMigrationRunnerTests
+{
+    [SkippableFact]
+    public async Task ARunAgainstAnUpToDateDatabase_AppliesNothing()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+        var scripts = Scripts(("001_a", "CREATE TABLE a (id INT)"), ("002_b", "CREATE TABLE b (id INT)"));
+
+        Assert.Equal(2, await ApplyAsync(schema, scripts));
+        Assert.Equal(0, await ApplyAsync(schema, scripts));
+        Assert.Equal(2, await schema.ScalarAsync<int>("SELECT COUNT(*) FROM schema_migrations"));
+    }
+
+    [SkippableFact]
+    public async Task OnlyTheScriptsMissingFromTheLedgerAreApplied()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        await ApplyAsync(schema, Scripts(("001_a", "CREATE TABLE a (id INT)")));
+
+        var applied = await ApplyAsync(schema, Scripts(
+            ("001_a", "SELECT 1/0"), // would throw if re-run; proves it is skipped, not merely tolerated
+            ("002_b", "CREATE TABLE b (id INT)")));
+
+        Assert.Equal(1, applied);
+        Assert.Equal(1, await CountTablesAsync(schema, "b"));
+    }
+
+    [SkippableFact]
+    public async Task ScriptsAreAppliedInOrdinalOrderRegardlessOfTheOrderTheyWereHandedOver()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        // 002 depends on 001. Handed over backwards, so only the sort can save it.
+        var outOfOrder = new[]
+        {
+            new MigrationScript(2, "002_add_column", "ALTER TABLE ordered ADD COLUMN label TEXT"),
+            new MigrationScript(1, "001_create_table", "CREATE TABLE ordered (id INT)"),
+        };
+
+        await ApplyAsync(schema, outOfOrder);
+
+        Assert.Equal(1, await schema.ScalarAsync<int>(
+            "SELECT COUNT(*) FROM information_schema.columns " +
+            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = 'ordered' AND column_name = 'label'"));
+    }
+
+    [SkippableFact]
+    public async Task AFailingMigrationThrows_AndLeavesTheDatabaseAtItsPreviousVersion()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var ex = await Assert.ThrowsAsync<PostgresMigrationException>(() => ApplyAsync(schema, Scripts(
+            ("001_good", "CREATE TABLE survivor (id INT)"),
+            ("002_bad", "CREATE TABLE nonsense (id NOT_A_TYPE)"))));
+
+        Assert.Equal("002_bad", ex.MigrationId);
+
+        // All-or-nothing: 001 succeeded inside the transaction and is rolled back with 002. A
+        // half-applied schema is a state nothing else in this system knows how to reason about,
+        // whereas "still on the previous version" is the state it was already in.
+        Assert.Equal(0, await CountTablesAsync(schema, "survivor"));
+        Assert.Equal(0, await CountTablesAsync(schema, "nonsense"));
+        Assert.Equal(0, await CountTablesAsync(schema, "schema_migrations"));
+    }
+
+    [SkippableFact]
+    public async Task TwoHostsStartingTogether_ApplyEveryMigrationExactlyOnce()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        // The only real proof of the advisory lock. Without it both runners read an empty ledger,
+        // both decide everything is outstanding, and the second one re-runs DDL the first already
+        // committed — which on a CREATE TABLE without IF NOT EXISTS is an outright failure and on a
+        // seed INSERT is silent duplication.
+        var scripts = Scripts(
+            ("001_a", "CREATE TABLE raced (id INT PRIMARY KEY)"),
+            ("002_b", "INSERT INTO raced (id) VALUES (1)"));
+
+        var results = await Task.WhenAll(
+            Task.Run(() => ApplyAsync(schema, scripts)),
+            Task.Run(() => ApplyAsync(schema, scripts)));
+
+        // One runner did all the work; the other found nothing to do. Which one is not determined.
+        Assert.Equal([0, 2], results.OrderBy(r => r));
+        Assert.Equal(2, await schema.ScalarAsync<int>("SELECT COUNT(*) FROM schema_migrations"));
+        Assert.Equal(1, await schema.ScalarAsync<int>("SELECT COUNT(*) FROM raced"));
+    }
+
+    [SkippableFact]
+    public async Task TheLedgerRecordsWhatWasAppliedAndWhen()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+        await ApplyAsync(schema, Scripts(("001_a", "CREATE TABLE a (id INT)")));
+
+        Assert.Equal("001_a", await schema.ScalarAsync<string>("SELECT id FROM schema_migrations"));
+        Assert.Equal(0, await schema.ScalarAsync<int>(
+            "SELECT COUNT(*) FROM schema_migrations WHERE applied_at IS NULL"));
+    }
+
+    private static async Task<int> ApplyAsync(
+        MigrationTestSchema schema, IReadOnlyList<MigrationScript> scripts)
+    {
+        var runner = new PostgresMigrationRunner(
+            new PostgresMigrationOptions("schema_migrations", schema.AdvisoryLockKey),
+            scripts,
+            NullLogger.Instance);
+
+        await using var connection = await schema.OpenAsync();
+        return await runner.ApplyAsync(connection);
+    }
+
+    private static Task<int> CountTablesAsync(MigrationTestSchema schema, string tableName) =>
+        schema.ScalarAsync<int>(
+            "SELECT COUNT(*) FROM information_schema.tables " +
+            $"WHERE table_schema = '{schema.SchemaName}' AND table_name = '{tableName}'");
+
+    private static MigrationScript[] Scripts(params (string Id, string Sql)[] scripts) =>
+        scripts.Select((s, i) => new MigrationScript(i + 1, s.Id, s.Sql)).ToArray();
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/SessionsControllerStatusFilterTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/SessionsControllerStatusFilterTests.cs
@@ -58,6 +58,11 @@ public sealed class SessionsControllerStatusFilterTests
     [InlineData("error")]
     [InlineData("Error")]
     [InlineData("ERROR")]
+    // 'cancelled' moved here from the rejected set when #301 gave it a state. The controller needed
+    // no change to accept it: the filter is parsed out of SessionStatus, so widening the enum widened
+    // the API. That is the design working, and it is why this case is worth keeping on both sides of
+    // the move rather than deleting — a regression to a hardcoded list would land right here.
+    [InlineData("cancelled")]
     public async Task GetSessions_StatusTheSchemaCanHold_Returns200(string status)
     {
         using var client = CreateObserverClient();
@@ -68,13 +73,17 @@ public sealed class SessionsControllerStatusFilterTests
     }
 
     /// <summary>
-    /// <c>errored</c> and <c>cancelled</c> are named explicitly rather than covered by a generic
-    /// "garbage" case: they are the two words #289's callers were actually writing, so a regression
-    /// that reinstated string passthrough would show up here by name.
+    /// <c>errored</c> is named explicitly rather than covered by a generic "garbage" case: it is one
+    /// of the two words #289's callers were actually writing, so a regression that reinstated string
+    /// passthrough would show up here by name.
     /// </summary>
+    /// <remarks>
+    /// Its companion, <c>cancelled</c>, has moved to the accepted set. It was rejected here only
+    /// because the schema had no word for it and the template could not deliver one to an existing
+    /// database; #301 fixed that, and this is the seam where the change becomes visible to a caller.
+    /// </remarks>
     [Theory]
     [InlineData("errored")]
-    [InlineData("cancelled")]
     [InlineData("nonsense")]
     [InlineData("1")]
     [InlineData("-1")]

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -621,7 +621,11 @@ public class ConversationOrchestratorTests
         _connectionTracker.Setup(t => t.Untrack("conn1")).Returns(info);
 
         var orchestrator = CreateOrchestrator();
-        await orchestrator.HandleDisconnectAsync("conn1", new OperationCanceledException(), CancellationToken.None);
+        using var stopping = new CancellationTokenSource();
+        await stopping.CancelAsync();
+
+        await orchestrator.HandleDisconnectAsync(
+            "conn1", new OperationCanceledException(), stopping.Token);
 
         _obsStore.Verify(
             s => s.EndSessionAsync(
@@ -631,6 +635,42 @@ public class ConversationOrchestratorTests
         _obsStore.Verify(
             s => s.EndSessionAsync(
                 It.IsAny<Guid>(), SessionStatus.Error, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// A transport that timed out is a failure, even though it arrives as the same exception type a
+    /// deliberate stop does.
+    /// </summary>
+    /// <remarks>
+    /// <c>TaskCanceledException</c> derives from <c>OperationCanceledException</c> and is what a
+    /// keepalive or read timeout throws with nobody having cancelled anything. Matching on the type
+    /// alone reclassified a broken transport as a tidy goodbye — and, because the error log had just
+    /// been routed through a status check, stopped recording it at any level at all.
+    /// </remarks>
+    [Fact]
+    public async Task HandleDisconnect_WithATimeoutRatherThanACancellation_StillRecordsError()
+    {
+        var sessionId = Guid.NewGuid();
+        var info = new ActiveConversationInfo("c1", "agent", "user1", DateTimeOffset.UtcNow, 1, sessionId);
+        _connectionTracker.Setup(t => t.Untrack("conn1")).Returns(info);
+
+        var orchestrator = CreateOrchestrator();
+
+        // Nothing cancelled: the token is live, the exception merely looks like a cancellation.
+        await orchestrator.HandleDisconnectAsync(
+            "conn1", new TaskCanceledException("read timed out"), CancellationToken.None);
+
+        _obsStore.Verify(
+            s => s.EndSessionAsync(
+                sessionId, SessionStatus.Error, "connection.dropped_with_exception",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _obsStore.Verify(
+            s => s.EndSessionAsync(
+                It.IsAny<Guid>(), SessionStatus.Cancelled, It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -614,8 +614,8 @@ public class ConversationOrchestratorTests
         // A client that navigated away, or a host shutting down, arrives here as an
         // OperationCanceledException. It is the single most common way a conversation ends and it is
         // not a failure — but until #301 gave the schema a word for it, every one of them was
-        // recorded as an error. That is not cosmetic: the dashboards' error-rate panel is literally
-        // `status = 'error'`, so ordinary disconnects inflated the number operators watch.
+        // recorded as an error, in the column the sessions list and the Grafana $status filter both
+        // read. (It does not move any error-rate number; no panel computes one from this column.)
         var sessionId = Guid.NewGuid();
         var info = new ActiveConversationInfo("c1", "agent", "user1", DateTimeOffset.UtcNow, 1, sessionId);
         _connectionTracker.Setup(t => t.Untrack("conn1")).Returns(info);
@@ -639,14 +639,97 @@ public class ConversationOrchestratorTests
     }
 
     /// <summary>
+    /// The write that closes the session must not carry the token that says the connection is gone,
+    /// or the session is never closed at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the defect #301 was filed about, arriving by a second route nobody had looked at.
+    /// SignalR aborts the connection <em>before</em> dispatching disconnect — its own source says so:
+    /// <c>// Ensure the connection is aborted before firing disconnect</c> — so the token the hub
+    /// hands this method is already cancelled every single time. Handing that token to the terminal
+    /// <c>EndSessionAsync</c> means the UPDATE is refused before it is ever sent, and
+    /// <c>PostgresObservabilityStore</c> catches <em>every</em> exception on a telemetry write and
+    /// logs a warning, cancellation included. The row is left <c>status='active'</c> with no
+    /// <c>ended_at</c>, for ever, on every ordinary disconnect.
+    /// </para>
+    /// <para>
+    /// The status fix on its own would have been theatre: it would have chosen the right word and
+    /// then failed to write it. Cleanup after a cancellation is not itself cancellable, which is the
+    /// same rule <c>RunConversationCommandHandler.EndRunSessionAsync</c> already follows.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public async Task HandleDisconnect_WithCancellation_EndsSessionWithALiveTokenSoTheWriteLands()
+    {
+        var sessionId = Guid.NewGuid();
+        var info = new ActiveConversationInfo("c1", "agent", "user1", DateTimeOffset.UtcNow, 1, sessionId);
+        _connectionTracker.Setup(t => t.Untrack("conn1")).Returns(info);
+
+        var orchestrator = CreateOrchestrator();
+
+        // Exactly what the hub passes: a token that is already cancelled.
+        using var aborted = new CancellationTokenSource();
+        await aborted.CancelAsync();
+
+        await orchestrator.HandleDisconnectAsync("conn1", new OperationCanceledException(), aborted.Token);
+
+        _obsStore.Verify(
+            s => s.EndSessionAsync(
+                sessionId,
+                SessionStatus.Cancelled,
+                It.IsAny<string?>(),
+                It.Is<CancellationToken>(t => !t.IsCancellationRequested)),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// The same rule on the error path: a connection that died from a transport fault also arrives
+    /// with an aborted token, and its session must still be closed.
+    /// </summary>
+    [Fact]
+    public async Task HandleDisconnect_WithException_EndsSessionWithALiveTokenSoTheWriteLands()
+    {
+        var sessionId = Guid.NewGuid();
+        var info = new ActiveConversationInfo("c1", "agent", "user1", DateTimeOffset.UtcNow, 1, sessionId);
+        _connectionTracker.Setup(t => t.Untrack("conn1")).Returns(info);
+
+        var orchestrator = CreateOrchestrator();
+
+        using var aborted = new CancellationTokenSource();
+        await aborted.CancelAsync();
+
+        await orchestrator.HandleDisconnectAsync("conn1", new InvalidOperationException("boom"), aborted.Token);
+
+        _obsStore.Verify(
+            s => s.EndSessionAsync(
+                sessionId,
+                SessionStatus.Error,
+                It.IsAny<string?>(),
+                It.Is<CancellationToken>(t => !t.IsCancellationRequested)),
+            Times.Once);
+    }
+
+    /// <summary>
     /// A transport that timed out is a failure, even though it arrives as the same exception type a
     /// deliberate stop does.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// <c>TaskCanceledException</c> derives from <c>OperationCanceledException</c> and is what a
     /// keepalive or read timeout throws with nobody having cancelled anything. Matching on the type
     /// alone reclassified a broken transport as a tidy goodbye — and, because the error log had just
     /// been routed through a status check, stopped recording it at any level at all.
+    /// </para>
+    /// <para>
+    /// Read this test for what it is: it pins the classification <em>rule</em>, not a production
+    /// guarantee. The only real caller is <c>AgentTelemetryHub.OnDisconnectedAsync</c>, which passes
+    /// <c>Context.ConnectionAborted</c> — and SignalR aborts the connection before dispatching
+    /// disconnect, so in production that token is always already cancelled and this branch cannot be
+    /// reached. Passing <c>CancellationToken.None</c> here exercises a caller shape the hub never
+    /// produces. That is worth stating plainly rather than letting the name imply cover that is not
+    /// there.
+    /// </para>
     /// </remarks>
     [Fact]
     public async Task HandleDisconnect_WithATimeoutRatherThanACancellation_StillRecordsError()

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -609,6 +609,32 @@ public class ConversationOrchestratorTests
     }
 
     [Fact]
+    public async Task HandleDisconnect_WithCancellation_RecordsCancelledRatherThanError()
+    {
+        // A client that navigated away, or a host shutting down, arrives here as an
+        // OperationCanceledException. It is the single most common way a conversation ends and it is
+        // not a failure — but until #301 gave the schema a word for it, every one of them was
+        // recorded as an error. That is not cosmetic: the dashboards' error-rate panel is literally
+        // `status = 'error'`, so ordinary disconnects inflated the number operators watch.
+        var sessionId = Guid.NewGuid();
+        var info = new ActiveConversationInfo("c1", "agent", "user1", DateTimeOffset.UtcNow, 1, sessionId);
+        _connectionTracker.Setup(t => t.Untrack("conn1")).Returns(info);
+
+        var orchestrator = CreateOrchestrator();
+        await orchestrator.HandleDisconnectAsync("conn1", new OperationCanceledException(), CancellationToken.None);
+
+        _obsStore.Verify(
+            s => s.EndSessionAsync(
+                sessionId, SessionStatus.Cancelled, "connection.cancelled", It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        _obsStore.Verify(
+            s => s.EndSessionAsync(
+                It.IsAny<Guid>(), SessionStatus.Error, It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task HandleDisconnect_WithException_RecordsAStableCodeRatherThanTheExceptionText()
     {
         // Fixing the status turned this from a swallowed write into a real one, and that is exactly what


### PR DESCRIPTION
Closes #301.

## The problem

The observability database got its tables from four SQL files mounted at
`/docker-entrypoint-initdb.d`. Postgres runs those exactly once — when it initialises an
empty data directory — and never again. So the template could add a table or a column,
prove it in CI, and ship it, while every consumer who already had data silently kept the
old shape. CI stayed blind because it rebuilt a fresh database every run.

That already cost something. `sessions.status` was guarded by
`CHECK (status IN ('active','completed','error'))`. Cancelling a run tried to write
`cancelled`, Postgres refused, and since a telemetry write must never fail the turn that
produced it, the refusal was swallowed. #289 fixed the symptom by narrowing the code to the
schema — a cancelled run recorded as `Error` — accepted only because no schema change could
reach a database that already held data.

## What this does

A versioned migration runner (`Infrastructure.Postgres`) applied lazily on first
connection, with an applied-migrations ledger, a cluster-wide advisory lock taken *before*
the ledger is read, and the whole run in one transaction. The `init-db` SQL becomes its
idempotent baseline. Both Postgres stores — observability and knowledge graph — now use it;
the graph store's hand-rolled locking was deleted rather than left running beside it. The
Compose `init-db` mount is gone, so the application owns the schema.

Then, and only then, `cancelled` becomes a real session state: migration 005 widens the
constraint, and the enum, the orchestrator, the sessions controller, the Grafana filter and
the React badge follow.

**Two deviations from the original plan, both deliberate:**

1. Role creation cannot come from the application — `CREATE ROLE` needs `CREATEROLE`, which
   no least-privilege app account should hold, and roles are cluster-scoped while migrations
   are database-scoped. `Dashboards/postgres-bootstrap/` keeps exactly that one file mounted.
2. The ledger records a **checksum** beside each id, which the plan did not call for.
   Without it, editing an already-applied migration is a no-op on every database that ran it
   and a full apply on every database created afterwards — the installed base splits in two
   and nothing reports it. That is structurally the same failure as #301 itself.

## The bug this found on `main`

Every SignalR disconnect left its session row at `status='active'` with no `ended_at`,
for ever — the same symptom #301 was filed about, by a route nobody had checked. SignalR
aborts the connection *before* dispatching disconnect (verified in `dotnet/aspnetcore`:
"Ensure the connection is aborted before firing disconnect"), so the token handed to the
orchestrator is always already cancelled. Passing it to the terminal `EndSessionAsync`
meant the UPDATE was refused before it was sent, and the store catches every exception on
a telemetry write and logs a warning. Picking the right status word would have been theatre
without this.

## Corrections to this branch's own claims

- The justification that cancelled runs inflated a dashboard error-rate panel, repeated
  five times, is **false** — no panel computes a rate from `sessions.status`. Corrected
  everywhere. The change stands on the column operators actually read.
- A second `PostgresSchemaGate` constructor documented as existing "for the test fixture"
  had no caller anywhere.
- Migration 005's comment overstated what discovering the constraint name buys. Mutation
  testing showed a hardcoded name passes for every database this template produces; the
  lookup earns its keep only for hand-migrated databases, which is now stated plainly and
  pinned by a control test.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — clean.
- `dotnet test src/AgenticHarness.slnx` — **9,967 passed / 3 skipped / 0 failed** (baseline
  9,928; +39).
- Frontend: 386 passed, `tsc --noEmit` clean.
- The upgrade path is proved control-then-treatment: a database on the previous release
  **rejects** `cancelled`, the same database after the runner **accepts** it. A database
  built by the original `init-db` SQL with no ledger is brought forward. A database whose
  constraint was hand-named is brought forward. Concurrency, re-run-is-a-no-op, failed
  migration rolls back, duplicate ordinal rejected, edited migration refused, CRLF is not
  an edit, legacy ledger row adopted.
- CI now applies the schema through the shipping runner instead of a `psql` loop, so the
  delivery path is exercised rather than bypassed.
- Every new test mutation-verified. Two unexpected passes were treated as findings, not
  relief, and both changed the code or the comment.

## Follow-up (deliberately not here)

A shared `.props` for the embedded-migration block, Grafana's `$status` as a query
variable, binding the enum to `StatusBadge.tsx` and the dashboard JSON by test, and
hoisting a `PostgresMigrationSet` type. Will file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
