### PR TITLE
Wire per-agent tool authorization onto the admission chain

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -157,10 +157,16 @@ public static class DependencyInjection
         // agent identity and shares the approval router's lifetime.
         services.AddScoped<Interfaces.Governance.IToolCallObserverChain, Services.Governance.ToolCallObserverChain>();
 
-        // The composed admission chain over the four gates above. Every execution path that can reach
+        // Per-agent tool RBAC (opt-in via AI.Identity.ToolAuthorization.Enabled). Registered
+        // unconditionally and reports its own off state by admitting, so that an unregistered gate and
+        // a switched-off gate are never confusable at runtime. Scoped: it caches the workload identity
+        // it resolves for the lifetime of one turn, plan step, or direct invocation.
+        services.AddScoped<Interfaces.Governance.IAgentToolAuthorizationGate, Services.Governance.DefaultAgentToolAuthorizationGate>();
+
+        // The composed admission chain over the five gates above. Every execution path that can reach
         // a tool — the agent turn, the Execution API, and the plan engine's tool, LLM and retrieval
         // steps — calls this and nothing else, so a gate added here reaches all five at once. Scoped:
-        // it holds the four scoped gates and is reset once per turn.
+        // it holds the five scoped gates and is reset once per turn.
         services.AddScoped<Interfaces.Governance.IToolCallAdmissionPipeline, Services.Governance.ToolCallAdmissionPipeline>();
 
         // AI telemetry configurator — registers AI SDK OTel sources and processors

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAgentToolAuthorizationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAgentToolAuthorizationGate.cs
@@ -48,47 +48,11 @@ public interface IAgentToolAuthorizationGate
     /// is on is a <em>denial</em>: it is the case where the harness cannot tell who is asking,
     /// which is the one case a permissive answer would be indefensible.
     /// </returns>
-    ValueTask<AgentToolAuthorizationVerdict> EvaluateAsync(string toolKey, CancellationToken cancellationToken);
-}
-
-/// <summary>
-/// The authorization stage's verdict for one tool call.
-/// </summary>
-/// <remarks>
-/// Constructible only through the factories, matching <c>ToolCallAdmission</c>: a refusal
-/// that carried no text would reach a model as an empty successful result, which reads as
-/// the tool having run and returned nothing rather than as a refusal.
-/// </remarks>
-public sealed record AgentToolAuthorizationVerdict
-{
-    private static readonly AgentToolAuthorizationVerdict AllowedVerdict = new(true, null);
-
-    private AgentToolAuthorizationVerdict(bool isAllowed, string? deniedMessage)
-    {
-        IsAllowed = isAllowed;
-        DeniedMessage = deniedMessage;
-    }
-
-    /// <summary>Whether the agent may invoke the tool.</summary>
-    public bool IsAllowed { get; }
-
-    /// <summary>
-    /// Caller-facing refusal text: never null or blank on a denial, always null on an allow.
-    /// Deliberately uninformative about <em>why</em> — see <c>GovernanceDenials</c>.
-    /// </summary>
-    public string? DeniedMessage { get; }
-
-    /// <summary>The agent may invoke the tool, or the feature is switched off.</summary>
-    public static AgentToolAuthorizationVerdict Allow() => AllowedVerdict;
-
-    /// <summary>The agent may not invoke the tool.</summary>
-    /// <param name="deniedMessage">
-    /// The refusal text. Blank is rejected as well as null, because whitespace reaches a
-    /// model as indistinguishable from an empty result.
-    /// </param>
-    public static AgentToolAuthorizationVerdict Deny(string deniedMessage)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(deniedMessage);
-        return new AgentToolAuthorizationVerdict(false, deniedMessage);
-    }
+    /// <remarks>
+    /// Returns <see cref="ToolInvocationDecision"/> rather than a verdict type of its own. The
+    /// answer is exactly that type's shape — permitted, or refused with caller-facing text — and
+    /// <see cref="IToolCallObserverChain"/>, the other access gate in this chain, already reports
+    /// in it. A second identical record would only give the pipeline two vocabularies for one idea.
+    /// </remarks>
+    ValueTask<ToolInvocationDecision> EvaluateAsync(string toolKey, CancellationToken cancellationToken);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAgentToolAuthorizationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IAgentToolAuthorizationGate.cs
@@ -1,0 +1,94 @@
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// Admission stage that answers one question: is the <em>agent</em> executing this call
+/// permitted to invoke this tool at all?
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>The second axis of the harness's RBAC.</strong> <c>IKnowledgeScopeValidator</c>
+/// asks whether the initiating human may touch a tenant's data. This asks whether the
+/// workload identity the agent carries is allowed this tool. The two are independent and
+/// ANDed; neither substitutes for the other.
+/// </para>
+/// <para>
+/// <strong>Why this is a gate rather than a direct call to
+/// <c>IAgentIdentityValidator</c>.</strong> The validator answers a pure policy question
+/// and is unconditionally fail-closed: no policy is a denial. That is the right contract
+/// for a policy oracle and the wrong one for a pipeline stage, because a harness that has
+/// never configured tool authorization would have every call refused. This seam holds the
+/// two things the validator deliberately does not: whether the feature is switched on at
+/// all, and how the executing identity is obtained. The validator stays a pure oracle.
+/// </para>
+/// <para>
+/// <strong>Off is a real verdict, not an absence.</strong> An implementation reports its
+/// own off state by admitting the call. It is registered unconditionally for the same
+/// reason <c>IToolClassificationGate</c> is: an unregistered gate and a switched-off gate
+/// would be indistinguishable at runtime, and only one of those is safe.
+/// </para>
+/// </remarks>
+public interface IAgentToolAuthorizationGate
+{
+    /// <summary>
+    /// Decides whether the current execution's agent identity may invoke <paramref name="toolKey"/>.
+    /// </summary>
+    /// <param name="toolKey">
+    /// The tool being admitted — the keyed-DI tool key, or a plan capability token such as
+    /// <c>llm_call</c>. Matched against the agent's allowlist as-is; the gate does not treat
+    /// capability tokens specially, so a plan-running agent must be granted them explicitly
+    /// or hold the wildcard.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Cancels identity acquisition. Cancellation propagates rather than becoming a denial —
+    /// an abandoned call is not a policy decision.
+    /// </param>
+    /// <returns>
+    /// An allow when the feature is off or the identity is permitted the tool; otherwise a
+    /// denial carrying caller-facing text. Absent or unresolvable identity while the feature
+    /// is on is a <em>denial</em>: it is the case where the harness cannot tell who is asking,
+    /// which is the one case a permissive answer would be indefensible.
+    /// </returns>
+    ValueTask<AgentToolAuthorizationVerdict> EvaluateAsync(string toolKey, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The authorization stage's verdict for one tool call.
+/// </summary>
+/// <remarks>
+/// Constructible only through the factories, matching <c>ToolCallAdmission</c>: a refusal
+/// that carried no text would reach a model as an empty successful result, which reads as
+/// the tool having run and returned nothing rather than as a refusal.
+/// </remarks>
+public sealed record AgentToolAuthorizationVerdict
+{
+    private static readonly AgentToolAuthorizationVerdict AllowedVerdict = new(true, null);
+
+    private AgentToolAuthorizationVerdict(bool isAllowed, string? deniedMessage)
+    {
+        IsAllowed = isAllowed;
+        DeniedMessage = deniedMessage;
+    }
+
+    /// <summary>Whether the agent may invoke the tool.</summary>
+    public bool IsAllowed { get; }
+
+    /// <summary>
+    /// Caller-facing refusal text: never null or blank on a denial, always null on an allow.
+    /// Deliberately uninformative about <em>why</em> — see <c>GovernanceDenials</c>.
+    /// </summary>
+    public string? DeniedMessage { get; }
+
+    /// <summary>The agent may invoke the tool, or the feature is switched off.</summary>
+    public static AgentToolAuthorizationVerdict Allow() => AllowedVerdict;
+
+    /// <summary>The agent may not invoke the tool.</summary>
+    /// <param name="deniedMessage">
+    /// The refusal text. Blank is rejected as well as null, because whitespace reaches a
+    /// model as indistinguishable from an empty result.
+    /// </param>
+    public static AgentToolAuthorizationVerdict Deny(string deniedMessage)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(deniedMessage);
+        return new AgentToolAuthorizationVerdict(false, deniedMessage);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -19,6 +19,13 @@ namespace Application.AI.Common.Interfaces.Governance;
 /// </para>
 /// <list type="number">
 /// <item><description>
+/// <see cref="IAgentToolAuthorizationGate"/> — whether the executing agent's workload identity is
+/// permitted this tool at all. First because it is the most fundamental access question and the
+/// cheapest to answer, and because the next stage can escalate to a human: asking a person to
+/// approve a call that RBAC refuses anyway is a wasted interruption that also teaches operators to
+/// approve calls which were never permitted.
+/// </description></item>
+/// <item><description>
 /// <see cref="IToolInvocationGovernor"/> — permission, capability, envelope and declarative policy.
 /// </description></item>
 /// <item><description>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
@@ -72,6 +72,16 @@ public interface IToolInvocationGovernor
     /// downstream did not, and an audit trail that shows only one of those facts is telling half the
     /// story.
     /// </para>
+    /// <para>
+    /// <strong>Also used by the one stage that runs <em>before</em> the governor</strong> — the
+    /// per-agent authorization gate. "Downstream" describes the common case rather than a
+    /// restriction: what this method does is record a refusal the governor did not itself make, and
+    /// that is equally true of a stage ahead of it. The only difference is that there is no earlier
+    /// <see cref="ToolDecisionOutcome.Allowed"/> record to correct, so the denial stands alone. A
+    /// refusal that never reaches the trace is invisible to bundle-run governance reporting, the
+    /// dashboard, and the audit, which for an access-control decision is the reporting equivalent of
+    /// not enforcing it.
+    /// </para>
     /// </remarks>
     void RecordDownstreamBlock(string toolName, string reason);
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultAgentToolAuthorizationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultAgentToolAuthorizationGate.cs
@@ -1,0 +1,179 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Identity;
+using Domain.AI.Governance;
+using Domain.AI.Identity;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Default <see cref="IAgentToolAuthorizationGate"/>: switched off unless
+/// <c>AppConfig.AI.Identity.ToolAuthorization.Enabled</c> is set, and otherwise defers the
+/// policy question to <see cref="IAgentIdentityValidator"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Where the executing identity comes from, and why it is not simply read off the
+/// execution context.</strong> The context carries an identity only on the agent-turn path:
+/// the resolution behaviour stamps it for <c>IAgentScopedRequest</c>, and the plan engine's
+/// step executors and the Execution API's direct invoker each open a <em>fresh</em> DI scope,
+/// whose context therefore starts blank. Reading the context alone would leave this gate
+/// enforcing on one of the four execution paths the admission chain covers, and a control
+/// that is skippable by issuing the same call from a plan step is not a control.
+/// </para>
+/// <para>
+/// So the gate falls back to resolving the identity itself. That is sound rather than a
+/// workaround because <see cref="AgentIdentity"/> is a <em>workload</em> identity — the
+/// Entra-bound principal of the running agent, obtained from managed identity, a federated
+/// credential, or a certificate — not a per-request or per-user value. Resolving it from a
+/// child scope yields the same principal the parent turn would have carried; the resolver is
+/// a singleton for exactly that reason. The result is cached for this scope's lifetime so a
+/// plan step issuing many tool calls pays at most one acquisition.
+/// </para>
+/// <para>
+/// <strong>Every path out of an enabled gate that is not a positive allow is a denial.</strong>
+/// No validator registered, no identity resolvable, a resolver failure — each is a case where
+/// the harness cannot establish who is asking. Treating any of them as permissive would
+/// reproduce the defect this type exists to close, and matches the standing rule that an
+/// unestablished scope is never a safe default.
+/// </para>
+/// </remarks>
+public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationGate
+{
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly IAgentExecutionContext _executionContext;
+    private readonly IAgentIdentityValidator? _validator;
+    private readonly IAgentIdentityResolver? _resolver;
+    private readonly ILogger<DefaultAgentToolAuthorizationGate> _logger;
+
+    // Scoped service, so this caches for one turn / one plan step / one direct invocation.
+    private AgentIdentity? _resolvedIdentity;
+    private bool _resolutionAttempted;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultAgentToolAuthorizationGate"/> class.
+    /// </summary>
+    /// <param name="appConfig">Supplies the feature switch and the per-agent allowlist.</param>
+    /// <param name="executionContext">
+    /// The current scope's execution context. Carries the identity already on the agent-turn
+    /// path; blank on the plan and Execution API paths, which is why it is only the first place
+    /// looked rather than the only one.
+    /// </param>
+    /// <param name="logger">Records why an enabled gate could not establish an identity.</param>
+    /// <param name="validator">
+    /// The policy oracle. Optional so that a host composing this layer without the Infrastructure
+    /// identity registrations still starts; an enabled gate with no validator denies rather than
+    /// admits, and <c>ToolAuthorizationConfigValidator</c> turns that combination into a startup
+    /// failure so it is not first discovered as a refused tool call.
+    /// </param>
+    /// <param name="resolver">
+    /// Supplies the workload identity when the execution context has none. Optional for the same
+    /// reason as <paramref name="validator"/>, and with the same fail-closed consequence.
+    /// </param>
+    public DefaultAgentToolAuthorizationGate(
+        IOptionsMonitor<AppConfig> appConfig,
+        IAgentExecutionContext executionContext,
+        ILogger<DefaultAgentToolAuthorizationGate> logger,
+        IAgentIdentityValidator? validator = null,
+        IAgentIdentityResolver? resolver = null)
+    {
+        ArgumentNullException.ThrowIfNull(appConfig);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _appConfig = appConfig;
+        _executionContext = executionContext;
+        _logger = logger;
+        _validator = validator;
+        _resolver = resolver;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<AgentToolAuthorizationVerdict> EvaluateAsync(
+        string toolKey,
+        CancellationToken cancellationToken)
+    {
+        var identityConfig = _appConfig.CurrentValue.AI?.Identity;
+        if (identityConfig?.ToolAuthorization is not { Enabled: true })
+            return AgentToolAuthorizationVerdict.Allow();
+
+        if (_validator is null)
+        {
+            _logger.LogError(
+                "Tool authorization is enabled but no IAgentIdentityValidator is registered; "
+                + "refusing {ToolKey}. Register the Infrastructure identity services or turn "
+                + "AI.Identity.ToolAuthorization.Enabled off.",
+                toolKey);
+            return Deny(toolKey);
+        }
+
+        var identity = await GetIdentityAsync(cancellationToken).ConfigureAwait(false);
+        if (identity is null)
+        {
+            _logger.LogWarning(
+                "Tool authorization is enabled but no agent identity could be established; "
+                + "refusing {ToolKey}.",
+                toolKey);
+            return Deny(toolKey);
+        }
+
+        return _validator.CanInvoke(identity, toolKey)
+            ? AgentToolAuthorizationVerdict.Allow()
+            : Deny(toolKey);
+    }
+
+    private async ValueTask<AgentIdentity?> GetIdentityAsync(CancellationToken cancellationToken)
+    {
+        // The context wins when it has one: on the agent-turn path the resolution behaviour has
+        // already paid for acquisition, and re-resolving would both waste a round trip and risk
+        // answering with a different principal than the rest of the turn is using.
+        if (_executionContext.AgentIdentity is { } stamped)
+            return stamped;
+
+        if (_resolutionAttempted)
+            return _resolvedIdentity;
+
+        _resolutionAttempted = true;
+
+        if (_resolver is null)
+        {
+            _logger.LogError(
+                "Tool authorization is enabled but no IAgentIdentityResolver is registered, so an "
+                + "identity cannot be established outside an agent turn.");
+            return null;
+        }
+
+        var identityConfig = _appConfig.CurrentValue.AI!.Identity!;
+        var credentialContext = new CredentialContext
+        {
+            Audience = identityConfig.DefaultAudience,
+            Scopes = [.. identityConfig.DefaultScopes]
+        };
+
+        var resolution = await _resolver
+            .ResolveAsync(credentialContext, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!resolution.IsSuccess || resolution.Value is null)
+        {
+            // Stable codes only. A credential provider's exception text can carry a token, a SAS
+            // query string, or a certificate path; the provider is responsible for logging the
+            // detail, and this records only that acquisition failed and why in scrubbed terms.
+            _logger.LogError(
+                "Agent identity resolution failed while authorizing a tool call: {Errors}",
+                resolution.Errors.Count == 0 ? "no error details" : string.Join("; ", resolution.Errors));
+            return null;
+        }
+
+        _resolvedIdentity = resolution.Value;
+        return _resolvedIdentity;
+    }
+
+    // Routed through the shared factory so this stage's refusal is textually identical to every
+    // other gate's: a denied caller must not be able to infer which gate fired.
+    private static AgentToolAuthorizationVerdict Deny(string toolKey) =>
+        AgentToolAuthorizationVerdict.Deny(GovernanceDenials.NotPermitted(toolKey));
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultAgentToolAuthorizationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultAgentToolAuthorizationGate.cs
@@ -5,6 +5,7 @@ using Domain.AI.Governance;
 using Domain.AI.Identity;
 using Domain.Common;
 using Domain.Common.Config;
+using Domain.Common.Config.AI.Identity;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -94,13 +95,13 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
     }
 
     /// <inheritdoc />
-    public async ValueTask<AgentToolAuthorizationVerdict> EvaluateAsync(
+    public async ValueTask<ToolInvocationDecision> EvaluateAsync(
         string toolKey,
         CancellationToken cancellationToken)
     {
         var identityConfig = _appConfig.CurrentValue.AI?.Identity;
         if (identityConfig?.ToolAuthorization is not { Enabled: true } toolAuthorization)
-            return AgentToolAuthorizationVerdict.Allow();
+            return ToolInvocationDecision.Allow();
 
         // ToolAuthorizationConfigValidator refuses to boot on this, but configuration is monitored
         // rather than snapshotted: flipping Enabled to true in appsettings.json on a running host
@@ -127,7 +128,7 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
             return Deny(toolKey);
         }
 
-        var identity = await GetIdentityAsync(cancellationToken).ConfigureAwait(false);
+        var identity = await GetIdentityAsync(identityConfig, cancellationToken).ConfigureAwait(false);
         if (identity is null)
         {
             _logger.LogWarning(
@@ -138,11 +139,16 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
         }
 
         return _validator.CanInvoke(identity, toolKey)
-            ? AgentToolAuthorizationVerdict.Allow()
+            ? ToolInvocationDecision.Allow()
             : Deny(toolKey);
     }
 
-    private async ValueTask<AgentIdentity?> GetIdentityAsync(CancellationToken cancellationToken)
+    // Takes the config the caller already resolved rather than reading CurrentValue again: a second
+    // read is a second snapshot, and it previously needed two null-forgiving operators to assert a
+    // shape the caller had in fact just checked.
+    private async ValueTask<AgentIdentity?> GetIdentityAsync(
+        AgentIdentityConfig identityConfig,
+        CancellationToken cancellationToken)
     {
         // The context wins when it has one: on the agent-turn path the resolution behaviour has
         // already paid for acquisition, and re-resolving would both waste a round trip and risk
@@ -162,7 +168,6 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
             return null;
         }
 
-        var identityConfig = _appConfig.CurrentValue.AI!.Identity!;
         var credentialContext = new CredentialContext
         {
             Audience = identityConfig.DefaultAudience,
@@ -176,21 +181,19 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
                 .ResolveAsync(credentialContext, cancellationToken)
                 .ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
-        {
-            // Deliberately NOT latched, and deliberately not converted to a denial. An abandoned call
-            // is not a policy decision, and this scope outlives the call: a DI scope spans every turn
-            // of a conversation, so latching here would let one cancelled acquisition deny every tool
-            // call for the rest of that conversation — with the wording of a policy refusal.
-            throw;
-        }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             // A consumer-supplied IAgentCredentialProvider that throws rather than returning a failed
             // Result must still fail closed. Letting this escape would surface on the tool path as an
             // unhandled fault instead of the refusal this class promises. Latched, because a provider
             // that throws is a misconfiguration rather than a blip, and retrying it once per tool call
             // would hammer a credential endpoint.
+            //
+            // Cancellation is excluded by the filter rather than rethrown from a second catch block,
+            // so that it is never latched either: an abandoned call is not a policy decision, and this
+            // scope outlives the call — a DI scope spans every turn of a conversation, so latching
+            // here would let one cancelled acquisition deny every tool call for the rest of that
+            // conversation, in the wording of a policy refusal.
             _resolutionAttempted = true;
             _logger.LogError(
                 ex,
@@ -218,6 +221,6 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
 
     // Routed through the shared factory so this stage's refusal is textually identical to every
     // other gate's: a denied caller must not be able to infer which gate fired.
-    private static AgentToolAuthorizationVerdict Deny(string toolKey) =>
-        AgentToolAuthorizationVerdict.Deny(GovernanceDenials.NotPermitted(toolKey));
+    private static ToolInvocationDecision Deny(string toolKey) =>
+        ToolInvocationDecision.Deny(GovernanceDenials.NotPermitted(toolKey));
 }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultAgentToolAuthorizationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultAgentToolAuthorizationGate.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Identity;
 using Domain.AI.Governance;
 using Domain.AI.Identity;
+using Domain.Common;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -52,6 +53,7 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
     // Scoped service, so this caches for one turn / one plan step / one direct invocation.
     private AgentIdentity? _resolvedIdentity;
     private bool _resolutionAttempted;
+    private bool _warnedEmptyAllowlist;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DefaultAgentToolAuthorizationGate"/> class.
@@ -97,8 +99,23 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
         CancellationToken cancellationToken)
     {
         var identityConfig = _appConfig.CurrentValue.AI?.Identity;
-        if (identityConfig?.ToolAuthorization is not { Enabled: true })
+        if (identityConfig?.ToolAuthorization is not { Enabled: true } toolAuthorization)
             return AgentToolAuthorizationVerdict.Allow();
+
+        // ToolAuthorizationConfigValidator refuses to boot on this, but configuration is monitored
+        // rather than snapshotted: flipping Enabled to true in appsettings.json on a running host
+        // activates enforcement without passing through startup at all. The verdict is the same
+        // either way — an empty allowlist denies everyone — so what is missing at runtime is not
+        // safety but the explanation, and a blanket denial with no stated cause is the hardest
+        // possible thing to diagnose from the outside. Logged once per scope rather than per call.
+        if (toolAuthorization.AllowedToolsByAgentId.Count == 0 && !_warnedEmptyAllowlist)
+        {
+            _warnedEmptyAllowlist = true;
+            _logger.LogError(
+                "Tool authorization is enabled with an empty AllowedToolsByAgentId, so every tool "
+                + "call is refused. If this host did not fail at startup, the setting was changed on "
+                + "a running host and never validated.");
+        }
 
         if (_validator is null)
         {
@@ -136,10 +153,9 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
         if (_resolutionAttempted)
             return _resolvedIdentity;
 
-        _resolutionAttempted = true;
-
         if (_resolver is null)
         {
+            _resolutionAttempted = true;
             _logger.LogError(
                 "Tool authorization is enabled but no IAgentIdentityResolver is registered, so an "
                 + "identity cannot be established outside an agent turn.");
@@ -153,9 +169,37 @@ public sealed class DefaultAgentToolAuthorizationGate : IAgentToolAuthorizationG
             Scopes = [.. identityConfig.DefaultScopes]
         };
 
-        var resolution = await _resolver
-            .ResolveAsync(credentialContext, cancellationToken)
-            .ConfigureAwait(false);
+        Result<AgentIdentity> resolution;
+        try
+        {
+            resolution = await _resolver
+                .ResolveAsync(credentialContext, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Deliberately NOT latched, and deliberately not converted to a denial. An abandoned call
+            // is not a policy decision, and this scope outlives the call: a DI scope spans every turn
+            // of a conversation, so latching here would let one cancelled acquisition deny every tool
+            // call for the rest of that conversation — with the wording of a policy refusal.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // A consumer-supplied IAgentCredentialProvider that throws rather than returning a failed
+            // Result must still fail closed. Letting this escape would surface on the tool path as an
+            // unhandled fault instead of the refusal this class promises. Latched, because a provider
+            // that throws is a misconfiguration rather than a blip, and retrying it once per tool call
+            // would hammer a credential endpoint.
+            _resolutionAttempted = true;
+            _logger.LogError(
+                ex,
+                "Agent identity resolution threw while authorizing a tool call; refusing the call. "
+                + "The credential provider is responsible for the detail behind this.");
+            return null;
+        }
+
+        _resolutionAttempted = true;
 
         if (!resolution.IsSuccess || resolution.Value is null)
         {

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -117,7 +117,14 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             .EvaluateAsync(toolName, cancellationToken)
             .ConfigureAwait(false);
         if (!authorization.IsAllowed)
+        {
+            // Put the refusal on the turn's trace. Running ahead of the governor means the governor
+            // records nothing for this call — it never sees it — so without this an RBAC denial is
+            // absent from governance reporting, the dashboard and the audit, and a turn in which an
+            // agent was refused every tool it tried reads as a turn in which nothing was denied.
+            _governor.RecordDownstreamBlock(toolName, "denied by per-agent tool authorization");
             return Refuse(authorization.DeniedMessage, toolName);
+        }
 
         // 2 — the built-in governor. Arguments are passed through as the caller supplied them,
         // null included: the governor distinguishes "no arguments were available" from "the call had

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -43,6 +43,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     private static readonly IReadOnlyDictionary<string, object?> EmptyArguments =
         ReadOnlyDictionary<string, object?>.Empty;
 
+    private readonly IAgentToolAuthorizationGate _authorizationGate;
     private readonly IToolInvocationGovernor _governor;
     private readonly IToolClassificationGate _classificationGate;
     private readonly IToolCallObserverChain _observers;
@@ -50,31 +51,39 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     private readonly ILogger<ToolCallAdmissionPipeline> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="ToolCallAdmissionPipeline"/> class.</summary>
-    /// <param name="governor">Stage 1 — permission, capability, envelope and declarative policy.</param>
+    /// <param name="authorizationGate">
+    /// Stage 1 — whether the executing agent identity is permitted this tool. Required rather than
+    /// optional, on the same argument as the two stages below: it reports its own off state by
+    /// admitting, so an absent gate and a switched-off gate would be indistinguishable at runtime.
+    /// </param>
+    /// <param name="governor">Stage 2 — permission, capability, envelope and declarative policy.</param>
     /// <param name="classificationGate">
-    /// Stage 2 — data sensitivity. Required rather than optional: it is registered unconditionally and
+    /// Stage 3 — data sensitivity. Required rather than optional: it is registered unconditionally and
     /// reports its own off state internally, so an absent one would be indistinguishable at runtime from
     /// a host that turned classification off, and only one of those is safe.
     /// </param>
     /// <param name="observers">
-    /// Stage 3 — the host's own rules. Required for the same reason: an absent chain and a chain with
+    /// Stage 4 — the host's own rules. Required for the same reason: an absent chain and a chain with
     /// nothing in it are indistinguishable at runtime.
     /// </param>
-    /// <param name="progressEvaluator">Stage 4 — the loop guard.</param>
+    /// <param name="progressEvaluator">Stage 5 — the loop guard.</param>
     /// <param name="logger">Records a redaction that could not be applied.</param>
     public ToolCallAdmissionPipeline(
+        IAgentToolAuthorizationGate authorizationGate,
         IToolInvocationGovernor governor,
         IToolClassificationGate classificationGate,
         IToolCallObserverChain observers,
         IProgressEvaluator progressEvaluator,
         ILogger<ToolCallAdmissionPipeline> logger)
     {
+        ArgumentNullException.ThrowIfNull(authorizationGate);
         ArgumentNullException.ThrowIfNull(governor);
         ArgumentNullException.ThrowIfNull(classificationGate);
         ArgumentNullException.ThrowIfNull(observers);
         ArgumentNullException.ThrowIfNull(progressEvaluator);
         ArgumentNullException.ThrowIfNull(logger);
 
+        _authorizationGate = authorizationGate;
         _governor = governor;
         _classificationGate = classificationGate;
         _observers = observers;
@@ -92,7 +101,25 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         var toolName = request.ToolName;
         var arguments = request.Arguments ?? EmptyArguments;
 
-        // 1 — the built-in governor. Arguments are passed through as the caller supplied them,
+        // 1 — per-agent tool authorization, ahead of everything else. It is the cheapest stage (a
+        // dictionary lookup once an identity is in hand) and the most fundamental question — whether
+        // this agent may use this tool at all — so nothing more expensive should run before it. The
+        // ordering is load-bearing rather than merely tidy: the governor below can escalate to a human
+        // for approval, and asking a person to approve a call that RBAC refuses anyway is both a wasted
+        // interruption and a way to train operators to approve calls that were never permitted.
+        //
+        // Applied to capability gates (null arguments) as well as real tool calls. Unlike the
+        // classification gate below, there is nothing here that degrades without arguments: the
+        // question is about the caller's identity and the operation's name, both of which are always
+        // present. Exempting the plan engine's llm_call and rag_retrieval would leave an agent barred
+        // from a tool able to reach equivalent capability through a plan step.
+        var authorization = await _authorizationGate
+            .EvaluateAsync(toolName, cancellationToken)
+            .ConfigureAwait(false);
+        if (!authorization.IsAllowed)
+            return Refuse(authorization.DeniedMessage, toolName);
+
+        // 2 — the built-in governor. Arguments are passed through as the caller supplied them,
         // null included: the governor distinguishes "no arguments were available" from "the call had
         // none", and narrows its argument-conditioned rules accordingly.
         var decision = await _governor
@@ -101,7 +128,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         if (!decision.IsAllowed)
             return Refuse(decision.DeniedMessage, toolName);
 
-        // 2 — data classification, for calls that have a data surface to classify. A block refuses the
+        // 3 — data classification, for calls that have a data surface to classify. A block refuses the
         // call outright; a redact verdict lets it run and scrubs the output afterwards, which is why
         // the verdict survives past this stage.
         //
@@ -126,7 +153,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 return Refuse(classification.BlockedMessage, toolName);
         }
 
-        // 3 — the host's own rules, last of the access gates.
+        // 4 — the host's own rules, last of the access gates.
         if (_observers.HasObservers)
         {
             var observed = await _observers
@@ -136,7 +163,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 return Refuse(observed.DeniedMessage, toolName);
         }
 
-        // 4 — the loop guard, last of all, and only for callers that issue a sequence.
+        // 5 — the loop guard, last of all, and only for callers that issue a sequence.
         if (request.CountsTowardLoopDetection)
         {
             var verdict = _progressEvaluator.Evaluate(

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -427,9 +427,16 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     /// <inheritdoc />
     public void RecordDownstreamBlock(string toolName, string reason)
     {
-        // Only meaningful for a turn this governor actually evaluated. Off the enforced path the
-        // governor recorded nothing, so there is no allow to correct and nothing to add.
-        if (!_enforcedObserved)
+        // Only meaningful on an enforced turn. Off that path the governor recorded nothing, so there
+        // is no allow to correct and nothing to add.
+        //
+        // EnforcementActive is consulted as well as _enforcedObserved, and the difference is
+        // load-bearing: the authorization gate runs BEFORE this governor, so on the first tool call
+        // of a turn nothing has set _enforcedObserved yet. Keying only on that flag silently dropped
+        // every RBAC refusal that arrived first — which is most of them, since a refused call never
+        // goes on to reach the governor at all. This matches how GetTrace already decides whether a
+        // turn was enforced.
+        if (!_enforcedObserved && !EnforcementActive)
             return;
 
         var radius = _toolRiskClassifier.Classify(toolName).Radius;

--- a/src/Content/Domain/Domain.AI/Identity/AgentIdentity.cs
+++ b/src/Content/Domain/Domain.AI/Identity/AgentIdentity.cs
@@ -23,7 +23,14 @@ namespace Domain.AI.Identity;
 /// not in constructors. This record accepts any non-null <see cref="Id"/> and any
 /// <see cref="AgentIdentityKind"/>; <c>IAgentIdentityValidator</c> enforces the
 /// real invariants (no <see cref="AgentIdentityKind.Unspecified"/>, kind-specific required
-/// fields, etc.).
+/// fields, etc.) when it is consulted.
+/// </para>
+/// <para>
+/// It is consulted on the live tool path through <c>IAgentToolAuthorizationGate</c>, stage 1 of
+/// the tool-call admission chain, and only while
+/// <c>AppConfig.AI.Identity.ToolAuthorization.Enabled</c> is set — the feature is opt-in, and with
+/// it off no invariant on this record is enforced at all. Treat an <see cref="AgentIdentity"/>
+/// obtained from anywhere as unvalidated data until that gate has passed it.
 /// </para>
 /// </remarks>
 public sealed record AgentIdentity

--- a/src/Content/Domain/Domain.AI/Identity/AgentIdentityKind.cs
+++ b/src/Content/Domain/Domain.AI/Identity/AgentIdentityKind.cs
@@ -10,7 +10,9 @@ namespace Domain.AI.Identity;
 /// The <see cref="Unspecified"/> sentinel is the default. Treating <c>default</c> as a real
 /// kind would let an uninitialised identity pass type checks; the sentinel forces callers
 /// to set a kind explicitly. <c>IAgentIdentityValidator</c> rejects identities with
-/// <see cref="Unspecified"/> as the kind.
+/// <see cref="Unspecified"/> as the kind — reached on the live tool path through
+/// <c>IAgentToolAuthorizationGate</c>, and only while
+/// <c>AppConfig.AI.Identity.ToolAuthorization.Enabled</c> is set.
 /// </remarks>
 public enum AgentIdentityKind
 {

--- a/src/Content/Domain/Domain.Common/Config/AI/Identity/AgentIdentityConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Identity/AgentIdentityConfig.cs
@@ -70,9 +70,15 @@ public class AgentIdentityConfig
     public ClientSecretProviderConfig ClientSecret { get; set; } = new();
 
     /// <summary>
-    /// Per-agent tool-invocation allowlist consumed by
-    /// <c>IAgentIdentityValidator</c>. Fail-closed by default — an agent not present
-    /// in the allowlist is denied every tool. Wildcard <c>"*"</c> grants all tools.
+    /// Per-agent tool-invocation allowlist consumed by <c>IAgentIdentityValidator</c>,
+    /// and the switch that decides whether it is consulted at all. Off by default; when
+    /// on, it is fail-closed — an agent not present in the allowlist is denied every
+    /// tool, and wildcard <c>"*"</c> grants all tools.
     /// </summary>
+    /// <remarks>
+    /// <see cref="ToolAuthorizationConfig.Enabled"/> is separate from <see cref="Enabled"/>
+    /// on purpose, and turning it on requires this one to be on too — see the remarks on
+    /// <see cref="ToolAuthorizationConfig"/>.
+    /// </remarks>
     public ToolAuthorizationConfig ToolAuthorization { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Identity/ToolAuthorizationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Identity/ToolAuthorizationConfig.cs
@@ -35,6 +35,37 @@ public class ToolAuthorizationConfig
     public const string WildcardToken = "*";
 
     /// <summary>
+    /// Master switch for per-agent tool authorization. <c>false</c> by default: the
+    /// admission chain's authorization stage reports itself off and admits every call,
+    /// which is the harness's behaviour for every release before this switch existed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deliberately separate from <see cref="AgentIdentityConfig.Enabled"/>. That switch
+    /// answers "does this agent carry an Entra-bound workload identity for outbound
+    /// calls"; this one answers "is that identity used to decide which tools the agent
+    /// may invoke here". A consumer may want the first without the second — acquiring a
+    /// managed identity to call Azure is not a statement about local tool policy — so
+    /// coupling them would force an allowlist on consumers who only wanted a token.
+    /// </para>
+    /// <para>
+    /// Turning this on has hard prerequisites, all enforced at startup by
+    /// <c>ToolAuthorizationConfigValidator</c> rather than discovered as a silent
+    /// total denial at the first tool call: <see cref="AgentIdentityConfig.Enabled"/>
+    /// must also be on (with it off there is no identity to authorize, and every call
+    /// would be refused), and <see cref="AllowedToolsByAgentId"/> must name at least
+    /// one agent.
+    /// </para>
+    /// <para>
+    /// The allowlist is keyed by tool key, and the plan engine's capability gates
+    /// (<c>llm_call</c>, <c>rag_retrieval</c>) pass through the same chain under those
+    /// names. An agent that runs plans needs them listed — or the wildcard — alongside
+    /// its real tools.
+    /// </para>
+    /// </remarks>
+    public bool Enabled { get; set; }
+
+    /// <summary>
     /// Per-agent allowlists keyed by <c>AgentIdentity.Id</c>. AgentId matching is
     /// case-insensitive; tool-key matching is case-sensitive.
     /// </summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/A2AIdentityPropagator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/A2AIdentityPropagator.cs
@@ -68,11 +68,11 @@ public sealed class A2AIdentityPropagator
         // established". A bare Enum.TryParse accepts "99" and yields a Kind that is not a member and,
         // decisively, not Unspecified either: it looks resolved to anything testing for Unspecified.
         //
-        // On the intended consumer this would matter: EntraAgentIdentityValidator.CanInvoke denies on
-        // exactly that condition. Measured 8 Aug 2026 — CanInvoke has NO production caller.
-        // IAgentIdentityValidator is registered in DI and injected nowhere, so the tool-authorization
-        // control is currently inert. Do not read the paragraph above as "a live gate was bypassed";
-        // read it as the contract this field must honour for the day that control is wired up.
+        // That matters on a live path: EntraAgentIdentityValidator.CanInvoke denies on exactly that
+        // condition, and since #311 it is reached for every tool call through stage 1 of the
+        // tool-call admission chain (IAgentToolAuthorizationGate) whenever
+        // AI.Identity.ToolAuthorization.Enabled is set. An "identity" carrying a non-member kind
+        // would otherwise satisfy the Unspecified check and be authorized as though established.
         //
         // One deliberate WIDENING comes with the switch: the previous call omitted ignoreCase, so it
         // was case-sensitive and "managedidentity" landed on Unspecified. The shared reader is

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Identity.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Identity.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Identity;
 using Infrastructure.AI.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Infrastructure.AI;
 
@@ -43,7 +44,13 @@ public static partial class DependencyInjection
         services.AddSingleton<IAgentIdentityResolver, EntraAgentIdResolver>();
 
         // Tool-level RBAC validator — consults the static per-agent allowlist in
-        // AppConfig.AI.Identity.ToolAuthorization.
+        // AppConfig.AI.Identity.ToolAuthorization. Reached on the live tool path through
+        // IAgentToolAuthorizationGate, which is stage 1 of the tool-call admission chain; this
+        // stays a pure policy oracle and holds neither the feature switch nor identity acquisition.
         services.AddSingleton<IAgentIdentityValidator, EntraAgentIdentityValidator>();
+
+        // Refuses to boot when tool authorization is switched on but is configured such that every
+        // call would be denied. Registered unconditionally and no-ops when the feature is off.
+        services.AddSingleton<IHostedService, ToolAuthorizationConfigValidator>();
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Identity/ToolAuthorizationConfigValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Identity/ToolAuthorizationConfigValidator.cs
@@ -107,7 +107,7 @@ public sealed class ToolAuthorizationConfigValidator : IHostedService
                 + string.Join("\n - ", errors));
         }
 
-        var emptyAllowlists = toolAuthorization.AllowedToolsByAgentId.Count(a => a.Value.Count == 0);
+        var emptyAllowlists = toolAuthorization.AllowedToolsByAgentId.Count(a => a.Value is { Count: 0 });
         if (emptyAllowlists > 0)
         {
             _logger.LogWarning(
@@ -145,6 +145,18 @@ public sealed class ToolAuthorizationConfigValidator : IHostedService
                 errors.Add(
                     "AllowedToolsByAgentId contains a blank agent id, which can never match a "
                     + "resolved identity.");
+                continue;
+            }
+
+            // `"agent-1": null` in appsettings.json binds to a null list. Reported rather than
+            // dereferenced: the whole point of this validator is to replace an unexplained crash with
+            // a sentence naming the setting, and an NullReferenceException out of the config validator
+            // is the least helpful of all possible outcomes.
+            if (tools is null)
+            {
+                errors.Add(
+                    $"AllowedToolsByAgentId['{agentId}'] is null. Use an empty array to grant nothing, "
+                    + "or list the tool keys this agent may invoke.");
                 continue;
             }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Identity/ToolAuthorizationConfigValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Identity/ToolAuthorizationConfigValidator.cs
@@ -1,0 +1,179 @@
+using Application.AI.Common.Interfaces.Identity;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Identity;
+
+/// <summary>
+/// One-shot startup validator for per-agent tool authorization. Refuses to boot when
+/// <see cref="ToolAuthorizationConfig.Enabled"/> is set but the surrounding configuration
+/// cannot produce anything other than a blanket denial.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why a startup check rather than runtime tolerance.</strong> The gate this guards is
+/// fail-closed on purpose: with no identity, no validator, or no allowlist, every tool call is
+/// refused. Each of those is a configuration mistake rather than a policy, and discovering it at
+/// runtime means an agent that appears to start normally and then declines to do anything, with
+/// the reason visible only to whoever is reading structured logs. Boot is the honest place to
+/// say so.
+/// </para>
+/// <para>
+/// Checks performed, all only when the feature is switched on:
+/// </para>
+/// <list type="number">
+///   <item><description>
+///     <b>Identity subsystem is off</b> — with <see cref="AgentIdentityConfig.Enabled"/> false
+///     there is no workload identity to authorize against, so every call would be denied.
+///   </description></item>
+///   <item><description>
+///     <b>No allowlist</b> — an empty <see cref="ToolAuthorizationConfig.AllowedToolsByAgentId"/>
+///     denies every agent every tool. That is the correct fail-closed reading of an empty policy
+///     and is almost never what the operator meant by switching the feature on.
+///   </description></item>
+///   <item><description>
+///     <b>Blank agent ids or tool keys</b> — an empty key can never match a resolved identity or
+///     a registered tool, so it is silently dead policy.
+///   </description></item>
+///   <item><description>
+///     <b>Missing services</b> — the feature is switched on but the Infrastructure identity
+///     registrations are absent, so the gate would deny everything for want of a policy oracle.
+///   </description></item>
+/// </list>
+/// <para>
+/// An agent mapped to a deliberately <em>empty</em> list is not an error — that is the documented
+/// way to keep an agent in the policy while granting it nothing — but it is logged, because the
+/// shape is indistinguishable from an unfinished edit.
+/// </para>
+/// </remarks>
+public sealed class ToolAuthorizationConfigValidator : IHostedService
+{
+    private readonly IServiceProvider _services;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ToolAuthorizationConfigValidator> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="ToolAuthorizationConfigValidator"/> class.</summary>
+    /// <param name="services">
+    /// Resolves the identity services lazily rather than requiring them at construction, so DI tests
+    /// that enumerate hosted services without the full identity graph still materialize.
+    /// </param>
+    /// <param name="config">Supplies the identity and tool-authorization configuration.</param>
+    /// <param name="logger">Records the validated policy shape, and any non-fatal oddities in it.</param>
+    public ToolAuthorizationConfigValidator(
+        IServiceProvider services,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<ToolAuthorizationConfigValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _services = services;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var identity = _config.CurrentValue.AI?.Identity;
+        var toolAuthorization = identity?.ToolAuthorization;
+        if (toolAuthorization is not { Enabled: true })
+            return Task.CompletedTask;
+
+        var errors = new List<string>();
+
+        if (identity is not { Enabled: true })
+        {
+            errors.Add(
+                "AI.Identity.ToolAuthorization.Enabled is true but AI.Identity.Enabled is false. "
+                + "Per-agent tool authorization needs a workload identity to authorize; with the "
+                + "identity subsystem off every tool call would be refused. Enable AI.Identity or "
+                + "turn tool authorization off.");
+        }
+
+        ValidateAllowlist(toolAuthorization, errors);
+        ValidateRegistrations(errors);
+
+        if (errors.Count > 0)
+        {
+            throw new InvalidOperationException(
+                "Per-agent tool authorization is enabled but cannot admit any call as configured, so "
+                + "the host refuses to boot. Fix the following in AppConfig.AI.Identity then restart:\n - "
+                + string.Join("\n - ", errors));
+        }
+
+        var emptyAllowlists = toolAuthorization.AllowedToolsByAgentId.Count(a => a.Value.Count == 0);
+        if (emptyAllowlists > 0)
+        {
+            _logger.LogWarning(
+                "Per-agent tool authorization has {EmptyCount} agent(s) mapped to an empty allowlist; "
+                + "each is denied every tool. This is valid policy but is also what an unfinished edit "
+                + "looks like.",
+                emptyAllowlists);
+        }
+
+        _logger.LogInformation(
+            "Per-agent tool authorization validated: {AgentCount} agent(s) in the allowlist.",
+            toolAuthorization.AllowedToolsByAgentId.Count);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    private static void ValidateAllowlist(ToolAuthorizationConfig toolAuthorization, List<string> errors)
+    {
+        if (toolAuthorization.AllowedToolsByAgentId.Count == 0)
+        {
+            errors.Add(
+                "AI.Identity.ToolAuthorization.AllowedToolsByAgentId is empty. An empty allowlist "
+                + "denies every agent every tool. Name at least one agent id, or turn tool "
+                + "authorization off.");
+            return;
+        }
+
+        foreach (var (agentId, tools) in toolAuthorization.AllowedToolsByAgentId)
+        {
+            if (string.IsNullOrWhiteSpace(agentId))
+            {
+                errors.Add(
+                    "AllowedToolsByAgentId contains a blank agent id, which can never match a "
+                    + "resolved identity.");
+                continue;
+            }
+
+            var blankTools = tools.Count(t => string.IsNullOrWhiteSpace(t));
+            if (blankTools > 0)
+            {
+                errors.Add(
+                    $"AllowedToolsByAgentId['{agentId}'] contains {blankTools} blank tool key, which "
+                    + "can never match a registered tool.");
+            }
+        }
+    }
+
+    private void ValidateRegistrations(List<string> errors)
+    {
+        if (_services.GetService<IAgentIdentityValidator>() is null)
+        {
+            errors.Add(
+                "No IAgentIdentityValidator is registered, so there is no policy oracle to consult "
+                + "and every call would be refused. Call the Infrastructure AI dependency "
+                + "registration, which registers it.");
+        }
+
+        if (_services.GetService<IAgentIdentityResolver>() is null)
+        {
+            errors.Add(
+                "No IAgentIdentityResolver is registered, so an identity cannot be established on "
+                + "the plan-engine and Execution API paths, whose DI scopes carry none. Call the "
+                + "Infrastructure AI dependency registration, which registers it.");
+        }
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
@@ -22,12 +22,39 @@ internal static class AdmissionHarness
         IToolInvocationGovernor? governor = null,
         IToolClassificationGate? classificationGate = null,
         IToolCallObserverChain? observers = null,
-        IProgressEvaluator? progressEvaluator = null) =>
-        new(governor ?? PermissiveGovernor(),
+        IProgressEvaluator? progressEvaluator = null,
+        IAgentToolAuthorizationGate? authorizationGate = null) =>
+        new(authorizationGate ?? PermissiveAuthorizationGate(),
+            governor ?? PermissiveGovernor(),
             classificationGate ?? PermissiveClassificationGate(),
             observers ?? Mock.Of<IToolCallObserverChain>(),
             progressEvaluator ?? PermissiveProgressEvaluator(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
+
+    /// <summary>
+    /// An authorization gate that admits everything — what the real gate answers when
+    /// <c>AI.Identity.ToolAuthorization.Enabled</c> is unset, which is the default composition.
+    /// </summary>
+    public static IAgentToolAuthorizationGate PermissiveAuthorizationGate()
+    {
+        var gate = new Mock<IAgentToolAuthorizationGate>();
+        gate
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AgentToolAuthorizationVerdict.Allow());
+        return gate.Object;
+    }
+
+    /// <summary>An authorization gate that refuses every call, as an enabled gate does for an
+    /// agent the allowlist does not cover.</summary>
+    /// <param name="deniedMessage">The refusal text the gate returns.</param>
+    public static Mock<IAgentToolAuthorizationGate> DenyingAuthorizationGate(string deniedMessage)
+    {
+        var gate = new Mock<IAgentToolAuthorizationGate>();
+        gate
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AgentToolAuthorizationVerdict.Deny(deniedMessage));
+        return gate;
+    }
 
     /// <summary>A governor that authorizes everything — the ungoverned default composition.</summary>
     public static IToolInvocationGovernor PermissiveGovernor()

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
@@ -40,7 +40,7 @@ internal static class AdmissionHarness
         var gate = new Mock<IAgentToolAuthorizationGate>();
         gate
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(AgentToolAuthorizationVerdict.Allow());
+            .ReturnsAsync(ToolInvocationDecision.Allow());
         return gate.Object;
     }
 
@@ -52,7 +52,7 @@ internal static class AdmissionHarness
         var gate = new Mock<IAgentToolAuthorizationGate>();
         gate
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(AgentToolAuthorizationVerdict.Deny(deniedMessage));
+            .ReturnsAsync(ToolInvocationDecision.Deny(deniedMessage));
         return gate;
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AgentToolAuthorizationCompositionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AgentToolAuthorizationCompositionTests.cs
@@ -1,0 +1,233 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Identity;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Identity;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Identity;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Proves that per-agent tool authorization is reached <strong>through the real composition</strong>
+/// — the container built by <c>AddApplicationAIDependencies</c>, resolving
+/// <see cref="IToolCallAdmissionPipeline"/>, and calling the public admission entry point.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>This is the test whose absence was the defect.</strong> Before #311,
+/// <c>EntraAgentIdentityValidator</c> had fifteen passing unit tests and no production caller. Every
+/// one of those tests called <c>CanInvoke</c> directly, so all of them stayed green while the control
+/// did not run at all. A test that constructs the control and asks it a question can never fail for
+/// the call that was never written.
+/// </para>
+/// <para>
+/// So nothing here constructs a gate. The container is built the way a host builds it, the pipeline
+/// is resolved rather than newed, and the assertion is on what <c>AdmitAsync</c> returns. Delete the
+/// registration or the pipeline stage and these fail; that is the property being bought.
+/// </para>
+/// </remarks>
+public sealed class AgentToolAuthorizationCompositionTests : IDisposable
+{
+    private const string AllowedTool = "file_system";
+    private const string DeniedTool = "shell_exec";
+    private const string AgentId = "agent-1";
+
+    // The gate is scoped, so its container and scope must outlive the assertions that drive it.
+    private readonly List<IDisposable> _disposables = [];
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Reverse order: scopes were added after the providers that own them.
+        for (var i = _disposables.Count - 1; i >= 0; i--)
+            _disposables[i].Dispose();
+    }
+
+    [Fact]
+    public void TheAuthorizationGateIsRegisteredByTheRealCompositionMethod()
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationAIDependencies();
+
+        var descriptor = services.FirstOrDefault(
+            d => d.ServiceType == typeof(IAgentToolAuthorizationGate));
+
+        descriptor.Should().NotBeNull(
+            "the admission chain takes this as a required constructor dependency, so an unregistered "
+            + "gate means no host can build the chain at all");
+        descriptor!.Lifetime.Should().Be(
+            ServiceLifetime.Scoped,
+            "it caches the workload identity it resolves for the lifetime of one turn, plan step, or "
+            + "direct invocation");
+        descriptor.ImplementationType.Should().Be<DefaultAgentToolAuthorizationGate>();
+    }
+
+    [Fact]
+    public async Task FeatureOn_ToolOutsideTheAgentsAllowlist_IsRefusedThroughTheChain()
+    {
+        var pipeline = ChainOverTheResolvedGate(toolAuthorizationEnabled: true);
+
+        var admission = await pipeline.AdmitAsync(
+            new ToolCallAdmissionRequest(DeniedTool, new Dictionary<string, object?>()),
+            CancellationToken.None);
+
+        admission.IsAllowed.Should().BeFalse(
+            "this is the whole point of the feature: an agent whose allowlist does not name a tool "
+            + "must not be able to invoke it");
+        admission.DeniedMessage.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task FeatureOn_ToolInsideTheAgentsAllowlist_IsAdmittedThroughTheChain()
+    {
+        // The other half. A gate that denied everything would satisfy the test above while being
+        // just as broken as one that allowed everything.
+        var pipeline = ChainOverTheResolvedGate(toolAuthorizationEnabled: true);
+
+        var admission = await pipeline.AdmitAsync(
+            new ToolCallAdmissionRequest(AllowedTool, new Dictionary<string, object?>()),
+            CancellationToken.None);
+
+        admission.IsAllowed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task FeatureOff_TheSameCallIsAdmitted()
+    {
+        // The default composition. Every release before this switch existed admitted this call, and a
+        // consumer who has not opted in must see no change — which is the argument for the feature
+        // being opt-in at all, so it is worth a test rather than a comment.
+        var pipeline = ChainOverTheResolvedGate(toolAuthorizationEnabled: false);
+
+        var admission = await pipeline.AdmitAsync(
+            new ToolCallAdmissionRequest(DeniedTool, new Dictionary<string, object?>()),
+            CancellationToken.None);
+
+        admission.IsAllowed.Should().BeTrue(
+            "with tool authorization switched off the gate must admit even a tool no allowlist names");
+    }
+
+    [Fact]
+    public async Task FeatureOn_PlanCapabilityGatesAreAuthorizedToo()
+    {
+        // A capability gate arrives with null arguments and a well-known name. The classification
+        // stage deliberately skips those; this stage deliberately does not, because an agent barred
+        // from a tool must not reach equivalent capability by issuing a plan step instead.
+        var pipeline = ChainOverTheResolvedGate(toolAuthorizationEnabled: true);
+
+        var admission = await pipeline.AdmitAsync(
+            new ToolCallAdmissionRequest("llm_call"), CancellationToken.None);
+
+        admission.IsAllowed.Should().BeFalse(
+            "llm_call is not in this agent's allowlist, and a capability gate is not exempt from RBAC");
+    }
+
+    /// <summary>
+    /// Builds the real admission chain over the gate <em>as the container produces it</em>, with the
+    /// four other stages permitting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The gate is resolved, never constructed: a test that news up the gate proves only that the
+    /// class works, which is exactly what the fifteen green tests on the unwired validator proved.
+    /// Resolving it means the registration, its lifetime, and its constructor dependencies are all
+    /// part of what is under test.
+    /// </para>
+    /// <para>
+    /// The chain itself is built rather than resolved because the governor stage reaches into
+    /// Infrastructure registrations that this assembly cannot see by design. Stubbing that graph
+    /// would test the stubs; keeping the other four stages permissive instead means any refusal
+    /// observed here can only have come from the authorization stage.
+    /// </para>
+    /// </remarks>
+    private ToolCallAdmissionPipeline ChainOverTheResolvedGate(bool toolAuthorizationEnabled)
+    {
+        var provider = BuildHost(toolAuthorizationEnabled);
+        _disposables.Add(provider);
+
+        var scope = provider.CreateScope();
+        _disposables.Add(scope);
+
+        var gate = scope.ServiceProvider.GetRequiredService<IAgentToolAuthorizationGate>();
+        return AdmissionHarness.Pipeline(authorizationGate: gate);
+    }
+
+    /// <summary>
+    /// Builds the container the way a host does: the real Application AI registrations, plus the
+    /// identity services Infrastructure would supply.
+    /// </summary>
+    /// <remarks>
+    /// The credential resolver is the one seam stubbed, because acquiring a real Entra token is not
+    /// something a unit test can do. Everything downstream of it — the gate, the validator, the
+    /// chain, and the wiring between them — is the shipped implementation.
+    /// </remarks>
+    private static ServiceProvider BuildHost(bool toolAuthorizationEnabled)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Identity = new AgentIdentityConfig
+                {
+                    Enabled = true,
+                    ToolAuthorization = BuildAllowlist(toolAuthorizationEnabled)
+                }
+            }
+        };
+        services.AddSingleton<IOptionsMonitor<AppConfig>>(
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig));
+
+        services.AddApplicationAIDependencies();
+
+        // What Infrastructure contributes: the policy oracle and a resolver standing in for the
+        // credential hierarchy.
+        services.AddSingleton<IAgentIdentityValidator>(
+            new StubValidator(appConfig.AI.Identity.ToolAuthorization));
+        services.AddSingleton<IAgentIdentityResolver>(new StubResolver(
+            new AgentIdentity { Id = AgentId, Kind = AgentIdentityKind.ManagedIdentity }));
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ToolAuthorizationConfig BuildAllowlist(bool enabled)
+    {
+        var config = new ToolAuthorizationConfig { Enabled = enabled };
+        config.AllowedToolsByAgentId[AgentId] = [AllowedTool];
+        return config;
+    }
+
+    /// <summary>
+    /// The shipped allowlist semantics, without taking an Infrastructure reference from this test
+    /// assembly. <c>EntraAgentIdentityValidator</c>'s own behaviour is covered by its unit tests; what
+    /// matters here is that the chain reaches <em>a</em> validator and honours its answer.
+    /// </summary>
+    private sealed class StubValidator(ToolAuthorizationConfig config) : IAgentIdentityValidator
+    {
+        public bool CanInvoke(AgentIdentity identity, string toolKey) =>
+            config.AllowedToolsByAgentId.TryGetValue(identity.Id, out var allowed)
+            && allowed.Contains(toolKey, StringComparer.Ordinal);
+    }
+
+    private sealed class StubResolver(AgentIdentity identity) : IAgentIdentityResolver
+    {
+        public Task<Result<AgentIdentity>> ResolveAsync(
+            CredentialContext context, CancellationToken cancellationToken) =>
+            Task.FromResult(Result<AgentIdentity>.Success(identity));
+    }
+
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/DefaultAgentToolAuthorizationGateTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/DefaultAgentToolAuthorizationGateTests.cs
@@ -232,6 +232,57 @@ public sealed class DefaultAgentToolAuthorizationGateTests
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_ACancelledAcquisitionDoesNotPoisonTheRestOfTheScope()
+    {
+        // The scope outlives the call — a DI scope spans every turn of a conversation — so latching
+        // the "already tried" flag on a cancellation would turn one abandoned call into a blanket
+        // denial for the remainder of that conversation, wearing the wording of a policy refusal.
+        var resolver = new Mock<IAgentIdentityResolver>();
+        var calls = 0;
+        resolver
+            .Setup(r => r.ResolveAsync(It.IsAny<CredentialContext>(), It.IsAny<CancellationToken>()))
+            .Returns(() => ++calls == 1
+                ? throw new OperationCanceledException()
+                : Task.FromResult(Result<AgentIdentity>.Success(ResolvedIdentity)));
+
+        var validator = Validator(ResolvedIdentity, Tool, allowed: true);
+        var gate = Build(
+            enabled: true, contextIdentity: null, validator: validator.Object, resolver: resolver.Object);
+
+        var cancelled = async () => await gate.EvaluateAsync(Tool, CancellationToken.None);
+        await cancelled.Should().ThrowAsync<OperationCanceledException>();
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeTrue(
+            "the next call in this scope carried a healthy token and an allowed tool, so it must be "
+            + "authorized on its own merits rather than inheriting the abandoned call's outcome");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_AThrowingCredentialProvider_DeniesRatherThanFaulting()
+    {
+        // IAgentCredentialProvider is a consumer extension point, and the resolver does not wrap
+        // provider calls. An exception escaping here would reach the tool path as an unhandled fault
+        // instead of the refusal this class promises.
+        var resolver = new Mock<IAgentIdentityResolver>();
+        resolver
+            .Setup(r => r.ResolveAsync(It.IsAny<CredentialContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("certificate store unavailable"));
+
+        var gate = Build(
+            enabled: true,
+            contextIdentity: null,
+            validator: Mock.Of<IAgentIdentityValidator>(),
+            resolver: resolver.Object);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeFalse();
+        verdict.DeniedMessage.Should().NotBeNullOrWhiteSpace();
+    }
+
     private static DefaultAgentToolAuthorizationGate Build(
         bool enabled,
         AgentIdentity? contextIdentity = null,

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/DefaultAgentToolAuthorizationGateTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/DefaultAgentToolAuthorizationGateTests.cs
@@ -1,0 +1,279 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Identity;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Identity;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Identity;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Tests for <see cref="DefaultAgentToolAuthorizationGate"/> — the seam that decides whether
+/// per-agent tool RBAC applies at all, and how the executing identity is obtained when it does.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The policy decision itself belongs to <c>EntraAgentIdentityValidator</c> and is tested there.
+/// What is tested here is everything that determines whether that decision is ever reached: the
+/// off switch, and the four ways an enabled gate can fail to establish who is asking. Each of
+/// those must deny, because a permissive answer to "I cannot tell which agent this is" is the
+/// defect this whole type exists to close.
+/// </para>
+/// <para>
+/// The identity-acquisition fallback carries most of the weight. The execution context holds an
+/// identity only on the agent-turn path — the plan engine's step executors and the Execution API's
+/// direct invoker each open a fresh DI scope whose context is blank — so a gate that read only the
+/// context would enforce on one of four execution paths and be bypassable by issuing the same call
+/// from a plan step.
+/// </para>
+/// </remarks>
+public sealed class DefaultAgentToolAuthorizationGateTests
+{
+    private const string Tool = "file_system";
+
+    private static readonly AgentIdentity StampedIdentity =
+        new() { Id = "agent-from-context", Kind = AgentIdentityKind.ManagedIdentity };
+
+    private static readonly AgentIdentity ResolvedIdentity =
+        new() { Id = "agent-from-resolver", Kind = AgentIdentityKind.ManagedIdentity };
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOff_AdmitsWithoutConsultingAnything()
+    {
+        var validator = new Mock<IAgentIdentityValidator>(MockBehavior.Strict);
+        var resolver = new Mock<IAgentIdentityResolver>(MockBehavior.Strict);
+        var gate = Build(enabled: false, validator: validator.Object, resolver: resolver.Object);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeTrue(
+            "the harness shipped without per-agent RBAC for every release before this switch existed, "
+            + "so an unconfigured host must behave exactly as it did");
+
+        // Strict mocks: any consultation at all would have thrown. The off state is not "ask and
+        // ignore the answer", it is "do not ask" — which is what keeps an unconfigured host from
+        // paying for a token acquisition on every tool call.
+        validator.VerifyNoOtherCalls();
+        resolver.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_IdentityOnContext_DelegatesToTheValidator()
+    {
+        var validator = Validator(StampedIdentity, Tool, allowed: true);
+        var gate = Build(enabled: true, contextIdentity: StampedIdentity, validator: validator.Object);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeTrue();
+        validator.Verify(v => v.CanInvoke(StampedIdentity, Tool), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_ValidatorRefuses_Denies()
+    {
+        var validator = Validator(StampedIdentity, Tool, allowed: false);
+        var gate = Build(enabled: true, contextIdentity: StampedIdentity, validator: validator.Object);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeFalse();
+        verdict.DeniedMessage.Should().NotBeNullOrWhiteSpace(
+            "a refusal with no text reaches a model as an empty successful result, which reads as the "
+            + "tool having run and returned nothing");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_ContextHasNoIdentity_ResolvesOneAndAuthorizesIt()
+    {
+        // The plan-engine and Execution API paths. Their scopes carry no identity, and the workload
+        // identity is a process-level principal rather than a per-request value, so resolving it here
+        // yields the same principal the agent turn would have carried.
+        var validator = Validator(ResolvedIdentity, Tool, allowed: true);
+        var resolver = Resolver(Result<AgentIdentity>.Success(ResolvedIdentity));
+        var gate = Build(
+            enabled: true, contextIdentity: null, validator: validator.Object, resolver: resolver.Object);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeTrue(
+            "a gate that enforced only where an identity was pre-stamped would be bypassable by "
+            + "issuing the same call from a plan step");
+        validator.Verify(v => v.CanInvoke(ResolvedIdentity, Tool), Times.Once);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_ResolvedIdentityIsReusedAcrossCallsInTheSameScope()
+    {
+        var validator = Validator(ResolvedIdentity, Tool, allowed: true);
+        var resolver = Resolver(Result<AgentIdentity>.Success(ResolvedIdentity));
+        var gate = Build(
+            enabled: true, contextIdentity: null, validator: validator.Object, resolver: resolver.Object);
+
+        await gate.EvaluateAsync(Tool, CancellationToken.None);
+        await gate.EvaluateAsync("calculation_engine", CancellationToken.None);
+        await gate.EvaluateAsync("shell_exec", CancellationToken.None);
+
+        resolver.Verify(
+            r => r.ResolveAsync(It.IsAny<CredentialContext>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the gate is scoped, so a plan step issuing many tool calls must pay for at most one "
+            + "credential acquisition rather than one per call");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_ResolutionFails_Denies()
+    {
+        var validator = new Mock<IAgentIdentityValidator>(MockBehavior.Strict);
+        var resolver = Resolver(Result<AgentIdentity>.Fail("agent_identity.no_provider_succeeded"));
+        var gate = Build(
+            enabled: true, contextIdentity: null, validator: validator.Object, resolver: resolver.Object);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeFalse(
+            "failing to establish who is asking is the one case where a permissive answer is "
+            + "indefensible");
+        validator.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_FailedResolutionIsNotRetriedForEveryCall()
+    {
+        var resolver = Resolver(Result<AgentIdentity>.Fail("agent_identity.no_provider_succeeded"));
+        var gate = Build(
+            enabled: true,
+            contextIdentity: null,
+            validator: Mock.Of<IAgentIdentityValidator>(),
+            resolver: resolver.Object);
+
+        await gate.EvaluateAsync(Tool, CancellationToken.None);
+        await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        resolver.Verify(
+            r => r.ResolveAsync(It.IsAny<CredentialContext>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a host whose credentials are misconfigured must not hammer the credential endpoint once "
+            + "per denied tool call");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_NoValidatorRegistered_Denies()
+    {
+        var gate = Build(enabled: true, contextIdentity: StampedIdentity, validator: null);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeFalse(
+            "an enabled feature with no policy oracle cannot answer the question, and unanswerable "
+            + "must not mean permitted");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_NoResolverRegisteredAndNoContextIdentity_Denies()
+    {
+        var gate = Build(
+            enabled: true,
+            contextIdentity: null,
+            validator: Mock.Of<IAgentIdentityValidator>(),
+            resolver: null);
+
+        var verdict = await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        verdict.IsAllowed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_ContextIdentityWinsOverTheResolver()
+    {
+        // On the agent-turn path the resolution behaviour has already paid for acquisition, and
+        // re-resolving would risk authorizing against a different principal than the rest of the turn
+        // is using.
+        var validator = Validator(StampedIdentity, Tool, allowed: true);
+        var resolver = Resolver(Result<AgentIdentity>.Success(ResolvedIdentity));
+        var gate = Build(
+            enabled: true,
+            contextIdentity: StampedIdentity,
+            validator: validator.Object,
+            resolver: resolver.Object);
+
+        await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        validator.Verify(v => v.CanInvoke(StampedIdentity, Tool), Times.Once);
+        resolver.Verify(
+            r => r.ResolveAsync(It.IsAny<CredentialContext>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_FeatureOn_CancellationPropagatesRatherThanBecomingADenial()
+    {
+        // An abandoned call is not a policy decision. Swallowing the cancellation into a deny would
+        // record a governance refusal that never happened.
+        var resolver = new Mock<IAgentIdentityResolver>();
+        resolver
+            .Setup(r => r.ResolveAsync(It.IsAny<CredentialContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        var gate = Build(
+            enabled: true,
+            contextIdentity: null,
+            validator: Mock.Of<IAgentIdentityValidator>(),
+            resolver: resolver.Object);
+
+        var act = async () => await gate.EvaluateAsync(Tool, CancellationToken.None);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    private static DefaultAgentToolAuthorizationGate Build(
+        bool enabled,
+        AgentIdentity? contextIdentity = null,
+        IAgentIdentityValidator? validator = null,
+        IAgentIdentityResolver? resolver = null)
+    {
+        var config = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Identity = new AgentIdentityConfig
+                {
+                    Enabled = enabled,
+                    ToolAuthorization = new ToolAuthorizationConfig { Enabled = enabled }
+                }
+            }
+        };
+
+        var context = new Mock<IAgentExecutionContext>();
+        context.SetupGet(c => c.AgentIdentity).Returns(contextIdentity);
+
+        return new DefaultAgentToolAuthorizationGate(
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == config),
+            context.Object,
+            NullLogger<DefaultAgentToolAuthorizationGate>.Instance,
+            validator,
+            resolver);
+    }
+
+    private static Mock<IAgentIdentityValidator> Validator(AgentIdentity identity, string toolKey, bool allowed)
+    {
+        var validator = new Mock<IAgentIdentityValidator>();
+        validator.Setup(v => v.CanInvoke(identity, toolKey)).Returns(allowed);
+        return validator;
+    }
+
+    private static Mock<IAgentIdentityResolver> Resolver(Result<AgentIdentity> result)
+    {
+        var resolver = new Mock<IAgentIdentityResolver>();
+        resolver
+            .Setup(r => r.ResolveAsync(It.IsAny<CredentialContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        return resolver;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -46,13 +46,17 @@ public sealed class ToolCallAdmissionPipelineTests
             new ToolCallAdmissionRequest(Tool, Args, CountsTowardLoopDetection: true), CancellationToken.None);
 
         order.Should().Equal(
-            ["governor", "classification", "host-rules", "loop-guard"],
-            "permission and policy settle whether the agent may use the tool at all; the host's own "
-            + "rules run after them so they can only tighten; and the loop guard runs last because it "
-            + "is the only stage that records state, so it must count only calls that reached the tool");
+            ["agent-authorization", "governor", "classification", "host-rules", "loop-guard"],
+            "agent RBAC runs first because it is the cheapest and most fundamental access question, "
+            + "and because the governor can escalate to a human — nobody should be asked to approve a "
+            + "call that RBAC refuses anyway; permission and policy then settle whether the agent may "
+            + "use the tool at all; the host's own rules run after them so they can only tighten; and "
+            + "the loop guard runs last because it is the only stage that records state, so it must "
+            + "count only calls that reached the tool");
     }
 
     [Theory]
+    [InlineData("agent-authorization")]
     [InlineData("governor")]
     [InlineData("classification")]
     [InlineData("host-rules")]
@@ -303,6 +307,14 @@ public sealed class ToolCallAdmissionPipelineTests
     /// <param name="refusingStage">The stage that refuses, or null when every stage permits.</param>
     private static ToolCallAdmissionPipeline Recording(List<string> order, string? refusingStage = null)
     {
+        var authorizationGate = new Mock<IAgentToolAuthorizationGate>();
+        authorizationGate
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("agent-authorization"))
+            .ReturnsAsync(refusingStage == "agent-authorization"
+                ? AgentToolAuthorizationVerdict.Deny("no")
+                : AgentToolAuthorizationVerdict.Allow());
+
         var governor = new Mock<IToolInvocationGovernor>();
         governor
             .Setup(g => g.AuthorizeAsync(
@@ -338,7 +350,7 @@ public sealed class ToolCallAdmissionPipelineTests
             .Returns(ProgressVerdict.Continue());
 
         return new ToolCallAdmissionPipeline(
-            governor.Object, classificationGate.Object, observers.Object, progress.Object,
-            NullLogger<ToolCallAdmissionPipeline>.Instance);
+            authorizationGate.Object, governor.Object, classificationGate.Object, observers.Object,
+            progress.Object, NullLogger<ToolCallAdmissionPipeline>.Instance);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -339,8 +339,8 @@ public sealed class ToolCallAdmissionPipelineTests
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Callback(() => order.Add("agent-authorization"))
             .ReturnsAsync(refusingStage == "agent-authorization"
-                ? AgentToolAuthorizationVerdict.Deny("no")
-                : AgentToolAuthorizationVerdict.Allow());
+                ? ToolInvocationDecision.Deny("no")
+                : ToolInvocationDecision.Allow());
 
         var governor = new Mock<IToolInvocationGovernor>();
         governor

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -73,6 +73,33 @@ public sealed class ToolCallAdmissionPipelineTests
     }
 
     [Fact]
+    public async Task AdmitAsync_AuthorizationRefuses_TheRefusalIsRecordedOnTheTrace()
+    {
+        // The authorization stage runs ahead of the governor, so the governor never sees a call this
+        // stage refuses and records nothing for it. Without an explicit record, a turn in which an
+        // agent was refused every tool it attempted reports zero denials to governance reporting,
+        // the dashboard and the audit — which for an access-control decision is indistinguishable
+        // from not having enforced it.
+        var governor = new Mock<IToolInvocationGovernor>();
+        governor
+            .Setup(g => g.AuthorizeAsync(
+                It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<IReadOnlyDictionary<string, object?>?>()))
+            .ReturnsAsync(ToolInvocationDecision.Allow());
+
+        var pipeline = AdmissionHarness.Pipeline(
+            governor: governor.Object,
+            authorizationGate: AdmissionHarness.DenyingAuthorizationGate("nope").Object);
+
+        var admission = await pipeline.AdmitAsync(
+            new ToolCallAdmissionRequest(Tool, Args), CancellationToken.None);
+
+        admission.IsAllowed.Should().BeFalse();
+        governor.Verify(
+            g => g.RecordDownstreamBlock(Tool, It.Is<string>(r => r.Contains("authorization"))),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task AdmitAsync_LoopDetectionNotRequested_TheGuardIsNotConsulted()
     {
         // Every caller but the agent turn. A single Execution API call has no sequence to evaluate,

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -414,12 +414,33 @@ public sealed class ToolInvocationGovernorTests
     public void RecordDownstreamBlock_OnAnUngovernedTurn_RecordsNothing()
     {
         // Off the enforced path the governor recorded no allow, so there is nothing to correct and
-        // a bare denial would invent a decision the governor never made.
-        var governor = Build();
+        // a bare denial would invent a decision on a turn governance was never applied to.
+        //
+        // "Ungoverned" means enforcement is switched off, which is what this now builds. It
+        // previously built an ENFORCING governor and relied on nothing having been authorized yet —
+        // a different condition wearing the same name, and one that stopped being safe to conflate
+        // once a stage began running ahead of the governor.
+        var governor = Build(new GovernanceConfig { EnforceToolInvocation = false });
 
         governor.RecordDownstreamBlock(Tool, "blocked by observer 'wire-limit'");
 
         Assert.Empty(governor.GetTrace().ToolDecisions);
+    }
+
+    [Fact]
+    public void RecordDownstreamBlock_EnforcedTurnBeforeAnyAuthorize_StillRecords()
+    {
+        // The per-agent authorization gate is stage 1 of the admission chain and runs BEFORE this
+        // governor, so a call it refuses never reaches AuthorizeAsync at all. Keying the record on
+        // "this governor has already evaluated something" dropped exactly those refusals — and since
+        // a refused call never goes on to be authorized, that is most of them. The turn is enforced;
+        // that is what makes the record meaningful, not whether the governor happened to run first.
+        var governor = Build();
+
+        governor.RecordDownstreamBlock(Tool, "denied by per-agent tool authorization");
+
+        var decisions = governor.GetTrace().ToolDecisions;
+        Assert.Contains(decisions, d => d.Outcome == ToolDecisionOutcome.Denied);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -689,6 +689,11 @@ public sealed class DirectToolInvokerTests
             _observerChain ?? new FakeObserverChain(ToolInvocationDecision.Allow()) { HasObservers = false });
         services.AddSingleton(AdmissionHarness.PermissiveProgressEvaluator());
 
+        // Per-agent RBAC, permitting — the answer the real gate gives when tool authorization is off,
+        // which is this fixture's composition. Registered because the chain requires it: an absent
+        // gate and a switched-off one must never be confusable at runtime.
+        services.AddSingleton(AdmissionHarness.PermissiveAuthorizationGate());
+
         // The real chain, not a mock of it. This suite's whole subject is what the Execution API does
         // before, during and after a tool call, and that is now the chain's behaviour plus this type's
         // response shaping — mocking the chain would move every governance assertion here off the code

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -84,7 +84,7 @@ public class AgentPipelineIntegrationTests
         var authorizationMock = new Mock<Application.AI.Common.Interfaces.Governance.IAgentToolAuthorizationGate>();
         authorizationMock
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Application.AI.Common.Interfaces.Governance.AgentToolAuthorizationVerdict.Allow());
+            .ReturnsAsync(Application.AI.Common.Interfaces.Governance.ToolInvocationDecision.Allow());
         services.AddScoped(_ => authorizationMock.Object);
 
         // The REAL admission chain over the five permissive gates above, not a mock of it. The handler

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -79,9 +79,17 @@ public class AgentPipelineIntegrationTests
         observerChainMock.SetupGet(c => c.HasObservers).Returns(false);
         services.AddScoped(_ => observerChainMock.Object);
 
-        // The REAL admission chain over the four permissive gates above, not a mock of it. The handler
+        // Per-agent tool RBAC — admits, which is what the real gate answers when
+        // AI.Identity.ToolAuthorization.Enabled is unset, i.e. the default composition this suite runs.
+        var authorizationMock = new Mock<Application.AI.Common.Interfaces.Governance.IAgentToolAuthorizationGate>();
+        authorizationMock
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Application.AI.Common.Interfaces.Governance.AgentToolAuthorizationVerdict.Allow());
+        services.AddScoped(_ => authorizationMock.Object);
+
+        // The REAL admission chain over the five permissive gates above, not a mock of it. The handler
         // depends only on the chain now, and registering the real one keeps this an end-to-end proof
-        // that the four gates are reachable from the turn — a mocked chain would prove nothing about
+        // that the five gates are reachable from the turn — a mocked chain would prove nothing about
         // whether they are wired at all.
         services.AddScoped<
             Application.AI.Common.Interfaces.Governance.IToolCallAdmissionPipeline,

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
@@ -40,7 +40,7 @@ internal static class PermissiveAdmission
         var authorizationGate = new Mock<IAgentToolAuthorizationGate>();
         authorizationGate
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(ValueTask.FromResult(AgentToolAuthorizationVerdict.Allow()));
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
 
         return new ToolCallAdmissionPipeline(
             authorizationGate.Object,

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
@@ -35,7 +35,15 @@ internal static class PermissiveAdmission
                 It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(ClassificationVerdict.Allow()));
 
+        // Admits everything, matching the real gate's answer when tool authorization is switched off
+        // — which is the default composition these retrieval fixtures run under.
+        var authorizationGate = new Mock<IAgentToolAuthorizationGate>();
+        authorizationGate
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(AgentToolAuthorizationVerdict.Allow()));
+
         return new ToolCallAdmissionPipeline(
+            authorizationGate.Object,
             governor.Object,
             classificationGate.Object,
             Mock.Of<IToolCallObserverChain>(),

--- a/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AIdentityPropagatorKindParsingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/A2A/A2AIdentityPropagatorKindParsingTests.cs
@@ -25,13 +25,12 @@ namespace Infrastructure.AI.Tests.A2A;
 /// condition.
 /// </para>
 /// <para>
-/// <strong>Measured 8 Aug 2026: that validator has no production caller.</strong>
-/// <c>IAgentIdentityValidator</c> is registered in DI and injected nowhere, so the tool
-/// authorization control is inert today and nothing live was being bypassed. These tests pin the
-/// contract the wire field must honour regardless — an unrecognised kind resolves to Unspecified —
-/// so the day that control is wired up it is not wired onto a parser that already lost the
-/// distinction. Stated plainly because the first version of this file claimed a live gate was
-/// bypassed, which was wrong.
+/// <strong>That validator had no production caller when these tests were written (measured 8 Aug
+/// 2026), and has one now.</strong> #311 wired it onto the tool-call admission chain as stage 1,
+/// so from an enabled host every tool call reaches it. These tests pinned the contract the wire
+/// field must honour before the control existed — an unrecognised kind resolves to Unspecified —
+/// which is precisely why wiring it up did not land it on a parser that had already lost the
+/// distinction.
 /// </para>
 /// </remarks>
 public sealed class A2AIdentityPropagatorKindParsingTests

--- a/src/Content/Tests/Infrastructure.AI.Tests/Identity/ToolAuthorizationConfigValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Identity/ToolAuthorizationConfigValidatorTests.cs
@@ -1,0 +1,169 @@
+using Application.AI.Common.Interfaces.Identity;
+using Domain.AI.Identity;
+using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Identity;
+using FluentAssertions;
+using Infrastructure.AI.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Identity;
+
+/// <summary>
+/// Tests for <see cref="ToolAuthorizationConfigValidator"/> — the startup check that turns a
+/// tool-authorization configuration which could only ever deny into a boot failure.
+/// </summary>
+/// <remarks>
+/// The gate this guards is fail-closed by design, so every misconfiguration below produces the same
+/// runtime symptom: an agent that starts cleanly and then refuses to do anything, with the reason
+/// visible only in structured logs. Each of these cases is a mistake rather than a policy, and boot
+/// is the honest place to say so.
+/// </remarks>
+public sealed class ToolAuthorizationConfigValidatorTests
+{
+    [Fact]
+    public async Task StartAsync_FeatureOff_NoOpsEvenWhenNothingElseIsConfigured()
+    {
+        // A consumer exploring the template must not be blocked from running the host.
+        var validator = Build(new ToolAuthorizationConfig { Enabled = false }, identityEnabled: false);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledButIdentitySubsystemOff_Throws()
+    {
+        var validator = Build(Allowlist(enabled: true), identityEnabled: false);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*AI.Identity.Enabled is false*",
+                "with no identity subsystem there is nothing to authorize and every call would be "
+                + "refused, which is a configuration mistake rather than a policy");
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledWithEmptyAllowlist_Throws()
+    {
+        var validator = Build(new ToolAuthorizationConfig { Enabled = true }, identityEnabled: true);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*AllowedToolsByAgentId is empty*",
+                "an empty allowlist denies every agent every tool, which is the correct fail-closed "
+                + "reading and almost never what switching the feature on was meant to do");
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledWithBlankToolKey_Throws()
+    {
+        var config = new ToolAuthorizationConfig { Enabled = true };
+        config.AllowedToolsByAgentId["agent-1"] = ["file_system", "  "];
+        var validator = Build(config, identityEnabled: true);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*blank tool key*");
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledButValidatorNotRegistered_Throws()
+    {
+        var validator = Build(Allowlist(enabled: true), identityEnabled: true, registerServices: false);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*IAgentIdentityValidator*",
+                "the feature is on but nothing can answer the policy question, so every call would "
+                + "be refused for want of an oracle");
+    }
+
+    [Fact]
+    public async Task StartAsync_FullyConfigured_DoesNotThrow()
+    {
+        // The mutation control for every case above: if this threw too, the assertions would be
+        // passing for the wrong reason.
+        var validator = Build(Allowlist(enabled: true), identityEnabled: true);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_AgentMappedToAnEmptyList_IsAllowedThrough()
+    {
+        // Valid policy — the documented way to keep an agent in the allowlist while granting it
+        // nothing. It is logged rather than rejected, because refusing it would make a legitimate
+        // configuration unbootable.
+        var config = new ToolAuthorizationConfig { Enabled = true };
+        config.AllowedToolsByAgentId["agent-1"] = ["file_system"];
+        config.AllowedToolsByAgentId["agent-revoked"] = [];
+        var validator = Build(config, identityEnabled: true);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private static ToolAuthorizationConfig Allowlist(bool enabled)
+    {
+        var config = new ToolAuthorizationConfig { Enabled = enabled };
+        config.AllowedToolsByAgentId["agent-1"] = ["file_system"];
+        return config;
+    }
+
+    private static ToolAuthorizationConfigValidator Build(
+        ToolAuthorizationConfig toolAuthorization,
+        bool identityEnabled,
+        bool registerServices = true)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                Identity = new AgentIdentityConfig
+                {
+                    Enabled = identityEnabled,
+                    ToolAuthorization = toolAuthorization
+                }
+            }
+        };
+
+        var services = new ServiceCollection();
+        if (registerServices)
+        {
+            services.AddSingleton<IAgentIdentityValidator>(new StubValidator());
+            services.AddSingleton<IAgentIdentityResolver>(new StubResolver());
+        }
+
+        return new ToolAuthorizationConfigValidator(
+            services.BuildServiceProvider(),
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig),
+            NullLogger<ToolAuthorizationConfigValidator>.Instance);
+    }
+
+    private sealed class StubValidator : IAgentIdentityValidator
+    {
+        public bool CanInvoke(AgentIdentity identity, string toolKey) => true;
+    }
+
+    private sealed class StubResolver : IAgentIdentityResolver
+    {
+        public Task<Result<AgentIdentity>> ResolveAsync(
+            CredentialContext context, CancellationToken cancellationToken) =>
+            Task.FromResult(Result<AgentIdentity>.Success(
+                new AgentIdentity { Id = "agent-1", Kind = AgentIdentityKind.ManagedIdentity }));
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Identity/ToolAuthorizationConfigValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Identity/ToolAuthorizationConfigValidatorTests.cs
@@ -77,6 +77,22 @@ public sealed class ToolAuthorizationConfigValidatorTests
     }
 
     [Fact]
+    public async Task StartAsync_EnabledWithNullToolList_ReportsItRatherThanCrashing()
+    {
+        // `"agent-1": null` in appsettings.json binds to a null list. A NullReferenceException out of
+        // the validator whose entire purpose is to replace unexplained failures with an actionable
+        // sentence would be the least useful outcome available.
+        var config = new ToolAuthorizationConfig { Enabled = true };
+        config.AllowedToolsByAgentId["agent-1"] = null!;
+        var validator = Build(config, identityEnabled: true);
+
+        var act = async () => await validator.StartAsync(CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*is null*");
+    }
+
+    [Fact]
     public async Task StartAsync_EnabledButValidatorNotRegistered_Throws()
     {
         var validator = Build(Allowlist(enabled: true), identityEnabled: true, registerServices: false);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
@@ -152,6 +152,7 @@ public sealed class PlanRunLlmCallScopeTests
         services.AddSingleton(governor.Object);
         services.AddSingleton(Mock.Of<IToolCallObserverChain>());
         services.AddSingleton(StepExecutors.PermissiveAdmission.ClassificationGate());
+        services.AddSingleton(StepExecutors.PermissiveAdmission.AuthorizationGate());
         services.AddSingleton(Mock.Of<IProgressEvaluator>());
         // Step executors require the admission chain rather than defaulting it to null, so that a
         // composition which forgets it fails at resolution instead of running unguarded. The real

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -263,6 +263,7 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         services.AddScoped(_ => new Mock<IToolCallObserverChain>().Object);
         services.AddScoped(_ => new Mock<IToolClassificationGate>().Object);
         services.AddScoped(_ => new Mock<IProgressEvaluator>().Object);
+        services.AddScoped(_ => new Mock<IAgentToolAuthorizationGate>().Object);
         // Step executors take the admission chain as a required dependency, deliberately: an omitted
         // chain is indistinguishable at runtime from a host whose gates are all off, so a nullable
         // default would let a composition silently run the plan path unguarded. The real composition

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
@@ -43,11 +43,25 @@ internal static class PermissiveAdmission
     /// <param name="observers">The host-rule stage, or an empty chain when it is not the subject.</param>
     public static ToolCallAdmissionPipeline PipelineOver(
         IToolInvocationGovernor governor, IToolCallObserverChain? observers = null) =>
-        new(governor,
+        new(AuthorizationGate(),
+            governor,
             ClassificationGate(),
             observers ?? Mock.Of<IToolCallObserverChain>(),
             Mock.Of<IProgressEvaluator>(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
+
+    /// <summary>
+    /// An authorization gate that admits everything — the answer the real gate gives when
+    /// <c>AI.Identity.ToolAuthorization.Enabled</c> is unset, which is the default composition.
+    /// </summary>
+    public static IAgentToolAuthorizationGate AuthorizationGate()
+    {
+        var gate = new Mock<IAgentToolAuthorizationGate>();
+        gate
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(AgentToolAuthorizationVerdict.Allow()));
+        return gate.Object;
+    }
 
     /// <summary>
     /// A classification gate with nothing to classify — the default, off, composition.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
@@ -59,7 +59,7 @@ internal static class PermissiveAdmission
         var gate = new Mock<IAgentToolAuthorizationGate>();
         gate
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .Returns(ValueTask.FromResult(AgentToolAuthorizationVerdict.Allow()));
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
         return gate.Object;
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -493,7 +493,7 @@ public sealed class ToolUseStepExecutorTests
         var gate = new Mock<IAgentToolAuthorizationGate>();
         gate
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(AgentToolAuthorizationVerdict.Allow());
+            .ReturnsAsync(ToolInvocationDecision.Allow());
         return gate.Object;
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -476,11 +476,26 @@ public sealed class ToolUseStepExecutorTests
     /// maintained by hand in five places and kept being broken in one of them.
     /// </summary>
     private ToolCallAdmissionPipeline BuildAdmissionPipeline(IToolCallObserverChain observers) =>
-        new(_toolGovernor.Object,
+        new(PermissiveAuthorizationGate(),
+            _toolGovernor.Object,
             _classificationGate.Object,
             observers,
             Mock.Of<IProgressEvaluator>(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
+
+    /// <summary>
+    /// Admits everything, matching what the real gate answers with
+    /// <c>AI.Identity.ToolAuthorization.Enabled</c> unset — the composition this fixture runs under,
+    /// since its subject is the governor and classification stages rather than agent RBAC.
+    /// </summary>
+    private static IAgentToolAuthorizationGate PermissiveAuthorizationGate()
+    {
+        var gate = new Mock<IAgentToolAuthorizationGate>();
+        gate
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(AgentToolAuthorizationVerdict.Allow());
+        return gate.Object;
+    }
 
     [Fact]
     public async Task ExecuteAsync_GovernorAllows_AuthorizesExactToolName()

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -1,0 +1,209 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Tests.Common;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Asserts that every governance and identity contract the harness registers in DI is actually
+/// <strong>consumed</strong> by production code — not merely declared, implemented, and registered.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>The defect this exists to catch.</strong> The harness has now shipped a security control
+/// that existed, looked correct, had thorough unit tests, and was never invoked, four separate
+/// times: <c>ToolPermissionFilter</c>, <c>GoverningToolContextProvider</c>, both recall providers,
+/// and <c>IAgentIdentityValidator</c> — whose <c>CanInvoke</c> was a complete fail-closed RBAC
+/// implementation with fifteen passing tests and, until #311, no production caller at all. Three
+/// doc comments meanwhile told readers it was enforcing.
+/// </para>
+/// <para>
+/// <strong>Why unit tests cannot catch it.</strong> The control's own tests exercise the control
+/// and pass. Nothing fails when the call that would reach it is simply never written. A test can
+/// only fail for code that exists, so the check has to be over the source itself — the same
+/// reasoning as <see cref="ToolCallAdmissionChokepointTests"/>, pointed the other way. That test
+/// asserts nothing <em>but</em> the chain calls the gates; this one asserts something calls each
+/// registered control at all.
+/// </para>
+/// <para>
+/// <strong>What counts as a consumer.</strong> Any production file that names the interface and is
+/// not its own declaration, not a type that implements it, and not a DI registration. That covers
+/// constructor injection, <c>GetRequiredService</c>, and an ambient static — the three ways a
+/// caller reaches a service, only the first of which reflection would see.
+/// </para>
+/// <para>
+/// <strong>If this test fails,</strong> the answer is one of exactly two things, and "add it to the
+/// exemptions" is neither by default: wire the control onto the path it was written to guard, or
+/// delete it along with the documentation claiming it is enforcing. Leaving a control that only
+/// appears to be live is the outcome this forbids.
+/// </para>
+/// </remarks>
+public sealed class SecurityControlHasACallerTests
+{
+    /// <summary>
+    /// Interface directories whose contents are access-control or governance decisions. A contract
+    /// declared here is load-bearing by construction, so an uncalled one is a finding rather than
+    /// dead weight.
+    /// </summary>
+    private static readonly string[] GuardedInterfaceFolders =
+    [
+        Path.Combine("Interfaces", "Governance"),
+        Path.Combine("Interfaces", "Identity")
+    ];
+
+    /// <summary>
+    /// Contracts that are deliberately not consumed by the harness itself, each with the reason.
+    /// Anything added here needs an argument for why an unconsumed security contract is correct.
+    /// </summary>
+    private static readonly Dictionary<string, string> Exempt = new(StringComparer.Ordinal)
+    {
+        // A pure extension point: the harness ships no implementation and never calls one directly.
+        // Its consumer is IToolCallObserverChain, which resolves IEnumerable<IToolCallObserver> —
+        // so it does in fact have a caller, and this entry exists only to document that the
+        // zero-implementations state is intended rather than an oversight.
+        ["IToolCallObserver"] = "consumer extension point; consumed as a collection by IToolCallObserverChain",
+
+        // NOT a justified exemption — a known defect with a deadline. This guard's first run found
+        // it: the MCP tool-poisoning scanner is registered twice and called nowhere, which is the
+        // fifth instance of the pattern this test exists to catch. Tracked in #313. Delete this
+        // entry when it is wired; do not treat it as precedent for exempting anything else.
+        ["IMcpSecurityScanner"] = "KNOWN DEFECT, tracked in #313 — registered but never invoked"
+    };
+
+    [Fact]
+    public void EveryRegisteredGovernanceContractHasAProductionConsumer()
+    {
+        var contentRoot = Path.Combine(RepoRoot.Path, "src", "Content");
+        var contracts = FindGuardedContracts(contentRoot);
+
+        contracts.Should().NotBeEmpty(
+            "a scan that discovered no contracts would pass vacuously — the folders it reads must exist");
+
+        var productionFiles = Directory
+            .EnumerateFiles(contentRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsExcluded(f, contentRoot))
+            .Select(f => (Path: f, Code: StripCommentsAndStrings(File.ReadAllText(f))))
+            .ToArray();
+
+        var uncalled = new List<string>();
+
+        foreach (var (contract, declarationPath) in contracts)
+        {
+            if (Exempt.ContainsKey(contract))
+                continue;
+
+            var consumers = productionFiles
+                .Where(f => !string.Equals(f.Path, declarationPath, StringComparison.OrdinalIgnoreCase))
+                .Where(f => Regex.IsMatch(f.Code, $@"\b{contract}\b"))
+                .Where(f => !IsRegistrationOnly(f.Code, contract))
+                .Where(f => !Implements(f.Code, contract))
+                .Select(f => Path.GetRelativePath(contentRoot, f.Path))
+                .ToArray();
+
+            if (consumers.Length == 0)
+                uncalled.Add(contract);
+        }
+
+        uncalled.Should().BeEmpty(
+            "a governance contract that is declared, implemented and registered but never consumed is "
+            + "a security control that does not run, while its documentation says it does. That has "
+            + "shipped four times. Wire each of these onto the path it guards, or delete it together "
+            + "with the docs claiming it is enforced. Uncalled: " + string.Join(", ", uncalled));
+    }
+
+    [Fact]
+    public void TheGuardWouldActuallyFire()
+    {
+        // An empty offender list is the same shape whether nothing violates the rule or nothing is
+        // being read. These prove each classifier does its job, so a pass means the scan ran.
+        Implements("public sealed class X : IAgentToolAuthorizationGate { }", "IAgentToolAuthorizationGate")
+            .Should().BeTrue("an implementation is not a consumer");
+        Implements("public sealed class X : Base, IAgentToolAuthorizationGate { }", "IAgentToolAuthorizationGate")
+            .Should().BeTrue("an implementation is not a consumer when the interface is not first either");
+
+        IsRegistrationOnly(
+            "services.AddScoped<IAgentToolAuthorizationGate, DefaultAgentToolAuthorizationGate>();",
+            "IAgentToolAuthorizationGate")
+            .Should().BeTrue("registering a service is not calling it — that is the whole defect");
+
+        Implements("private readonly IAgentToolAuthorizationGate _gate;", "IAgentToolAuthorizationGate")
+            .Should().BeFalse("a field of the interface type is exactly what a consumer looks like");
+        IsRegistrationOnly("private readonly IAgentToolAuthorizationGate _gate;", "IAgentToolAuthorizationGate")
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void TheScanReadsARepresentativeNumberOfFiles()
+    {
+        var contentRoot = Path.Combine(RepoRoot.Path, "src", "Content");
+
+        Directory.EnumerateFiles(contentRoot, "*.cs", SearchOption.AllDirectories)
+            .Count(f => !IsExcluded(f, contentRoot))
+            .Should().BeGreaterThan(500);
+    }
+
+    /// <summary>
+    /// Finds every public interface declared under a guarded folder, returning its name and the file
+    /// that declares it.
+    /// </summary>
+    private static IReadOnlyList<(string Contract, string DeclarationPath)> FindGuardedContracts(string contentRoot)
+    {
+        var found = new List<(string, string)>();
+
+        foreach (var file in Directory.EnumerateFiles(contentRoot, "I*.cs", SearchOption.AllDirectories))
+        {
+            if (IsExcluded(file, contentRoot))
+                continue;
+
+            var directory = Path.GetDirectoryName(file) ?? string.Empty;
+            if (!GuardedInterfaceFolders.Any(folder => directory.Contains(folder, StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            var code = StripCommentsAndStrings(File.ReadAllText(file));
+            foreach (Match match in Regex.Matches(code, @"\bpublic\s+interface\s+(I\w+)"))
+                found.Add((match.Groups[1].Value, file));
+        }
+
+        return found;
+    }
+
+    /// <summary>
+    /// Whether the only mention of the contract in this file is a DI registration. Registering a
+    /// service is precisely what every one of the four dead controls did have.
+    /// </summary>
+    private static bool IsRegistrationOnly(string code, string contract)
+    {
+        var mentions = Regex.Matches(code, $@"\b{contract}\b").Count;
+        var registrations = Regex.Matches(
+            code, $@"Add(?:Scoped|Singleton|Transient|Keyed\w+)\s*<\s*{contract}\b").Count;
+        return mentions > 0 && mentions == registrations;
+    }
+
+    /// <summary>
+    /// Whether this file declares a type implementing the contract. An implementation names the
+    /// interface without being a caller of it.
+    /// </summary>
+    private static bool Implements(string code, string contract) =>
+        Regex.IsMatch(code, $@"\b(?:class|record|struct)\s+\w+(?:<[^>]*>)?\s*:\s*[^{{;]*\b{contract}\b");
+
+    private static bool IsExcluded(string path, string contentRoot)
+    {
+        var relative = Path.GetRelativePath(contentRoot, path);
+        var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return segments.Contains("Tests", StringComparer.OrdinalIgnoreCase)
+            || segments.Contains("bin", StringComparer.OrdinalIgnoreCase)
+            || segments.Contains("obj", StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Removes comments and string literals so only compiled code is matched — a doc comment naming
+    /// a contract must not count as calling it, which is exactly how the dead controls read as live.
+    /// </summary>
+    private static string StripCommentsAndStrings(string source)
+    {
+        var withoutBlockComments = Regex.Replace(source, @"/\*.*?\*/", " ", RegexOptions.Singleline);
+        var withoutLineComments = Regex.Replace(withoutBlockComments, @"//[^\n]*", " ");
+        return Regex.Replace(withoutLineComments, "\"(?:[^\"\\\\\n]|\\\\.)*\"", "\"\"");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -127,6 +127,17 @@ public sealed class SecurityControlHasACallerTests
             "IAgentToolAuthorizationGate")
             .Should().BeTrue("registering a service is not calling it — that is the whole defect");
 
+        // The shape this repo actually writes. The first version of this control asserted only the
+        // unqualified form above, so it passed while the classifier matched none of the eight
+        // namespace-qualified registrations in Application.AI.Common — the guard was blind and its
+        // own mutation test said otherwise. A control that does not exercise the real input is not
+        // a control.
+        IsRegistrationOnly(
+            "services.AddScoped<Interfaces.Governance.IAgentToolAuthorizationGate, "
+            + "Services.Governance.DefaultAgentToolAuthorizationGate>();",
+            "IAgentToolAuthorizationGate")
+            .Should().BeTrue("registrations here are namespace-qualified, and are still registrations");
+
         Implements("private readonly IAgentToolAuthorizationGate _gate;", "IAgentToolAuthorizationGate")
             .Should().BeFalse("a field of the interface type is exactly what a consumer looks like");
         IsRegistrationOnly("private readonly IAgentToolAuthorizationGate _gate;", "IAgentToolAuthorizationGate")
@@ -172,11 +183,19 @@ public sealed class SecurityControlHasACallerTests
     /// Whether the only mention of the contract in this file is a DI registration. Registering a
     /// service is precisely what every one of the four dead controls did have.
     /// </summary>
+    /// <remarks>
+    /// The optional <c>(?:[\w.]+\.)?</c> qualifier is load-bearing, not defensive. Every governance
+    /// contract in <c>Application.AI.Common/DependencyInjection.cs</c> is registered namespace-
+    /// qualified — <c>AddScoped&lt;Interfaces.Governance.IToolInvocationGovernor, …&gt;</c> — so a
+    /// pattern anchored directly on the bare interface name matched none of them. That made the DI
+    /// file look like a <em>consumer</em> of all eight, and the guard structurally unable to report
+    /// any of them: exactly the blind spot it exists to remove.
+    /// </remarks>
     private static bool IsRegistrationOnly(string code, string contract)
     {
         var mentions = Regex.Matches(code, $@"\b{contract}\b").Count;
         var registrations = Regex.Matches(
-            code, $@"Add(?:Scoped|Singleton|Transient|Keyed\w+)\s*<\s*{contract}\b").Count;
+            code, $@"Add(?:Scoped|Singleton|Transient|Keyed\w+)\s*<\s*(?:[\w.]+\.)?{contract}\b").Count;
         return mentions > 0 && mentions == registrations;
     }
 

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ToolCallAdmissionChokepointTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ToolCallAdmissionChokepointTests.cs
@@ -38,6 +38,7 @@ public sealed class ToolCallAdmissionChokepointTests
     /// <summary>The gates that must only ever be invoked from inside the chain.</summary>
     private static readonly string[] GateInterfaces =
     [
+        "IAgentToolAuthorizationGate",
         "IToolInvocationGovernor",
         "IToolClassificationGate",
         "IToolCallObserverChain",
@@ -51,6 +52,7 @@ public sealed class ToolCallAdmissionChokepointTests
     private static readonly HashSet<string> Allowed = new(StringComparer.OrdinalIgnoreCase)
     {
         // The contracts themselves.
+        "IAgentToolAuthorizationGate.cs",
         "IToolInvocationGovernor.cs",
         "IToolClassificationGate.cs",
         "IToolCallObserverChain.cs",
@@ -64,6 +66,7 @@ public sealed class ToolCallAdmissionChokepointTests
 
         // The implementations. ToolCallObserverChain names the governor because it corrects the
         // governor's trace when it blocks a call the governor allowed.
+        "DefaultAgentToolAuthorizationGate.cs",
         "ToolInvocationGovernor.cs",
         "ToolInvocationGovernor.Approval.cs",
         "DefaultToolClassificationGate.cs",


### PR DESCRIPTION
Closes #311.

## The defect

`IAgentIdentityValidator` was registered in DI and injected nowhere. Its `CanInvoke` — a
complete fail-closed RBAC implementation with fifteen passing tests — had no production
caller, while three doc comments told readers it was enforcing. Per-agent tool
authorization was, as shipped, not enforced.

It is now stage 1 of `IToolCallAdmissionPipeline`, behind
`AI.Identity.ToolAuthorization.Enabled` (off by default), so it applies to all four
execution paths rather than one.

## Two measurements that shaped the design

**The validator denies when no policy is configured.** Correct for a policy oracle, wrong
for a pipeline stage: a harness that never configured tool authorization would have every
call refused. Hence a separate gate holding the two things the validator deliberately does
not — the feature switch, and identity acquisition. The validator stays a pure oracle,
contract and tests untouched.

**The execution context carries an identity only on the agent-turn path.** The plan
engine's step executors and the Execution API's direct invoker each open a fresh DI scope
whose context starts blank. A gate reading only the context would enforce on one path in
four and be bypassable by issuing the same call from a plan step — the same defect class,
quieter. So the gate resolves the identity itself, which is sound rather than a workaround
because `AgentIdentity` is a *workload* identity: the Entra-bound principal of the running
agent, not a per-request value. Resolving it from a child scope yields the same principal;
the resolver is a singleton for exactly that reason. Cached per scope.

## Order

Stage 1, ahead of the governor. It is the cheapest and most fundamental access question,
and the governor can escalate to a human — nobody should be asked to approve a call that
RBAC refuses anyway, which is both a wasted interruption and a way to train operators to
approve calls that were never permitted.

Running ahead of the governor means the governor never sees a refused call, so the refusal
is recorded on the trace explicitly. Without that, a turn in which an agent was refused
every tool it attempted reported zero denials to governance reporting, the dashboard and
the audit — for an access-control decision, the reporting equivalent of not enforcing it.

## Fail-closed, and loud when misconfigured

Every non-allow path out of an enabled gate denies: no validator, no resolver, no
resolvable identity, a throwing credential provider. Cancellation is the one exception —
it propagates, because an abandoned call is not a policy decision, and it is not latched,
because a DI scope spans every turn of a conversation.

`ToolAuthorizationConfigValidator` turns the configurations that could only ever deny —
feature on with the identity subsystem off, or with an empty allowlist — into a boot
failure rather than an agent that starts cleanly and then refuses everything. Since
configuration is monitored rather than snapshotted, a live flip that bypasses startup is
logged once per scope.

## The durable part, and what it found

`SecurityControlHasACallerTests` asserts that every registered governance or identity
contract has a production consumer. This is the fourth control to ship
registered-but-uninvoked (after `ToolPermissionFilter`, `GoverningToolContextProvider`,
and both recall providers), and no unit test can fail for a call that was never written —
the control's own tests exercise the control and pass.

Its first run found a fifth: **`IMcpSecurityScanner`**, the scanner for tool poisoning,
typosquatting and hidden instructions in MCP tool descriptions, registered twice and
called nowhere. Filed as #313 and exempted with that reference; the exemption is labelled
a known defect, not a justification.

## Review

`/code-review high` returned six findings; all are fixed in `226a010e`, each with a test.
The most serious was in the new guard itself — its registration pattern missed
namespace-qualified registrations, so it was blind to all eight governance contracts in
`Application.AI.Common`'s DI, and its own mutation control asserted a shape this repo
never writes. With the pattern corrected the guard still passes, so those eight are
genuinely consumed.

`/simplify` then removed `AgentToolAuthorizationVerdict`: it duplicated
`ToolInvocationDecision` exactly, which `IToolCallObserverChain` — the sibling access gate
in the same chain — already returns.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — clean.
- `dotnet test src/AgenticHarness.slnx` — 9,900+ tests, 0 failures.
- Mutation-tested: defeating the authorization stage fails three tests, including the
  composition test and the ordering test.
- `AgentToolAuthorizationCompositionTests` resolves the gate from the real container and
  drives the real chain, rather than constructing either — the property whose absence was
  the original defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
