### PR TITLE
refactor: extract the governance trace out of the tool invocation governor (#297)

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -124,9 +124,15 @@ public static class DependencyInjection
         // Scoped agent execution context — carries agent identity through the pipeline
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
 
+        // The turn's governance audit trail. Every stage that can stop a tool call writes here and the
+        // admission chain snapshots it, which is what lets the governor below stay stateless and lets a
+        // test assert on the trail without constructing one. Scoped: one trail per agent turn, reset by
+        // the chain between turns.
+        services.AddScoped<Interfaces.Governance.IGovernanceTraceRecorder, Services.Governance.GovernanceTraceRecorder>();
+
         // Per-invocation tool governor — runs the permission / graded-autonomy / capability / policy
         // checks on the agent's live tool-call path (opt-in via GovernanceConfig.EnforceToolInvocation)
-        // and records the per-turn governance trace. Scoped: one per agent turn.
+        // and writes every decision to the trace recorder above. Scoped: one per agent turn.
         services.AddScoped<Interfaces.Governance.IToolInvocationGovernor, Services.Governance.ToolInvocationGovernor>();
 
         // Human approval routing for the governor's "requires approval" verdict (opt-in via

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IGovernanceTraceRecorder.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IGovernanceTraceRecorder.cs
@@ -1,0 +1,77 @@
+using Domain.AI.Governance;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// The turn's governance audit trail, as a thing that can be written to and snapshotted — separately
+/// from the components that decide what goes into it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this is its own type.</strong> Accumulating the trail used to be
+/// <see cref="IToolInvocationGovernor"/>'s second job, and it was the only reason that type held
+/// mutable state at all. The two jobs have different consumers: the authorization logic only ever
+/// <em>writes</em> here, while tests, diagnostics, bundle-run reporting and the dashboard only ever
+/// <em>read</em>. Splitting them means the trail can be asserted on without standing up a governor and
+/// its twelve dependencies, and the governor is left stateless.
+/// </para>
+/// <para>
+/// <strong>One record per decision.</strong> Every stage that can stop a tool call writes here exactly
+/// once for that call — the governor for its own verdicts, and
+/// <see cref="IToolInvocationGovernor.RecordDownstreamBlock"/> on behalf of the stages that run before
+/// and after it. A stage that writes a second line for a call another stage already recorded makes
+/// every such call count twice for anyone tallying denials, which is why refusals are routed through
+/// the governor rather than written here directly.
+/// </para>
+/// <para>
+/// Scoped to one agent turn, and reset between turns by the admission chain. Nested MediatR sends
+/// within a conversation share one DI scope, so without that reset <see cref="Snapshot"/> would return
+/// the cumulative list and per-turn traces would double-count when aggregated.
+/// </para>
+/// </remarks>
+public interface IGovernanceTraceRecorder
+{
+    /// <summary>
+    /// Whether this turn counts as governed: enforcement was active when a call was authorized
+    /// (<see cref="MarkEnforced"/>), <em>or</em> it is active right now.
+    /// </summary>
+    /// <remarks>
+    /// Both halves are load-bearing. The observed half survives a bundle run whose ambient capability
+    /// envelope has already torn down by the time the trace is assembled — a turn that authorized under
+    /// enforcement is still an enforced turn. The live half covers a turn under global enforcement that
+    /// never reached the governor at all, either because it made no tool calls or because a stage ahead
+    /// of the governor refused the only one it tried.
+    /// </remarks>
+    bool EnforcementEnabled { get; }
+
+    /// <summary>
+    /// Notes that a call was authorized while enforcement was active, so this turn keeps reporting as
+    /// governed after any ambient enforcement signal has gone away.
+    /// </summary>
+    void MarkEnforced();
+
+    /// <summary>Appends one decision to the turn's trail.</summary>
+    /// <param name="decision">The decision, as the recording stage wants it to read to an auditor.</param>
+    void Record(ToolDecisionRecord decision);
+
+    /// <summary>
+    /// Raises an escalation reason code for the turn. Codes are deduplicated case-insensitively, so a
+    /// stage that detects the same condition repeatedly contributes one code rather than one per
+    /// occurrence.
+    /// </summary>
+    /// <param name="reasonCode">
+    /// The stable code, e.g. <c>progress.spin_detected</c>. Blank is rejected: a code nothing can be
+    /// keyed off is noise on an audit trail.
+    /// </param>
+    void RecordEscalation(string reasonCode);
+
+    /// <summary>Takes an immutable snapshot of everything recorded so far this turn.</summary>
+    /// <returns>
+    /// The trace. <see cref="GovernanceTrace.Empty"/> — by reference — when the turn was ungoverned and
+    /// nothing was recorded, so a caller can cheaply tell "nothing happened" from "nothing was allowed".
+    /// </returns>
+    GovernanceTrace Snapshot();
+
+    /// <summary>Clears the trail so the next turn starts clean.</summary>
+    void Reset();
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IProgressEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IProgressEvaluator.cs
@@ -6,10 +6,28 @@ namespace Application.AI.Common.Interfaces.Governance;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Complements <see cref="IToolInvocationGovernor"/> at the same invocation chokepoint
-/// (<c>GovernedAIFunction</c>): the governor answers "may this tool run?" while the evaluator answers
-/// "is the agent still making progress?". Detection is pure call-signature counting — no model
-/// involvement — so it is cheap, deterministic, and unit-testable.
+/// Complements <see cref="IToolInvocationGovernor"/> at the same invocation chokepoint: the governor
+/// answers "may this tool run?" while the evaluator answers "is the agent still making progress?".
+/// Detection is pure call-signature counting — no model involvement — so it is cheap, deterministic,
+/// and unit-testable.
+/// </para>
+/// <para>
+/// <strong>Deciding and recording are ONE operation, and separating them is a defect.</strong> This
+/// looks like poor separation of concerns and has been proposed as a cleanup; it is neither. The
+/// harness invokes an assistant message's tool calls <em>in parallel</em>
+/// (<c>AllowConcurrentInvocation</c> is set by the agent factory), against the one turn-scoped
+/// evaluator. Answering and recording inside a single critical section is what makes a batch of
+/// identical calls serialise, so the second one sees the first. Split into "ask now, record later" —
+/// even with nothing at all between the two calls — every member of the batch asks before any of them
+/// has been recorded, they are all told they are the first, and <strong>the entire batch is
+/// admitted</strong>. <c>ProgressEvaluatorConcurrencyTests</c> carries the measurement and is the
+/// control that fails if anyone tries it again.
+/// </para>
+/// <para>
+/// The property that separating them was meant to buy — that a call refused by some other gate is
+/// never counted — is instead a property of <em>where</em> the chain calls this: at the single point
+/// where a call has cleared every stage, below every path that returns a refusal. See
+/// <see cref="IToolCallAdmissionPipeline"/>.
 /// </para>
 /// <para>
 /// Scoped to one agent turn. Nested MediatR sends within a conversation share one DI scope (and thus
@@ -22,7 +40,7 @@ namespace Application.AI.Common.Interfaces.Governance;
 public interface IProgressEvaluator
 {
     /// <summary>
-    /// Records a tool call and decides whether the agent is spinning.
+    /// Records a tool call and decides whether the agent is spinning, as one atomic operation.
     /// </summary>
     /// <param name="toolName">The tool the agent is invoking.</param>
     /// <param name="argumentsSignatureFactory">
@@ -37,16 +55,22 @@ public interface IProgressEvaluator
     /// evaluator records nothing, never invokes the factory, and always returns
     /// <see cref="ProgressVerdict.Continue"/>.
     /// </returns>
+    /// <remarks>
+    /// Call this only for a call that is going to run. It counts what it is given, so a caller that
+    /// consults it before the other gates have finished would have it count calls that are then
+    /// blocked — which is not a bookkeeping nicety but defeats the guard outright. An agent retrying a
+    /// blocked call with one argument changed each time presents a fresh signature every attempt,
+    /// resetting the no-progress counter every attempt, and never trips the guard it is spinning
+    /// against. That shipped once.
+    /// </remarks>
     ProgressVerdict Evaluate(string toolName, Func<string?> argumentsSignatureFactory);
 
-    /// <summary>
-    /// The distinct escalation reason codes the guard raised this turn. Empty unless a spin was
-    /// detected while configured for <c>ProgressGuardAction.Escalate</c>. The turn handler folds these
-    /// into the turn's <c>GovernanceTrace.EscalationReasonCodes</c>.
-    /// </summary>
-    IReadOnlyList<string> EscalationReasonCodes { get; }
-
-    /// <summary>Clears the recorded call history and escalations so the next turn starts clean.</summary>
+    /// <summary>Clears the recorded call history so the next turn starts clean.</summary>
+    /// <remarks>
+    /// Escalation reason codes are <em>not</em> cleared here — they live on
+    /// <see cref="IGovernanceTraceRecorder"/> with the rest of the turn's governance trail, and are
+    /// cleared when that is reset.
+    /// </remarks>
     void Reset();
 }
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -40,15 +40,21 @@ namespace Application.AI.Common.Interfaces.Governance;
 /// </description></item>
 /// <item><description>
 /// <see cref="IProgressEvaluator"/> — the loop guard, last of all because it is the only stage that
-/// <strong>mutates</strong> state. It records the call's signature and resets the no-progress counter,
-/// so it must only ever count calls that actually reached the tool. Running it earlier let blocked
-/// calls reset the counter, and an agent retrying a blocked call with a slightly different argument
-/// each time never tripped the guard it was spinning against.
+/// <strong>mutates</strong> state. Asking it about a call is also what records that call, so it must
+/// only ever be asked about calls that have cleared everything else. Running it earlier let blocked
+/// calls reset the no-progress counter, and an agent retrying a blocked call with a slightly different
+/// argument each time never tripped the guard it was spinning against.
 /// </description></item>
 /// </list>
 /// <para>
 /// Any change that does not preserve that order is wrong, and
 /// <c>ToolCallAdmissionPipelineTests</c> pins it in a single assertion.
+/// </para>
+/// <para>
+/// <strong>Do not try to fix the loop guard's coupling by splitting it.</strong> Making it answer
+/// without recording, so its position here stopped mattering, is an obvious-looking cleanup and has
+/// been proposed as one. It is a defect — see <see cref="IProgressEvaluator"/>. The coupling is what
+/// makes the guard work; this position is what makes the coupling safe.
 /// </para>
 /// </remarks>
 public interface IToolCallAdmissionPipeline
@@ -116,21 +122,22 @@ public interface IToolCallAdmissionPipeline
     /// The turn's governance trace: every decision the chain's stages recorded, as one record.
     /// </summary>
     /// <remarks>
-    /// Composed here rather than at each caller. The trace is the governor's decision list with any
-    /// escalation reason codes the loop guard raised folded in, and knowing that those two belong in
-    /// one record is knowledge about how the stages compose — which is this type's job and nobody
-    /// else's. Two callers previously assembled it by hand from two injected stages.
+    /// Surfaced here rather than at each caller. Every stage writes its own decisions and escalation
+    /// codes to one shared <see cref="IGovernanceTraceRecorder"/>, so this is a single snapshot rather
+    /// than a composition — but knowing that the turn has exactly one trail, and which type holds it,
+    /// is knowledge about how the stages fit together, which is this type's job and nobody else's. Two
+    /// callers previously assembled the trace by hand from two injected stages.
     /// </remarks>
     Domain.AI.Governance.GovernanceTrace GetTrace();
 
     /// <summary>
-    /// Clears the per-turn state the chain's stages accumulate — the governor's decision trace and the
-    /// loop guard's call history.
+    /// Clears the per-turn state the chain accumulates — the governance trail and the loop guard's
+    /// call history.
     /// </summary>
     /// <remarks>
     /// Called once at the start of a turn or a single invocation. Resetting the whole chain in one call
-    /// is deliberate: the two stateful stages were previously reset independently at each arming site,
-    /// and a site that reset one but not the other carried a turn's history into the next.
+    /// is deliberate: the stateful parts were previously reset independently at each arming site, and a
+    /// site that reset one but not the other carried a turn's history into the next.
     /// </remarks>
     void Reset();
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
@@ -17,7 +17,8 @@ namespace Application.AI.Common.Interfaces.Governance;
 /// </para>
 /// <para>
 /// Scoped to one agent turn. The implementation reads the ambient <c>IAgentExecutionContext</c> for
-/// the agent identity and accumulates a per-turn decision trace exposed via <see cref="GetTrace"/>.
+/// the agent identity and writes every decision to the turn's <see cref="IGovernanceTraceRecorder"/>,
+/// which is where the trail is read from and reset. This type decides; it does not remember.
 /// </para>
 /// </remarks>
 public interface IToolInvocationGovernor
@@ -49,9 +50,6 @@ public interface IToolInvocationGovernor
         CancellationToken cancellationToken,
         IReadOnlyDictionary<string, object?>? arguments = null);
 
-    /// <summary>Snapshots the governance decisions recorded so far for this turn.</summary>
-    GovernanceTrace GetTrace();
-
     /// <summary>
     /// Records that a gate running <em>after</em> this governor refused a call the governor had
     /// already allowed, so the turn's trace reflects what happened rather than what was authorized.
@@ -82,17 +80,15 @@ public interface IToolInvocationGovernor
     /// dashboard, and the audit, which for an access-control decision is the reporting equivalent of
     /// not enforcing it.
     /// </para>
+    /// <para>
+    /// Routed through the governor rather than written straight to
+    /// <see cref="IGovernanceTraceRecorder"/> because of the blast radius: the record carries one, the
+    /// governor already holds the risk classifier that resolves it, and a stage that classified the
+    /// tool itself would be a second opinion on how dangerous it is. The recorder can answer the other
+    /// question the record needs — whether the turn is governed at all — on its own.
+    /// </para>
     /// </remarks>
     void RecordDownstreamBlock(string toolName, string reason);
-
-    /// <summary>
-    /// Clears the recorded decisions so the next turn starts clean. The governor is registered
-    /// scoped, but nested MediatR sends within a conversation share one DI scope (and thus one
-    /// governor instance), so a multi-turn conversation must reset between turns — otherwise
-    /// <see cref="GetTrace"/> returns the cumulative list and per-turn traces double-count when
-    /// aggregated. Mirrors the per-turn reset of the adjacent scoped <c>ILlmUsageCapture</c>.
-    /// </summary>
-    void Reset();
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Governance/GovernanceEnforcement.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/GovernanceEnforcement.cs
@@ -1,0 +1,47 @@
+using Domain.Common.Config.AI;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// The single answer to "is per-invocation tool governance active for the flow running right now?" —
+/// the switch that decides whether the governor engages and whether a turn is reported as governed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A plain predicate rather than an injected service: it is one expression over configuration and
+/// ambient state, not a seam a consumer replaces, and wrapping it in a registered type bought nothing
+/// but ceremony. It exists as a named thing at all because it has more than one caller —
+/// <see cref="ToolInvocationGovernor"/> asks it whether to run, and
+/// <see cref="GovernanceTraceRecorder"/> asks it whether the turn was governed — and a rule this
+/// consequential held in two copies is how the copies drift.
+/// </para>
+/// <para>
+/// <strong>The answer is live, not sticky.</strong> A bundle run arms enforcement for the duration of
+/// its ambient capability envelope, and it goes away when that scope disposes. Callers that need the
+/// sticky form — "was this turn ever governed?" — must read
+/// <see cref="Interfaces.Governance.IGovernanceTraceRecorder.EnforcementEnabled"/>, which folds this
+/// together with what was observed while authorizing. Using the sticky form to decide whether to
+/// enforce would keep a bundle's enforcement armed after its run had ended.
+/// </para>
+/// </remarks>
+public static class GovernanceEnforcement
+{
+    /// <summary>
+    /// Whether per-invocation enforcement is active for the current flow: the host opted in globally
+    /// via <c>GovernanceConfig.EnforceToolInvocation</c>, <em>or</em> a bundle run is in progress.
+    /// </summary>
+    /// <param name="governance">The live governance configuration.</param>
+    /// <returns><see langword="true"/> when the governor must engage.</returns>
+    /// <remarks>
+    /// A bundle executes an externally-authored agent, so its whole flow must be governed and must fail
+    /// closed. The presence of a per-caller <c>CapabilityEnvelope</c> is the single ambient fact that
+    /// is derived from, which means there is no way to publish an envelope without also arming the
+    /// governor.
+    /// </remarks>
+    public static bool IsActive(GovernanceConfig governance)
+    {
+        ArgumentNullException.ThrowIfNull(governance);
+
+        return governance.EnforceToolInvocation || CapabilityEnvelopeAccessor.Current is not null;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/GovernanceTraceRecorder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/GovernanceTraceRecorder.cs
@@ -1,0 +1,108 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Default <see cref="IGovernanceTraceRecorder"/>: a thread-safe, per-turn collector of governance
+/// decisions and escalation codes that emits an immutable <see cref="GovernanceTrace"/> on demand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately holds no judgement of its own. It does not decide what a decision means, which stage
+/// was entitled to record it, or whether a call should have been allowed — it stores what it is told
+/// and reports it back. That is what makes it constructible in a test with one argument, which is the
+/// point: asserting on an audit trail should not require standing up the machinery that produces one.
+/// </para>
+/// <para>
+/// The lock covers the two collections only. The enforcement question is read outside it — it touches
+/// nothing the lock protects, and holding a lock across a configuration lookup and an ambient-state
+/// read would lengthen a critical section that a parallel batch of tool calls contends on.
+/// </para>
+/// </remarks>
+public sealed class GovernanceTraceRecorder : IGovernanceTraceRecorder
+{
+    private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
+
+    private readonly object _lock = new();
+    private readonly List<ToolDecisionRecord> _decisions = [];
+
+    // Case-insensitive to honour GovernanceTrace.EscalationReasonCodes' "distinct" contract and to
+    // stay aligned with GovernanceTrace.Merge, which unions codes the same way when folding per-turn
+    // traces into a conversation.
+    private readonly HashSet<string> _escalations = new(StringComparer.OrdinalIgnoreCase);
+
+    // A one-way latch within a turn, cleared only at a turn boundary. Volatile rather than lock-guarded
+    // so the every-tool-call write (MarkEnforced) costs nothing on the governed path.
+    private volatile bool _enforcementObserved;
+
+    /// <summary>Initializes a new instance of the <see cref="GovernanceTraceRecorder"/> class.</summary>
+    /// <param name="governanceConfig">Supplies the live "is governance on for this flow" signal.</param>
+    public GovernanceTraceRecorder(IOptionsMonitor<GovernanceConfig> governanceConfig)
+    {
+        ArgumentNullException.ThrowIfNull(governanceConfig);
+        _governanceConfig = governanceConfig;
+    }
+
+    /// <inheritdoc />
+    public bool EnforcementEnabled =>
+        // Short-circuits before the configuration and ambient-state reads on the common governed path.
+        _enforcementObserved || GovernanceEnforcement.IsActive(_governanceConfig.CurrentValue);
+
+    /// <inheritdoc />
+    public void MarkEnforced() => _enforcementObserved = true;
+
+    /// <inheritdoc />
+    public void Record(ToolDecisionRecord decision)
+    {
+        ArgumentNullException.ThrowIfNull(decision);
+
+        lock (_lock)
+            _decisions.Add(decision);
+    }
+
+    /// <inheritdoc />
+    public void RecordEscalation(string reasonCode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reasonCode);
+
+        lock (_lock)
+            _escalations.Add(reasonCode);
+    }
+
+    /// <inheritdoc />
+    public GovernanceTrace Snapshot()
+    {
+        var enforced = EnforcementEnabled;
+
+        lock (_lock)
+        {
+            // The shared empty instance, by reference, when there is genuinely nothing to report. An
+            // ungoverned turn that recorded nothing is the overwhelmingly common case — the default
+            // composition never enforces — and callers distinguish it by identity.
+            if (!enforced && _decisions.Count == 0 && _escalations.Count == 0)
+                return GovernanceTrace.Empty;
+
+            return new GovernanceTrace
+            {
+                EnforcementEnabled = enforced,
+                ToolDecisions = [.. _decisions],
+                EscalationReasonCodes = [.. _escalations]
+            };
+        }
+    }
+
+    /// <inheritdoc />
+    public void Reset()
+    {
+        _enforcementObserved = false;
+
+        lock (_lock)
+        {
+            _decisions.Clear();
+            _escalations.Clear();
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ProgressEvaluator.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ProgressEvaluator.cs
@@ -35,6 +35,13 @@ namespace Application.AI.Common.Services.Governance;
 /// A previously-seen signature the agent abandons in favour of a genuinely new call resets the
 /// no-progress counter, so the guard never blocks an agent that is still exploring.
 /// </para>
+/// <para>
+/// <strong>The lock spans reading the counters and updating them, and must keep doing so.</strong>
+/// Tool calls arrive in parallel batches, so a version that read them, released, and wrote back later
+/// would let every member of a batch decide against the same stale state and admit the lot. See
+/// <see cref="IProgressEvaluator"/>. Publishing a detected spin happens outside the lock — that is
+/// observability, not detection state.
+/// </para>
 /// </remarks>
 public sealed class ProgressEvaluator : IProgressEvaluator
 {
@@ -50,36 +57,38 @@ public sealed class ProgressEvaluator : IProgressEvaluator
     private static readonly string ToolArgsSeparator = ((char)0x1F).ToString();
 
     private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
+    private readonly IGovernanceTraceRecorder _trace;
     private readonly ILogger<ProgressEvaluator> _logger;
 
     private readonly object _lock = new();
     private readonly HashSet<string> _seenSignatures = new(StringComparer.Ordinal);
-    private bool _escalated;
     private string? _lastSignature;
     private int _consecutiveCount;
     private int _callsSinceNewSignature;
 
+    /// <summary>Initializes a new instance of the <see cref="ProgressEvaluator"/> class.</summary>
+    /// <param name="governanceConfig">Supplies the guard's opt-in switch and its two thresholds.</param>
+    /// <param name="trace">Receives the escalation reason code when a spin is detected in escalate mode.</param>
+    /// <param name="logger">Records a broken loop for operators.</param>
     public ProgressEvaluator(
         IOptionsMonitor<GovernanceConfig> governanceConfig,
+        IGovernanceTraceRecorder trace,
         ILogger<ProgressEvaluator> logger)
     {
-        _governanceConfig = governanceConfig;
-        _logger = logger;
-    }
+        ArgumentNullException.ThrowIfNull(governanceConfig);
+        ArgumentNullException.ThrowIfNull(trace);
+        ArgumentNullException.ThrowIfNull(logger);
 
-    /// <inheritdoc />
-    public IReadOnlyList<string> EscalationReasonCodes
-    {
-        get
-        {
-            lock (_lock)
-                return _escalated ? [SpinEscalationReasonCode] : [];
-        }
+        _governanceConfig = governanceConfig;
+        _trace = trace;
+        _logger = logger;
     }
 
     /// <inheritdoc />
     public ProgressVerdict Evaluate(string toolName, Func<string?> argumentsSignatureFactory)
     {
+        ArgumentNullException.ThrowIfNull(argumentsSignatureFactory);
+
         var guard = _governanceConfig.CurrentValue.ProgressGuard;
         if (!guard.Enabled)
             return ProgressVerdict.Continue();
@@ -87,6 +96,9 @@ public sealed class ProgressEvaluator : IProgressEvaluator
         // Factory invoked only past the enabled-gate, so the disabled (default) path never pays the
         // argument-serialisation cost on the hot tool-call path.
         var signature = string.Concat(toolName, ToolArgsSeparator, argumentsSignatureFactory() ?? string.Empty);
+
+        // Set inside the lock, acted on outside it. Null means no spin.
+        string? spinReason = null;
 
         lock (_lock)
         {
@@ -109,28 +121,37 @@ public sealed class ProgressEvaluator : IProgressEvaluator
 
             // Repetition is the more specific / faster signal, so check it first.
             if (guard.RepetitionThreshold >= 2 && _consecutiveCount >= guard.RepetitionThreshold)
-                return RecordSpin(GovernanceConventions.SpinReasonValues.Repetition, toolName, guard.OnSpin);
-
-            if (guard.NoProgressWindow >= 2 && _callsSinceNewSignature >= guard.NoProgressWindow)
-                return RecordSpin(GovernanceConventions.SpinReasonValues.NoProgress, toolName, guard.OnSpin);
-
-            return ProgressVerdict.Continue();
+                spinReason = GovernanceConventions.SpinReasonValues.Repetition;
+            else if (guard.NoProgressWindow >= 2 && _callsSinceNewSignature >= guard.NoProgressWindow)
+                spinReason = GovernanceConventions.SpinReasonValues.NoProgress;
         }
+
+        // Publishing a spin happens outside the lock on purpose. It writes to the shared governance
+        // trail, which has a lock of its own, and this critical section is the one a whole parallel
+        // batch of tool calls queues behind — nesting another component's lock inside it lengthens the
+        // section for every waiting call and couples two lock orders for no benefit. Nothing here
+        // touches the counters.
+        return spinReason is null
+            ? ProgressVerdict.Continue()
+            : PublishSpin(spinReason, toolName, guard.OnSpin);
     }
 
     /// <summary>
-    /// Records a detected spin (metric + structured log, and an escalation reason code when configured
-    /// for <see cref="ProgressGuardAction.Escalate"/>) and returns the halt verdict. Called while
-    /// holding <see cref="_lock"/>.
+    /// Publishes a detected spin (metric + structured log, and an escalation reason code on the turn's
+    /// governance trace when configured for <see cref="ProgressGuardAction.Escalate"/>) and returns the
+    /// halt verdict. Called <em>without</em> holding <see cref="_lock"/> — it touches none of the
+    /// counters, and it writes to a component with a lock of its own.
     /// </summary>
-    private ProgressVerdict RecordSpin(string reason, string toolName, ProgressGuardAction action)
+    private ProgressVerdict PublishSpin(string reason, string toolName, ProgressGuardAction action)
     {
         var mode = action == ProgressGuardAction.Escalate
             ? GovernanceConventions.SpinModeValues.Escalate
             : GovernanceConventions.SpinModeValues.Stop;
 
+        // Onto the shared turn trail, which is where the turn handler reads escalations from. It used
+        // to be a property of this type that the admission chain had to remember to fold in.
         if (action == ProgressGuardAction.Escalate)
-            _escalated = true;
+            _trace.RecordEscalation(SpinEscalationReasonCode);
 
         GovernanceMetrics.SpinInterventions.Add(1, new TagList
         {
@@ -156,7 +177,6 @@ public sealed class ProgressEvaluator : IProgressEvaluator
         lock (_lock)
         {
             _seenSignatures.Clear();
-            _escalated = false;
             _lastSignature = null;
             _consecutiveCount = 0;
             _callsSinceNewSignature = 0;

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -48,6 +48,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     private readonly IToolClassificationGate _classificationGate;
     private readonly IToolCallObserverChain _observers;
     private readonly IProgressEvaluator _progressEvaluator;
+    private readonly IGovernanceTraceRecorder _trace;
     private readonly ILogger<ToolCallAdmissionPipeline> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="ToolCallAdmissionPipeline"/> class.</summary>
@@ -67,6 +68,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// nothing in it are indistinguishable at runtime.
     /// </param>
     /// <param name="progressEvaluator">Stage 5 — the loop guard.</param>
+    /// <param name="trace">The turn's governance trail, which the stages write to and this type snapshots.</param>
     /// <param name="logger">Records a redaction that could not be applied.</param>
     public ToolCallAdmissionPipeline(
         IAgentToolAuthorizationGate authorizationGate,
@@ -74,6 +76,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         IToolClassificationGate classificationGate,
         IToolCallObserverChain observers,
         IProgressEvaluator progressEvaluator,
+        IGovernanceTraceRecorder trace,
         ILogger<ToolCallAdmissionPipeline> logger)
     {
         ArgumentNullException.ThrowIfNull(authorizationGate);
@@ -81,6 +84,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         ArgumentNullException.ThrowIfNull(classificationGate);
         ArgumentNullException.ThrowIfNull(observers);
         ArgumentNullException.ThrowIfNull(progressEvaluator);
+        ArgumentNullException.ThrowIfNull(trace);
         ArgumentNullException.ThrowIfNull(logger);
 
         _authorizationGate = authorizationGate;
@@ -88,6 +92,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         _classificationGate = classificationGate;
         _observers = observers;
         _progressEvaluator = progressEvaluator;
+        _trace = trace;
         _logger = logger;
     }
 
@@ -170,7 +175,10 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 return Refuse(observed.DeniedMessage, toolName);
         }
 
-        // 5 — the loop guard, last of all, and only for callers that issue a sequence.
+        // 5 — the loop guard, and only for callers that issue a sequence. Asking it about a call is
+        // also what records that call, so it must be asked LAST, below every path above that returns
+        // a refusal. Splitting it so that stopped mattering is a defect, not a cleanup — see
+        // IProgressEvaluator for why, and ProgressEvaluatorConcurrencyTests for the measurement.
         if (request.CountsTowardLoopDetection)
         {
             var verdict = _progressEvaluator.Evaluate(
@@ -228,26 +236,12 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     }
 
     /// <inheritdoc />
-    public GovernanceTrace GetTrace()
-    {
-        var trace = _governor.GetTrace();
-        var spinEscalations = _progressEvaluator.EscalationReasonCodes;
-        if (spinEscalations is null or { Count: 0 })
-            return trace;
-
-        // Dedup case-insensitively to honour GovernanceTrace.EscalationReasonCodes' "distinct" contract
-        // and stay aligned with GovernanceTrace.Merge's OrdinalIgnoreCase union.
-        return trace with
-        {
-            EscalationReasonCodes =
-                [.. trace.EscalationReasonCodes.Concat(spinEscalations).Distinct(StringComparer.OrdinalIgnoreCase)]
-        };
-    }
+    public GovernanceTrace GetTrace() => _trace.Snapshot();
 
     /// <inheritdoc />
     public void Reset()
     {
-        _governor.Reset();
+        _trace.Reset();
         _progressEvaluator.Reset();
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -50,6 +50,13 @@ namespace Application.AI.Common.Services.Governance;
 /// sandbox never granted the capability for), and once by letting an approval obtained for one
 /// gate's reason satisfy a later gate whose reason the approver was never shown.
 /// </para>
+/// <para>
+/// <strong>Stateless.</strong> Every decision is written to the turn-scoped
+/// <see cref="IGovernanceTraceRecorder"/> and nothing is kept here. That is deliberate: accumulating
+/// the audit trail was this type's second job and the only reason it held mutable state, and the two
+/// jobs have different consumers — this one only writes, while diagnostics, reporting and tests only
+/// read. Reading the trail therefore no longer requires constructing a governor.
+/// </para>
 /// </remarks>
 public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
 {
@@ -62,17 +69,11 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     private readonly IDenialTracker _denialTracker;
     private readonly ICapabilityEnforcer _capabilityEnforcer;
     private readonly IToolApprovalRouter _approvalRouter;
+    private readonly IGovernanceTraceRecorder _trace;
     private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
     private readonly IOptionsMonitor<PermissionsConfig> _permissionsConfig;
     private readonly IOptionsMonitor<SandboxConfig> _sandboxConfig;
     private readonly ILogger<ToolInvocationGovernor> _logger;
-
-    private readonly object _lock = new();
-    private readonly List<ToolDecisionRecord> _decisions = [];
-
-    // Set true the first time a tool is authorized under active enforcement this turn, so GetTrace reports
-    // the turn as enforced even if it is called after the bundle run's ambient scope has torn down.
-    private bool _enforcedObserved;
 
     public ToolInvocationGovernor(
         IAgentExecutionContext executionContext,
@@ -84,6 +85,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         IDenialTracker denialTracker,
         ICapabilityEnforcer capabilityEnforcer,
         IToolApprovalRouter approvalRouter,
+        IGovernanceTraceRecorder trace,
         IOptionsMonitor<GovernanceConfig> governanceConfig,
         IOptionsMonitor<PermissionsConfig> permissionsConfig,
         IOptionsMonitor<SandboxConfig> sandboxConfig,
@@ -98,6 +100,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         _denialTracker = denialTracker;
         _capabilityEnforcer = capabilityEnforcer;
         _approvalRouter = approvalRouter;
+        _trace = trace;
         _governanceConfig = governanceConfig;
         _permissionsConfig = permissionsConfig;
         _sandboxConfig = sandboxConfig;
@@ -106,9 +109,9 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
 
     /// <summary>
     /// Whether the current flow is a bundle run — i.e. a per-caller <see cref="CapabilityEnvelope"/> has been
-    /// published for it. A bundle executes an externally-authored agent, so its whole flow must be governed
-    /// and fail closed; this is the single ambient fact the enforcement decision derives from, so there is no
-    /// way to publish an envelope without also arming the governor.
+    /// published for it. Read here only to decide how a <em>missing agent identity</em> is treated, which is
+    /// stricter inside a bundle than outside one. It is a narrower question than "should this flow be
+    /// governed", which is <see cref="GovernanceEnforcement.IsActive"/>'s and is answered there alone.
     /// </summary>
     private static bool BundleRunActive => CapabilityEnvelopeAccessor.Current is not null;
 
@@ -142,16 +145,6 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     private static bool EnvelopeGrantsToolWhenArmed(string toolName)
         => CapabilityEnvelopeAccessor.Current is not { } envelope || envelope.GrantsTool(toolName);
 
-    /// <summary>
-    /// Whether per-invocation enforcement is active for the current flow. True when the host has opted in
-    /// globally (<c>GovernanceConfig.EnforceToolInvocation</c>) <em>or</em> a bundle run is active
-    /// (<see cref="BundleRunActive"/>) — bundle runs must always be governed so the per-caller capability
-    /// envelope is never inert. Off both paths this is false and the governor is a pure pass-through,
-    /// unchanged for existing deployments.
-    /// </summary>
-    private bool EnforcementActive =>
-        _governanceConfig.CurrentValue.EnforceToolInvocation || BundleRunActive;
-
     /// <inheritdoc />
     public async ValueTask<ToolInvocationDecision> AuthorizeAsync(
         string toolName,
@@ -159,13 +152,14 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         IReadOnlyDictionary<string, object?>? arguments = null)
     {
         // Opt-in: when enforcement is off the governor never engages — pure pass-through, no record,
-        // no behaviour change for existing deployments.
-        if (!EnforcementActive)
+        // no behaviour change for existing deployments. Read live rather than from the trace's sticky
+        // form, so a bundle run stops being enforced the moment its envelope scope disposes.
+        if (!GovernanceEnforcement.IsActive(_governanceConfig.CurrentValue))
             return ToolInvocationDecision.Allow();
 
-        // Enforcement ran this turn; remember it so the trace reports the turn as governed even if GetTrace
-        // is called after a bundle run's ambient envelope scope has already disposed.
-        _enforcedObserved = true;
+        // Enforcement ran this turn; remember it so the trace reports the turn as governed even if it
+        // is assembled after a bundle run's ambient envelope scope has already disposed.
+        _trace.MarkEnforced();
 
         var profile = _toolRiskClassifier.Classify(toolName);
 
@@ -181,7 +175,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
                 _logger.LogWarning(
                     "Tool governance: no AgentId in execution context for {ToolName} during a bundle run — denied (fail-closed)",
                     toolName);
-                Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Denied,
+                _trace.Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Denied,
                     "no agent identity in a bundle run", profile.Radius,
                     RequiredApproval: false, ApprovalGranted: false, Enforced: true));
                 return ToolInvocationDecision.Deny(GovernanceDenials.NotPermitted(toolName));
@@ -189,7 +183,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
 
             _logger.LogWarning(
                 "Tool governance: no AgentId in execution context for {ToolName} — allowed ungoverned and recorded", toolName);
-            Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed,
+            _trace.Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed,
                 "no agent identity in execution context", profile.Radius,
                 RequiredApproval: false, ApprovalGranted: false, Enforced: false));
             return ToolInvocationDecision.Allow();
@@ -338,7 +332,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
             approvedBy = gate.Reason;
         }
 
-        Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed,
+        _trace.Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed,
             approvedBy is null ? "allowed" : $"approved by human: {approvedBy}",
             profile.Radius,
             RequiredApproval: approvedBy is not null,
@@ -358,7 +352,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         string toolName, ToolDecisionOutcome outcome, string reason, BlastRadius radius,
         bool requiredApproval, string agentId)
     {
-        Record(new ToolDecisionRecord(toolName, outcome, reason, radius,
+        _trace.Record(new ToolDecisionRecord(toolName, outcome, reason, radius,
             RequiredApproval: requiredApproval, ApprovalGranted: false, Enforced: true));
 
         if (_governanceConfig.CurrentValue.EnableAudit)
@@ -418,29 +412,22 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         };
     }
 
-    private void Record(ToolDecisionRecord record)
-    {
-        lock (_lock)
-            _decisions.Add(record);
-    }
-
     /// <inheritdoc />
     public void RecordDownstreamBlock(string toolName, string reason)
     {
         // Only meaningful on an enforced turn. Off that path the governor recorded nothing, so there
         // is no allow to correct and nothing to add.
         //
-        // EnforcementActive is consulted as well as _enforcedObserved, and the difference is
-        // load-bearing: the authorization gate runs BEFORE this governor, so on the first tool call
-        // of a turn nothing has set _enforcedObserved yet. Keying only on that flag silently dropped
-        // every RBAC refusal that arrived first — which is most of them, since a refused call never
-        // goes on to reach the governor at all. This matches how GetTrace already decides whether a
-        // turn was enforced.
-        if (!_enforcedObserved && !EnforcementActive)
+        // The recorder's EnforcementEnabled is the sticky-OR-live form, and both halves are
+        // load-bearing here: the authorization gate runs BEFORE this governor, so on the first tool
+        // call of a turn nothing has marked the turn enforced yet. Keying only on what was observed
+        // silently dropped every RBAC refusal that arrived first — which is most of them, since a
+        // refused call never goes on to reach the governor at all.
+        if (!_trace.EnforcementEnabled)
             return;
 
         var radius = _toolRiskClassifier.Classify(toolName).Radius;
-        Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Denied, reason, radius,
+        _trace.Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Denied, reason, radius,
             RequiredApproval: false, ApprovalGranted: false, Enforced: true));
 
         // Deliberately no audit write. This method corrects the trace on behalf of a gate that has
@@ -448,35 +435,5 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         // every downstream block count twice for anyone tallying denials from the audit stream. The
         // caller audits because it always can — this method is inert off the enforced path, and a host
         // may register observers with governance enforcement switched off.
-    }
-
-    /// <inheritdoc />
-    public void Reset()
-    {
-        lock (_lock)
-        {
-            _decisions.Clear();
-            _enforcedObserved = false;
-        }
-    }
-
-    /// <inheritdoc />
-    public GovernanceTrace GetTrace()
-    {
-        // Prefer the snapshot taken while authorizing: a bundle run's ambient enforcement signal may have
-        // torn down by the time the trace is assembled, but a turn that authorized under enforcement is
-        // still an enforced turn.
-        var enforced = _enforcedObserved || EnforcementActive;
-        lock (_lock)
-        {
-            if (!enforced && _decisions.Count == 0)
-                return GovernanceTrace.Empty;
-
-            return new GovernanceTrace
-            {
-                EnforcementEnabled = enforced,
-                ToolDecisions = _decisions.ToList()
-            };
-        }
     }
 }

--- a/src/Content/Domain/Domain.AI/Governance/GovernanceTrace.cs
+++ b/src/Content/Domain/Domain.AI/Governance/GovernanceTrace.cs
@@ -2,14 +2,14 @@ namespace Domain.AI.Governance;
 
 /// <summary>
 /// An immutable snapshot of the governance decisions an agent's tool calls passed through
-/// during a turn or conversation. Produced by <c>IToolInvocationGovernor</c> and surfaced on
-/// the agent-turn and conversation results so an evaluation can grade the agent's governance
-/// behaviour <em>independently of whether the task succeeded</em> — the core anti-"governance
-/// theater" instrument from Loop Engineering.
+/// during a turn or conversation. Surfaced on the agent-turn and conversation results so an
+/// evaluation can grade the agent's governance behaviour <em>independently of whether the task
+/// succeeded</em> — the core anti-"governance theater" instrument from Loop Engineering.
 /// </summary>
 /// <remarks>
-/// This is a read-only projection. The governor accumulates decisions in a mutable, thread-safe
-/// collector as the agent runs, then emits this snapshot at the boundary.
+/// This is a read-only projection. Every stage that can stop a tool call writes into one mutable,
+/// thread-safe per-turn collector (<c>IGovernanceTraceRecorder</c>) as the agent runs, and the
+/// admission chain emits this snapshot from it at the boundary.
 /// </remarks>
 public sealed record GovernanceTrace
 {

--- a/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
@@ -95,6 +95,22 @@ public class DependencyInjectionTests
     }
 
     [Fact]
+    public void AddApplicationAIDependencies_RegistersGovernanceTraceRecorder_AsScoped()
+    {
+        // Scoped, and it matters which: the trail is per turn. A singleton would accumulate every
+        // turn of every conversation in the process into one trace, and a transient would give each
+        // stage of the same turn a private trail nobody else could read — the governor's decisions
+        // and the loop guard's escalations would each land somewhere the turn handler never looks.
+        var services = CreateServicesWithAIDependencies();
+
+        var descriptor = services.FirstOrDefault(d => d.ServiceType == typeof(IGovernanceTraceRecorder));
+        descriptor.Should().NotBeNull();
+        descriptor!.Lifetime.Should().Be(ServiceLifetime.Scoped);
+        descriptor.ImplementationType.Should().Be(typeof(GovernanceTraceRecorder));
+    }
+
+
+    [Fact]
     public void AddApplicationAIDependencies_RegistersToolConverter_AsSingleton()
     {
         var services = CreateServicesWithAIDependencies();

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
+using Domain.Common.Config.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Application.AI.Common.Tests.Governance;
@@ -23,13 +25,28 @@ internal static class AdmissionHarness
         IToolClassificationGate? classificationGate = null,
         IToolCallObserverChain? observers = null,
         IProgressEvaluator? progressEvaluator = null,
-        IAgentToolAuthorizationGate? authorizationGate = null) =>
+        IAgentToolAuthorizationGate? authorizationGate = null,
+        IGovernanceTraceRecorder? trace = null) =>
         new(authorizationGate ?? PermissiveAuthorizationGate(),
             governor ?? PermissiveGovernor(),
             classificationGate ?? PermissiveClassificationGate(),
             observers ?? Mock.Of<IToolCallObserverChain>(),
             progressEvaluator ?? PermissiveProgressEvaluator(),
+            trace ?? TraceRecorder(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
+
+    /// <summary>
+    /// A real trace recorder, ungoverned by default — the shipped composition, where nothing is
+    /// enforced and the turn's trace comes back empty.
+    /// </summary>
+    /// <remarks>
+    /// Real rather than mocked because the recorder is the thing the chain's <c>GetTrace</c> now
+    /// answers from, and a mock of it would make every trace assertion a test of the mock.
+    /// </remarks>
+    /// <param name="governance">Governance config to run under; defaults to everything off.</param>
+    public static GovernanceTraceRecorder TraceRecorder(GovernanceConfig? governance = null) =>
+        new(Mock.Of<IOptionsMonitor<GovernanceConfig>>(
+            m => m.CurrentValue == (governance ?? new GovernanceConfig())));
 
     /// <summary>
     /// An authorization gate that admits everything — what the real gate answers when
@@ -82,7 +99,11 @@ internal static class AdmissionHarness
         return gate.Object;
     }
 
-    /// <summary>A loop guard that never halts.</summary>
+    /// <summary>A loop guard that never halts — what the real one answers while switched off.</summary>
+    /// <remarks>
+    /// Set up explicitly rather than left to <c>Mock.Of</c>: a loose mock returns null from
+    /// <c>Evaluate</c>, and the chain is entitled to assume a verdict exists.
+    /// </remarks>
     public static IProgressEvaluator PermissiveProgressEvaluator()
     {
         var progress = new Mock<IProgressEvaluator>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceTraceRecorderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceTraceRecorderTests.cs
@@ -1,0 +1,219 @@
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Verifies the turn's governance trail on its own — which is the point of it having been pulled out
+/// of <c>ToolInvocationGovernor</c>. Every assertion here used to require constructing a governor and
+/// its twelve dependencies, and driving a tool call through it, to observe a list.
+/// </summary>
+public sealed class GovernanceTraceRecorderTests
+{
+    private const string Tool = "file_system";
+
+    private static GovernanceTraceRecorder Create(bool enforceGlobally = false) =>
+        AdmissionHarness.TraceRecorder(new GovernanceConfig { EnforceToolInvocation = enforceGlobally });
+
+    private static ToolDecisionRecord Decision(string reason, ToolDecisionOutcome outcome = ToolDecisionOutcome.Allowed) =>
+        new(Tool, outcome, reason, BlastRadius.Low,
+            RequiredApproval: false, ApprovalGranted: false, Enforced: true);
+
+    [Fact]
+    public void Snapshot_UngovernedAndNothingRecorded_IsTheSharedEmptyTrace()
+    {
+        // By reference. Callers distinguish "this turn was never governed and nothing happened" from
+        // "nothing was allowed" by identity, and the default composition never enforces, so this is
+        // overwhelmingly the common answer.
+        Create().Snapshot().Should().BeSameAs(GovernanceTrace.Empty);
+    }
+
+    [Fact]
+    public void Snapshot_KeepsDecisionsInTheOrderTheyWereRecorded()
+    {
+        // The trace reads as a narrative of the turn to an auditor; a set would lose the sequence in
+        // which the agent attempted things.
+        var recorder = Create();
+
+        recorder.Record(Decision("first"));
+        recorder.Record(Decision("second", ToolDecisionOutcome.Denied));
+        recorder.Record(Decision("third"));
+
+        recorder.Snapshot().ToolDecisions.Select(d => d.Reason)
+            .Should().Equal("first", "second", "third");
+    }
+
+    [Fact]
+    public void Snapshot_IsACopy_NotALiveViewOfTheTrail()
+    {
+        // A caller holding a snapshot must not see a later tool call appear inside it. The turn
+        // handler puts this on the turn result and the trail keeps running until the scope ends.
+        var recorder = Create();
+        recorder.Record(Decision("first"));
+
+        var snapshot = recorder.Snapshot();
+        recorder.Record(Decision("second"));
+
+        snapshot.ToolDecisions.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void RecordEscalation_DeduplicatesCaseInsensitively()
+    {
+        // GovernanceTrace.EscalationReasonCodes is contractually distinct, and GovernanceTrace.Merge
+        // unions codes case-insensitively when folding per-turn traces into a conversation. A trail
+        // that deduplicated case-sensitively would produce a turn trace the merge then collapsed,
+        // so the same conversation would report different counts depending on where you read it.
+        var recorder = Create();
+
+        recorder.RecordEscalation("progress.spin_detected");
+        recorder.RecordEscalation("PROGRESS.SPIN_DETECTED");
+        recorder.RecordEscalation("escalation.timeout");
+
+        recorder.Snapshot().EscalationReasonCodes
+            .Should().BeEquivalentTo(["progress.spin_detected", "escalation.timeout"]);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RecordEscalation_BlankCode_IsRejected(string code)
+    {
+        // A code nothing can be keyed off is noise on an audit trail, and worse than absent: it makes
+        // a turn look escalated to anything counting codes.
+        var recorder = Create();
+
+        recorder.Invoking(r => r.RecordEscalation(code)).Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Snapshot_EscalationsButNoDecisions_IsNotTheEmptyTrace()
+    {
+        // The loop guard can raise an escalation for a call it refused before the governor recorded
+        // anything. Collapsing that to Empty would lose the only evidence the turn was escalated.
+        var recorder = Create();
+
+        recorder.RecordEscalation("progress.spin_detected");
+
+        var snapshot = recorder.Snapshot();
+        snapshot.Should().NotBeSameAs(GovernanceTrace.Empty);
+        snapshot.EscalationReasonCodes.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void EnforcementEnabled_GlobalOptInOn_IsTrueWithoutAnyToolCall()
+    {
+        // A turn under global enforcement that made no tool calls is still a governed turn. Reporting
+        // it as ungoverned would tell governance reporting that enforcement was off in exactly the
+        // turns where nothing needed stopping.
+        var recorder = Create(enforceGlobally: true);
+
+        recorder.EnforcementEnabled.Should().BeTrue();
+        recorder.Snapshot().EnforcementEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnforcementEnabled_BundleEnvelopeArmed_TracksTheAmbientScope()
+    {
+        var recorder = Create();
+
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AllowedTools = [Tool] }))
+            recorder.EnforcementEnabled.Should().BeTrue("a bundle run is always governed");
+
+        recorder.EnforcementEnabled.Should().BeFalse("the run ended and nothing was authorized under it");
+    }
+
+    [Fact]
+    public void MarkEnforced_SurvivesTheAmbientEnvelopeTearingDown()
+    {
+        // The trace is assembled after the run, by which time the ambient envelope is long gone. A
+        // turn that authorized under enforcement is still an enforced turn.
+        var recorder = Create();
+
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AllowedTools = [Tool] }))
+            recorder.MarkEnforced();
+
+        recorder.EnforcementEnabled.Should().BeTrue();
+        recorder.Snapshot().EnforcementEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Reset_ClearsDecisionsEscalationsAndTheEnforcedFlag()
+    {
+        // Nested MediatR sends within a conversation share one DI scope and therefore one trail, so a
+        // turn that did not clear it would double-count when per-turn traces are merged.
+        var recorder = Create();
+        recorder.Record(Decision("first"));
+        recorder.RecordEscalation("progress.spin_detected");
+        recorder.MarkEnforced();
+
+        recorder.Reset();
+
+        recorder.EnforcementEnabled.Should().BeFalse();
+        recorder.Snapshot().Should().BeSameAs(GovernanceTrace.Empty);
+    }
+
+    [Fact]
+    public void Record_NullDecision_IsRejected()
+    {
+        Create().Invoking(r => r.Record(null!)).Should().Throw<ArgumentNullException>();
+    }
+}
+
+/// <summary>
+/// Verifies the single shared answer to "is per-invocation governance on for this flow?" — the switch
+/// the governor reads to decide whether to engage and the trail reads to decide whether the turn was
+/// governed. It is one predicate precisely so those two can never disagree.
+/// </summary>
+public sealed class GovernanceEnforcementTests
+{
+    private static GovernanceConfig Config(bool enforceGlobally) =>
+        new() { EnforceToolInvocation = enforceGlobally };
+
+    [Fact]
+    public void IsActive_DefaultComposition_IsFalse()
+    {
+        // The shipped default. Governance is opt-in, and off it the governor is a pure pass-through.
+        GovernanceEnforcement.IsActive(Config(enforceGlobally: false)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsActive_GlobalOptIn_IsTrue()
+    {
+        GovernanceEnforcement.IsActive(Config(enforceGlobally: true)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsActive_InsideABundleRun_IsTrueEvenWithTheGlobalSwitchOff()
+    {
+        // A bundle executes an externally-authored agent, so its whole flow must be governed. The
+        // presence of a per-caller envelope is the single fact this derives from, which means there is
+        // no way to publish an envelope without also arming the governor.
+        var config = Config(enforceGlobally: false);
+
+        using var armed = CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AllowedTools = ["t"] });
+
+        GovernanceEnforcement.IsActive(config).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsActive_IsLive_NotSticky()
+    {
+        // Load-bearing: this is what the governor reads to decide whether to enforce, so a bundle's
+        // enforcement must end with its run. The sticky form — "was this turn ever governed?" — lives
+        // on the trail instead, and using it here would keep enforcement armed after the run ended.
+        var config = Config(enforceGlobally: false);
+
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AllowedTools = ["t"] }))
+            GovernanceEnforcement.IsActive(config).Should().BeTrue();
+
+        GovernanceEnforcement.IsActive(config).Should().BeFalse();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionClassificationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionClassificationTests.cs
@@ -100,7 +100,8 @@ public sealed class GovernedAIFunctionClassificationTests
             AdmissionHarness.Pipeline(classificationGate: gate.Object, progressEvaluator: progress.Object), inner);
 
         progress.Verify(p => p.Evaluate(It.IsAny<string>(), It.IsAny<Func<string?>>()), Times.Never,
-            "a classification-blocked call must not reach the progress guard");
+            "a classification-blocked call must not reach the progress guard — asking it is also what "
+            + "counts the call, and a blocked call never executed");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionProgressTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionProgressTests.cs
@@ -85,7 +85,8 @@ public sealed class GovernedAIFunctionProgressTests
             .Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<IReadOnlyDictionary<string, object?>?>()))
             .ReturnsAsync(ToolInvocationDecision.Deny("Error: tool 'file_system' is not permitted."));
 
-        // Strict: any call to Evaluate at all is the defect, not just a particular verdict.
+        // Strict: any call to Evaluate at all is the defect, not just a particular verdict — asking
+        // the guard is also what records the call.
         var progress = new Mock<IProgressEvaluator>(MockBehavior.Strict);
 
         await InvokeUnder(
@@ -112,12 +113,12 @@ public sealed class GovernedAIFunctionProgressTests
     [Fact]
     public async Task InvokeAsync_ObserverBlocks_ProgressNotConsulted()
     {
-        // The progress evaluator is the only stage on this path that RECORDS state: it remembers the
-        // call's signature and resets the no-progress counter whenever it sees a new one. Counting a
-        // call an observer blocked is not a bookkeeping nicety — it defeats the guard outright. An
-        // agent retrying a blocked call with one value changed each time (10000, 10001, 10002 …)
-        // presents a brand-new signature on every attempt, so every attempt would reset the counter
-        // and the spin against the observer's own rule would run to the iteration ceiling.
+        // The progress evaluator is the only stage on this path that RECORDS state: asking it about a
+        // call is also what remembers that call. Counting a call an observer blocked is not a
+        // bookkeeping nicety — it defeats the guard outright. An agent retrying a blocked call with one
+        // value changed each time (10000, 10001, 10002 …) presents a brand-new signature on every
+        // attempt, so every attempt would reset the counter and the spin against the observer's own
+        // rule would run to the iteration ceiling.
         var (inner, wasInvoked) = MakeInner();
         var observers = AdmissionHarness.ObserverChain(
             ToolInvocationDecision.Deny("Error: tool 'file_system' is not permitted."));

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ProgressEvaluatorConcurrencyTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ProgressEvaluatorConcurrencyTests.cs
@@ -1,0 +1,151 @@
+using Application.AI.Common.Services.Governance;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Pins the loop guard's behaviour when tool calls arrive <strong>at the same time</strong>, which is
+/// how the agent actually issues them.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this file exists.</strong> The guard both answers "is this a repeat?" and records the
+/// call, in one locked step. That coupling reads as poor separation of concerns and was refactored
+/// away — answer now, record once the call is admitted — with every other test still green, because
+/// every other test calls the guard one call at a time. In a batch it was broken: the agent factory
+/// sets <c>AllowConcurrentInvocation</c>, so an assistant message's tool calls run in parallel against
+/// the one turn-scoped guard, and with the two halves separated they all asked before any of them had
+/// been recorded. Every one was told it was the first. The whole batch ran.
+/// </para>
+/// <para>
+/// <strong>Why it repeats the batch rather than running one.</strong> A single batch is not evidence.
+/// A split guard passes a one-shot batch whenever the threads happen not to interleave, and measuring
+/// that is not optional — the first version of this file did exactly one batch, and a deliberately
+/// re-split evaluator passed it twice in a row. Repeating the batch turns a scheduling coincidence
+/// into a vanishing one. The assertion is safe in the other direction by construction: an atomic guard
+/// cannot admit a second identical call however the threads are scheduled, so more iterations can only
+/// ever expose a real defect, never invent one.
+/// </para>
+/// </remarks>
+public sealed class ProgressEvaluatorConcurrencyTests
+{
+    private const int Batch = 8;
+    private const int Rounds = 200;
+
+    private static ProgressEvaluator Create(ProgressGuardConfig guard) =>
+        new(Mock.Of<IOptionsMonitor<GovernanceConfig>>(m =>
+                m.CurrentValue == new GovernanceConfig { ProgressGuard = guard }),
+            AdmissionHarness.TraceRecorder(),
+            NullLogger<ProgressEvaluator>.Instance);
+
+    private static ProgressGuardConfig Guard() => new()
+    {
+        Enabled = true,
+        RepetitionThreshold = 2,
+        NoProgressWindow = 100
+    };
+
+    /// <summary>
+    /// Fires <see cref="Batch"/> identical calls simultaneously, <see cref="Rounds"/> times over, and
+    /// reports the largest number admitted in any one round.
+    /// </summary>
+    /// <remarks>
+    /// The same threads are reused across rounds and re-synchronised on a multi-phase barrier, whose
+    /// between-rounds action banks the previous round's tally and clears the guard's history. That is
+    /// much faster than standing up a batch per round, and it keeps every round's threads genuinely
+    /// released together rather than trickling in from the thread pool.
+    /// </remarks>
+    private static async Task<int> WorstRoundAsync(ProgressEvaluator evaluator, Func<int, string> signatureForRound)
+    {
+        var admitted = 0;
+        var worst = 0;
+        var round = 0;
+
+        using var betweenRounds = new Barrier(Batch, _ =>
+        {
+            worst = Math.Max(worst, Volatile.Read(ref admitted));
+            Volatile.Write(ref admitted, 0);
+            evaluator.Reset();
+            round++;
+        });
+
+        await Task.WhenAll(Enumerable.Range(0, Batch).Select(_ => Task.Run(() =>
+        {
+            for (var i = 0; i < Rounds; i++)
+            {
+                // Phase boundary: banks the previous round and clears the guard, then releases all
+                // Batch threads into the same round together.
+                betweenRounds.SignalAndWait();
+                var signature = signatureForRound(Volatile.Read(ref round));
+                if (!evaluator.Evaluate("read", () => signature).ShouldHalt)
+                    Interlocked.Increment(ref admitted);
+            }
+
+            // One last phase so the final round is banked like the others.
+            betweenRounds.SignalAndWait();
+        })));
+
+        return worst;
+    }
+
+    [Fact]
+    public async Task Evaluate_ParallelIdenticalCalls_AdmitsOnlyTheFirst()
+    {
+        // The model emitted the same call eight times in one message. With a repetition threshold of
+        // two, exactly one may run: the second identical call is already a repeat.
+        var evaluator = Create(Guard());
+
+        (await WorstRoundAsync(evaluator, _ => "x")).Should().Be(1,
+            "answering and recording happen in one critical section, so a batch of identical calls "
+            + "serialises and each one sees the calls before it");
+    }
+
+    [Fact]
+    public async Task Evaluate_ParallelIdenticalCalls_LeavesTheCountersConsistentWithWhatRan()
+    {
+        // The counters must reflect the batch, not lag behind it: a guard that admitted one call but
+        // recorded eight would then refuse a genuinely different call afterwards.
+        var evaluator = Create(Guard());
+
+        await WorstRoundAsync(evaluator, _ => "x");
+        evaluator.Reset();
+
+        evaluator.Evaluate("read", () => "x").ShouldHalt.Should().BeFalse("a cleared turn starts fresh");
+        evaluator.Evaluate("read", () => "x").ShouldHalt.Should().BeTrue("still the same repeated call");
+        evaluator.Evaluate("read", () => "y").ShouldHalt.Should().BeFalse(
+            "a genuinely new call must release the agent, however many times the old one was tried");
+    }
+
+    [Fact]
+    public async Task Evaluate_ParallelDistinctCalls_AdmitsThemAll()
+    {
+        // The other direction, and the one that matters for false positives: eight different calls in
+        // one batch are eight pieces of new information, and the guard must not touch any of them. A
+        // guard that over-counted under contention would cut off an agent that is working fine, which
+        // is a worse failure than catching a spin late.
+        var evaluator = Create(new ProgressGuardConfig
+        {
+            Enabled = true,
+            RepetitionThreshold = 2,
+            NoProgressWindow = 2
+        });
+
+        using var releaseTogether = new Barrier(Batch);
+        var admitted = 0;
+
+        await Task.WhenAll(Enumerable.Range(0, Batch).Select(i => Task.Run(() =>
+        {
+            releaseTogether.SignalAndWait();
+            if (!evaluator.Evaluate("read", () => $"arg-{i}").ShouldHalt)
+                Interlocked.Increment(ref admitted);
+        })));
+
+        admitted.Should().Be(Batch, "every call in the batch introduced a new signature");
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ProgressEvaluatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ProgressEvaluatorTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Governance;
@@ -12,16 +11,27 @@ namespace Application.AI.Common.Tests.Governance;
 /// <summary>
 /// Verifies the deterministic spin / no-progress detector: it is inert when disabled, trips on
 /// consecutive repetition and on a no-progress window, resets the no-progress counter when a genuinely
-/// new call appears, raises an escalation code only in Escalate mode, and clears cleanly on reset.
+/// new call appears, raises an escalation code onto the turn's trace only in Escalate mode, and clears
+/// cleanly on reset.
 /// </summary>
+/// <remarks>
+/// Behaviour under concurrent tool calls — which is how the agent actually issues them — lives in
+/// <see cref="ProgressEvaluatorConcurrencyTests"/>. Everything here is single-threaded and would stay
+/// green against an implementation that is broken in a batch, which is exactly why that file exists.
+/// </remarks>
 public sealed class ProgressEvaluatorTests
 {
-    private static ProgressEvaluator Create(ProgressGuardConfig guard)
+    private readonly GovernanceTraceRecorder _trace = AdmissionHarness.TraceRecorder();
+
+    private ProgressEvaluator Create(ProgressGuardConfig guard)
     {
         var governance = new GovernanceConfig { ProgressGuard = guard };
         var monitor = Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == governance);
-        return new ProgressEvaluator(monitor, NullLogger<ProgressEvaluator>.Instance);
+        return new ProgressEvaluator(monitor, _trace, NullLogger<ProgressEvaluator>.Instance);
     }
+
+    /// <summary>The escalation codes as the turn handler reads them — off the shared trail.</summary>
+    private IReadOnlyList<string> Escalations => _trace.Snapshot().EscalationReasonCodes;
 
     [Fact]
     public void Evaluate_GuardDisabled_AlwaysContinues()
@@ -31,7 +41,20 @@ public sealed class ProgressEvaluatorTests
         for (var i = 0; i < 10; i++)
             Assert.False(evaluator.Evaluate("file_system", () => "{\"path\":\"a\"}").ShouldHalt);
 
-        Assert.Empty(evaluator.EscalationReasonCodes);
+        Assert.Empty(Escalations);
+    }
+
+    [Fact]
+    public void Evaluate_GuardDisabled_NeverInvokesTheSignatureFactory()
+    {
+        // The factory serialises the call arguments. Off the enabled path — the default composition —
+        // the agent's hot tool-call path must not pay for that.
+        var evaluator = Create(new ProgressGuardConfig { Enabled = false });
+        var invoked = false;
+
+        evaluator.Evaluate("read", () => { invoked = true; return "x"; });
+
+        Assert.False(invoked);
     }
 
     [Fact]
@@ -137,11 +160,11 @@ public sealed class ProgressEvaluatorTests
         var halt = evaluator.Evaluate("read", () => "x");
 
         Assert.True(halt.ShouldHalt);
-        Assert.Empty(evaluator.EscalationReasonCodes);
+        Assert.Empty(Escalations);
     }
 
     [Fact]
-    public void Evaluate_EscalateMode_RaisesEscalationCode()
+    public void Evaluate_EscalateMode_RaisesEscalationCodeOntoTheTurnTrace()
     {
         var evaluator = Create(new ProgressGuardConfig
         {
@@ -154,7 +177,9 @@ public sealed class ProgressEvaluatorTests
         var halt = evaluator.Evaluate("read", () => "x");
 
         Assert.True(halt.ShouldHalt);
-        Assert.Equal([ProgressEvaluator.SpinEscalationReasonCode], evaluator.EscalationReasonCodes);
+        // On the shared trail, which is where the turn handler reads escalations from — not on a
+        // property of the evaluator that the admission chain then has to remember to fold in.
+        Assert.Equal([ProgressEvaluator.SpinEscalationReasonCode], Escalations);
     }
 
     [Fact]
@@ -170,12 +195,14 @@ public sealed class ProgressEvaluatorTests
         for (var i = 0; i < 5; i++)
             evaluator.Evaluate("read", () => "x");
 
-        Assert.Single(evaluator.EscalationReasonCodes);
+        Assert.Single(Escalations);
     }
 
     [Fact]
-    public void Reset_ClearsHistoryAndEscalations()
+    public void Reset_ClearsHistoryButNotTheTurnTrace()
     {
+        // Two different owners clear two different things. The guard's call history is its own; the
+        // escalation codes belong to the governance trail, which the admission chain resets.
         var evaluator = Create(new ProgressGuardConfig
         {
             Enabled = true,
@@ -185,13 +212,17 @@ public sealed class ProgressEvaluatorTests
 
         evaluator.Evaluate("read", () => "x");
         evaluator.Evaluate("read", () => "x"); // trips + escalates
-        Assert.NotEmpty(evaluator.EscalationReasonCodes);
+        Assert.NotEmpty(Escalations);
 
         evaluator.Reset();
 
-        Assert.Empty(evaluator.EscalationReasonCodes);
+        Assert.NotEmpty(Escalations);
         // History cleared: the next identical call starts a fresh consecutive run, so it must not halt.
         Assert.False(evaluator.Evaluate("read", () => "x").ShouldHalt);
+
+        _trace.Reset();
+
+        Assert.Empty(Escalations);
     }
 
     [Theory]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Changes;
 using Domain.AI.Governance;
 using Microsoft.Extensions.Logging.Abstractions;
 using FluentAssertions;
@@ -24,9 +25,14 @@ namespace Application.AI.Common.Tests.Governance;
 /// Two orderings are safety properties rather than preferences. The host's own rules run <em>last of
 /// the access gates</em>, so consumer-authored code can only ever tighten an outcome the built-in
 /// gates already permitted. And the loop guard runs <em>last of all</em>, because it is the only stage
-/// that mutates: it records the call's signature, and counting a call that was then blocked let an
-/// agent reset the no-progress counter on every retry and spin indefinitely against the very rule
-/// blocking it.
+/// that mutates: asking it about a call is also what records that call, and counting a call that was
+/// then blocked let an agent reset the no-progress counter on every retry and spin indefinitely
+/// against the very rule blocking it.
+/// </para>
+/// <para>
+/// The guard's coupling is not a defect to be refactored away — see
+/// <c>ProgressEvaluatorConcurrencyTests</c>, which is the control showing that splitting it admits a
+/// whole parallel batch. This position is what makes the coupling safe.
 /// </para>
 /// </remarks>
 public sealed class ToolCallAdmissionPipelineTests
@@ -51,8 +57,8 @@ public sealed class ToolCallAdmissionPipelineTests
             + "and because the governor can escalate to a human — nobody should be asked to approve a "
             + "call that RBAC refuses anyway; permission and policy then settle whether the agent may "
             + "use the tool at all; the host's own rules run after them so they can only tighten; and "
-            + "the loop guard runs last because it is the only stage that records state, so it must "
-            + "count only calls that reached the tool");
+            + "the loop guard runs last because asking it is also what records the call, so it must "
+            + "only ever be asked about calls that reached the tool");
     }
 
     [Theory]
@@ -60,6 +66,7 @@ public sealed class ToolCallAdmissionPipelineTests
     [InlineData("governor")]
     [InlineData("classification")]
     [InlineData("host-rules")]
+    [InlineData("loop-guard")]
     public async Task AdmitAsync_AStageRefuses_NothingAfterItRuns(string refusingStage)
     {
         var order = new List<string>();
@@ -282,49 +289,48 @@ public sealed class ToolCallAdmissionPipelineTests
     }
 
     [Fact]
-    public void Reset_ClearsEveryStatefulStage_NotJustTheGovernor()
+    public void Reset_ClearsEveryStatefulPartOfTheChain()
     {
         // These were reset independently at each arming site, and a site that reset one but not the
-        // other carried a turn's history into the next. One call now covers both.
-        var governor = new Mock<IToolInvocationGovernor>();
+        // other carried a turn's history into the next. One call now covers both — the shared
+        // governance trail, and the loop guard's own call history, which is the only per-turn state
+        // that does not live on the trail.
+        var trace = AdmissionHarness.TraceRecorder();
+        trace.Record(new ToolDecisionRecord(Tool, ToolDecisionOutcome.Denied, "nope", BlastRadius.Low,
+            RequiredApproval: false, ApprovalGranted: false, Enforced: true));
+        trace.RecordEscalation("progress.spin_detected");
         var progress = new Mock<IProgressEvaluator>();
 
-        AdmissionHarness.Pipeline(governor: governor.Object, progressEvaluator: progress.Object).Reset();
+        AdmissionHarness.Pipeline(progressEvaluator: progress.Object, trace: trace).Reset();
 
-        governor.Verify(g => g.Reset(), Times.Once);
+        trace.Snapshot().Should().BeSameAs(GovernanceTrace.Empty);
         progress.Verify(p => p.Reset(), Times.Once);
     }
 
     [Fact]
-    public void GetTrace_FoldsTheLoopGuardsEscalationsIntoTheGovernorsTrace()
+    public void GetTrace_ReportsWhatEveryStageRecorded_AsOneRecord()
     {
-        var governor = new Mock<IToolInvocationGovernor>();
-        governor.Setup(g => g.GetTrace()).Returns(new GovernanceTrace { EscalationReasonCodes = ["from_governor"] });
-        var progress = new Mock<IProgressEvaluator>();
-        progress.SetupGet(p => p.EscalationReasonCodes).Returns(["spin_detected", "FROM_GOVERNOR"]);
+        // The governor's decisions and the loop guard's escalation codes arrive at the trail
+        // independently, and the turn wants them as one record. This used to be composed by hand here
+        // — and, before the chain existed, by hand at two separate callers.
+        var trace = AdmissionHarness.TraceRecorder();
+        trace.Record(new ToolDecisionRecord(Tool, ToolDecisionOutcome.Denied, "policy", BlastRadius.Low,
+            RequiredApproval: false, ApprovalGranted: false, Enforced: true));
+        trace.RecordEscalation("progress.spin_detected");
+        trace.RecordEscalation("PROGRESS.SPIN_DETECTED");
 
-        var trace = AdmissionHarness
-            .Pipeline(governor: governor.Object, progressEvaluator: progress.Object)
-            .GetTrace();
+        var snapshot = AdmissionHarness.Pipeline(trace: trace).GetTrace();
 
-        trace.EscalationReasonCodes.Should().BeEquivalentTo(
-            ["from_governor", "spin_detected"],
+        snapshot.ToolDecisions.Should().ContainSingle().Which.Reason.Should().Be("policy");
+        snapshot.EscalationReasonCodes.Should().BeEquivalentTo(
+            ["progress.spin_detected"],
             "codes are unioned case-insensitively to honour the trace's distinct contract");
     }
 
     [Fact]
-    public void GetTrace_NoEscalations_ReturnsTheGovernorsTraceUnchanged()
+    public void GetTrace_NothingRecordedAndNothingEnforced_IsTheEmptyTrace()
     {
-        var expected = new GovernanceTrace { EnforcementEnabled = true };
-        var governor = new Mock<IToolInvocationGovernor>();
-        governor.Setup(g => g.GetTrace()).Returns(expected);
-        var progress = new Mock<IProgressEvaluator>();
-        progress.SetupGet(p => p.EscalationReasonCodes).Returns([]);
-
-        AdmissionHarness
-            .Pipeline(governor: governor.Object, progressEvaluator: progress.Object)
-            .GetTrace()
-            .Should().BeSameAs(expected);
+        AdmissionHarness.Pipeline().GetTrace().Should().BeSameAs(GovernanceTrace.Empty);
     }
 
     /// <summary>
@@ -374,10 +380,13 @@ public sealed class ToolCallAdmissionPipelineTests
         progress
             .Setup(p => p.Evaluate(It.IsAny<string>(), It.IsAny<Func<string?>>()))
             .Callback(() => order.Add("loop-guard"))
-            .Returns(ProgressVerdict.Continue());
+            .Returns(refusingStage == "loop-guard"
+                ? ProgressVerdict.Halt("no")
+                : ProgressVerdict.Continue());
 
         return new ToolCallAdmissionPipeline(
             authorizationGate.Object, governor.Object, classificationGate.Object, observers.Object,
-            progress.Object, NullLogger<ToolCallAdmissionPipeline>.Instance);
+            progress.Object, AdmissionHarness.TraceRecorder(),
+            NullLogger<ToolCallAdmissionPipeline>.Instance);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
@@ -68,13 +68,25 @@ public sealed class ToolInvocationGovernorEnvelopeTests
             .ReturnsAsync(ToolApprovalResult.NotRouted("tool approval routing is disabled"));
     }
 
-    private ToolInvocationGovernor Build() => new(
-        _context.Object, _permissions.Object, _riskClassifier, _autonomy.Object, _policyEngine.Object,
-        Mock.Of<IGovernanceAuditService>(), _denialTracker.Object, _capabilities.Object, _approvalRouter.Object,
-        Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == _governanceOff),
-        Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
-        Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
-        NullLogger<ToolInvocationGovernor>.Instance);
+    /// <summary>
+    /// The turn's governance trail, assigned by <see cref="Build"/> so it reads the governor's config —
+    /// the ambient bundle envelope these tests arm has to mean the same thing to both.
+    /// </summary>
+    private GovernanceTraceRecorder _trace = null!;
+
+    private ToolInvocationGovernor Build()
+    {
+        var governanceMonitor = Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == _governanceOff);
+        _trace = new GovernanceTraceRecorder(governanceMonitor);
+
+        return new ToolInvocationGovernor(
+            _context.Object, _permissions.Object, _riskClassifier, _autonomy.Object, _policyEngine.Object,
+            Mock.Of<IGovernanceAuditService>(), _denialTracker.Object, _capabilities.Object, _approvalRouter.Object,
+            _trace, governanceMonitor,
+            Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+            Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
+            NullLogger<ToolInvocationGovernor>.Instance);
+    }
 
     private static CapabilityEnvelope Envelope() => new() { AllowedTools = [Tool] };
 
@@ -133,7 +145,7 @@ public sealed class ToolInvocationGovernorEnvelopeTests
             await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         // Scope disposed — the ambient envelope is gone, but the trace must still say the turn was enforced.
-        Assert.True(governor.GetTrace().EnforcementEnabled);
+        Assert.True(_trace.Snapshot().EnforcementEnabled);
     }
 
     [Fact]
@@ -144,7 +156,7 @@ public sealed class ToolInvocationGovernorEnvelopeTests
         using (CapabilityEnvelopeAccessor.Begin(Envelope()))
             await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
-        governor.Reset();
+        _trace.Reset();
         _permissions.Invocations.Clear();
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -65,25 +65,44 @@ public sealed class ToolInvocationGovernorTests
     }
 
     /// <summary>
+    /// The turn's governance trail, which the governor writes to and this fixture reads. Assigned by
+    /// <see cref="Build"/>, because it reads the governor's config: whether a turn counts as governed
+    /// is derived from the same switch, so a recorder built from a different config would disagree with
+    /// the governor it is recording for.
+    /// </summary>
+    private GovernanceTraceRecorder _trace = null!;
+
+    /// <summary>The trail as the turn handler reads it. Real, not mocked — it is the assertion target.</summary>
+    private GovernanceTrace Trace => _trace.Snapshot();
+
+    /// <summary>
     /// Builds the governor under test. Pass <paramref name="governance"/> to override the default
     /// config — the only thing the per-test constructions ever varied, which is why they were folded
     /// back into this helper: each was an 8-line copy that had to be edited whenever the constructor
     /// gained a parameter.
     /// </summary>
-    private ToolInvocationGovernor Build(GovernanceConfig? governance = null) => new(
-        _context.Object,
-        _permissions.Object,
-        _riskClassifier,
-        _autonomy.Object,
-        _policyEngine.Object,
-        Mock.Of<IGovernanceAuditService>(),
-        _denialTracker.Object,
-        _capabilities.Object,
-        _approvalRouter.Object,
-        Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == (governance ?? _governance)),
-        Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
-        Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
-        NullLogger<ToolInvocationGovernor>.Instance);
+    private ToolInvocationGovernor Build(GovernanceConfig? governance = null)
+    {
+        var governanceMonitor =
+            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == (governance ?? _governance));
+        _trace = new GovernanceTraceRecorder(governanceMonitor);
+
+        return new ToolInvocationGovernor(
+            _context.Object,
+            _permissions.Object,
+            _riskClassifier,
+            _autonomy.Object,
+            _policyEngine.Object,
+            Mock.Of<IGovernanceAuditService>(),
+            _denialTracker.Object,
+            _capabilities.Object,
+            _approvalRouter.Object,
+            _trace,
+            governanceMonitor,
+            Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
+            Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
+            NullLogger<ToolInvocationGovernor>.Instance);
+    }
 
     [Fact]
     public async Task AuthorizeAsync_EnforcementDisabled_AllowsAndDoesNotEvaluate()
@@ -94,7 +113,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.True(decision.IsAllowed);
-        Assert.Same(GovernanceTrace.Empty, governor.GetTrace());
+        Assert.Same(GovernanceTrace.Empty, Trace);
         _permissions.Verify(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
             It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()), Times.Never);
     }
@@ -118,7 +137,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.True(decision.IsAllowed);
-        var trace = governor.GetTrace();
+        var trace = Trace;
         Assert.True(trace.EnforcementEnabled);
         var record = Assert.Single(trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.Allowed, record.Outcome);
@@ -138,7 +157,7 @@ public sealed class ToolInvocationGovernorTests
 
         Assert.False(decision.IsAllowed);
         Assert.NotNull(decision.DeniedMessage);
-        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        var record = Assert.Single(Trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.Denied, record.Outcome);
         Assert.True(record.Enforced);
         _denialTracker.Verify(x => x.RecordDenial(Agent, Tool, null), Times.Once);
@@ -156,7 +175,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        var trace = governor.GetTrace();
+        var trace = Trace;
         var record = Assert.Single(trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.PendingApproval, record.Outcome);
         Assert.True(record.RequiredApproval);
@@ -180,7 +199,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        var record = Assert.Single(Trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.PendingApproval, record.Outcome);
         Assert.True(record.RequiredApproval);
     }
@@ -197,7 +216,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        var record = Assert.Single(Trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.Denied, record.Outcome);
         Assert.Contains("capability", record.Reason, StringComparison.OrdinalIgnoreCase);
     }
@@ -205,20 +224,21 @@ public sealed class ToolInvocationGovernorTests
     [Fact]
     public async Task Reset_ClearsPriorTurnDecisions_NoCrossTurnDoubleCount()
     {
-        // The governor is scoped but shared across turns of a conversation (nested MediatR sends
-        // share one DI scope), so each turn must Reset() or the trace accumulates and the merged
+        // The trail is scoped but shared across turns of a conversation (nested MediatR sends share
+        // one DI scope), so each turn must reset it or the trace accumulates and the merged
         // conversation trace double-counts. This guards that regression.
         var governor = Build();
 
         // Turn 1
         await governor.AuthorizeAsync(Tool, CancellationToken.None);
-        Assert.Equal(1, governor.GetTrace().ToolInvocationCount);
+        Assert.Equal(1, Trace.ToolInvocationCount);
 
-        // Turn 2 begins
-        governor.Reset();
+        // Turn 2 begins. The reset is on the trail now, not the governor — the governor keeps nothing
+        // to clear.
+        _trace.Reset();
         await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
-        var trace = governor.GetTrace();
+        var trace = Trace;
         Assert.Equal(1, trace.ToolInvocationCount); // this turn only, not cumulative
         Assert.Equal(1, trace.AllowedCount);
     }
@@ -238,7 +258,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        Assert.Equal(ToolDecisionOutcome.Denied, Assert.Single(governor.GetTrace().ToolDecisions).Outcome);
+        Assert.Equal(ToolDecisionOutcome.Denied, Assert.Single(Trace.ToolDecisions).Outcome);
     }
 
     [Fact]
@@ -288,7 +308,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.True(decision.IsAllowed);
-        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        var record = Assert.Single(Trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.Allowed, record.Outcome);
         Assert.True(record.RequiredApproval);
         Assert.True(record.ApprovalGranted);
@@ -312,7 +332,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        Assert.Equal(ToolDecisionOutcome.Denied, Assert.Single(governor.GetTrace().ToolDecisions).Outcome);
+        Assert.Equal(ToolDecisionOutcome.Denied, Assert.Single(Trace.ToolDecisions).Outcome);
     }
 
     [Fact]
@@ -329,7 +349,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        Assert.Equal(ToolDecisionOutcome.Denied, Assert.Single(governor.GetTrace().ToolDecisions).Outcome);
+        Assert.Equal(ToolDecisionOutcome.Denied, Assert.Single(Trace.ToolDecisions).Outcome);
     }
 
     [Fact]
@@ -405,7 +425,7 @@ public sealed class ToolInvocationGovernorTests
 
         governor.RecordDownstreamBlock(Tool, "blocked by observer 'wire-limit'");
 
-        var decisions = governor.GetTrace().ToolDecisions;
+        var decisions = Trace.ToolDecisions;
         Assert.Contains(decisions, d => d.Outcome == ToolDecisionOutcome.Allowed);
         Assert.Contains(decisions, d => d.Outcome == ToolDecisionOutcome.Denied);
     }
@@ -424,7 +444,7 @@ public sealed class ToolInvocationGovernorTests
 
         governor.RecordDownstreamBlock(Tool, "blocked by observer 'wire-limit'");
 
-        Assert.Empty(governor.GetTrace().ToolDecisions);
+        Assert.Empty(Trace.ToolDecisions);
     }
 
     [Fact]
@@ -439,7 +459,7 @@ public sealed class ToolInvocationGovernorTests
 
         governor.RecordDownstreamBlock(Tool, "denied by per-agent tool authorization");
 
-        var decisions = governor.GetTrace().ToolDecisions;
+        var decisions = Trace.ToolDecisions;
         Assert.Contains(decisions, d => d.Outcome == ToolDecisionOutcome.Denied);
     }
 
@@ -453,7 +473,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        var record = Assert.Single(Trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.PendingApproval, record.Outcome);
         Assert.False(record.ApprovalGranted);
         _denialTracker.Verify(x => x.RecordDenial(Agent, Tool, null), Times.Once);
@@ -501,7 +521,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.True(decision.IsAllowed);
-        Assert.True(Assert.Single(governor.GetTrace().ToolDecisions).ApprovalGranted);
+        Assert.True(Assert.Single(Trace.ToolDecisions).ApprovalGranted);
     }
 
     [Fact]
@@ -516,7 +536,7 @@ public sealed class ToolInvocationGovernorTests
         var decision = await governor.AuthorizeAsync(Tool, CancellationToken.None);
 
         Assert.False(decision.IsAllowed);
-        var record = Assert.Single(governor.GetTrace().ToolDecisions);
+        var record = Assert.Single(Trace.ToolDecisions);
         Assert.Equal(ToolDecisionOutcome.PendingApproval, record.Outcome);
         Assert.True(record.RequiredApproval);
         Assert.False(record.ApprovalGranted);

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -689,6 +689,11 @@ public sealed class DirectToolInvokerTests
             _observerChain ?? new FakeObserverChain(ToolInvocationDecision.Allow()) { HasObservers = false });
         services.AddSingleton(AdmissionHarness.PermissiveProgressEvaluator());
 
+        // The turn's governance trail. Real rather than mocked, and registered for the same reason as
+        // the gates above: the chain requires it, so a container without it is a composition that
+        // cannot exist in production.
+        services.AddSingleton<IGovernanceTraceRecorder>(AdmissionHarness.TraceRecorder());
+
         // Per-agent RBAC, permitting — the answer the real gate gives when tool authorization is off,
         // which is this fixture's composition. Registered because the chain requires it: an absent
         // gate and a switched-off one must never be confusable at runtime.

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -59,11 +59,19 @@ public class AgentPipelineIntegrationTests
         services.AddScoped(_ => governorMock.Object);
 
         // Progress / spin guard — not under test here; permissive mock so the handler resolves.
+        // Evaluate is set up explicitly because a loose mock would return null and the chain assumes
+        // a verdict exists.
         var progressMock = new Mock<Application.AI.Common.Interfaces.Governance.IProgressEvaluator>();
         progressMock
             .Setup(p => p.Evaluate(It.IsAny<string>(), It.IsAny<Func<string?>>()))
             .Returns(Application.AI.Common.Interfaces.Governance.ProgressVerdict.Continue());
         services.AddScoped(_ => progressMock.Object);
+
+        // The turn's governance trail — real, and required by the admission chain the handler resolves.
+        services.AddScoped<Application.AI.Common.Interfaces.Governance.IGovernanceTraceRecorder>(_ =>
+            new Application.AI.Common.Services.Governance.GovernanceTraceRecorder(
+                Mock.Of<Microsoft.Extensions.Options.IOptionsMonitor<Domain.Common.Config.AI.GovernanceConfig>>(
+                    m => m.CurrentValue == new Domain.Common.Config.AI.GovernanceConfig())));
 
         // Classification DLP gate — not under test here; permissive mock so the handler resolves.
         var classificationMock = new Mock<Application.AI.Common.Interfaces.Governance.IToolClassificationGate>();

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
+using Domain.Common.Config.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Infrastructure.AI.RAG.Tests.Orchestration;
@@ -42,12 +44,24 @@ internal static class PermissiveAdmission
             .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow()));
 
+        // Never halts, and never returns null from Evaluate the way a loose mock would — the chain is
+        // entitled to assume a verdict exists.
+        var progress = new Mock<IProgressEvaluator>();
+        progress
+            .Setup(p => p.Evaluate(It.IsAny<string>(), It.IsAny<Func<string?>>()))
+            .Returns(ProgressVerdict.Continue());
+
+        // A real, ungoverned recorder, so the chain reports the empty trace.
+        var trace = new GovernanceTraceRecorder(
+            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == new GovernanceConfig()));
+
         return new ToolCallAdmissionPipeline(
             authorizationGate.Object,
             governor.Object,
             classificationGate.Object,
             Mock.Of<IToolCallObserverChain>(),
-            Mock.Of<IProgressEvaluator>(),
+            progress.Object,
+            trace,
             NullLogger<ToolCallAdmissionPipeline>.Instance);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
@@ -153,7 +153,8 @@ public sealed class PlanRunLlmCallScopeTests
         services.AddSingleton(Mock.Of<IToolCallObserverChain>());
         services.AddSingleton(StepExecutors.PermissiveAdmission.ClassificationGate());
         services.AddSingleton(StepExecutors.PermissiveAdmission.AuthorizationGate());
-        services.AddSingleton(Mock.Of<IProgressEvaluator>());
+        services.AddSingleton(StepExecutors.PermissiveAdmission.ProgressGuard());
+        services.AddSingleton(StepExecutors.PermissiveAdmission.TraceRecorder());
         // Step executors require the admission chain rather than defaulting it to null, so that a
         // composition which forgets it fails at resolution instead of running unguarded. The real
         // chain over the gates above — a mock of the chain would not exercise the code an enveloped

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -262,7 +262,8 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         services.AddScoped(_ => new Mock<IToolInvocationGovernor>().Object);
         services.AddScoped(_ => new Mock<IToolCallObserverChain>().Object);
         services.AddScoped(_ => new Mock<IToolClassificationGate>().Object);
-        services.AddScoped(_ => new Mock<IProgressEvaluator>().Object);
+        services.AddScoped(_ => StepExecutors.PermissiveAdmission.ProgressGuard());
+        services.AddScoped(_ => StepExecutors.PermissiveAdmission.TraceRecorder());
         services.AddScoped(_ => new Mock<IAgentToolAuthorizationGate>().Object);
         // Step executors take the admission chain as a required dependency, deliberately: an omitted
         // chain is indistinguishable at runtime from a host whose gates are all off, so a nullable

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
+using Domain.Common.Config.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Infrastructure.AI.Tests.Planner.StepExecutors;
@@ -47,8 +49,32 @@ internal static class PermissiveAdmission
             governor,
             ClassificationGate(),
             observers ?? Mock.Of<IToolCallObserverChain>(),
-            Mock.Of<IProgressEvaluator>(),
+            ProgressGuard(),
+            TraceRecorder(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
+
+    /// <summary>A loop guard that never halts — what the real one answers while switched off.</summary>
+    /// <remarks>
+    /// Not <c>Mock.Of&lt;IProgressEvaluator&gt;()</c>: that returns null from <c>Evaluate</c>, and the
+    /// chain is entitled to assume a verdict exists. These fixtures pass either way today only because
+    /// no plan path opts into loop detection, which is a coincidence rather than a guarantee.
+    /// </remarks>
+    public static IProgressEvaluator ProgressGuard()
+    {
+        var progress = new Mock<IProgressEvaluator>();
+        progress
+            .Setup(p => p.Evaluate(It.IsAny<string>(), It.IsAny<Func<string?>>()))
+            .Returns(ProgressVerdict.Continue());
+        return progress.Object;
+    }
+
+    /// <summary>
+    /// A real, ungoverned trace recorder, so the chain reports the empty trace rather than the null a
+    /// loose mock would return.
+    /// </summary>
+    public static IGovernanceTraceRecorder TraceRecorder() =>
+        new GovernanceTraceRecorder(
+            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == new GovernanceConfig()));
 
     /// <summary>
     /// An authorization gate that admits everything — the answer the real gate gives when

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -188,6 +188,9 @@ public sealed class SubPlanEnvelopeConfinementTests
                 It.IsAny<Domain.AI.Changes.BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(),
                 It.IsAny<CancellationToken>())
             == new ValueTask<ToolApprovalResult>(ToolApprovalResult.NotRouted("routing disabled"))));
+        // Resolved from this container rather than stubbed, so the real governor writes its decisions
+        // to a real trail reading the same governance config the envelope arms.
+        services.AddScoped<IGovernanceTraceRecorder, GovernanceTraceRecorder>();
         services.AddScoped<IToolInvocationGovernor, ToolInvocationGovernor>();
         services.AddScoped<IPlanExecutor, GovernorProbePlanExecutor>();
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -480,7 +480,8 @@ public sealed class ToolUseStepExecutorTests
             _toolGovernor.Object,
             _classificationGate.Object,
             observers,
-            Mock.Of<IProgressEvaluator>(),
+            PermissiveAdmission.ProgressGuard(),
+            PermissiveAdmission.TraceRecorder(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
 
     /// <summary>


### PR DESCRIPTION
Closes the parts of #297 that survive contact. Item 3 shipped, item 1 attempted and reverted with a measurement, item 2 struck.

## Item 3 — the audit trail moves out of the governor ✅

`ToolInvocationGovernor` both decided and accumulated the record of its decisions, and that record was the only reason it held mutable state. The trail now lives behind `IGovernanceTraceRecorder`:

- **The governor is stateless.** No lock, no decision list, no observed-enforcement flag.
- **The chain stops composing.** `GetTrace()` was assembling the governor's decisions and the loop guard's escalation codes by hand; every stage now writes into one shared trail and the chain takes a snapshot. Net allocation win — the old path built an array, a `Concat` enumerator, a `Distinct` set and a record clone per escalating turn.
- **The trail is assertable on its own**, which is the point: `GovernanceTraceRecorderTests` builds one with a single argument, where the same assertions previously needed a governor and its twelve dependencies.

`GovernanceEnforcement.IsActive` is the single shared answer to "is governance on for this flow", so the governor's decision to engage and the trail's decision to report the turn as governed cannot drift apart.

## Item 1 — split the loop guard: measured, reverted ⛔

The issue asked to split `IProgressEvaluator` so that asking "is the agent spinning?" no longer records the call, making the guard's position in the chain stop mattering. **It was built, and it is a defect.**

The harness invokes an assistant message's tool calls in parallel (`AllowConcurrentInvocation`), against one turn-scoped guard. With the halves separated — even with nothing between them — every member of a batch asks before any has been recorded, all are told they are the first, and the whole batch is admitted.

```
CAUSE:     Splitting decide from record makes the guard check-then-act.
CONTROL:   Same probe, same 8-call batch. Split: 8 of 8 admitted. Atomic: 1 of 8.
COVERAGE:  Parallel batches are the default, not an edge case.
```

The coupling is what makes the guard work; running last in the chain is what makes the coupling safe. Both are now stated once, with pointers rather than five restatements.

**`ProgressEvaluatorConcurrencyTests` is the control that was missing** — the split passed the entire existing suite because every existing test drove the guard one call at a time. It repeats the batch 200 times, because a single batch is not evidence: the first version of the file did one batch and a deliberately re-split guard passed it twice. Verified in both directions — 8/8 clean runs pass, 8/8 defect runs fail.

## Item 2 — struck

PR #309 reduced the five near-identical ambient accessors it was filed against to two. A generic base plus two named aliases is not smaller than the two types it would replace.

## Review

`/code-review` raised 4 findings (the concurrency regression above, plus an inverted doc claim, two fixtures on loose mocks, and a rationale this change half-invalidated) — all resolved. `/simplify` ran 4 agents; applied the hot-path lock improvements, collapsed the enforcement check from a DI-registered type to a plain predicate, and corrected three now-false doc claims.

**Deliberately not fixed here, worth follow-up issues:**
1. Three permissive-admission test helpers duplicate each other across test assemblies — pre-existing drift this change made more painful (one new dependency, eight edits).
2. `RecordDownstreamBlock` could move to the recorder, so `ToolCallObserverChain` stops injecting a 14-dependency governor for one call. Security-relevant seam; deserves its own review.
3. `AgentExecutionContextFactory.ContextProviders.cs` holds a third copy of the governance-on check that **omits the bundle-run term** — so the governing context provider is not attached on a bundle run with the global switch off. Pre-existing and unverified; flagging rather than fixing.

## Test plan

- `dotnet build src/AgenticHarness.slnx` — clean, 0 new warnings
- `dotnet test src/AgenticHarness.slnx` — **10,289 passing, 0 failing**
- Mutation-verified: 8 defects injected across the trail, the enforcement predicate and the guard; all 8 caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)
