### PR TITLE
fix: bind the session-status vocabulary to every place it is written

### DIFF
--- a/Dashboards/Grafana Dashboards/sessionDetail.json
+++ b/Dashboards/Grafana Dashboards/sessionDetail.json
@@ -177,21 +177,17 @@
                   "color": "green",
                   "index": 0
                 },
-                "failed": {
+                "error": {
                   "color": "red",
                   "index": 1
                 },
-                "running": {
+                "active": {
                   "color": "blue",
                   "index": 2
                 },
-                "timeout": {
-                  "color": "yellow",
-                  "index": 3
-                },
                 "cancelled": {
                   "color": "orange",
-                  "index": 4
+                  "index": 3
                 }
               },
               "type": "value"

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Infrastructure.AI.KnowledgeGraph.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/Infrastructure.AI.KnowledgeGraph.csproj
@@ -20,11 +20,7 @@
     <ProjectReference Include="..\Infrastructure.Postgres\Infrastructure.Postgres.csproj" />
   </ItemGroup>
 
-  <!-- Explicit LogicalName; see the note in Infrastructure.Observability.csproj. -->
-  <ItemGroup>
-    <EmbeddedResource Include="Migrations\*.sql">
-      <LogicalName>Migrations.%(Filename)%(Extension)</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
+  <!-- Embeds Migrations\*.sql; the reasoning lives in the imported file. -->
+  <Import Project="..\Infrastructure.Postgres\PostgresMigrations.props" />
 
 </Project>

--- a/src/Content/Infrastructure/Infrastructure.Observability/Infrastructure.Observability.csproj
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Infrastructure.Observability.csproj
@@ -25,17 +25,7 @@
     <ProjectReference Include="..\Infrastructure.Postgres\Infrastructure.Postgres.csproj" />
   </ItemGroup>
 
-  <!--
-    LogicalName is set explicitly so the resource names are exactly
-    "Migrations.<file>.sql". MSBuild's default naming derives from the root
-    namespace and folder path and rewrites characters it considers invalid, which
-    would make the name something to be verified rather than known — and a
-    migration set that silently resolves to empty reads as "schema is up to date".
-  -->
-  <ItemGroup>
-    <EmbeddedResource Include="Migrations\*.sql">
-      <LogicalName>Migrations.%(Filename)%(Extension)</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
+  <!-- Embeds Migrations\*.sql; the reasoning lives in the imported file. -->
+  <Import Project="..\Infrastructure.Postgres\PostgresMigrations.props" />
 
 </Project>

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Npgsql;
 
@@ -20,6 +21,15 @@ namespace Infrastructure.Postgres.Migrations;
 /// restart to recover from a condition that fixes itself.
 /// </para>
 /// <para>
+/// It does, however, cool down for <see cref="FailureCooldown"/>. Not latching is right for a
+/// transient fault and wrong for a permanent one, and the runner now has a permanent one it can
+/// report: a migration whose checksum no longer matches what this database applied will fail every
+/// time until a human intervenes. Without a cooldown that failure is re-attempted on every physical
+/// connection for the life of the process, each attempt taking the cluster-wide advisory lock to be
+/// told the same thing. The cooldown keeps the recovery property — the next request after the window
+/// tries again — while making a hopeless failure cheap.
+/// </para>
+/// <para>
 /// Deliberately NOT <see cref="IDisposable"/>. It was, briefly, because it holds a
 /// <see cref="SemaphoreSlim"/> — and the ceremony was immediately skipped by one of its two
 /// consumers, which is the tell that it was never needed. A <see cref="SemaphoreSlim"/> only needs
@@ -37,9 +47,27 @@ namespace Infrastructure.Postgres.Migrations;
 /// </remarks>
 public sealed class PostgresSchemaGate
 {
+    /// <summary>
+    /// How long a failed attempt is reused before the database is asked again.
+    /// </summary>
+    /// <remarks>
+    /// Short enough that a database which was briefly unreachable is picked up on the next request
+    /// rather than needing a restart, long enough that a failure which will not fix itself — a
+    /// migration whose checksum no longer matches, a missing privilege — is not re-attempted once per
+    /// physical connection for the life of the process. Not configurable: nothing about a consumer's
+    /// deployment makes a different number right, and an option here would be one more thing to get
+    /// wrong for no gain.
+    /// </remarks>
+    private static readonly TimeSpan FailureCooldown = TimeSpan.FromSeconds(5);
+
     private readonly PostgresMigrationRunner _runner;
     private readonly SemaphoreSlim _gate = new(1, 1);
+    private readonly TimeProvider _time;
     private volatile bool _ready;
+
+    // Both written and read only while holding _gate, so neither needs to be volatile.
+    private ExceptionDispatchInfo? _lastFailure;
+    private long _failedAt;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="PostgresSchemaGate"/> class.
@@ -47,6 +75,10 @@ public sealed class PostgresSchemaGate
     /// <param name="options">Ledger table and advisory lock key for this migration set.</param>
     /// <param name="scripts">The migration set, in any order.</param>
     /// <param name="logger">Logger recording which migrations were applied.</param>
+    /// <param name="timeProvider">
+    /// Clock used for the failure cooldown; defaults to the system clock. Injectable so the cooldown
+    /// can be tested without a test that sleeps.
+    /// </param>
     /// <remarks>
     /// The gate builds its own runner rather than taking one, because both consumers were otherwise
     /// writing the same nested double-construction. There was briefly a second, runner-taking
@@ -59,9 +91,11 @@ public sealed class PostgresSchemaGate
     public PostgresSchemaGate(
         PostgresMigrationOptions options,
         IReadOnlyList<MigrationScript> scripts,
-        ILogger logger)
+        ILogger logger,
+        TimeProvider? timeProvider = null)
     {
         _runner = new PostgresMigrationRunner(options, scripts, logger);
+        _time = timeProvider ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -79,8 +113,25 @@ public sealed class PostgresSchemaGate
         {
             if (_ready) return;
 
-            await _runner.ApplyAsync(connection, cancellationToken);
-            _ready = true;
+            // Within the cooldown, hand back the failure that is already known rather than asking the
+            // database again. The caller sees exactly what it would have seen; what it does not do is
+            // make another round trip and take the cluster-wide advisory lock to be told the same
+            // thing. The rethrown stack trace is the ORIGINAL attempt's, which is the useful one.
+            if (_lastFailure is not null && _time.GetElapsedTime(_failedAt) < FailureCooldown)
+                _lastFailure.Throw();
+
+            try
+            {
+                await _runner.ApplyAsync(connection, cancellationToken);
+                _ready = true;
+                _lastFailure = null;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _lastFailure = ExceptionDispatchInfo.Capture(ex);
+                _failedAt = _time.GetTimestamp();
+                throw;
+            }
         }
         finally
         {

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
@@ -30,6 +30,34 @@ namespace Infrastructure.Postgres.Migrations;
 /// tries again — while making a hopeless failure cheap.
 /// </para>
 /// <para>
+/// <strong>Where to call it from.</strong> There are two shapes in this repo and the choice is not
+/// arbitrary, so a third Postgres-backed store should copy the one that matches its own structure
+/// rather than whichever it read first.
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <em>A store with one place it opens connections</em> — <c>PostgreSqlGraphStore</c> — calls
+/// <see cref="EnsureAsync"/> there. Simplest, and the preferred shape when the seam exists.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <em>A store with no such seam</em> — <c>PostgresObservabilityStore</c>, where eighteen call sites
+/// take commands straight off an <c>NpgsqlDataSource</c> — hooks
+/// <c>NpgsqlDataSourceBuilder.UsePhysicalConnectionInitializer</c> instead. That reaches every one of
+/// them without threading a call through all eighteen, and it runs before the first query rather
+/// than racing it. Note that it needs both the sync and async initializer; the sync one should throw,
+/// because a synchronous <c>Open()</c> would skip the migration entirely.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// A factory to unify the two was considered and is the wrong shape: what differs is not how the
+/// data source is built but whether the store has a single point at which a connection becomes
+/// available, which is a property of the store, not of its configuration.
+/// </para>
+/// <para>
 /// Deliberately NOT <see cref="IDisposable"/>. It was, briefly, because it holds a
 /// <see cref="SemaphoreSlim"/> — and the ceremony was immediately skipped by one of its two
 /// consumers, which is the tell that it was never needed. A <see cref="SemaphoreSlim"/> only needs

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
@@ -145,6 +145,15 @@ public sealed class PostgresSchemaGate
             // database again. The caller sees exactly what it would have seen; what it does not do is
             // make another round trip and take the cluster-wide advisory lock to be told the same
             // thing. The rethrown stack trace is the ORIGINAL attempt's, which is the useful one.
+            //
+            // Accepted, with eyes open: rethrowing restores dispatch state onto the one shared
+            // exception object, so a caller that was served a moment ago and is now formatting it for
+            // a log can see an interleaved stack trace. The alternative — wrapping a fresh exception
+            // per replay — was rejected because it changes the TYPE the caller sees between the first
+            // failure and the replays whenever the original was not a PostgresMigrationException, and
+            // a caller catching by type getting different answers for the same fault is a worse
+            // problem than an occasionally untidy log line during a five-second window on a system
+            // that is already broken.
             if (_lastFailure is not null && _time.GetElapsedTime(_failedAt) < FailureCooldown)
                 _lastFailure.Throw();
 
@@ -156,6 +165,25 @@ public sealed class PostgresSchemaGate
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                // Only a failure that belongs to the DATABASE is cached, and the filter on this catch
+                // is what ensures it. Caching one caller's cancellation would replay that client's
+                // disconnect to every other caller for the whole window — including callers whose
+                // connection is fine — turning a self-healing condition into five seconds of
+                // guaranteed failure, and in the observability store, whose writes are swallowed by
+                // design, five seconds of silently dropped telemetry.
+                //
+                // Review raised that the filter tests only the outermost type and would therefore
+                // miss a cancellation buried inside a driver exception. Measured against Npgsql
+                // rather than reasoned about: a command cancelled by its token throws
+                // OperationCanceledException on the OUTSIDE, wrapping PostgresException 57014. The
+                // outermost type is exactly the right thing to test, and the runner's filter excludes
+                // it too. A chain-walking guard was written for this, could not be made to fail under
+                // mutation, and was removed — an inert check that reads as protection is worse than
+                // none. ACancelledCaller_DoesNotPoisonTheCooldownForOthers pins the behaviour.
+                //
+                // Server-side faults that are NOT cancellations — a command timeout, a 57P01 admin
+                // shutdown — are cached, deliberately. They affect every caller equally, so bounded
+                // replay is exactly what this cooldown is for.
                 _lastFailure = ExceptionDispatchInfo.Capture(ex);
                 _failedAt = _time.GetTimestamp();
                 throw;
@@ -166,4 +194,5 @@ public sealed class PostgresSchemaGate
             _gate.Release();
         }
     }
+
 }

--- a/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/Migrations/PostgresSchemaGate.cs
@@ -161,6 +161,12 @@ public sealed class PostgresSchemaGate
             {
                 await _runner.ApplyAsync(connection, cancellationToken);
                 _ready = true;
+
+                // Releases the reference; it is NOT observable behaviour, and saying so matters
+                // because it reads like state management. Once _ready is set, both checks above
+                // short-circuit before the cooldown is ever consulted, so a stale cached failure is
+                // unreachable by construction — deleting this line fails no test, and a test claiming
+                // to cover it was removed rather than propped up.
                 _lastFailure = null;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -194,5 +200,4 @@ public sealed class PostgresSchemaGate
             _gate.Release();
         }
     }
-
 }

--- a/src/Content/Infrastructure/Infrastructure.Postgres/PostgresMigrations.props
+++ b/src/Content/Infrastructure/Infrastructure.Postgres/PostgresMigrations.props
@@ -1,0 +1,39 @@
+<Project>
+
+  <!--
+    Embeds a project's Migrations\*.sql so PostgresMigrationRunner can read them from the built
+    assembly rather than from disk. Import this from any project that ships a migration set:
+
+      <Import Project="..\Infrastructure.Postgres\PostgresMigrations.props" />
+
+    It sits at the project root and not in a build\ folder, which is the usual home for shared MSBuild
+    files, because .gitignore excludes [Bb]uild\ — it was written there first and git silently refused
+    to track it, which would have left every other clone importing a file that does not exist. The
+    NuGet build\ convention buys nothing here anyway: this is consumed by ProjectReference and an
+    explicit Import, not by package restore.
+
+    LogicalName is set explicitly so the resource names are exactly "Migrations.<file>.sql".
+    MSBuild's default naming derives from the root namespace and the folder path and rewrites
+    characters it considers invalid, which would make the resource name something to be verified
+    rather than known. That matters more here than it usually would: a migration set that silently
+    resolves to empty reads as "the schema is already up to date". EmbeddedSqlMigrationSource throws
+    on an empty set for exactly that reason, so the failure is loud — but it is a runtime failure on
+    first connection, in whichever environment connects first, so it is worth not causing.
+
+    Owned here rather than copy-pasted into each store, which is how it started: two identical item
+    groups, and the paragraph above living in only one of them while the other pointed at it.
+
+    An explicit import, not an automatic rule in Directory.Build.props keyed on the presence of a
+    Migrations folder. Automatic would make it impossible to forget, which is the tempting part, but
+    it would also silently embed .sql from any project that happens to grow a folder of that name —
+    EF Core uses the same folder name by convention — and a project file that says nothing about
+    embedding resources while embedding them is harder to reason about than one line of import.
+  -->
+
+  <ItemGroup>
+    <EmbeddedResource Include="Migrations\*.sql">
+      <LogicalName>Migrations.%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
+</Project>

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixture.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixture.cs
@@ -1,36 +1,26 @@
-using System.Net.Sockets;
 using Infrastructure.Observability.Persistence;
 using Infrastructure.Postgres.Migrations;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging;
 using Npgsql;
+using Tests.Common;
 using Xunit;
 
 namespace Infrastructure.Observability.Tests.Integration;
 
 public sealed class PostgresFixture : IAsyncLifetime
 {
-    private const string DefaultConnectionString =
-        "Host=localhost;Port=5432;Database=observability;Username=observability;Password=observability";
-
     public NpgsqlDataSource DataSource { get; private set; } = null!;
     public string RunTag { get; } = $"test-{Guid.NewGuid():N}";
     public bool IsAvailable { get; private set; }
     public ILogger<Infrastructure.Observability.Persistence.PostgresObservabilityStore> StoreLogger { get; }
         = NullLogger<Infrastructure.Observability.Persistence.PostgresObservabilityStore>.Instance;
 
-    /// <summary>
-    /// True when the connection string was supplied explicitly via the
-    /// <c>OBSERVABILITY_TEST_CONN</c> environment variable rather than falling back to the
-    /// localhost default. When set, the operator (or CI) is asserting that Postgres is provisioned,
-    /// so any connectivity failure is a real defect that must surface loudly rather than silently
-    /// disabling the suite.
-    /// </summary>
-    private static bool IsConnectionExplicitlyConfigured =>
-        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN"));
-
-    public string ConnectionString { get; } =
-        Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN") ?? DefaultConnectionString;
+    // Connection string, the environment override, what counts as "absent", and the skip wording all
+    // come from PostgresAvailability. They used to live here AND in Infrastructure.Postgres.Tests'
+    // MigrationTestSchema, which meant the rule for when a Postgres suite may skip was written twice
+    // with nothing to catch the two disagreeing.
+    public string ConnectionString { get; } = PostgresAvailability.ConnectionString;
 
     /// <summary>
     /// Probes the target Postgres server and sets <see cref="IsAvailable"/>.
@@ -54,7 +44,7 @@ public sealed class PostgresFixture : IAsyncLifetime
             await cmd.ExecuteScalarAsync();
             IsAvailable = true;
         }
-        catch (Exception ex) when (!IsConnectionExplicitlyConfigured && IsServerAbsent(ex))
+        catch (Exception ex) when (PostgresAvailability.ShouldSkip(ex))
         {
             // No Postgres listening on the default localhost endpoint and none was demanded via
             // OBSERVABILITY_TEST_CONN — treat as "not provisioned" so local dev runs can skip.
@@ -87,30 +77,6 @@ public sealed class PostgresFixture : IAsyncLifetime
     }
 
     /// <summary>
-    /// Returns <c>true</c> only when the failure indicates no server is listening at all
-    /// (connection refused / host unreachable). A reachable server that rejects the probe for any
-    /// other reason — authentication, missing database, schema problems — is NOT "absent" and must
-    /// not be masked as an unavailable fixture.
-    /// </summary>
-    private static bool IsServerAbsent(Exception ex)
-    {
-        for (var current = ex; current is not null; current = current.InnerException)
-        {
-            if (current is SocketException socket &&
-                (socket.SocketErrorCode is SocketError.ConnectionRefused
-                    or SocketError.HostNotFound
-                    or SocketError.HostUnreachable
-                    or SocketError.NetworkUnreachable
-                    or SocketError.TimedOut))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
     /// Skips the calling test (reported as <em>skipped</em>, not passed) when Postgres is not
     /// available. Tests in this collection must call this instead of an early <c>return</c>: a bare
     /// <c>if (!IsAvailable) return;</c> makes xUnit report the test as a green PASS with zero
@@ -119,11 +85,7 @@ public sealed class PostgresFixture : IAsyncLifetime
     /// through <c>Skip.IfNot</c> (Xunit.SkippableFact) instead surfaces the opt-out honestly as
     /// a skipped test, keeping the green count meaningful. Callers must be <c>[SkippableFact]</c>.
     /// </summary>
-    public void SkipIfUnavailable() =>
-        Skip.IfNot(
-            IsAvailable,
-            "Postgres is not provisioned for this run (set OBSERVABILITY_TEST_CONN or start a local " +
-            "Postgres on localhost:5432). The test is skipped rather than reported as a silent pass.");
+    public void SkipIfUnavailable() => Skip.IfNot(IsAvailable, PostgresAvailability.SkipReason);
 
     public string NewConversationId() => $"{RunTag}-{Guid.NewGuid():N}";
 

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixtureSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Integration/PostgresFixtureSolutionReviewFixTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Tests.Common;
 using Xunit;
 
 namespace Infrastructure.Observability.Tests.Integration;
@@ -16,7 +17,10 @@ namespace Infrastructure.Observability.Tests.Integration;
 [Collection("PostgresFixtureFix")]
 public sealed class PostgresFixtureSolutionReviewFixTests
 {
-    private const string EnvVar = "OBSERVABILITY_TEST_CONN";
+    // From the shared policy, not re-typed. This test is the one that exercises the variable for
+    // real, so a copy here would have falsified the extraction's whole claim — "stated once, nothing
+    // to notice the two drifting apart" — on the day it was made.
+    private const string EnvVar = PostgresAvailability.ConnectionVariable;
 
     /// <summary>
     /// A localhost endpoint on a port nothing listens on yields a connection-refused

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusDashboardAgreementTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusDashboardAgreementTests.cs
@@ -1,0 +1,153 @@
+using System.Text.Json;
+using Domain.AI.Observability.Models;
+using Tests.Common;
+using Xunit;
+
+namespace Infrastructure.Observability.Tests.Schema;
+
+/// <summary>
+/// Proves the Grafana dashboards use exactly the session statuses the code can write — the last two
+/// places the vocabulary is encoded, and the only two nothing was checking.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="SessionStatusSchemaAgreementTests"/> binds the enum to the migration SQL, and
+/// <c>StatusBadge.tsx</c> is keyed by a union type so the compiler catches a missing case. The
+/// dashboards had neither, and it showed: <c>sessionDetail.json</c> was colouring
+/// <c>failed</c>, <c>running</c> and <c>timeout</c> — three values this system has never once
+/// written — while <c>active</c> and <c>error</c> had no mapping at all. The state an operator most
+/// needs to spot rendered as plain uncoloured text, and had done for at least two status changes.
+/// </para>
+/// <para>
+/// Deliberately the same technique as its sibling: read a checked-in artifact, no container, cannot
+/// be skipped. A dashboard is data, and data that encodes a vocabulary can be checked against the
+/// vocabulary's source. The reason this was missed is not that it was hard.
+/// </para>
+/// <para>
+/// <strong>Why <c>$status</c> stays a hardcoded list rather than becoming a query variable.</strong>
+/// The obvious fix is to have Grafana populate the filter with
+/// <c>SELECT DISTINCT status FROM sessions</c>, which would remove this site from the vocabulary
+/// entirely. It is the wrong trade here: a query variable can only offer statuses that have already
+/// occurred, so a fresh installation shows an empty filter and a status with no rows yet cannot be
+/// selected — including <c>error</c>, on precisely the day an operator first needs it. A complete
+/// static list plus this test gives the full vocabulary at all times and still cannot drift.
+/// </para>
+/// </remarks>
+public sealed class SessionStatusDashboardAgreementTests
+{
+    private static readonly string DashboardDirectory =
+        RepoRoot.Combine("Dashboards", "Grafana Dashboards");
+
+    private static HashSet<string> WritableStatuses() =>
+        Enum.GetValues<SessionStatus>().Select(s => s.ToDbValue()).ToHashSet(StringComparer.Ordinal);
+
+    [Theory]
+    [InlineData("sessions.json")]
+    [InlineData("sessionDetail.json")]
+    public void EveryDashboardStatusMapping_CoversExactlyTheStatusesTheCodeCanWrite(string dashboard)
+    {
+        var mappings = ReadSessionStatusMappings(dashboard);
+
+        // Set equality both ways, for the same reasons the schema agreement test gives. A missing
+        // value renders uncoloured, which reads as "nothing notable here" for a status that may be
+        // the most notable thing on the page. An extra value is dead configuration that looks
+        // maintained — it is exactly how 'failed'/'running'/'timeout' survived being fictional.
+        Assert.NotEmpty(mappings);
+
+        foreach (var (path, values) in mappings)
+        {
+            Assert.Equal(
+                WritableStatuses().OrderBy(v => v, StringComparer.Ordinal),
+                values.OrderBy(v => v, StringComparer.Ordinal));
+            Assert.True(values.Count > 0, path);
+        }
+    }
+
+    /// <summary>
+    /// The <c>$status</c> filter offers every status and nothing else, plus Grafana's own
+    /// <c>All</c> sentinel.
+    /// </summary>
+    [Fact]
+    public void TheStatusFilterVariable_OffersExactlyTheStatusesTheCodeCanWrite()
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(DashboardDirectory, "sessions.json")));
+
+        var variable = document.RootElement
+            .GetProperty("templating").GetProperty("list").EnumerateArray()
+            .Single(v => v.GetProperty("name").GetString() == "status");
+
+        Assert.Equal("custom", variable.GetProperty("type").GetString());
+
+        var offered = variable.GetProperty("query").GetString()!
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Where(v => !string.Equals(v, "All", StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(
+            WritableStatuses().OrderBy(v => v, StringComparer.Ordinal),
+            offered.OrderBy(v => v, StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// Guards the reader: if the dashboards are reshaped so no session-status mapping is recognised,
+    /// this class must fail rather than assert nothing across two green tests.
+    /// </summary>
+    [Fact]
+    public void BothDashboards_DeclareASessionStatusMapping()
+    {
+        Assert.NotEmpty(ReadSessionStatusMappings("sessions.json"));
+        Assert.NotEmpty(ReadSessionStatusMappings("sessionDetail.json"));
+    }
+
+    /// <summary>
+    /// Finds every Grafana <c>value</c> mapping in a dashboard that is about session status, and
+    /// returns the values each one maps.
+    /// </summary>
+    /// <remarks>
+    /// Identified by content rather than by position, because a panel index is the first thing to
+    /// change when someone rearranges a dashboard and a path-based reader would then silently check
+    /// nothing. A mapping counts as a session-status mapping when it names at least one status only
+    /// this vocabulary uses. That test matters: <c>tool_executions.status</c> is a genuinely
+    /// different vocabulary (<c>success</c>/<c>failure</c>/<c>timeout</c>) living in the same files,
+    /// and a looser rule would drag those mappings in and fail on correct configuration. The overlap
+    /// is real — both vocabularies contain the word <c>timeout</c> at some point in their history —
+    /// so the discriminator is the values unique to sessions, not the values they share.
+    /// </remarks>
+    private static List<(string Path, HashSet<string> Values)> ReadSessionStatusMappings(string dashboard)
+    {
+        var discriminators = new[] { "active", "completed", "cancelled", "error" };
+        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(DashboardDirectory, dashboard)));
+
+        var found = new List<(string, HashSet<string>)>();
+        Walk(document.RootElement, "$");
+        return found;
+
+        void Walk(JsonElement element, string path)
+        {
+            switch (element.ValueKind)
+            {
+                case JsonValueKind.Array:
+                    var index = 0;
+                    foreach (var item in element.EnumerateArray())
+                        Walk(item, $"{path}[{index++}]");
+                    break;
+
+                case JsonValueKind.Object:
+                    if (element.TryGetProperty("type", out var type)
+                        && type.ValueKind == JsonValueKind.String
+                        && type.GetString() == "value"
+                        && element.TryGetProperty("options", out var options)
+                        && options.ValueKind == JsonValueKind.Object)
+                    {
+                        var values = options.EnumerateObject().Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+                        if (values.Overlaps(discriminators))
+                            found.Add(($"{dashboard} {path}", values));
+                    }
+
+                    foreach (var property in element.EnumerateObject())
+                        Walk(property.Value, $"{path}.{property.Name}");
+                    break;
+            }
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusDashboardAgreementTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusDashboardAgreementTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Domain.AI.Observability.Models;
 using Tests.Common;
 using Xunit;
 
@@ -11,9 +10,9 @@ namespace Infrastructure.Observability.Tests.Schema;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="SessionStatusSchemaAgreementTests"/> binds the enum to the migration SQL, and
-/// <c>StatusBadge.tsx</c> is keyed by a union type so the compiler catches a missing case. The
-/// dashboards had neither, and it showed: <c>sessionDetail.json</c> was colouring
+/// <see cref="SessionStatusSchemaAgreementTests"/> binds the enum to the migration SQL and
+/// <see cref="SessionStatusFrontendAgreementTests"/> binds it to the dashboard's TypeScript union.
+/// The Grafana dashboards had neither, and it showed: <c>sessionDetail.json</c> was colouring
 /// <c>failed</c>, <c>running</c> and <c>timeout</c> — three values this system has never once
 /// written — while <c>active</c> and <c>error</c> had no mapping at all. The state an operator most
 /// needs to spot rendered as plain uncoloured text, and had done for at least two status changes.
@@ -38,28 +37,42 @@ public sealed class SessionStatusDashboardAgreementTests
     private static readonly string DashboardDirectory =
         RepoRoot.Combine("Dashboards", "Grafana Dashboards");
 
-    private static HashSet<string> WritableStatuses() =>
-        Enum.GetValues<SessionStatus>().Select(s => s.ToDbValue()).ToHashSet(StringComparer.Ordinal);
-
-    [Theory]
-    [InlineData("sessions.json")]
-    [InlineData("sessionDetail.json")]
-    public void EveryDashboardStatusMapping_CoversExactlyTheStatusesTheCodeCanWrite(string dashboard)
+    /// <summary>
+    /// Every session-status mapping in every dashboard uses exactly the statuses the code can write.
+    /// </summary>
+    /// <remarks>
+    /// Scans the whole dashboard directory rather than naming the two files that carry a mapping
+    /// today. Binding to filenames is the same coupling this class already refuses at the panel level
+    /// — the reader finds mappings by content precisely so rearranging a dashboard cannot turn it
+    /// into a no-op, and hardcoding which files to open would have reintroduced that one level up.
+    /// Seven dashboards exist; the day an eighth grows a session panel it is covered without anyone
+    /// remembering to add it here.
+    /// </remarks>
+    [Fact]
+    public void EveryDashboardStatusMapping_CoversExactlyTheStatusesTheCodeCanWrite()
     {
-        var mappings = ReadSessionStatusMappings(dashboard);
+        var dashboards = Directory.GetFiles(DashboardDirectory, "*.json");
+        Assert.NotEmpty(dashboards);
+
+        var mappings = dashboards.SelectMany(ReadSessionStatusMappings).ToArray();
+
+        // The reader's own guard, and the reason it names a floor rather than just "not empty": two
+        // dashboards carry a session-status mapping today, so if a change to their shape stopped the
+        // reader recognising them, this class would otherwise pass while checking nothing.
+        Assert.True(mappings.Length >= 2,
+            $"Expected at least two session-status mappings across {dashboards.Length} dashboards, " +
+            $"found {mappings.Length}. The reader is probably no longer recognising them.");
 
         // Set equality both ways, for the same reasons the schema agreement test gives. A missing
         // value renders uncoloured, which reads as "nothing notable here" for a status that may be
         // the most notable thing on the page. An extra value is dead configuration that looks
         // maintained — it is exactly how 'failed'/'running'/'timeout' survived being fictional.
-        Assert.NotEmpty(mappings);
-
         foreach (var (path, values) in mappings)
         {
             Assert.Equal(
-                WritableStatuses().OrderBy(v => v, StringComparer.Ordinal),
-                values.OrderBy(v => v, StringComparer.Ordinal));
-            Assert.True(values.Count > 0, path);
+                SessionStatusVocabulary.Writable,
+                SessionStatusVocabulary.Ordered(values).ToArray());
+            Assert.NotEmpty(path);
         }
     }
 
@@ -84,19 +97,8 @@ public sealed class SessionStatusDashboardAgreementTests
             .ToHashSet(StringComparer.Ordinal);
 
         Assert.Equal(
-            WritableStatuses().OrderBy(v => v, StringComparer.Ordinal),
-            offered.OrderBy(v => v, StringComparer.Ordinal));
-    }
-
-    /// <summary>
-    /// Guards the reader: if the dashboards are reshaped so no session-status mapping is recognised,
-    /// this class must fail rather than assert nothing across two green tests.
-    /// </summary>
-    [Fact]
-    public void BothDashboards_DeclareASessionStatusMapping()
-    {
-        Assert.NotEmpty(ReadSessionStatusMappings("sessions.json"));
-        Assert.NotEmpty(ReadSessionStatusMappings("sessionDetail.json"));
+            SessionStatusVocabulary.Writable,
+            SessionStatusVocabulary.Ordered(offered).ToArray());
     }
 
     /// <summary>
@@ -112,12 +114,21 @@ public sealed class SessionStatusDashboardAgreementTests
     /// and a looser rule would drag those mappings in and fail on correct configuration. The overlap
     /// is real — both vocabularies contain the word <c>timeout</c> at some point in their history —
     /// so the discriminator is the values unique to sessions, not the values they share.
+    /// <para>
+    /// It therefore stays a hand-written list rather than being derived from
+    /// <see cref="SessionStatusVocabulary.Writable"/>, which looks like a fifth copy and was raised as
+    /// one. Deriving it would break the discrimination the moment a session status shares a word with
+    /// the tool vocabulary — <c>timeout</c> is the obvious candidate — at which point this reader
+    /// would start dragging in tool-result mappings and failing on correct configuration. The floor
+    /// assertion above is what stops the list silently weakening instead.
+    /// </para>
     /// </remarks>
-    private static List<(string Path, HashSet<string> Values)> ReadSessionStatusMappings(string dashboard)
+    private static List<(string Path, HashSet<string> Values)> ReadSessionStatusMappings(string dashboardPath)
     {
         var discriminators = new[] { "active", "completed", "cancelled", "error" };
-        using var document = JsonDocument.Parse(File.ReadAllText(Path.Combine(DashboardDirectory, dashboard)));
+        using var document = JsonDocument.Parse(File.ReadAllText(dashboardPath));
 
+        var dashboard = Path.GetFileName(dashboardPath);
         var found = new List<(string, HashSet<string>)>();
         Walk(document.RootElement, "$");
         return found;

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusFrontendAgreementTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusFrontendAgreementTests.cs
@@ -1,0 +1,68 @@
+using System.Text.RegularExpressions;
+using Tests.Common;
+using Xunit;
+
+namespace Infrastructure.Observability.Tests.Schema;
+
+/// <summary>
+/// Binds the dashboard's <c>SessionStatus</c> union to the C# enum — the last of the five places this
+/// vocabulary is written down, and the one that was still relying on a comment.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why the TypeScript compiler is not enough, despite appearances.</strong> The badge's style
+/// map is keyed by the union, so a value in the union with no style is a build error. That is real,
+/// and it is also not the failure mode. It catches the union drifting from the map <em>inside</em>
+/// TypeScript; nothing catches the union drifting from the C# enum that produces the values. Add a
+/// status and the enum, the migration and both Grafana dashboards go red while the frontend compiles
+/// perfectly and renders the badge with no colour — the exact symptom this branch just finished
+/// fixing in Grafana, one layer over.
+/// </para>
+/// <para>
+/// A previous version of the sibling dashboard test asserted the compiler had this covered. It did
+/// not, and saying so was worse than saying nothing, because it is the kind of claim that stops
+/// anyone checking.
+/// </para>
+/// <para>
+/// Reading the union out of the file rather than generating it: the file also carries a colour per
+/// status, and colour is human judgement — the badge argues in its own comments why cancelled is
+/// slate rather than amber. Generating would turn that judgement into a codegen merge and fight
+/// Grafana-style edit-and-export workflows for no extra guarantee. A red test on drift buys the same
+/// thing.
+/// </para>
+/// </remarks>
+public sealed class SessionStatusFrontendAgreementTests
+{
+    private static readonly string BadgeFile = RepoRoot.Combine(
+        "src", "Content", "Presentation", "Presentation.Dashboard",
+        "src", "routes", "Sessions", "StatusBadge.tsx");
+
+    /// <summary>
+    /// Matches the exported union and captures everything between the <c>=</c> and the <c>;</c>.
+    /// </summary>
+    private static readonly Regex UnionDeclaration = new(
+        @"export\s+type\s+SessionStatus\s*=\s*(?<values>[^;]+);",
+        RegexOptions.Singleline);
+
+    [Fact]
+    public void TheDashboardsStatusUnion_MatchesTheStatusesTheCodeCanWrite()
+    {
+        var match = UnionDeclaration.Match(File.ReadAllText(BadgeFile));
+
+        // The reader's own guard. A rename or reformat that stops this matching must fail loudly
+        // rather than compare the enum against an empty set and pass.
+        Assert.True(match.Success,
+            $"No 'export type SessionStatus = ...' declaration found in {BadgeFile}. If the union " +
+            "moved or was renamed, repoint this test — do not delete it; nothing else binds the " +
+            "frontend vocabulary to the C# enum.");
+
+        var declared = match.Groups["values"].Value
+            .Split('|', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Select(v => v.Trim('\'', '"'))
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.Equal(
+            SessionStatusVocabulary.Writable,
+            SessionStatusVocabulary.Ordered(declared));
+    }
+}

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusVocabulary.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Schema/SessionStatusVocabulary.cs
@@ -1,0 +1,28 @@
+using Domain.AI.Observability.Models;
+
+namespace Infrastructure.Observability.Tests.Schema;
+
+/// <summary>
+/// The statuses the code can actually persist — the one definition every agreement test in this
+/// folder measures its artifact against.
+/// </summary>
+/// <remarks>
+/// Extracted because two suites had begun deriving it separately. That is a small duplication with a
+/// nasty shape: if <c>ToDbValue</c> ever needs an exclusion — a status the code can express but never
+/// writes — one suite would get it and the other would go on asserting the old set, and these are the
+/// only guards on this vocabulary that cannot be skipped.
+/// </remarks>
+internal static class SessionStatusVocabulary
+{
+    /// <summary>Every status the code can write, as the schema stores it.</summary>
+    public static IReadOnlyList<string> Writable { get; } =
+        [.. Enum.GetValues<SessionStatus>()
+               .Select(s => s.ToDbValue())
+               .OrderBy(v => v, StringComparer.Ordinal)];
+
+    /// <summary>The same set, ordered, for comparison against an artifact's values.</summary>
+    /// <param name="values">Values read out of a checked-in artifact.</param>
+    /// <returns>The values in the same order <see cref="Writable"/> uses.</returns>
+    public static IEnumerable<string> Ordered(IEnumerable<string> values) =>
+        values.OrderBy(v => v, StringComparer.Ordinal);
+}

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
@@ -22,6 +22,8 @@
   <ItemGroup>
     <ProjectReference Include="../../Infrastructure/Infrastructure.Postgres/Infrastructure.Postgres.csproj" />
     <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
+    <!-- FakeTimeProvider, so the schema gate's failure cooldown is tested without a sleeping test. -->
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <!--
       The observability assembly is referenced so the upgrade-path test can run the real shipped
       migration set rather than a set written for the test. A test that invented its own scripts

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/Infrastructure.Postgres.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Infrastructure/Infrastructure.Postgres/Infrastructure.Postgres.csproj" />
+    <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
     <!--
       The observability assembly is referenced so the upgrade-path test can run the real shipped
       migration set rather than a set written for the test. A test that invented its own scripts

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
@@ -1,9 +1,9 @@
-using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 using Infrastructure.Postgres.Migrations;
 using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
+using Tests.Common;
 using Xunit;
 
 namespace Infrastructure.Postgres.Tests;
@@ -29,9 +29,6 @@ namespace Infrastructure.Postgres.Tests;
 /// </remarks>
 public sealed class MigrationTestSchema : IAsyncDisposable
 {
-    private const string DefaultConnectionString =
-        "Host=localhost;Port=5432;Database=observability;Username=observability;Password=observability";
-
     /// <summary>
     /// Ledger table used by tests that do not care which ledger they write to.
     /// </summary>
@@ -69,11 +66,11 @@ public sealed class MigrationTestSchema : IAsyncDisposable
     /// </remarks>
     private long AdvisoryLockKey { get; }
 
-    private static string ConnectionString =>
-        Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN") ?? DefaultConnectionString;
-
-    private static bool IsConnectionExplicitlyConfigured =>
-        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("OBSERVABILITY_TEST_CONN"));
+    // Connection string, the environment override, what counts as an absent server, and the skip
+    // wording all come from PostgresAvailability, which Infrastructure.Observability.Tests' fixture
+    // also uses. Both suites had their own copy; that made the rule for when a Postgres suite may
+    // skip a thing stated twice, with nothing to notice the two drifting apart.
+    private static string ConnectionString => PostgresAvailability.ConnectionString;
 
     /// <summary>
     /// Creates an empty schema and returns a data source scoped to it, or skips the calling test when
@@ -105,12 +102,9 @@ public sealed class MigrationTestSchema : IAsyncDisposable
 
             return new MigrationTestSchema(NpgsqlDataSource.Create(builder.ConnectionString), schemaName);
         }
-        catch (Exception ex) when (!IsConnectionExplicitlyConfigured && IsServerAbsent(ex))
+        catch (Exception ex) when (PostgresAvailability.ShouldSkip(ex))
         {
-            Skip.If(true,
-                "Postgres is not provisioned for this run (set OBSERVABILITY_TEST_CONN or start a " +
-                "local Postgres on localhost:5432). The test is skipped rather than reported as a " +
-                "silent pass.");
+            Skip.If(true, PostgresAvailability.SkipReason);
             throw; // unreachable; Skip.If throws.
         }
         finally
@@ -195,24 +189,6 @@ public sealed class MigrationTestSchema : IAsyncDisposable
     {
         await using var cmd = DataSource.CreateCommand(sql);
         await cmd.ExecuteNonQueryAsync();
-    }
-
-    private static bool IsServerAbsent(Exception ex)
-    {
-        for (var current = ex; current is not null; current = current.InnerException)
-        {
-            if (current is SocketException socket &&
-                socket.SocketErrorCode is SocketError.ConnectionRefused
-                    or SocketError.HostNotFound
-                    or SocketError.HostUnreachable
-                    or SocketError.NetworkUnreachable
-                    or SocketError.TimedOut)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /// <inheritdoc />

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
@@ -66,12 +66,6 @@ public sealed class MigrationTestSchema : IAsyncDisposable
     /// </remarks>
     private long AdvisoryLockKey { get; }
 
-    // Connection string, the environment override, what counts as an absent server, and the skip
-    // wording all come from PostgresAvailability, which Infrastructure.Observability.Tests' fixture
-    // also uses. Both suites had their own copy; that made the rule for when a Postgres suite may
-    // skip a thing stated twice, with nothing to notice the two drifting apart.
-    private static string ConnectionString => PostgresAvailability.ConnectionString;
-
     /// <summary>
     /// Creates an empty schema and returns a data source scoped to it, or skips the calling test when
     /// no Postgres is provisioned. Callers must be <c>[SkippableFact]</c>.
@@ -82,7 +76,7 @@ public sealed class MigrationTestSchema : IAsyncDisposable
         NpgsqlDataSource? probe = null;
         try
         {
-            probe = NpgsqlDataSource.Create(ConnectionString);
+            probe = NpgsqlDataSource.Create(PostgresAvailability.ConnectionString);
 
             await using (var ping = probe.CreateCommand("SELECT 1"))
                 await ping.ExecuteScalarAsync();
@@ -98,7 +92,7 @@ public sealed class MigrationTestSchema : IAsyncDisposable
             // each physical open landed in the throwaway schema and every command after it landed in
             // public. The tests still passed their early assertions and then failed on counts that had
             // collected every other test's rows, which is a good deal more confusing than an error.
-            var builder = new NpgsqlConnectionStringBuilder(ConnectionString) { SearchPath = schemaName };
+            var builder = new NpgsqlConnectionStringBuilder(PostgresAvailability.ConnectionString) { SearchPath = schemaName };
 
             return new MigrationTestSchema(NpgsqlDataSource.Create(builder.ConnectionString), schemaName);
         }

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/MigrationTestSchema.cs
@@ -183,6 +183,21 @@ public sealed class MigrationTestSchema : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Migration options scoped to this throwaway schema.
+    /// </summary>
+    /// <param name="name">Distinguishes ledgers when one test needs more than one.</param>
+    /// <returns>Options whose ledger is local to this schema and whose lock key is unique to it.</returns>
+    /// <remarks>
+    /// Use this rather than a hardcoded key in a test class. Postgres advisory locks are cluster-wide,
+    /// not schema-scoped, so a fixed key serializes every test that uses it against every other —
+    /// invisible while one process runs a class sequentially, and a real queue the moment two
+    /// processes share a cluster, which is exactly the second-worktree arrangement this repo
+    /// recommends for running work in parallel.
+    /// </remarks>
+    public PostgresMigrationOptions OptionsFor(string name) =>
+        new($"{name}_migrations", AdvisoryLockKey);
+
     /// <summary>Runs a statement against this schema.</summary>
     /// <param name="sql">The statement to run.</param>
     public async Task ExecuteAsync(string sql)

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresAvailabilityTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresAvailabilityTests.cs
@@ -1,0 +1,109 @@
+using System.Net.Sockets;
+using Npgsql;
+using Tests.Common;
+using Xunit;
+
+namespace Infrastructure.Postgres.Tests;
+
+/// <summary>
+/// Covers the rule that decides whether a Postgres suite skips or fails — which, until it was
+/// centralised, was written twice and tested nowhere.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The consequence of getting this wrong is asymmetric and that is why it is worth its own tests.
+/// Too strict and a developer with no Postgres sees a wall of red that means nothing. Too loose and
+/// a reachable server rejecting every connection — wrong password, missing database, a schema that
+/// never got created — is reported as "not provisioned", and roughly a hundred integration tests
+/// vanish from the run while the summary still says green. The second failure is the dangerous one
+/// because it looks exactly like success.
+/// </para>
+/// <para>
+/// <strong>These tests never set the environment variable.</strong> It is process-global, xUnit runs
+/// classes in parallel, and the suites in this assembly open real connections using the value it
+/// controls — a test that flipped it would hand another test a bogus connection string, producing a
+/// failure with no relationship to the code under test. So the environment-dependent half of
+/// <c>ShouldSkip</c> is left to the integration suites that exercise it for real, and the classifier
+/// underneath, which is pure and is where the actual subtlety lives, is covered exhaustively here.
+/// </para>
+/// </remarks>
+public sealed class PostgresAvailabilityTests
+{
+    [Theory]
+    [InlineData(SocketError.ConnectionRefused)]
+    [InlineData(SocketError.HostNotFound)]
+    [InlineData(SocketError.HostUnreachable)]
+    [InlineData(SocketError.NetworkUnreachable)]
+    [InlineData(SocketError.TimedOut)]
+    public void NothingListening_CountsAsAbsent(SocketError code) =>
+        Assert.True(PostgresAvailability.IsServerAbsent(new SocketException((int)code)));
+
+    /// <summary>
+    /// A server that answers and then refuses is present, not absent.
+    /// </summary>
+    /// <remarks>
+    /// <c>ConnectionReset</c> and <c>AccessDenied</c> are the interesting pair: both are socket
+    /// errors, so a check that merely asked "is there a SocketException in here" would call them
+    /// absence and skip the suite. Something was listening in both cases.
+    /// </remarks>
+    [Theory]
+    [InlineData(SocketError.ConnectionReset)]
+    [InlineData(SocketError.AccessDenied)]
+    [InlineData(SocketError.AddressAlreadyInUse)]
+    public void AServerThatAnswersAndRefuses_IsNotAbsent(SocketError code) =>
+        Assert.False(PostgresAvailability.IsServerAbsent(new SocketException((int)code)));
+
+    [Fact]
+    public void AnAuthenticationFailure_IsNotAbsent() =>
+        Assert.False(PostgresAvailability.IsServerAbsent(
+            new PostgresException("password authentication failed", "FATAL", "FATAL", "28P01")));
+
+    /// <summary>
+    /// The socket error is found however deeply Npgsql has wrapped it.
+    /// </summary>
+    /// <remarks>
+    /// This is the whole reason the check walks the chain rather than pattern-matching the exception
+    /// it is handed. Npgsql surfaces a refused connection as an <c>NpgsqlException</c> wrapping the
+    /// <see cref="SocketException"/>, and the depth is an implementation detail that has changed
+    /// across versions — so a check written against one level of nesting would start skipping
+    /// suites, or start failing them, on a package bump and for no other reason.
+    /// </remarks>
+    [Fact]
+    public void TheSocketErrorIsFoundHoweverDeeplyItIsWrapped()
+    {
+        var buried = new InvalidOperationException(
+            "outer",
+            new NpgsqlException(
+                "Failed to connect",
+                new SocketException((int)SocketError.ConnectionRefused)));
+
+        Assert.True(PostgresAvailability.IsServerAbsent(buried));
+    }
+
+    [Fact]
+    public void AFailureWithNoSocketErrorAnywhere_IsNotAbsent() =>
+        Assert.False(PostgresAvailability.IsServerAbsent(
+            new InvalidOperationException("outer", new TimeoutException("inner"))));
+
+    /// <summary>
+    /// The skip message names the override, so an operator reading it can act on it.
+    /// </summary>
+    /// <remarks>
+    /// Not decoration: the message is the only place a developer learns that the suite is opt-in and
+    /// how to opt in. Binding it to the variable's own constant means renaming the variable cannot
+    /// leave the instructions pointing at a name that no longer exists.
+    /// </remarks>
+    [Fact]
+    public void TheSkipReason_TellsTheReaderHowToProvisionPostgres()
+    {
+        Assert.Contains(PostgresAvailability.ConnectionVariable, PostgresAvailability.SkipReason,
+            StringComparison.Ordinal);
+        Assert.Contains("skipped rather than reported as a silent pass", PostgresAvailability.SkipReason,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheDefaultConnectionString_TargetsLocalhost() =>
+        Assert.Contains("Host=localhost", PostgresAvailability.DefaultConnectionString,
+            StringComparison.Ordinal);
+}

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresSchemaGateTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresSchemaGateTests.cs
@@ -15,21 +15,25 @@ namespace Infrastructure.Postgres.Tests;
 /// </remarks>
 public sealed class PostgresSchemaGateTests
 {
-    private static MigrationScript[] Working() =>
-        [new("001_ok", "CREATE TABLE IF NOT EXISTS gate_probe (id INT)")];
+    /// <summary>
+    /// Creates the probe table, and fails if something already created it.
+    /// </summary>
+    /// <remarks>
+    /// Plain <c>CREATE TABLE</c> rather than the <c>IF NOT EXISTS</c> form, because that is what lets
+    /// the recovery test fail for a reason outside the script and then stop failing: pre-create the
+    /// table, the script collides, drop it, and the same gate instance succeeds. It is equally safe in
+    /// the run-once test, where the ready flag means the script executes exactly once anyway.
+    /// <para>
+    /// This was briefly two helpers — an idempotent one and this one — which existed only to justify
+    /// each other and cost a paragraph explaining a distinction with no behavioural consequence.
+    /// </para>
+    /// </remarks>
+    private static MigrationScript[] CreatesProbe() =>
+        [new("001_probe", "CREATE TABLE gate_probe (id INT)")];
 
     private static MigrationScript[] Broken() =>
         [new("001_broken", "CREATE TABLE gate_broken (id NOT_A_TYPE)")];
 
-    /// <summary>
-    /// Valid SQL that fails only if <c>gate_probe</c> already exists.
-    /// </summary>
-    /// <remarks>
-    /// Plain <c>CREATE TABLE</c>, deliberately not the <c>IF NOT EXISTS</c> form <see cref="Working"/>
-    /// uses. The recovery test needs a script that fails for a reason outside itself and then stops
-    /// failing, so that one gate instance can do both; with <c>IF NOT EXISTS</c> the pre-created table
-    /// is a no-op and nothing ever throws.
-    /// </remarks>
     /// <summary>
     /// Sleeps server-side long enough to be cancelled mid-flight, then creates the probe table.
     /// </summary>
@@ -37,12 +41,15 @@ public sealed class PostgresSchemaGateTests
     /// The sleep is what gives a test a window in which the migration is genuinely running, so a
     /// cancellation arrives from Postgres rather than being rejected by the gate before it starts.
     /// The table creation after it is the evidence a later, uncancelled run actually completed.
+    /// <para>
+    /// Kept short. The cancelled attempt rolls back, so the caller that must succeed afterwards sits
+    /// through the sleep a second time for no benefit — at a full second that was most of the class's
+    /// wall-clock. 400ms leaves an ample margin over the 150ms cancellation without paying for it
+    /// twice. <c>IF NOT EXISTS</c> here because this script is deliberately run twice.
+    /// </para>
     /// </remarks>
     private static MigrationScript[] SlowThenCreatesProbe() =>
-        [new("001_slow", "SELECT pg_sleep(1); CREATE TABLE IF NOT EXISTS gate_probe (id INT)")];
-
-    private static MigrationScript[] FailsIfProbeExists() =>
-        [new("001_probe", "CREATE TABLE gate_probe (id INT)")];
+        [new("001_slow", "SELECT pg_sleep(0.4); CREATE TABLE IF NOT EXISTS gate_probe (id INT)")];
 
     [SkippableFact]
     public async Task TheMigrationsRunOnce_HoweverManyConnectionsAsk()
@@ -50,7 +57,7 @@ public sealed class PostgresSchemaGateTests
         await using var schema = await MigrationTestSchema.CreateAsync();
 
         var options = schema.OptionsFor("once");
-        var gate = new PostgresSchemaGate(options, Working(), NullLogger.Instance);
+        var gate = new PostgresSchemaGate(options, CreatesProbe(), NullLogger.Instance);
 
         for (var i = 0; i < 5; i++)
         {
@@ -161,7 +168,7 @@ public sealed class PostgresSchemaGateTests
 
         var clock = new FakeTimeProvider();
         var gate = new PostgresSchemaGate(
-            schema.OptionsFor("recover"), FailsIfProbeExists(), NullLogger.Instance, clock);
+            schema.OptionsFor("recover"), CreatesProbe(), NullLogger.Instance, clock);
         await using var connection = await schema.OpenAsync();
 
         // Make the working script fail for a reason outside itself.
@@ -203,7 +210,7 @@ public sealed class PostgresSchemaGateTests
         // is how the first version of this test managed to pass with the guard deleted. The failure
         // has to come back from Postgres for the caching decision to be exercised at all.
         await using (var slow = await schema.OpenAsync())
-        using (var cancelling = new CancellationTokenSource(TimeSpan.FromMilliseconds(250)))
+        using (var cancelling = new CancellationTokenSource(TimeSpan.FromMilliseconds(150)))
         {
             await Assert.ThrowsAnyAsync<Exception>(() => gate.EnsureAsync(slow, cancelling.Token));
         }

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresSchemaGateTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresSchemaGateTests.cs
@@ -1,0 +1,141 @@
+using Infrastructure.Postgres.Migrations;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Infrastructure.Postgres.Tests;
+
+/// <summary>
+/// The gate's own behaviour: run once, then get out of the way — and do not hammer a database that
+/// has already said no.
+/// </summary>
+/// <remarks>
+/// These use a real Postgres because the thing being counted is database round trips, and a fake
+/// runner would let the test agree with itself. The clock is fake so nothing sleeps.
+/// </remarks>
+public sealed class PostgresSchemaGateTests
+{
+    private static readonly PostgresMigrationOptions Options =
+        new("gate_test_migrations", 0x67617465745F31L);
+
+    private static MigrationScript[] Working() =>
+        [new("001_ok", "CREATE TABLE IF NOT EXISTS gate_probe (id INT)")];
+
+    private static MigrationScript[] Broken() =>
+        [new("001_broken", "CREATE TABLE gate_broken (id NOT_A_TYPE)")];
+
+    [SkippableFact]
+    public async Task TheMigrationsRunOnce_HoweverManyConnectionsAsk()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var gate = new PostgresSchemaGate(Options, Working(), NullLogger.Instance);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await using var connection = await schema.OpenAsync();
+            await gate.EnsureAsync(connection);
+        }
+
+        // One ledger row, not five: the second caller onwards short-circuits on the ready flag rather
+        // than re-running and relying on the runner to find nothing pending.
+        Assert.Equal(1, await schema.ScalarAsync<int>(
+            $"SELECT COUNT(*) FROM {Options.LedgerTable}"));
+    }
+
+    /// <summary>
+    /// A failure is reported to every caller, but only re-attempted against the database once per
+    /// cooldown window.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Exception identity is the instrument. A run that reaches Postgres builds a new
+    /// <see cref="PostgresMigrationException"/> around whatever the server said, so the very same
+    /// object coming back twice can only mean the second call never went.
+    /// </para>
+    /// <para>
+    /// The first instrument tried here was the ledger table — present means an attempt happened.
+    /// It does not: the whole run is one transaction, so a failure rolls back the
+    /// <c>CREATE TABLE IF NOT EXISTS</c> for the ledger along with everything else, which
+    /// <c>AFailingMigrationThrows_AndLeavesTheDatabaseAtItsPreviousVersion</c> already asserts. The
+    /// test failed for a reason that had nothing to do with the cooldown.
+    /// </para>
+    /// </remarks>
+    [SkippableFact]
+    public async Task WithinTheCooldown_AFailureIsReplayedWithoutTouchingTheDatabase()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var clock = new FakeTimeProvider();
+        var gate = new PostgresSchemaGate(Options, Broken(), NullLogger.Instance, clock);
+
+        await using var connection = await schema.OpenAsync();
+
+        var first = await Assert.ThrowsAsync<PostgresMigrationException>(
+            () => gate.EnsureAsync(connection));
+
+        clock.Advance(TimeSpan.FromSeconds(4));
+
+        var second = await Assert.ThrowsAsync<PostgresMigrationException>(
+            () => gate.EnsureAsync(connection));
+
+        Assert.Same(first, second);
+    }
+
+    /// <summary>
+    /// After the cooldown the database is asked again, so a fault that has since been fixed recovers
+    /// without a restart.
+    /// </summary>
+    /// <remarks>
+    /// This is the property the cooldown must not break, and it is the reason a failure does not
+    /// simply latch: Postgres being briefly unreachable while a host starts is ordinary.
+    /// </remarks>
+    [SkippableFact]
+    public async Task AfterTheCooldown_TheDatabaseIsAskedAgain()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var clock = new FakeTimeProvider();
+        var gate = new PostgresSchemaGate(Options, Broken(), NullLogger.Instance, clock);
+
+        await using var connection = await schema.OpenAsync();
+
+        var first = await Assert.ThrowsAsync<PostgresMigrationException>(
+            () => gate.EnsureAsync(connection));
+
+        clock.Advance(TimeSpan.FromSeconds(6));
+
+        var second = await Assert.ThrowsAsync<PostgresMigrationException>(
+            () => gate.EnsureAsync(connection));
+
+        // A different object, so this failure was produced by a fresh run rather than replayed from
+        // the cache. Same reasoning as the cooldown test, read the other way round.
+        Assert.NotSame(first, second);
+    }
+
+    /// <summary>
+    /// A gate that failed and then succeeds forgets the failure.
+    /// </summary>
+    /// <remarks>
+    /// Without clearing it, a gate that recovered would still be holding a stale exception. Nothing
+    /// would read it while <c>_ready</c> is set, so this is not a live defect — it is the assertion
+    /// that keeps it from becoming one if the ready check is ever reordered.
+    /// </remarks>
+    [SkippableFact]
+    public async Task ASuccessfulRunAfterAFailure_ClearsTheCachedFailure()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var clock = new FakeTimeProvider();
+        var broken = new PostgresSchemaGate(Options, Broken(), NullLogger.Instance, clock);
+        await using var connection = await schema.OpenAsync();
+
+        await Assert.ThrowsAsync<PostgresMigrationException>(() => broken.EnsureAsync(connection));
+
+        var fixedGate = new PostgresSchemaGate(Options, Working(), NullLogger.Instance, clock);
+        await fixedGate.EnsureAsync(connection);
+        await fixedGate.EnsureAsync(connection);
+
+        Assert.Equal(1, await schema.CountTablesAsync("gate_probe"));
+    }
+}

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresSchemaGateTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/PostgresSchemaGateTests.cs
@@ -15,21 +15,42 @@ namespace Infrastructure.Postgres.Tests;
 /// </remarks>
 public sealed class PostgresSchemaGateTests
 {
-    private static readonly PostgresMigrationOptions Options =
-        new("gate_test_migrations", 0x67617465745F31L);
-
     private static MigrationScript[] Working() =>
         [new("001_ok", "CREATE TABLE IF NOT EXISTS gate_probe (id INT)")];
 
     private static MigrationScript[] Broken() =>
         [new("001_broken", "CREATE TABLE gate_broken (id NOT_A_TYPE)")];
 
+    /// <summary>
+    /// Valid SQL that fails only if <c>gate_probe</c> already exists.
+    /// </summary>
+    /// <remarks>
+    /// Plain <c>CREATE TABLE</c>, deliberately not the <c>IF NOT EXISTS</c> form <see cref="Working"/>
+    /// uses. The recovery test needs a script that fails for a reason outside itself and then stops
+    /// failing, so that one gate instance can do both; with <c>IF NOT EXISTS</c> the pre-created table
+    /// is a no-op and nothing ever throws.
+    /// </remarks>
+    /// <summary>
+    /// Sleeps server-side long enough to be cancelled mid-flight, then creates the probe table.
+    /// </summary>
+    /// <remarks>
+    /// The sleep is what gives a test a window in which the migration is genuinely running, so a
+    /// cancellation arrives from Postgres rather than being rejected by the gate before it starts.
+    /// The table creation after it is the evidence a later, uncancelled run actually completed.
+    /// </remarks>
+    private static MigrationScript[] SlowThenCreatesProbe() =>
+        [new("001_slow", "SELECT pg_sleep(1); CREATE TABLE IF NOT EXISTS gate_probe (id INT)")];
+
+    private static MigrationScript[] FailsIfProbeExists() =>
+        [new("001_probe", "CREATE TABLE gate_probe (id INT)")];
+
     [SkippableFact]
     public async Task TheMigrationsRunOnce_HoweverManyConnectionsAsk()
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
 
-        var gate = new PostgresSchemaGate(Options, Working(), NullLogger.Instance);
+        var options = schema.OptionsFor("once");
+        var gate = new PostgresSchemaGate(options, Working(), NullLogger.Instance);
 
         for (var i = 0; i < 5; i++)
         {
@@ -40,7 +61,7 @@ public sealed class PostgresSchemaGateTests
         // One ledger row, not five: the second caller onwards short-circuits on the ready flag rather
         // than re-running and relying on the runner to find nothing pending.
         Assert.Equal(1, await schema.ScalarAsync<int>(
-            $"SELECT COUNT(*) FROM {Options.LedgerTable}"));
+            $"SELECT COUNT(*) FROM {options.LedgerTable}"));
     }
 
     /// <summary>
@@ -67,7 +88,7 @@ public sealed class PostgresSchemaGateTests
         await using var schema = await MigrationTestSchema.CreateAsync();
 
         var clock = new FakeTimeProvider();
-        var gate = new PostgresSchemaGate(Options, Broken(), NullLogger.Instance, clock);
+        var gate = new PostgresSchemaGate(schema.OptionsFor("cooldown"), Broken(), NullLogger.Instance, clock);
 
         await using var connection = await schema.OpenAsync();
 
@@ -96,7 +117,7 @@ public sealed class PostgresSchemaGateTests
         await using var schema = await MigrationTestSchema.CreateAsync();
 
         var clock = new FakeTimeProvider();
-        var gate = new PostgresSchemaGate(Options, Broken(), NullLogger.Instance, clock);
+        var gate = new PostgresSchemaGate(schema.OptionsFor("recovery"), Broken(), NullLogger.Instance, clock);
 
         await using var connection = await schema.OpenAsync();
 
@@ -114,27 +135,84 @@ public sealed class PostgresSchemaGateTests
     }
 
     /// <summary>
-    /// A gate that failed and then succeeds forgets the failure.
+    /// One gate instance that fails and is then given a working database recovers, and stays ready.
     /// </summary>
     /// <remarks>
-    /// Without clearing it, a gate that recovered would still be holding a stale exception. Nothing
-    /// would read it while <c>_ready</c> is set, so this is not a live defect — it is the assertion
-    /// that keeps it from becoming one if the ready check is ever reordered.
+    /// <para>
+    /// The failure is environmental rather than in the script, so the SAME gate can fail and then
+    /// succeed: <c>gate_probe</c> is pre-created with a conflicting shape, the script's plain
+    /// <c>CREATE TABLE</c> collides with it, and dropping the table repairs the condition without
+    /// touching the gate. An earlier version of this test built a second gate for the successful run,
+    /// which meant the failing instance's recovery was never exercised at all.
+    /// </para>
+    /// <para>
+    /// <strong>What this deliberately does not claim.</strong> It was originally named for clearing
+    /// the cached failure, and review showed it did not test that — deleting the line that clears it
+    /// left every test here green. Nothing can test it through behaviour: once the run succeeds the
+    /// ready flag short-circuits before the cooldown is ever consulted, so a stale cached failure is
+    /// unreachable by construction. That line releases a reference; it is not observable, and the
+    /// test no longer pretends otherwise.
+    /// </para>
     /// </remarks>
     [SkippableFact]
-    public async Task ASuccessfulRunAfterAFailure_ClearsTheCachedFailure()
+    public async Task AGateThatFailedAndThenSucceeds_IsReadyAndStaysReady()
     {
         await using var schema = await MigrationTestSchema.CreateAsync();
 
         var clock = new FakeTimeProvider();
-        var broken = new PostgresSchemaGate(Options, Broken(), NullLogger.Instance, clock);
+        var gate = new PostgresSchemaGate(
+            schema.OptionsFor("recover"), FailsIfProbeExists(), NullLogger.Instance, clock);
         await using var connection = await schema.OpenAsync();
 
-        await Assert.ThrowsAsync<PostgresMigrationException>(() => broken.EnsureAsync(connection));
+        // Make the working script fail for a reason outside itself.
+        await schema.ExecuteAsync("CREATE TABLE gate_probe (other_column TEXT)");
+        await Assert.ThrowsAsync<PostgresMigrationException>(() => gate.EnsureAsync(connection));
 
-        var fixedGate = new PostgresSchemaGate(Options, Working(), NullLogger.Instance, clock);
-        await fixedGate.EnsureAsync(connection);
-        await fixedGate.EnsureAsync(connection);
+        await schema.ExecuteAsync("DROP TABLE gate_probe");
+        clock.Advance(TimeSpan.FromSeconds(6));
+
+        await gate.EnsureAsync(connection);
+        await gate.EnsureAsync(connection);
+
+        Assert.Equal(1, await schema.CountTablesAsync("gate_probe"));
+        Assert.Equal(1, await schema.ScalarAsync<int>(
+            $"SELECT COUNT(*) FROM {schema.OptionsFor("recover").LedgerTable}"));
+    }
+
+    /// <summary>
+    /// A caller cancelling does not poison the gate for everyone else.
+    /// </summary>
+    /// <remarks>
+    /// The cooldown exists for failures that belong to the database. A cancellation belongs to one
+    /// caller, and caching it would replay one client's disconnect to every other caller for the
+    /// whole window — including callers whose connection is fine and whose schema would have applied
+    /// cleanly. In the observability store, whose writes are swallowed by design, that is a window of
+    /// silently dropped telemetry where previously the next caller simply retried and succeeded.
+    /// </remarks>
+    [SkippableFact]
+    public async Task ACancelledCaller_DoesNotPoisonTheCooldownForOthers()
+    {
+        await using var schema = await MigrationTestSchema.CreateAsync();
+
+        var clock = new FakeTimeProvider();
+        var gate = new PostgresSchemaGate(
+            schema.OptionsFor("cancel"), SlowThenCreatesProbe(), NullLogger.Instance, clock);
+
+        // Cancelled DURING the migration, not before it. An already-cancelled token would throw at
+        // the in-process lock on the first line of EnsureAsync, before the runner is reached — which
+        // is how the first version of this test managed to pass with the guard deleted. The failure
+        // has to come back from Postgres for the caching decision to be exercised at all.
+        await using (var slow = await schema.OpenAsync())
+        using (var cancelling = new CancellationTokenSource(TimeSpan.FromMilliseconds(250)))
+        {
+            await Assert.ThrowsAnyAsync<Exception>(() => gate.EnsureAsync(slow, cancelling.Token));
+        }
+
+        // No clock advance: still well inside the cooldown window. This caller has its own healthy
+        // connection and a live token, so it must be served by the database rather than by a cached
+        // copy of somebody else's cancellation.
+        await using var healthy = await schema.OpenAsync();
+        await gate.EnsureAsync(healthy);
 
         Assert.Equal(1, await schema.CountTablesAsync("gate_probe"));
     }

--- a/src/Content/Tests/Tests.Common/PostgresAvailability.cs
+++ b/src/Content/Tests/Tests.Common/PostgresAvailability.cs
@@ -1,0 +1,113 @@
+using System.Net.Sockets;
+
+namespace Tests.Common;
+
+/// <summary>
+/// Decides whether a Postgres-backed test suite should run, skip, or fail loudly — one answer, for
+/// every suite that asks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two suites need this: <c>Infrastructure.Observability.Tests</c>'s <c>PostgresFixture</c> and
+/// <c>Infrastructure.Postgres.Tests</c>'s <c>MigrationTestSchema</c>. Both had grown their own copy
+/// of the connection string, the environment-variable override, the socket-error list, and the skip
+/// message. That is a <em>policy</em>, not a utility, and it was stated twice with nothing that went
+/// red when the two disagreed: adding a socket error, honouring a second environment variable, or
+/// changing the default port would have fixed one suite and quietly left the other on the old rule.
+/// </para>
+/// <para>
+/// <strong>The policy.</strong> Nothing listening on the default local endpoint means Postgres was
+/// never provisioned, so the suite skips — that is the ordinary state of a developer machine and it
+/// must not read as failure. <em>Any</em> other failure means something is genuinely wrong: a
+/// reachable server rejecting the probe (wrong password, missing database, schema drift) is a
+/// defect, not an absence. And when the connection string was supplied explicitly, the operator or
+/// CI is asserting Postgres is there, so every failure is loud — including a refused connection,
+/// which in that context means the thing that was promised is missing.
+/// </para>
+/// <para>
+/// <strong>Why the probe itself is not here.</strong> This project has no package references at all
+/// and that is deliberate — it is referenced by nearly every test project, so anything added here is
+/// added everywhere. Npgsql and Xunit.SkippableFact would both have to come along to host the four
+/// lines that open a connection and the one line that skips. Those four lines also genuinely differ
+/// between the two callers: one keeps the data source it built, the other throws it away. What was
+/// duplicated is the decision, and the decision is expressible in the framework alone.
+/// </para>
+/// </remarks>
+public static class PostgresAvailability
+{
+    /// <summary>
+    /// The environment variable that overrides the connection string and, by being set at all,
+    /// asserts that Postgres is provisioned.
+    /// </summary>
+    public const string ConnectionVariable = "OBSERVABILITY_TEST_CONN";
+
+    /// <summary>The local endpoint assumed when nothing is configured.</summary>
+    public const string DefaultConnectionString =
+        "Host=localhost;Port=5432;Database=observability;Username=observability;Password=observability";
+
+    /// <summary>The connection string these suites should use.</summary>
+    public static string ConnectionString =>
+        Environment.GetEnvironmentVariable(ConnectionVariable) ?? DefaultConnectionString;
+
+    /// <summary>
+    /// True when the connection string came from the environment rather than the default.
+    /// </summary>
+    /// <remarks>
+    /// The caller has asserted Postgres is present, so a connectivity failure is a real defect and
+    /// must surface rather than silently disabling a hundred tests. This is what keeps CI honest:
+    /// CI always sets the variable, so CI can never skip its way to green.
+    /// </remarks>
+    public static bool IsExplicitlyConfigured =>
+        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ConnectionVariable));
+
+    /// <summary>
+    /// Why a suite was skipped. Shared so both suites tell an operator the same thing.
+    /// </summary>
+    public static string SkipReason =>
+        $"Postgres is not provisioned for this run (set {ConnectionVariable} or start a local " +
+        "Postgres on localhost:5432). The test is skipped rather than reported as a silent pass.";
+
+    /// <summary>
+    /// Whether a probe failure means "Postgres was never provisioned here" — the only case a suite
+    /// may skip on.
+    /// </summary>
+    /// <param name="exception">The failure the connection probe threw.</param>
+    /// <returns><c>true</c> to skip the suite; <c>false</c> to let the failure surface.</returns>
+    /// <remarks>
+    /// Intended as an exception filter, so a failure that is not an absence never enters the catch
+    /// block and keeps its original stack trace:
+    /// <c>catch (Exception ex) when (PostgresAvailability.ShouldSkip(ex))</c>.
+    /// </remarks>
+    public static bool ShouldSkip(Exception exception) =>
+        !IsExplicitlyConfigured && IsServerAbsent(exception);
+
+    /// <summary>
+    /// Whether a failure means nothing is listening at all, as opposed to something answering and
+    /// refusing.
+    /// </summary>
+    /// <param name="exception">The failure to inspect, including its inner exceptions.</param>
+    /// <returns><c>true</c> when no server is reachable.</returns>
+    /// <remarks>
+    /// Walks the inner-exception chain because Npgsql wraps the <see cref="SocketException"/>. The
+    /// listed codes are the ways "nothing is there" arrives; everything else — authentication, a
+    /// missing database, a schema problem — is a reachable server saying no, which must never be
+    /// masked as an unavailable fixture.
+    /// </remarks>
+    public static bool IsServerAbsent(Exception exception)
+    {
+        for (var current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is SocketException socket &&
+                socket.SocketErrorCode is SocketError.ConnectionRefused
+                    or SocketError.HostNotFound
+                    or SocketError.HostUnreachable
+                    or SocketError.NetworkUnreachable
+                    or SocketError.TimedOut)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Content/Tests/Tests.Common/PostgresAvailability.cs
+++ b/src/Content/Tests/Tests.Common/PostgresAvailability.cs
@@ -56,8 +56,13 @@ public static class PostgresAvailability
     /// The caller has asserted Postgres is present, so a connectivity failure is a real defect and
     /// must surface rather than silently disabling a hundred tests. This is what keeps CI honest:
     /// CI always sets the variable, so CI can never skip its way to green.
+    /// <para>
+    /// Private on purpose. It is half of <see cref="ShouldSkip"/>, and a public half is an invitation
+    /// to re-derive the skip decision at a call site — which is the exact duplication this type was
+    /// extracted to end.
+    /// </para>
     /// </remarks>
-    public static bool IsExplicitlyConfigured =>
+    private static bool IsExplicitlyConfigured =>
         !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ConnectionVariable));
 
     /// <summary>


### PR DESCRIPTION
Closes #307 — the follow-ups deliberately deferred from #306.

## The bug this found

`sessionDetail.json` was colouring `failed`, `running` and `timeout` — three session
statuses this system has **never once written** — while `active` and `error` had no mapping
at all. The state an operator most needs to spot rendered as plain uncoloured text, and had
done through at least two changes to the vocabulary. `sessions.json` was correct, which is
the useful part: the same list is maintained in five places and nothing compared them, so
one site drifted and its neighbour didn't.

## What now holds the vocabulary together

The session-status vocabulary lives in the C# enum, the migration SQL, two Grafana
dashboards and a TypeScript union. Before this, one binding existed. Now four of the five
are bound by tests that read the checked-in artifact — no container, cannot be skipped, and
they fail together naming each site.

The TypeScript one is worth calling out because **#306 claimed it was already covered and
it was not**. The compiler catches the union drifting from its style map *within*
TypeScript; nothing caught the union drifting from the enum that produces the values. Add a
status and C#, SQL and both dashboards go red while the frontend compiles clean and renders
the washed-out badge — the identical symptom, one layer over.

## Also here

- **The Postgres skip-or-fail rule is stated once**, in `Tests.Common`, and tested for the
  first time. Both suites had their own copy. Getting it too loose means a reachable server
  refusing every connection reads as "not provisioned" and ~100 integration tests vanish
  while the summary stays green — a failure that looks exactly like success.
- **`Infrastructure.Postgres` owns the migration-embedding glob**, imported in a line by
  each store instead of copy-pasted.
- **A failure cooldown on the schema gate.** A checksum mismatch never self-heals, and
  without a cooldown it was re-attempted on every physical connection for the life of the
  process, each attempt taking a cluster-wide lock to be told the same thing.
- **Guidance on which of two data-source wiring shapes a new store should copy**, and why a
  factory to unify them is the wrong shape.

## Two things I got wrong, corrected here

- I added a guard against one caller's cancellation poisoning the cooldown for everyone.
  It was **inert**. Measured rather than reasoned: Npgsql throws
  `OperationCanceledException` on the *outside*, wrapping `PostgresException 57014`, so the
  existing filters already excluded it. The guard is gone; the measurement is in the code so
  the next reviewer doesn't re-raise it. The regression test stays — widening the filter
  turns it red.
- Two of my own tests didn't test their names. One built a second object for the recovery
  step so the thing meant to recover never did; the other passed an already-cancelled token,
  which trips a lock before the code under test is reached. Both now fail when the behaviour
  they describe is broken.

## Deliberately not done

Deriving the dashboard reader's discriminator from the enum (it must be the values *unique*
to sessions — `tool_executions.status` shares these files and already contains `timeout`).
Latching rather than cooling down on permanent failures (forces a restart after a human
repairs the ledger in place). Hosting the glob in `Directory.Build.props` behind an opt-in
property. Renaming `OBSERVABILITY_TEST_CONN`, which is misleading now that it gates a
non-observability suite but breaks every local setup.

One reported item was **not real**: the #301 origin story was said to be retold ~16 times.
It appears 5 times across 4 files, each justifying its own local code, with the runner's
class doc already canonical. Measured before editing; nothing to consolidate.

## Test plan

- `dotnet test src/AgenticHarness.slnx` — **9,988 passed / 3 skipped / 0 failed** (branch
  started at 9,967).
- Frontend 386 passed, `tsc --noEmit` clean.
- Every new test mutation-verified. Two unexpected passes were treated as findings: one
  removed inert code, one rewrote a test that could not fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
