### PR TITLE
refactor: move EnumNameHelper into Domain.Common and delete the weak copies

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/ChangeProposalCommandHelper.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/ChangeProposalCommandHelper.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces.Changes;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.Common;
 using Domain.Common.Config;

--- a/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Changes/SubmitChangeProposal/SubmitChangeProposalCommandHandler.cs
@@ -1,7 +1,7 @@
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Changes;
 using Application.AI.Common.Interfaces.Governance;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Agents;
 using Domain.AI.Changes;
 using Domain.AI.Governance;

--- a/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -4,7 +4,7 @@ using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Sandbox;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Bundles;
 using Domain.AI.Changes;
 using Domain.AI.Governance;

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -1,6 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Sandbox;
 using Microsoft.Extensions.Options;

--- a/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyValidationRules.cs
+++ b/src/Content/Application/Application.Core/CQRS/Autonomy/AutonomyValidationRules.cs
@@ -1,4 +1,4 @@
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 
 namespace Application.Core.CQRS.Autonomy;

--- a/src/Content/Application/Application.Core/Permissions/AutonomyDecisionEvaluator.cs
+++ b/src/Content/Application/Application.Core/Permissions/AutonomyDecisionEvaluator.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces.Governance;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;

--- a/src/Content/Application/Application.Core/Permissions/AutonomyTierRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/AutonomyTierRuleProvider.cs
@@ -1,6 +1,6 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Permissions;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Agents;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -2,7 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
 using Domain.AI.Skills;

--- a/src/Content/Application/Application.Core/Validation/ContentCaptureConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ContentCaptureConfigValidator.cs
@@ -1,4 +1,4 @@
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config.AI.Telemetry;
 using FluentValidation;

--- a/src/Content/Application/Application.Core/Validation/LogsConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/LogsConfigValidator.cs
@@ -1,4 +1,4 @@
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config.Observability;
 using FluentValidation;

--- a/src/Content/Domain/Domain.AI/Iac/IacScanSeverityParser.cs
+++ b/src/Content/Domain/Domain.AI/Iac/IacScanSeverityParser.cs
@@ -1,3 +1,5 @@
+using Domain.Common.Helpers;
+
 namespace Domain.AI.Iac;
 
 /// <summary>
@@ -16,9 +18,53 @@ public static class IacScanSeverityParser
     /// <param name="value">The configured severity, e.g. <c>"High"</c>.</param>
     /// <param name="severity">The parsed severity when recognised.</param>
     /// <returns><see langword="true"/> when the value maps to a known severity; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// Delegates to <see cref="EnumNameHelper.TryParseName{TEnum}(string?, out TEnum)"/> rather than
+    /// restating the rule. This method previously implemented two of that helper's four guards —
+    /// trim and <see cref="Enum.IsDefined{TEnum}(TEnum)"/> — so <c>"2"</c> and <c>"Low,Critical"</c>
+    /// both parsed. <c>"2"</c> resolved to <see cref="IacScanSeverity.High"/>, making a configured
+    /// severity mean the same thing whether it was written as a name or as an opaque number, which
+    /// is the interchangeability the shared helper exists to refuse. <c>"Low,Critical"</c> is a
+    /// bitwise OR landing on a defined member, which <see cref="Enum.IsDefined{TEnum}(TEnum)"/>
+    /// cannot distinguish from having named that member outright.
+    /// </para>
+    /// <para>
+    /// This overload is for <em>configuration</em> — the blocking threshold — where refusing is the
+    /// safe answer because every caller treats it as a startup or generation failure. A severity
+    /// reported by a scanner against a specific finding has the opposite failure direction and must
+    /// use <see cref="ParseFindingSeverity"/> instead.
+    /// </para>
+    /// </remarks>
     public static bool TryParse(string? value, out IacScanSeverity severity)
-        => Enum.TryParse(value?.Trim(), ignoreCase: true, out severity)
-           && Enum.IsDefined(severity);
+        => EnumNameHelper.TryParseName(value, out severity);
+
+    /// <summary>
+    /// Reads the severity a scanner reported for a specific finding, resolving anything
+    /// unrecognisable to <see cref="IacScanSeverity.Critical"/>.
+    /// </summary>
+    /// <param name="value">The severity as scraped from scanner output.</param>
+    /// <returns>The named severity, or <see cref="IacScanSeverity.Critical"/> when it cannot be read.</returns>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why unreadable means Critical rather than "ignore it".</strong> The same parse serves
+    /// two callers whose failure directions are opposite. For the configured blocking threshold,
+    /// refusing fails closed: the generators return <c>iac.scan.invalid_blocking_severity</c> and
+    /// the startup validator throws. For a finding's severity it failed <em>open</em> — the tfsec
+    /// parser dropped the entire finding, and the Checkov and ARM-TTK parsers silently kept their
+    /// <see cref="IacScanSeverity.Medium"/> default — so a scanner reporting something the harness
+    /// could not read made a blocking scan pass quietly. A security scanner saying something we do
+    /// not understand is the last thing that should lower a gate.
+    /// </para>
+    /// <para>
+    /// This applies only when a severity was <em>reported and could not be read</em>. A finding with
+    /// no severity line at all keeps each parser's existing default, because Checkov emits severities
+    /// only when wired to its platform, and treating every unadorned finding as Critical would block
+    /// every scan.
+    /// </para>
+    /// </remarks>
+    public static IacScanSeverity ParseFindingSeverity(string? value)
+        => TryParse(value, out var severity) ? severity : IacScanSeverity.Critical;
 
     /// <summary>
     /// Decides whether a scan passes the gate: it passes when no finding is at or

--- a/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/GraphNodeMemoryExtensions.cs
+++ b/src/Content/Domain/Domain.AI/KnowledgeGraph/Models/GraphNodeMemoryExtensions.cs
@@ -1,3 +1,5 @@
+using Domain.Common.Helpers;
+
 namespace Domain.AI.KnowledgeGraph.Models;
 
 /// <summary>
@@ -35,12 +37,24 @@ public static class GraphNodeMemoryExtensions
     /// <see cref="MemoryTrust.Trusted"/> when no marker is present (legacy nodes, or nodes written
     /// while the memory guard was disabled), so unmarked facts remain recallable.
     /// </summary>
+    /// <remarks>
+    /// This is a round-trip of a value this system wrote itself, which is the category #300 left
+    /// alone on the grounds that tightening a parse can reject data already on disk. It is converted
+    /// here because that was checked rather than assumed: <see cref="WithTrust"/> is the only writer
+    /// and it persists <c>trust.ToString().ToLowerInvariant()</c>, so no numeric or composite form
+    /// has ever been stored and nothing existing is refused.
+    /// <para>
+    /// The check mattered because the fallback is <see cref="MemoryTrust.Untrusted"/>'s opposite: a
+    /// marker that fails to parse reads as recallable. Had numeric markers existed, refusing them
+    /// would have turned quarantined facts back into recallable ones — a tightening that fails open.
+    /// </para>
+    /// </remarks>
     public static MemoryTrust GetTrust(this GraphNode node)
     {
         ArgumentNullException.ThrowIfNull(node);
 
         return node.Properties.TryGetValue(TrustPropertyKey, out var raw)
-            && Enum.TryParse<MemoryTrust>(raw, ignoreCase: true, out var trust)
+            && EnumNameHelper.TryParseName<MemoryTrust>(raw, out var trust)
                 ? trust
                 : MemoryTrust.Trusted;
     }

--- a/src/Content/Domain/Domain.Common/Helpers/EnumNameHelper.cs
+++ b/src/Content/Domain/Domain.Common/Helpers/EnumNameHelper.cs
@@ -1,4 +1,4 @@
-namespace Application.Common.Helpers;
+namespace Domain.Common.Helpers;
 
 /// <summary>
 /// Parses enum values supplied as configuration or wire data, by <em>name</em> only.
@@ -18,10 +18,17 @@ namespace Application.Common.Helpers;
 /// changes a safety comparison.
 /// </para>
 /// <para>
-/// This helper lives in <c>Application.Common</c> deliberately: it is the layer both
-/// <c>Application.Core</c> (which validates these values at boot) and <c>Application.AI.Common</c>
-/// (which parses them again at runtime) can reference. Before #296 the two had separate rules, so
-/// the boot validator rejected <c>"3"</c> while the runtime parser accepted it as <c>High</c>.
+/// This helper lives in <c>Domain.Common</c> deliberately: it is the innermost layer, referenced by
+/// every other one, so <em>every</em> layer that reads an enum by name can reach the same rule.
+/// Before #296 the boot validator and the runtime parser had separate rules, so the validator
+/// rejected <c>"3"</c> while the parser accepted it as <c>High</c>.
+/// </para>
+/// <para>
+/// It sat in <c>Application.Common</c> until #312 moved it here. That placement was one ring too far
+/// out to be reachable from the Domain, and the Domain — unable to reference it — had hand-rolled two
+/// weaker copies of the same rule rather than go without. <c>Domain.Common</c> has no project
+/// references of its own, so the move adds no dependency anywhere and bends no arrows: the body uses
+/// only <see cref="Enum"/>, <see cref="char"/> and <see cref="string"/>.
 /// </para>
 /// </remarks>
 public static class EnumNameHelper

--- a/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/LlmWorkEpisodeSynthesizer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.KnowledgeGraph/WorkMemory/LlmWorkEpisodeSynthesizer.cs
@@ -7,7 +7,7 @@ using Application.AI.Common.Interfaces.WorkMemory;
 using Application.AI.Common.Json;
 using Application.AI.Common.Prompts.Exceptions;
 using Application.AI.Common.Prompts.Interfaces;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Learnings;
 using Domain.AI.Prompts;
 using Domain.AI.WorkMemory;

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/QueryTransform/LlmQueryClassifier.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/QueryTransform/LlmQueryClassifier.cs
@@ -4,7 +4,7 @@ using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.Prompts.Exceptions;
 using Application.AI.Common.Prompts.Interfaces;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Prompts;
 using Domain.AI.RAG.Enums;
 using Domain.AI.RAG.Models;

--- a/src/Content/Infrastructure/Infrastructure.AI/A2A/A2AIdentityPropagator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/A2A/A2AIdentityPropagator.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces.Agent;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.A2A;
 using Domain.AI.Identity;
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Agents;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/ChangeProposalBackgroundService.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces.Changes;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.Common.Config;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces.Changes;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Infrastructure/Infrastructure.AI/Governance/AutonomyConfigValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Governance/AutonomyConfigValidator.cs
@@ -1,4 +1,4 @@
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
 using Domain.Common.Config;

--- a/src/Content/Infrastructure/Infrastructure.AI/Governance/CapabilityEnvelopeResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Governance/CapabilityEnvelopeResolver.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
 using Application.AI.Common.Interfaces.Governance;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Bundles;
 using Domain.AI.Governance;
 using Domain.Common.Config;

--- a/src/Content/Infrastructure/Infrastructure.AI/Governance/DefaultAutonomyTierResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Governance/DefaultAutonomyTierResolver.cs
@@ -1,6 +1,6 @@
 using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Governance;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Agents;
 using Domain.AI.Governance;
 using Domain.Common.Config;

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/ArmTtkParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/ArmTtkParser.cs
@@ -53,10 +53,12 @@ public static partial class ArmTtkParser
 
             var joined = string.Join(" ", detail).Trim();
             var severity = IacScanSeverity.Medium;
+            // A reported-but-unreadable severity resolves to Critical rather than leaving the Medium
+            // default in place — see IacScanSeverityParser.ParseFindingSeverity.
             var sevMatch = SeverityToken().Match(joined);
-            if (sevMatch.Success && IacScanSeverityParser.TryParse(sevMatch.Groups["sev"].Value, out var parsed))
+            if (sevMatch.Success)
             {
-                severity = parsed;
+                severity = IacScanSeverityParser.ParseFindingSeverity(sevMatch.Groups["sev"].Value);
             }
 
             findings.Add(new IacScanFinding

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/CheckovParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/CheckovParser.cs
@@ -73,10 +73,12 @@ public static partial class CheckovParser
                 continue;
             }
 
+            // A reported-but-unreadable severity resolves to Critical rather than leaving the Medium
+            // default in place — see IacScanSeverityParser.ParseFindingSeverity.
             var sevMatch = SeverityLine().Match(line);
-            if (sevMatch.Success && IacScanSeverityParser.TryParse(sevMatch.Groups["sev"].Value, out var parsed))
+            if (sevMatch.Success)
             {
-                severity = parsed;
+                severity = IacScanSeverityParser.ParseFindingSeverity(sevMatch.Groups["sev"].Value);
             }
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/TfsecParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/TfsecParser.cs
@@ -73,10 +73,13 @@ public static partial class TfsecParser
                 continue;
             }
 
+            // A reported-but-unreadable severity resolves to Critical rather than leaving severity
+            // null, which made Flush drop the finding outright — see
+            // IacScanSeverityParser.ParseFindingSeverity.
             var sevMatch = SeverityLine().Match(line);
-            if (sevMatch.Success && IacScanSeverityParser.TryParse(sevMatch.Groups["sev"].Value, out var parsed))
+            if (sevMatch.Success)
             {
-                severity = parsed;
+                severity = IacScanSeverityParser.ParseFindingSeverity(sevMatch.Groups["sev"].Value);
                 continue;
             }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/IncidentResponsePlanValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/IncidentResponse/IncidentResponsePlanValidator.cs
@@ -1,4 +1,4 @@
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Governance;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.IncidentResponse;

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/ContentCapturePolicy.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/ContentCapturePolicy.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces.Telemetry;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
@@ -1,6 +1,6 @@
 using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Tools;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
 using Domain.AI.Models;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
@@ -1,7 +1,7 @@
 using Application.AI.Common.CQRS.Changes.SubmitChangeProposal;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.AI.SkillTraining;

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces.Telemetry;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config.Observability;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/SessionsController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/SessionsController.cs
@@ -1,5 +1,5 @@
 using Application.AI.Common.Interfaces;
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using Domain.AI.Context;
 using Domain.AI.Observability.Models;
 using Microsoft.AspNetCore.Authorization;

--- a/src/Content/Tests/Application.Common.Tests/Helpers/GovernanceEnumParseChokepointTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Helpers/GovernanceEnumParseChokepointTests.cs
@@ -62,7 +62,22 @@ public sealed class GovernanceEnumParseChokepointTests
         // MergeGate short-circuits its real apply on `Mode == Shadow`, so any value that is not
         // exactly Shadow writes for real. A numeric config value turned a dry run into production
         // writes — the sharpest consequence found anywhere in this sweep.
-        "OrchestratorMode"
+        "OrchestratorMode",
+
+        // Domain-layer enums, reachable only since #312 moved the helper into Domain.Common. Both
+        // were parsed by hand-rolled weaker copies of this rule before that.
+        //
+        // IacScanSeverity decides whether an infrastructure scan blocks a proposal. It is read from
+        // two directions with opposite failure semantics: the configured blocking threshold, where
+        // refusing fails closed, and each finding's severity as scraped from Checkov / tfsec /
+        // ARM-TTK output, where refusing failed open until #312 gave that path its own reader.
+        // Those scrapers capture `\w+`, which includes digits, so the numeric form is reachable from
+        // tool output and not just from config.
+        "IacScanSeverity",
+
+        // MemoryTrust marks a fact as quarantined. Its reader falls back to Trusted — recallable —
+        // so anything that makes the marker unreadable fails open.
+        "MemoryTrust"
     ];
 
     /// <summary>
@@ -74,6 +89,14 @@ public sealed class GovernanceEnumParseChokepointTests
         "EnumNameHelper.cs"
     };
 
+    /// <summary>
+    /// Files exempt from the <em>inferred</em> matcher only, because its file-level attribution can
+    /// name an enum the file merely mentions. Deliberately separate from <see cref="Allowed"/>:
+    /// silencing a heuristic false positive must not also switch off <see cref="BareParseOf"/> for
+    /// that file, which is the precise check the guard was built for. Empty today.
+    /// </summary>
+    private static readonly HashSet<string> AllowedInferred = new(StringComparer.OrdinalIgnoreCase);
+
     private const string SourceGlob = "*.cs";
 
     /// <summary>
@@ -82,6 +105,31 @@ public sealed class GovernanceEnumParseChokepointTests
     /// </summary>
     private static Regex BareParseOf(string enumName)
         => new($@"\bEnum\.(TryParse|Parse)\s*<\s*{enumName}\s*>", RegexOptions.None, TimeSpan.FromSeconds(5));
+
+    /// <summary>
+    /// Matches a framework parse whose enum type is <em>inferred</em> from the <c>out</c> variable
+    /// rather than written as a type argument — <c>Enum.TryParse(raw, true, out severity)</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>This shape was invisible to the guard until #312, and it is the shape the offender
+    /// used.</strong> <c>IacScanSeverityParser</c> parsed a severity that decides whether an
+    /// infrastructure scan blocks a proposal, with two of the four guards and no type argument, so
+    /// <see cref="BareParseOf"/> could not see it however many enums the array listed. Adding an
+    /// enum name to a matcher that cannot match the call shape is a test that only looks like a
+    /// control — which is the failure this whole family of guards exists to prevent.
+    /// </para>
+    /// <para>
+    /// The call text alone cannot say which enum an inferred parse targets, so a file is an offender
+    /// when it contains one <em>and</em> names a governance enum. That is a heuristic and could flag
+    /// a file that parses something else while merely mentioning a governance enum; measured across
+    /// production source it flags nothing beyond the two files that should be flagged, and the
+    /// existing one-entry allowlist absorbs the helper itself. A future false positive is a
+    /// reviewer's decision, which the guard's design already treats as the point.
+    /// </para>
+    /// </remarks>
+    private static readonly Regex InferredParse =
+        new(@"\bEnum\.(TryParse|Parse)\s*\(", RegexOptions.None, TimeSpan.FromSeconds(5));
 
     [Fact]
     public void GovernanceEnumsAreParsedOnlyThroughEnumNameHelper()
@@ -95,9 +143,19 @@ public sealed class GovernanceEnumParseChokepointTests
                 continue;
 
             var code = StripCommentsAndStrings(File.ReadAllText(file));
+
             var named = GovernanceEnums.Where(e => BareParseOf(e).IsMatch(code)).ToArray();
-            if (named.Length > 0)
-                offenders.Add($"{Path.GetRelativePath(contentRoot, file)} → {string.Join(", ", named)}");
+
+            // An inferred parse names no type, so attribute it to whichever governance enums the
+            // file mentions — see the remarks on InferredParse for why that heuristic is the only
+            // thing a source scan can do here, and what it measured.
+            var inferred = InferredParse.IsMatch(code) && !AllowedInferred.Contains(Path.GetFileName(file))
+                ? GovernanceEnums.Where(e => Regex.IsMatch(code, $@"\b{e}\b")).ToArray()
+                : [];
+
+            var offending = named.Union(inferred, StringComparer.Ordinal).ToArray();
+            if (offending.Length > 0)
+                offenders.Add($"{Path.GetRelativePath(contentRoot, file)} → {string.Join(", ", offending)}");
         }
 
         offenders.Should().BeEmpty(
@@ -134,6 +192,32 @@ public sealed class GovernanceEnumParseChokepointTests
 
         GovernanceEnums.Any(e => BareParseOf(e).IsMatch(otherEnum)).Should().BeFalse(
             "round-trips of values this system wrote itself are deliberately out of scope");
+    }
+
+    /// <summary>
+    /// The inferred form, which the guard could not see until #312. This is the control for that
+    /// gap: the exact source line <c>IacScanSeverityParser</c> carried, which listed
+    /// <c>IacScanSeverity</c> in the array above and still went unreported, because the matcher
+    /// required a type argument the call does not have.
+    /// </summary>
+    [Fact]
+    public void TheGuardCatchesAParseWhoseEnumTypeIsInferred()
+    {
+        var theOffendingLine = StripCommentsAndStrings(
+            "public static bool TryParse(string? value, out IacScanSeverity severity)"
+            + " => Enum.TryParse(value?.Trim(), ignoreCase: true, out severity) && Enum.IsDefined(severity);");
+
+        InferredParse.IsMatch(theOffendingLine).Should().BeTrue(
+            "an inferred parse is the same defect wearing different syntax");
+        GovernanceEnums.Any(e => BareParseOf(e).IsMatch(theOffendingLine)).Should().BeFalse(
+            "and the type-argument matcher alone genuinely cannot see it — that is why this exists");
+
+        // The explicit form must not be double-reported by the inferred matcher's own call paren.
+        InferredParse.IsMatch(StripCommentsAndStrings("Enum.TryParse<AutonomyLevel>(raw, out var t);"))
+            .Should().BeFalse("a type argument means the enum is named, and BareParseOf owns that case");
+
+        InferredParse.IsMatch(StripCommentsAndStrings("var ok = int.TryParse(raw, out var n);"))
+            .Should().BeFalse("only Enum.TryParse / Enum.Parse are in scope");
     }
 
     [Fact]

--- a/src/Content/Tests/Domain.AI.Tests/Iac/IacScanSeverityParserTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Iac/IacScanSeverityParserTests.cs
@@ -1,0 +1,125 @@
+using Domain.AI.Iac;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.Iac;
+
+/// <summary>
+/// Tests for <see cref="IacScanSeverityParser"/>, which decides both what a valid configured
+/// blocking severity is and what severity a scanner finding carries.
+/// </summary>
+/// <remarks>
+/// The type had no tests before #312, despite deciding whether an infrastructure scan blocks a
+/// deployment. It hand-rolled two of <c>EnumNameHelper</c>'s four guards; the refusal cases below
+/// are the two it used to accept.
+/// <para>
+/// The two entry points have deliberately opposite failure directions, which is the property most
+/// worth pinning here: refusing a configured threshold fails closed, while refusing a scanner's
+/// reported severity would fail open, so that path resolves to Critical instead.
+/// </para>
+/// </remarks>
+public sealed class IacScanSeverityParserTests
+{
+    [Theory]
+    [InlineData("Low", IacScanSeverity.Low)]
+    [InlineData("high", IacScanSeverity.High)]
+    [InlineData("CRITICAL", IacScanSeverity.Critical)]
+    [InlineData("  Medium  ", IacScanSeverity.Medium)]
+    public void TryParse_NamedSeverity_Parses(string value, IacScanSeverity expected)
+    {
+        IacScanSeverityParser.TryParse(value, out var severity).Should().BeTrue();
+        severity.Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The numeric form, which used to parse: <c>"2"</c> resolved to <see cref="IacScanSeverity.High"/>.
+    /// The problem is not that the two readers of a configured threshold disagreed — they share this
+    /// method, so they never did — it is that a name and an opaque number were interchangeable, and
+    /// <c>"99"</c> produced a severity no comparison could ever match. The severity regexes in the
+    /// Checkov and tfsec parsers capture <c>\w+</c>, which includes digits, so the numeric form was
+    /// reachable from scanner output as well as from config.
+    /// </summary>
+    [Theory]
+    [InlineData("2")]
+    [InlineData(" 2")]
+    [InlineData("99")]
+    [InlineData("-1")]
+    [InlineData("+3")]
+    public void TryParse_NumericForm_IsRefused(string value)
+    {
+        IacScanSeverityParser.TryParse(value, out _).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// A comma reads as a bitwise OR, and when the OR lands on a defined member
+    /// <c>Enum.IsDefined</c> cannot tell it apart from having named that member — which is why the
+    /// old two-guard implementation accepted it.
+    /// </summary>
+    [Theory]
+    [InlineData("Low,Critical")]
+    [InlineData("Low, High")]
+    public void TryParse_CommaComposite_IsRefused(string value)
+    {
+        IacScanSeverityParser.TryParse(value, out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Severe")]
+    public void TryParse_BlankOrUnknown_IsRefused(string? value)
+    {
+        IacScanSeverityParser.TryParse(value, out _).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Critical", IacScanSeverity.Critical)]
+    [InlineData("low", IacScanSeverity.Low)]
+    public void ParseFindingSeverity_NamedSeverity_ReadsIt(string value, IacScanSeverity expected)
+    {
+        IacScanSeverityParser.ParseFindingSeverity(value).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The finding path fails closed. Before #312 an unreadable severity left the tfsec parser's
+    /// severity null, and its flush dropped the whole finding; Checkov and ARM-TTK kept their Medium
+    /// default. Either way a scanner reporting something the harness could not read made a scan that
+    /// should have blocked pass quietly.
+    /// </summary>
+    [Theory]
+    [InlineData("3")]
+    [InlineData("99")]
+    [InlineData("Low,Critical")]
+    [InlineData("banana")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ParseFindingSeverity_UnreadableSeverity_IsCritical(string? value)
+    {
+        IacScanSeverityParser.ParseFindingSeverity(value).Should().Be(
+            IacScanSeverity.Critical,
+            "a security scanner saying something we cannot read must not lower the gate");
+    }
+
+    /// <summary>
+    /// The property that makes the fallback safe: Critical is the top of the scale, so a finding
+    /// carrying it blocks at every configured threshold.
+    /// </summary>
+    [Theory]
+    [InlineData(IacScanSeverity.Low)]
+    [InlineData(IacScanSeverity.Medium)]
+    [InlineData(IacScanSeverity.High)]
+    [InlineData(IacScanSeverity.Critical)]
+    public void Passes_UnreadableFindingSeverity_BlocksAtEveryThreshold(IacScanSeverity blocking)
+    {
+        var finding = new IacScanFinding
+        {
+            Scanner = "tfsec",
+            RuleId = "rule-1",
+            Severity = IacScanSeverityParser.ParseFindingSeverity("3"),
+            Message = "unreadable severity"
+        };
+
+        IacScanSeverityParser.Passes([finding], blocking).Should().BeFalse();
+    }
+}

--- a/src/Content/Tests/Domain.AI.Tests/KnowledgeGraph/HarmonicMemoryModelsTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/KnowledgeGraph/HarmonicMemoryModelsTests.cs
@@ -81,6 +81,43 @@ public sealed class HarmonicMemoryModelsTests
         stamped.GetAbstraction().Should().Be("kept");
     }
 
+    /// <summary>
+    /// The marker is read by name only, since #312. <c>WithTrust</c> is the only writer and it
+    /// persists the lowercase name, so no stored marker is refused by this — but a hand-written or
+    /// tampered numeric marker no longer resolves to a member by accident.
+    /// </summary>
+    [Theory]
+    [InlineData("1")]
+    [InlineData(" 1")]
+    [InlineData("99")]
+    [InlineData("Trusted,Untrusted")]
+    public void GetTrust_NonNameMarker_FallsBackToTrustedRatherThanResolvingByNumber(string raw)
+    {
+        var node = BareNode() with
+        {
+            Properties = new Dictionary<string, string> { [GraphNodeMemoryExtensions.TrustPropertyKey] = raw }
+        };
+
+        node.GetTrust().Should().Be(
+            MemoryTrust.Trusted,
+            "a marker that is not a member name is not a marker, and an unreadable marker reads as "
+            + "recallable — the documented fallback");
+    }
+
+    [Theory]
+    [InlineData("untrusted", MemoryTrust.Untrusted)]
+    [InlineData("UNTRUSTED", MemoryTrust.Untrusted)]
+    [InlineData("trusted", MemoryTrust.Trusted)]
+    public void GetTrust_NamedMarker_RoundTrips(string raw, MemoryTrust expected)
+    {
+        var node = BareNode() with
+        {
+            Properties = new Dictionary<string, string> { [GraphNodeMemoryExtensions.TrustPropertyKey] = raw }
+        };
+
+        node.GetTrust().Should().Be(expected);
+    }
+
     [Fact]
     public void GetAbstraction_OnNodeWithoutAbstraction_ReturnsNull()
     {

--- a/src/Content/Tests/Domain.Common.Tests/Helpers/EnumNameHelperTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Helpers/EnumNameHelperTests.cs
@@ -1,8 +1,8 @@
-using Application.Common.Helpers;
+using Domain.Common.Helpers;
 using FluentAssertions;
 using Xunit;
 
-namespace Application.Common.Tests.Helpers;
+namespace Domain.Common.Tests.Helpers;
 
 /// <summary>
 /// Tests for <see cref="EnumNameHelper"/>.


### PR DESCRIPTION
Closes #312.

## The move

The harness has one rule for parsing an enum by name — established in #296, swept across ~20 call sites in #300. The Domain layer could not reach it: the helper sat in `Application.Common`, and Domain depends on nothing by design. So the Domain had grown two hand-rolled copies — `IacScanSeverityParser` with two of the four guards, `GraphNodeMemoryExtensions` with none.

`Domain.Common` has no project references and the helper's body uses only `Enum`, `char` and `string`, so the move adds no dependency anywhere and bends no arrows. 26 call sites rewired mechanically.

## Three things the issue did not anticipate

### 1. The guard from #300 could not see the shape it needed to catch

It matched only a parse that names its type argument. Both Domain copies inferred the type from the `out` variable — invisible to it. **Verified by putting the bad code back: the guard passed.** Adding the two Domain enums to its list, as the issue suggested, would have been decorative — a test that only looks like a control, which is the exact failure this family of guards exists to prevent.

The matcher now covers the inferred form. Measured across production source, exactly two files use it — the offender and the allowlisted helper — so closing the gap needed no new allowlist entries. The same mutation now **fails and names the file**.

The inferred matcher also gets its own allowlist, so silencing a heuristic false positive can't switch off the precise matcher for that file.

### 2. One parser served two callers with opposite failure directions

Refusing a configured blocking threshold **fails closed**: the generators return `iac.scan.invalid_blocking_severity`, the startup validator throws.

Refusing a severity a scanner reported against a finding **failed open**: the tfsec parser dropped the finding outright; Checkov and ARM-TTK silently kept their `Medium` default. So a scanner reporting something unreadable made a blocking scan pass quietly. Because the scrapers capture `\w+`, tightening the shared parse widened that path — a `Severity 3` line went from Critical (blocks) to dropped or Medium.

I had applied the does-this-fail-open test to the memory marker and **not** to this one. The finding side now has its own reader that resolves anything unreadable to **Critical**. A finding with *no* severity reported keeps each parser's existing default, because Checkov emits severities only when wired to its platform and blanket-Critical would block every scan.

### 3. The trust-marker conversion needed a check, not an assumption

`GetTrust` round-trips a value we wrote ourselves — the category #300 deliberately left alone. Converted because it was **checked**: `WithTrust` is the only writer and persists the lowercase name, so nothing stored is refused.

The check mattered. The fallback is *recallable*, so had numeric markers existed, refusing them would have turned quarantined facts back into visible ones — a tightening that fails open.

## Also

`IacScanSeverityParser` had **no tests at all**, despite deciding whether an infrastructure scan blocks a deployment. It has them now, including the numeric and comma-composite forms it used to accept, and the property that makes the new fallback safe: Critical blocks at every configured threshold.

Three comments in the first draft asserted a drift between the boot validator and the scanners that **never existed** — they share this method — and named the wrong severity for `"2"` (it meant `High`; the enum is Low=0/Medium=1/High=2/Critical=3). Caught in review, verified against source, rewritten.

## Verification

- Build: **0 errors, 0 C# warnings**.
- 22 test projects. The full-solution run shows this repo's known sandbox-process flake (`ProcessSandboxExecutorTests` ×2, `SandboxAttestationBindingTests` ×1). Control: `Infrastructure.AI.Tests` in isolation is **2924/2924**, and the failing set differs run to run (2 then 3) with none touching enum parsing.
- Mutation-tested: reverting the parser to its inferred bare form **passed** the guard before the matcher fix and **fails, naming the file**, after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgyekFt9vVUfL75GP1HL7d
