### PR TITLE
fix: govern the context-provider tool channel on bundle runs (#347)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -51,8 +51,8 @@ public partial class AgentExecutionContextFactory
     /// <param name="disclosableSkills">The skills the framework provider is given, built once by the caller.</param>
     /// <param name="baseline">What the agent was already charged for; see <see cref="PerTurnBudgetBaseline"/>.</param>
     /// <returns>
-    /// The ordered rail as a read-only list, or <see langword="null"/> when this agent needs no
-    /// providers at all.
+    /// The ordered rail as a read-only list. Never empty: the governance wrapper is on every agent's
+    /// rail (see the attachment site below), so there is no such thing as an agent with no providers.
     /// </returns>
     /// <remarks>
     /// The rail is returned read-only, so appending to it throws rather than silently displacing the
@@ -62,7 +62,7 @@ public partial class AgentExecutionContextFactory
     /// which is why the guard has to be the instance's own behaviour: no type on that path can express
     /// "this list is finished".
     /// </remarks>
-    private IList<AIContextProvider>? BuildMergedAIContextProviders(
+    private IList<AIContextProvider> BuildMergedAIContextProviders(
         int skillCount,
         IReadOnlyList<string>? effectiveAllowlist,
         IReadOnlyList<DisclosableSkill> disclosableSkills,
@@ -129,8 +129,10 @@ public partial class AgentExecutionContextFactory
         // capability envelope that GovernanceEnforcement.IsActive reads. Any condition evaluated at this
         // point therefore answers for the wrong moment, and the one that used to be here (the global
         // switch alone) published a bundle's disclosure tools unwrapped on the default composition. The
-        // provider is transparent unless an admission chain is ambient for the turn, so attaching it
-        // always costs an ungoverned host one inert list entry and nothing else.
+        // provider is transparent unless an admission chain is ambient for the turn, so what an
+        // ungoverned host pays is one list entry plus, on an agent that has skills, a bounded re-wrap of
+        // the three framework disclosure tools once per turn — orders of magnitude under the LLM call it
+        // rides along with.
         providers.Add(new Services.Agent.GoverningToolContextProvider(
             _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>()));
 
@@ -138,7 +140,7 @@ public partial class AgentExecutionContextFactory
 
         // AsReadOnly wraps rather than copies, so the returned list is a live view of a list nothing
         // else holds a reference to — the local goes out of scope here.
-        return providers.Count > 0 ? providers.AsReadOnly() : null;
+        return providers.AsReadOnly();
     }
 
     /// <summary>
@@ -184,10 +186,7 @@ public partial class AgentExecutionContextFactory
     /// Appends the measurer that charges whatever <paramref name="providers"/> inject into each turn to
     /// the budget of the agent named by <paramref name="baseline"/>.
     /// </summary>
-    /// <param name="providers">
-    /// The rail built for this agent, mutated in place. An empty rail means the agent has no providers, so
-    /// there is nothing per-turn to charge and nothing is appended.
-    /// </param>
+    /// <param name="providers">The rail built for this agent, mutated in place.</param>
     /// <param name="baseline">What the agent was already charged for, which the measurer subtracts.</param>
     /// <remarks>
     /// <strong>This is the canonical statement of the lastness rule.</strong> The measurer must be last:

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -120,15 +120,19 @@ public partial class AgentExecutionContextFactory
         }
 
         // Governance wrapper — added after the recall providers so it wraps the final, filtered tool
-        // set. When tool-invocation enforcement is on, this guarantees the governor gates every tool the
-        // agent can call, including framework progressive-disclosure tools that bypass ToolChainBuilder.
-        // Inert (and skipped entirely) when enforcement is off, so default behaviour is unchanged.
-        if (_appConfig.CurrentValue.AI?.Governance?.EnforceToolInvocation == true)
-        {
-            providers.Add(new Services.Agent.GoverningToolContextProvider(
-                _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>()));
-            _logger.LogDebug("Wired GoverningToolContextProvider (tool-invocation enforcement enabled)");
-        }
+        // set, guaranteeing the governor gates every tool the agent can call including the framework
+        // progressive-disclosure tools that bypass ToolChainBuilder.
+        //
+        // ATTACHED UNCONDITIONALLY, AND THAT IS THE FIX, NOT AN OVERSIGHT (issue #347). Whether
+        // governance is on cannot be decided here: this rail is built once, at agent construction, and
+        // agents are cached — while a bundle run arms enforcement later and per run, through the ambient
+        // capability envelope that GovernanceEnforcement.IsActive reads. Any condition evaluated at this
+        // point therefore answers for the wrong moment, and the one that used to be here (the global
+        // switch alone) published a bundle's disclosure tools unwrapped on the default composition. The
+        // provider is transparent unless an admission chain is ambient for the turn, so attaching it
+        // always costs an ungoverned host one inert list entry and nothing else.
+        providers.Add(new Services.Agent.GoverningToolContextProvider(
+            _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>()));
 
         AppendPerTurnBudgetProvider(providers, baseline);
 

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -136,9 +136,34 @@ public sealed class GoverningToolContextProvider : AIContextProvider
 
     /// <summary>
     /// Returns <paramref name="tool"/> wrapped in a <see cref="GovernedAIFunction"/> when it is an
-    /// unwrapped callable function, or the tool unchanged when it is already governed or is not a
-    /// function. Extracted for unit testing of the wrapping decision.
+    /// unwrapped callable function, or the tool unchanged when it is already governed, is not a
+    /// function, or is one of the two skill-content transport tools. Extracted for unit testing of the
+    /// wrapping decision.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why <c>load_skill</c> and <c>read_skill_resource</c> are not governed.</strong> They are
+    /// not capabilities an agent is granted — they are how the agent reads the instructions for skills it
+    /// has <em>already</em> been assigned, and the provider that publishes them is built from this agent's
+    /// own skills, so neither can name a skill the agent was not given. Gating them on a tool grant asks
+    /// the wrong question: on a bundle run the ambient capability envelope lists the domain tools the
+    /// caller may invoke, would never list a framework transport tool, and the governor refuses anything
+    /// the envelope does not name — so wrapping these would leave a bundle agent unable to load the
+    /// instructions of the skills it shipped with, silently, with a refusal string where its own skill
+    /// body should be.
+    /// </para>
+    /// <para>
+    /// The exemption reuses <see cref="ToolPermissionFilter.SkillDisclosureToolNames"/> rather than
+    /// restating the pair, because that filter already exempts exactly these two for exactly this reason.
+    /// Two copies of "which tools are content transport" is how one of them ends up out of date.
+    /// <c>run_skill_script</c> is deliberately <em>not</em> in that set and is governed here: executing a
+    /// skill's script is a capability, and on a bundle run it is one the caller's envelope must grant.
+    /// </para>
+    /// </remarks>
     internal static AITool Govern(AITool tool)
-        => tool is AIFunction fn and not GovernedAIFunction ? new GovernedAIFunction(fn) : tool;
+        => tool is AIFunction fn
+           && tool is not GovernedAIFunction
+           && !ToolPermissionFilter.SkillDisclosureToolNames.Contains(fn.Name)
+            ? new GovernedAIFunction(fn)
+            : tool;
 }

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -33,6 +33,17 @@ namespace Application.AI.Common.Services.Agent;
 /// have been publishable in the first place.
 /// </para>
 /// <para>
+/// <strong>That inertness is what licenses attaching this provider unconditionally, and it must stay
+/// unconditional (issue #347).</strong> The rail is assembled once, when the agent is constructed, and
+/// agents are cached — but a bundle run arms enforcement afterwards and per run, by publishing a
+/// capability envelope (see <see cref="Governance.GovernanceEnforcement.IsActive"/>). A guard at
+/// construction therefore cannot see the flow that most needs governing: the earlier one read the host's
+/// global switch alone, and on the default composition a bundle's progressive-disclosure tools — two of
+/// which are exempt from <see cref="ToolPermissionFilter"/> by design, leaving this their only gate —
+/// reached the model unwrapped. Re-adding any condition here reopens that hole for a saving of one list
+/// entry on an ungoverned host.
+/// </para>
+/// <para>
 /// <b>This provider overrides <see cref="AIContextProvider.InvokingCoreAsync"/>, not
 /// <c>ProvideAIContextAsync</c>, and that choice is load-bearing.</b> <c>ProvideAIContextAsync</c> is
 /// contractually an <em>additive</em> hook: the base implementation merges whatever it returns into the

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
@@ -1,0 +1,225 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Context;
+using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Application.AI.Common.Tests.Governance;
+using Application.AI.Common.Tests.Helpers;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
+using Domain.AI.Models;
+using Domain.AI.Skills;
+using Domain.AI.Tools;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Pins the security property that decides whether <see cref="GoverningToolContextProvider"/> is worth
+/// having at all: a tool the model is offered through the <see cref="AIContextProvider"/> channel must
+/// reach the admission chain, on <em>every</em> flow where governance is active — including a bundle run
+/// with the host's global enforcement switch left off.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two channels put tools in front of the model. Most arrive through <c>ToolChainBuilder</c>, which wraps
+/// them on the way past. The framework's own progressive-disclosure tools do not: they are contributed by
+/// <see cref="AgentSkillsProvider"/> and exist only on the provider rail, so the wrapper this suite is
+/// about is the only thing that can gate them. Two of the three — <c>load_skill</c> and
+/// <c>read_skill_resource</c> — are additionally exempt from <see cref="ToolPermissionFilter"/> by design,
+/// which leaves the admission chain as their sole gate rather than their second one.
+/// </para>
+/// <para>
+/// A bundle run is exactly the flow that cannot afford to miss them: it executes an externally-authored
+/// agent whose nested <c>SKILL.md</c> files were shipped by the bundle author, under a per-caller
+/// capability envelope that says which tools that caller is allowed. Governance being active is therefore
+/// not solely the host's global opt-in — the presence of an envelope arms it too
+/// (<see cref="GovernanceEnforcement.IsActive"/>). Before issue #347 the rail read the global switch alone,
+/// so on a default composition a bundle's disclosure tools were published unwrapped and the envelope was
+/// never consulted for them.
+/// </para>
+/// <para>
+/// The assertions here drive a real admission chain from a real tool invocation rather than checking that
+/// the wrapper type is present on the rail. A type assertion would still pass if the wrapper stopped
+/// enforcing, which is the failure mode this assembly's <c>CLAUDE.md</c> records shipping repeatedly.
+/// </para>
+/// </remarks>
+public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposable
+{
+    private const string SkillName = "bundle-skill";
+
+    /// <summary>The one tool the bundle's skill declares, so the agent is built holding something real.</summary>
+    private const string AllowedTool = "file_system";
+
+    /// <summary>
+    /// The refusal a denying governor returns. Asserted on rather than merely "something happened",
+    /// so a tool that ran for real and produced its own error text cannot be mistaken for a refusal.
+    /// </summary>
+    private const string DenialMessage = "Error: tool call refused by the admission chain.";
+
+    private readonly SkillDirectoryFixture _skills = new("bundlegovernance");
+    private readonly string _skillDir;
+    private readonly string _skillsRoot;
+
+    public AgentExecutionContextFactoryBundleGovernanceTests()
+    {
+        _skillDir = _skills.CreateSkill(
+            Path.Combine("skills", SkillName),
+            "# Bundle Skill\n\nBUNDLE_BODY",
+            "A skill shipped inside an agent bundle.");
+        _skillsRoot = Path.GetDirectoryName(_skillDir)!;
+    }
+
+    public void Dispose() => _skills.Dispose();
+
+    /// <summary>
+    /// A skill in the shape a staged bundle produces: parsed from a real directory on disk, so the
+    /// framework provider will serve its body on demand and therefore publishes the disclosure tools.
+    /// </summary>
+    private SkillDefinition MakeSkill() => new()
+    {
+        Id = SkillName,
+        Name = SkillName,
+        Description = "A skill shipped inside an agent bundle.",
+        Instructions = "# Bundle Skill\n\nBUNDLE_BODY",
+        BaseDirectory = _skillDir,
+        AllowedTools = [AllowedTool]
+    };
+
+    private AgentExecutionContextFactory CreateFactory(bool globalEnforcement)
+    {
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig { DefaultDeployment = "gpt-4o" },
+                Skills = new SkillsConfig { BasePath = _skillsRoot },
+                Governance = new GovernanceConfig { EnforceToolInvocation = globalEnforcement }
+            }
+        };
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>(AllowedTool, (_, _) => new StubTool(AllowedTool));
+        var sp = services.BuildServiceProvider();
+
+        return new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig),
+            sp,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp, new PassThroughToolConverter()),
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader());
+    }
+
+    /// <summary>
+    /// Builds the agent, drives its rail the way the runtime does, and returns the disclosure tool the
+    /// model would finally be offered.
+    /// </summary>
+    private async Task<AIFunction> ResolveDisclosureToolAsync(AgentExecutionContextFactory factory)
+    {
+        var context = await factory.MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+        var finished = await AIContextRailDriver.DriveAsync(context);
+
+        var tool = finished.Tools?
+            .OfType<AIFunction>()
+            .SingleOrDefault(t => t.Name == AgentSkillsProvider.ReadSkillResourceToolName);
+
+        // Control for every test in this class: the channel under test must actually carry a tool. If
+        // progressive disclosure stopped publishing one, every assertion below would pass vacuously.
+        tool.Should().NotBeNull(
+            "the framework's skill-disclosure tools are the tools that exist only on the provider rail; "
+            + "without one on the finished context there is nothing here to govern or to fail to govern");
+
+        return tool!;
+    }
+
+    /// <summary>
+    /// Invokes <paramref name="tool"/> with an admission chain armed that refuses everything, and reports
+    /// what came back as text.
+    /// </summary>
+    /// <remarks>
+    /// A governed tool never reaches its inner implementation and returns the refusal. An ungoverned one
+    /// runs for real against an empty argument set and either returns its own output or throws; both are
+    /// reported here as ordinary text so the failure reads as a failed assertion about governance rather
+    /// than as an unhandled error somewhere else.
+    /// </remarks>
+    private static async Task<string?> InvokeUnderRefusingChainAsync(AIFunction tool)
+    {
+        var governor = new Mock<IToolInvocationGovernor>();
+        governor
+            .Setup(g => g.AuthorizeAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>?>()))
+            .ReturnsAsync(ToolInvocationDecision.Deny(DenialMessage));
+
+        using var armed = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor.Object));
+
+        try
+        {
+            var result = await tool.InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+            return result?.ToString();
+        }
+        catch (Exception ex)
+        {
+            return $"the tool executed and threw {ex.GetType().Name}";
+        }
+    }
+
+    /// <summary>
+    /// The control. With the host's global switch on, the disclosure tool is governed — which is what
+    /// makes the refusal below a usable instrument for the case that follows.
+    /// </summary>
+    [Fact]
+    public async Task MapToAgentContext_GlobalEnforcementOn_DisclosureToolReachesTheAdmissionChain()
+    {
+        var tool = await ResolveDisclosureToolAsync(CreateFactory(globalEnforcement: true));
+
+        var result = await InvokeUnderRefusingChainAsync(tool);
+
+        result.Should().Contain(DenialMessage,
+            "with enforcement on, a tool contributed through the provider channel must still be admitted "
+            + "through the chain — if this refusal is not observable here, the assertion below proves nothing");
+    }
+
+    /// <summary>
+    /// The defect (#347). A bundle run arms enforcement through its capability envelope, not through the
+    /// host's global switch, so the disclosure tools must be governed on a default composition too.
+    /// </summary>
+    [Fact]
+    public async Task MapToAgentContext_BundleRunWithGlobalEnforcementOff_DisclosureToolReachesTheAdmissionChain()
+    {
+        // The bundle-run fact, published exactly as BundleRunExecutor publishes it around the whole
+        // conversation — so the agent below is constructed inside the envelope, as it is in production.
+        var envelope = new CapabilityEnvelope
+        {
+            AllowedTools = [AllowedTool],
+            AutonomyCeiling = AutonomyLevel.Autonomous
+        };
+
+        using var bundleRun = CapabilityEnvelopeAccessor.Begin(envelope);
+
+        var tool = await ResolveDisclosureToolAsync(CreateFactory(globalEnforcement: false));
+
+        var result = await InvokeUnderRefusingChainAsync(tool);
+
+        result.Should().Contain(DenialMessage,
+            "a bundle runs an agent the host did not write, under a per-caller grant; read_skill_resource "
+            + "is exempt from the tool allowlist by design, so the admission chain is its only gate. A "
+            + "disclosure tool published unwrapped here is a capability the envelope was never asked about");
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
@@ -1,6 +1,5 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
-using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Context;
@@ -28,32 +27,36 @@ using Xunit;
 namespace Application.AI.Common.Tests.Factories;
 
 /// <summary>
-/// Pins the security property that decides whether <see cref="GoverningToolContextProvider"/> is worth
-/// having at all: a tool the model is offered through the <see cref="AIContextProvider"/> channel must
-/// reach the admission chain, on <em>every</em> flow where governance is active — including a bundle run
-/// with the host's global enforcement switch left off.
+/// Pins where <see cref="GoverningToolContextProvider"/> draws its line on a bundle run: a
+/// <em>capability</em> offered through the <see cref="AIContextProvider"/> channel must reach the
+/// admission chain even when the host's global enforcement switch is off, while the two tools that
+/// merely carry skill content must not.
 /// </summary>
 /// <remarks>
 /// <para>
 /// Two channels put tools in front of the model. Most arrive through <c>ToolChainBuilder</c>, which wraps
-/// them on the way past. The framework's own progressive-disclosure tools do not: they are contributed by
-/// <see cref="AgentSkillsProvider"/> and exist only on the provider rail, so the wrapper this suite is
-/// about is the only thing that can gate them. Two of the three — <c>load_skill</c> and
-/// <c>read_skill_resource</c> — are additionally exempt from <see cref="ToolPermissionFilter"/> by design,
-/// which leaves the admission chain as their sole gate rather than their second one.
+/// them for governance on the way past. The framework's own progressive-disclosure tools do not: they are
+/// contributed by <see cref="AgentSkillsProvider"/>, exist only on the provider rail, and so this wrapper
+/// is the only thing that can gate them.
 /// </para>
 /// <para>
-/// A bundle run is exactly the flow that cannot afford to miss them: it executes an externally-authored
-/// agent whose nested <c>SKILL.md</c> files were shipped by the bundle author, under a per-caller
-/// capability envelope that says which tools that caller is allowed. Governance being active is therefore
-/// not solely the host's global opt-in — the presence of an envelope arms it too
-/// (<see cref="GovernanceEnforcement.IsActive"/>). Before issue #347 the rail read the global switch alone,
-/// so on a default composition a bundle's disclosure tools were published unwrapped and the envelope was
-/// never consulted for them.
+/// A bundle run is the flow that makes the distinction matter. It executes an externally-authored agent
+/// under a per-caller capability envelope naming the tools that caller may invoke, and enforcement is
+/// armed by the envelope's presence rather than by the host's opt-in
+/// (<see cref="GovernanceEnforcement.IsActive"/>). Before issue #347 the rail read the global switch
+/// alone, so on a default composition <em>everything</em> on this channel was published unwrapped —
+/// including <c>run_skill_script</c>, which executes a bundle author's script.
 /// </para>
 /// <para>
-/// The assertions here drive a real admission chain from a real tool invocation rather than checking that
-/// the wrapper type is present on the rail. A type assertion would still pass if the wrapper stopped
+/// The line is not "wrap everything". An envelope grants domain tools, so a governed <c>load_skill</c> or
+/// <c>read_skill_resource</c> would be refused for want of a grant no operator writes, and the bundle
+/// would lose the instructions of the skills it shipped with — a failure that produces a working-looking
+/// agent missing half its prompt. Those two are therefore exempt, using the same set
+/// <see cref="ToolPermissionFilter"/> already exempts them by. <c>run_skill_script</c> is not.
+/// </para>
+/// <para>
+/// The assertions here drive a real admission chain from a real tool invocation rather than checking
+/// which wrapper type sits on the rail. A type assertion would still pass if the wrapper stopped
 /// enforcing, which is the failure mode this assembly's <c>CLAUDE.md</c> records shipping repeatedly.
 /// </para>
 /// </remarks>
@@ -89,6 +92,13 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
     /// A skill in the shape a staged bundle produces: parsed from a real directory on disk, so the
     /// framework provider will serve its body on demand and therefore publishes the disclosure tools.
     /// </summary>
+    /// <remarks>
+    /// It declares <c>run_skill_script</c> as well as its domain tool, and that is the whole point of the
+    /// scenario rather than setup noise. A bundle declares what it <em>wants</em>; the caller's envelope
+    /// is what it <em>gets</em>. Without the declaration, <see cref="ToolPermissionFilter"/> strips the
+    /// script tool off the rail before governance is reached and the interesting case never arises —
+    /// which is exactly what happened the first time this test was written.
+    /// </remarks>
     private SkillDefinition MakeSkill() => new()
     {
         Id = SkillName,
@@ -96,18 +106,23 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
         Description = "A skill shipped inside an agent bundle.",
         Instructions = "# Bundle Skill\n\nBUNDLE_BODY",
         BaseDirectory = _skillDir,
-        AllowedTools = [AllowedTool]
+        AllowedTools = [AllowedTool, AgentSkillsProvider.RunSkillScriptToolName]
     };
 
-    private AgentExecutionContextFactory CreateFactory(bool globalEnforcement)
+    /// <remarks>
+    /// Governance is left unconfigured, so the host's global <c>EnforceToolInvocation</c> switch is off.
+    /// That is the default composition and the one that carried the defect — enforcement here comes from
+    /// the ambient envelope alone, which is the whole point. Setting the switch would prove nothing
+    /// either way: the factory reads it nowhere.
+    /// </remarks>
+    private AgentExecutionContextFactory CreateFactory()
     {
         var appConfig = new AppConfig
         {
             AI = new AIConfig
             {
                 AgentFramework = new AgentFrameworkConfig { DefaultDeployment = "gpt-4o" },
-                Skills = new SkillsConfig { BasePath = _skillsRoot },
-                Governance = new GovernanceConfig { EnforceToolInvocation = globalEnforcement }
+                Skills = new SkillsConfig { BasePath = _skillsRoot }
             }
         };
 
@@ -126,23 +141,23 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
     }
 
     /// <summary>
-    /// Builds the agent, drives its rail the way the runtime does, and returns the disclosure tool the
-    /// model would finally be offered.
+    /// Builds the agent, drives its rail the way the runtime does, and returns the named tool the model
+    /// would finally be offered.
     /// </summary>
-    private async Task<AIFunction> ResolveDisclosureToolAsync(AgentExecutionContextFactory factory)
+    private async Task<AIFunction> ResolveOfferedToolAsync(AgentExecutionContextFactory factory, string toolName)
     {
         var context = await factory.MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
         var finished = await AIContextRailDriver.DriveAsync(context);
 
         var tool = finished.Tools?
             .OfType<AIFunction>()
-            .SingleOrDefault(t => t.Name == AgentSkillsProvider.ReadSkillResourceToolName);
+            .SingleOrDefault(t => t.Name == toolName);
 
-        // Control for every test in this class: the channel under test must actually carry a tool. If
-        // progressive disclosure stopped publishing one, every assertion below would pass vacuously.
+        // Control for every test in this class: the channel under test must actually carry the tool. If
+        // progressive disclosure stopped publishing it, every assertion below would pass vacuously.
         tool.Should().NotBeNull(
-            "the framework's skill-disclosure tools are the tools that exist only on the provider rail; "
-            + "without one on the finished context there is nothing here to govern or to fail to govern");
+            $"'{toolName}' exists only on the provider rail, so without it on the finished context there "
+            + "is nothing here to govern or to fail to govern");
 
         return tool!;
     }
@@ -159,13 +174,7 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
     /// </remarks>
     private static async Task<string?> InvokeUnderRefusingChainAsync(AIFunction tool)
     {
-        var governor = new Mock<IToolInvocationGovernor>();
-        governor
-            .Setup(g => g.AuthorizeAsync(
-                It.IsAny<string>(),
-                It.IsAny<CancellationToken>(),
-                It.IsAny<IReadOnlyDictionary<string, object?>?>()))
-            .ReturnsAsync(ToolInvocationDecision.Deny(DenialMessage));
+        var governor = AdmissionHarness.DenyingGovernor(DenialMessage);
 
         using var armed = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor.Object));
 
@@ -176,50 +185,80 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
         }
         catch (Exception ex)
         {
-            return $"the tool executed and threw {ex.GetType().Name}";
+            // The message matters as much as the type: it is what tells whoever reads the failure that
+            // the tool got as far as validating its own arguments, which only an ungoverned tool does.
+            return $"the tool executed and threw {ex.GetType().Name}: {ex.Message}";
         }
     }
 
     /// <summary>
-    /// The control. With the host's global switch on, the disclosure tool is governed — which is what
-    /// makes the refusal below a usable instrument for the case that follows.
+    /// Publishes an ambient capability envelope exactly as <c>BundleRunExecutor</c> does around a whole
+    /// bundle conversation, so the agent built inside it is built at the moment production builds it.
     /// </summary>
-    [Fact]
-    public async Task MapToAgentContext_GlobalEnforcementOn_DisclosureToolReachesTheAdmissionChain()
-    {
-        var tool = await ResolveDisclosureToolAsync(CreateFactory(globalEnforcement: true));
-
-        var result = await InvokeUnderRefusingChainAsync(tool);
-
-        result.Should().Contain(DenialMessage,
-            "with enforcement on, a tool contributed through the provider channel must still be admitted "
-            + "through the chain — if this refusal is not observable here, the assertion below proves nothing");
-    }
-
-    /// <summary>
-    /// The defect (#347). A bundle run arms enforcement through its capability envelope, not through the
-    /// host's global switch, so the disclosure tools must be governed on a default composition too.
-    /// </summary>
-    [Fact]
-    public async Task MapToAgentContext_BundleRunWithGlobalEnforcementOff_DisclosureToolReachesTheAdmissionChain()
-    {
-        // The bundle-run fact, published exactly as BundleRunExecutor publishes it around the whole
-        // conversation — so the agent below is constructed inside the envelope, as it is in production.
-        var envelope = new CapabilityEnvelope
+    /// <remarks>
+    /// The grant deliberately lists only the skill's domain tool. That is what a real envelope looks
+    /// like — an operator grants the tools a caller may invoke, never the framework's own plumbing —
+    /// and it is the condition under which a governed transport tool would be refused.
+    /// </remarks>
+    private static IDisposable BeginBundleRun() =>
+        CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope
         {
             AllowedTools = [AllowedTool],
             AutonomyCeiling = AutonomyLevel.Autonomous
-        };
+        });
 
-        using var bundleRun = CapabilityEnvelopeAccessor.Begin(envelope);
+    /// <summary>
+    /// The defect (#347). A bundle run arms enforcement through its capability envelope rather than the
+    /// host's global switch, so a capability published on the provider rail has to be admitted through
+    /// the chain on a default composition too — where before it was published unwrapped.
+    /// </summary>
+    [Fact]
+    public async Task MapToAgentContext_BundleRun_SkillScriptToolReachesTheAdmissionChain()
+    {
+        using var bundleRun = BeginBundleRun();
 
-        var tool = await ResolveDisclosureToolAsync(CreateFactory(globalEnforcement: false));
+        var tool = await ResolveOfferedToolAsync(
+            CreateFactory(), AgentSkillsProvider.RunSkillScriptToolName);
 
         var result = await InvokeUnderRefusingChainAsync(tool);
 
         result.Should().Contain(DenialMessage,
-            "a bundle runs an agent the host did not write, under a per-caller grant; read_skill_resource "
-            + "is exempt from the tool allowlist by design, so the admission chain is its only gate. A "
-            + "disclosure tool published unwrapped here is a capability the envelope was never asked about");
+            "running a skill's script is a capability, and a bundle runs an agent the host did not write. "
+            + "Published unwrapped, it executes without the caller's envelope ever being asked");
+    }
+
+    /// <summary>
+    /// The other half, and the reason the wrapper cannot simply cover everything on the rail: the two
+    /// content-transport tools must stay ungoverned or a bundle cannot read the skills it shipped with.
+    /// </summary>
+    /// <remarks>
+    /// The refusal asserted above is the control for these: it proves the armed chain is real and that
+    /// this instrument can see a refusal, so "no refusal" here is a fact about the exemption rather than
+    /// about a chain that was never armed. What the envelope does to an unexempt tool is pinned
+    /// end-to-end against the real governor by
+    /// <c>ToolInvocationGovernorEnvelopeTests.ResolverAllowsToolTheEnvelopeDoesNotGrant_IsStillDenied</c>
+    /// — a bundle's envelope names domain tools, so a governed <c>read_skill_resource</c> would be
+    /// refused there and the agent would get a refusal string where its own skill body belongs.
+    /// </remarks>
+    [Theory]
+    [InlineData(AgentSkillsProvider.LoadSkillToolName)]
+    [InlineData(AgentSkillsProvider.ReadSkillResourceToolName)]
+    public async Task MapToAgentContext_BundleRun_SkillContentToolIsNotGated(string toolName)
+    {
+        using var bundleRun = BeginBundleRun();
+
+        var tool = await ResolveOfferedToolAsync(CreateFactory(), toolName);
+
+        var result = await InvokeUnderRefusingChainAsync(tool);
+
+        result.Should().NotContain(DenialMessage,
+            "these two carry the instructions for skills the agent was already assigned — they are not "
+            + "capabilities a caller is granted, and the provider only ever advertises this agent's own "
+            + "skills. Gating them asks a question no envelope answers, and the agent silently loses its "
+            + "own skill bodies");
+
+        result.Should().Contain("executed",
+            "and it must be ungated because it RAN, not because the chain was never armed — the tool "
+            + "reaching its own argument validation is what proves it got past the wrapper");
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -99,9 +99,15 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
     /// Builds the factory with the optional providers switched on or off individually, so the tests can
     /// assert what holds across configurations rather than only in the fully-loaded one.
     /// </summary>
+    /// <remarks>
+    /// Governance is deliberately left unconfigured, which means the host's <c>EnforceToolInvocation</c>
+    /// switch is off — the default composition, and the one that carried the #347 defect. The factory
+    /// reads that switch nowhere, because whether governance is active is a per-run fact a rail built
+    /// once at construction cannot know; so the rail below is the rail every host gets. Re-adding a
+    /// condition on the switch would drop the governance wrapper from these expectations and fail.
+    /// </remarks>
     private AgentExecutionContextFactory CreateFactory(
         bool recall = true,
-        bool governance = true,
         bool budgetTracker = true)
     {
         var appConfig = new AppConfig
@@ -111,8 +117,7 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
                 AgentFramework = new AgentFrameworkConfig { DefaultDeployment = "gpt-4o" },
                 Skills = new SkillsConfig { BasePath = _skillsRoot },
                 KnowledgeBridge = new KnowledgeBridgeConfig { Enabled = recall },
-                LearningsRecall = new LearningsRecallConfig { Enabled = recall },
-                Governance = new GovernanceConfig { EnforceToolInvocation = governance }
+                LearningsRecall = new LearningsRecallConfig { Enabled = recall }
             }
         };
 
@@ -146,18 +151,10 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 
     // ── The whole rail, in order ──────────────────────────────────────────────
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task MapToAgentContext_EveryOptionalProviderEnabled_RailIsThisSequenceWhicheverWayEnforcementIsSet(
-        bool globalEnforcement)
+    [Fact]
+    public async Task MapToAgentContext_EveryOptionalProviderEnabled_RailIsExactlyThisSequence()
     {
-        // Run both ways because the governance wrapper is attached unconditionally (issue #347). Whether
-        // enforcement is active is a per-run fact — a bundle run arms it through its capability envelope,
-        // long after this rail was built and cached — so a rail that varied with the host's global switch
-        // would be answering for the wrong moment. Both rows assert the same sequence on purpose.
-        var context = await CreateFactory(governance: globalEnforcement)
-            .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+        var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
         RailTypes(context).Should().Equal(
             [
@@ -232,21 +229,17 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
     // ── Rule 2 continued: the measurer is last, in every configuration ────────
 
     [Theory]
-    [InlineData(true, true)]
-    [InlineData(true, false)]
-    [InlineData(false, true)]
-    [InlineData(false, false)]
-    public async Task MapToAgentContext_AnyOptionalProviderCombination_BudgetMeasurerIsLast(bool recall, bool governance)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MapToAgentContext_AnyOptionalProviderCombination_BudgetMeasurerIsLast(bool recall)
     {
-        var context = await CreateFactory(recall, governance)
+        var context = await CreateFactory(recall)
             .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
         var rail = context.AIContextProviders!;
 
-        // Control: the recall rows really do differ, so this is not the same case asserted four times.
-        // Without it, a factory that ignored the flag would satisfy every row. The governance flag is
-        // deliberately absent from the arithmetic — the wrapper is attached whichever way it is set
-        // (issue #347), so a rail whose length moved with it would be the defect, not the expectation.
+        // Control: the two rows really do differ, so this is not the same case asserted twice. Without
+        // it, a factory that ignored the flag would satisfy both.
         rail.Count.Should().Be(4 + (recall ? 2 : 0));
 
         rail[^1].Should().BeOfType<PerTurnBudgetContextProvider>(
@@ -264,9 +257,9 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
         // Run fully loaded on purpose. Asserting this against a two-provider rail would pass for any
         // factory that merely omits the measurer, including one that also dropped or reordered the
         // providers that only appear when the optional features are on — the case with something to break.
-        var tracked = await CreateFactory(recall: true, governance: true, budgetTracker: true)
+        var tracked = await CreateFactory(recall: true, budgetTracker: true)
             .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
-        var untracked = await CreateFactory(recall: true, governance: true, budgetTracker: false)
+        var untracked = await CreateFactory(recall: true, budgetTracker: false)
             .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
         // Control: "minus the measurer" is only meaningful if the tracked rail ends with one. Without

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -146,10 +146,18 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 
     // ── The whole rail, in order ──────────────────────────────────────────────
 
-    [Fact]
-    public async Task MapToAgentContext_EveryOptionalProviderEnabled_RailIsExactlyThisSequence()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MapToAgentContext_EveryOptionalProviderEnabled_RailIsThisSequenceWhicheverWayEnforcementIsSet(
+        bool globalEnforcement)
     {
-        var context = await CreateFactory().MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
+        // Run both ways because the governance wrapper is attached unconditionally (issue #347). Whether
+        // enforcement is active is a per-run fact — a bundle run arms it through its capability envelope,
+        // long after this rail was built and cached — so a rail that varied with the host's global switch
+        // would be answering for the wrong moment. Both rows assert the same sequence on purpose.
+        var context = await CreateFactory(governance: globalEnforcement)
+            .MapToAgentContextAsync([MakeSkill()], new SkillAgentOptions());
 
         RailTypes(context).Should().Equal(
             [
@@ -235,9 +243,11 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 
         var rail = context.AIContextProviders!;
 
-        // Control: the configurations really do differ, so this is four cases and not the same one asserted
-        // four times. Without it, a factory that ignored both flags would satisfy every row.
-        rail.Count.Should().Be(3 + (recall ? 2 : 0) + (governance ? 1 : 0));
+        // Control: the recall rows really do differ, so this is not the same case asserted four times.
+        // Without it, a factory that ignored the flag would satisfy every row. The governance flag is
+        // deliberately absent from the arithmetic — the wrapper is attached whichever way it is set
+        // (issue #347), so a rail whose length moved with it would be the defect, not the expectation.
+        rail.Count.Should().Be(4 + (recall ? 2 : 0));
 
         rail[^1].Should().BeOfType<PerTurnBudgetContextProvider>(
             "the measurer charges the difference between what it is handed and the baseline it was built "

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
@@ -73,6 +73,27 @@ internal static class AdmissionHarness
         return gate;
     }
 
+    /// <summary>
+    /// A governor that refuses every call, as the real one does for a tool outside the caller's grant.
+    /// </summary>
+    /// <param name="deniedMessage">The refusal text the governor returns.</param>
+    /// <remarks>
+    /// The mirror of <see cref="DenyingAuthorizationGate"/>, and here for the same reason: the
+    /// <c>AuthorizeAsync</c> setup carries a trailing optional argument, so every hand-rolled copy is
+    /// another place to get the matcher shape wrong when that signature moves.
+    /// </remarks>
+    public static Mock<IToolInvocationGovernor> DenyingGovernor(string deniedMessage)
+    {
+        var governor = new Mock<IToolInvocationGovernor>();
+        governor
+            .Setup(g => g.AuthorizeAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>?>()))
+            .ReturnsAsync(ToolInvocationDecision.Deny(deniedMessage));
+        return governor;
+    }
+
     /// <summary>A governor that authorizes everything — the ungoverned default composition.</summary>
     public static IToolInvocationGovernor PermissiveGovernor()
     {

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -27,6 +27,15 @@ namespace Presentation.Common.Tests.Composition;
 /// registered control at all.
 /// </para>
 /// <para>
+/// <strong>What this file does and does not cover.</strong> The consumer scan reads
+/// <em>interfaces</em> declared under the guarded folders, so of the four defects named above it could
+/// only ever have caught the last. The other three are concrete classes implementing no guarded
+/// contract, and no exemption list can be curated into covering them without becoming the very smell
+/// this test warns about. <see cref="NoFactoryDecidesAPerRunFactAtConstructionTime"/> covers the
+/// second failure mode those three shared — a control wired correctly but decided at the wrong moment
+/// — by reading source shape rather than contracts.
+/// </para>
+/// <para>
 /// <strong>What counts as a consumer.</strong> Any production file that names the interface and is
 /// not its own declaration, not a type that implements it, and not a DI registration. That covers
 /// constructor injection, <c>GetRequiredService</c>, and an ambient static — the three ways a
@@ -69,6 +78,16 @@ public sealed class SecurityControlHasACallerTests
         // by ScanningMcpToolProvider, which screens every tool definition an external MCP server
         // advertises before it can reach the model (#313), so the entry is gone rather than renewed.
     };
+
+    /// <summary>
+    /// Reads that mean a factory is answering a question whose answer belongs to one run, not to the
+    /// lifetime of a cached object. See <see cref="NoFactoryDecidesAPerRunFactAtConstructionTime"/>.
+    /// </summary>
+    private static readonly (string Pattern, string What)[] PerRunFactPatterns =
+    [
+        (@"\bEnforceToolInvocation\b", "the global tool-invocation enforcement switch"),
+        (@"\b\w*Accessor\s*\.\s*Current\b", "an ambient per-run accessor")
+    ];
 
     [Fact]
     public void EveryRegisteredGovernanceContractHasAProductionConsumer()
@@ -151,6 +170,78 @@ public sealed class SecurityControlHasACallerTests
         Directory.EnumerateFiles(contentRoot, "*.cs", SearchOption.AllDirectories)
             .Count(f => !IsExcluded(f, contentRoot))
             .Should().BeGreaterThan(500);
+    }
+
+    /// <summary>
+    /// Asserts that no factory answers a question whose answer is only true for the duration of one
+    /// run — the second way a security control ends up not running, and the one the consumer scan
+    /// above is structurally blind to.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The defect this exists to catch (#347).</strong> A factory builds an agent once and the
+    /// agent is cached. Enforcement, though, can be armed per run: a bundle executes an
+    /// externally-authored agent under a per-caller capability envelope published ambiently for that
+    /// run only. <c>GoverningToolContextProvider</c> was attached behind the host's global enforcement
+    /// switch, read at construction — a moment that cannot see the envelope — so on the default
+    /// composition a bundle's progressive-disclosure tools reached the model ungoverned. The control
+    /// was registered, wired and consumed; it simply answered the question at the wrong moment.
+    /// </para>
+    /// <para>
+    /// The rule the harness already follows everywhere else is stated on
+    /// <c>ToolAdmissionAccessor</c>: wire unconditionally, decide at invocation.
+    /// <c>ToolChainBuilder</c> — the other channel tools reach the model by — has always wrapped for
+    /// governance with no config read anywhere near it. This makes that rule structural for factories
+    /// rather than a comment at each site.
+    /// </para>
+    /// <para>
+    /// <strong>If this fails,</strong> the fix is not an exemption: move the decision to the moment it
+    /// can be answered. A gate belongs at invocation, where the ambient state it depends on is live.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void NoFactoryDecidesAPerRunFactAtConstructionTime()
+    {
+        var contentRoot = Path.Combine(RepoRoot.Path, "src", "Content");
+
+        var factoryFiles = Directory
+            .EnumerateFiles(contentRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsExcluded(f, contentRoot))
+            .Where(f => (Path.GetDirectoryName(f) ?? string.Empty)
+                .Contains(Path.DirectorySeparatorChar + "Factories", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+
+        // Control: a scan that found no factories would pass while reading nothing.
+        factoryFiles.Should().NotBeEmpty("the folders this reads must exist for its verdict to mean anything");
+
+        // Control: each pattern must fire on the shape it is written for. Without this the assertion
+        // below is satisfied equally by a rule that matches nothing — the blind-guard failure this
+        // file's other classifiers already had once.
+        Regex.IsMatch("if (config.AI?.Governance?.EnforceToolInvocation == true)", PerRunFactPatterns[0].Pattern)
+            .Should().BeTrue("control: the enforcement-switch pattern must match the read it forbids");
+        Regex.IsMatch("var envelope = CapabilityEnvelopeAccessor.Current;", PerRunFactPatterns[1].Pattern)
+            .Should().BeTrue("control: the ambient-accessor pattern must match the read it forbids");
+
+        var offenders = new List<string>();
+
+        foreach (var file in factoryFiles)
+        {
+            // Comments are stripped first on purpose: this file's own explanation of why the condition
+            // was removed names the switch, and a guard that flagged its own rationale would be useless.
+            var code = StripCommentsAndStrings(File.ReadAllText(file));
+
+            foreach (var (pattern, what) in PerRunFactPatterns)
+            {
+                if (Regex.IsMatch(code, pattern))
+                    offenders.Add($"{Path.GetRelativePath(contentRoot, file)} reads {what}");
+            }
+        }
+
+        offenders.Should().BeEmpty(
+            "a factory runs once and its output is cached, so anything it decides is frozen before the "
+            + "run that needs it exists. Reading per-run state there produces a control that looks wired "
+            + "and does not fire — #347, where a bundle's disclosure tools reached the model ungoverned. "
+            + "Attach unconditionally and gate at invocation instead. Found: " + string.Join("; ", offenders));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #347.

## What was wrong

A tool can reach the model by two routes. Most go through `ToolChainBuilder`, which wraps them for governance on the way past. The framework's progressive-disclosure tools do not — they are contributed by `AgentSkillsProvider` and exist only on the `AIContextProvider` rail, where `GoverningToolContextProvider` is the only thing that can gate them.

That provider was attached only when the host's global `EnforceToolInvocation` switch was on. But a **bundle run** arms enforcement per run, by publishing an ambient `CapabilityEnvelope` — the case `GovernanceEnforcement.IsActive` covers and the global switch does not. So on the default composition, a bundle's disclosure tools were published unwrapped and the caller's grant was never consulted for them, including `run_skill_script`, which executes a bundle author's script.

## Why the condition could not simply be widened

The rail is built once, at agent construction, and agents are cached. The envelope is published later and per run. Any condition evaluated at that site answers for the wrong moment. The provider is transparent when no admission chain is ambient, so it is now attached unconditionally and the condition is gone.

The strongest argument that this is the right depth is that the sibling channel already worked this way: `ToolChainBuilder` has always wrapped unconditionally, with no config read anywhere near it. The condition on this channel was the outlier, and "wire unconditionally, decide at invocation" is already the stated rule on `ToolAdmissionAccessor`.

## Where the line is drawn — and why it is not "wrap everything"

Review caught that wrapping everything would have **broken bundle runs**. A capability envelope names the domain tools a caller may invoke; it would never name a framework transport tool, and the governor refuses anything the envelope does not name. Governed, `load_skill` and `read_skill_resource` would be refused for want of a grant no operator writes, and the bundle agent would run with a refusal string where its own skill bodies belong — a working-looking agent missing half its prompt.

Those two are exempt, reusing `ToolPermissionFilter.SkillDisclosureToolNames`, which already exempts exactly this pair for exactly this reason. They are not capabilities: they carry the instructions for skills the agent was already assigned, and the provider only ever advertises this agent's own skills.

`run_skill_script` is **not** exempt. Executing a skill's script is a capability, and on a bundle run it is one the caller's envelope must grant. That is a deliberate tightening: a bundle that needs it now requires an operator grant.

## Evidence

Both directions were measured, not assumed.

- **Before the fix**, the bundle case reported `the tool executed and threw ArgumentException` — the disclosure tool ran without ever being admitted.
- **Restoring the condition** fails the new bundle test, three rail-order assertions, and the new factory guard.
- **Removing the content-tool exemption** fails both content-tool cases.
- The first version of the script-tool test passed vacuously because `ToolPermissionFilter` stripped `run_skill_script` before governance was reached; the skill now declares it, which is what a bundle does.
- Full solution suite green.

## Also in this PR

- `BuildMergedAIContextProviders` can no longer return null or an empty rail; the unreachable branch and the doc sentences describing it are gone.
- `NoFactoryDecidesAPerRunFactAtConstructionTime` — a source-scan guard so the next factory that decides a per-run fact at construction fails structurally rather than by review.
- `SecurityControlHasACallerTests`' remarks claimed its interface scan covered three concrete classes it cannot see; corrected.
- `AdmissionHarness.DenyingGovernor`, so that setup has one home instead of six.

## Deliberately not done

Extracting a shared `AgentExecutionContextFactory` test harness. Two review angles flagged the duplication and it is real, but the right fix covers 13 hand-rolled construction sites, not the 2 here, and a partial extraction would add a third pattern. That is #349.

## Behaviour note for reviewers

`ReservedPlanCapabilityFilter` now also runs unconditionally on this channel, matching `ToolChainBuilder`. This closes a real drift, and means a consumer-contributed tool colliding with a reserved plan-capability name is dropped with an Error log on ungoverned hosts too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgyekFt9vVUfL75GP1HL7d
