### PR TITLE
Gate tools by declared behaviour, not by name lists (#324)

### DIFF
--- a/documentation/security/10-reference.html
+++ b/documentation/security/10-reference.html
@@ -466,6 +466,12 @@
                             detection rules were calibrated against, and the limits they knowingly carry.
                         </li>
                         <li>
+                            <a href="tool-behavior-gating.md">Gating Tools By Declared Behaviour</a>
+                            (Markdown source, <code>documentation/security/tool-behavior-gating.md</code>) —
+                            requiring approval for every tool not declared read-only, why a read-only claim
+                            from an unvouched-for MCP server buys nothing, and how the exemption list works.
+                        </li>
+                        <li>
                             <a href="../architecture/04-networking-and-security.html">Architecture Guide → Networking &amp; Security</a>
                             — the deployment side: VNets, private endpoints, Key Vault, managed identity.
                         </li>

--- a/documentation/security/tool-behavior-gating.md
+++ b/documentation/security/tool-behavior-gating.md
@@ -1,0 +1,113 @@
+# Gating Tools By Declared Behaviour
+
+> Date: 2026-08-10. Target: .NET 10 (Microsoft Agentic Harness). Audience: harness engineers and template consumers who run agents with tools they did not all write themselves.
+
+## 1. Executive summary
+
+Tool governance in the harness works from **lists of names** — a plugin's allow and deny lists, per-agent tool authorization, declarative YAML policy. Every one of them requires somebody to enumerate the dangerous tools correctly, and to keep doing so forever, including for tools that arrive at runtime from an MCP server nobody on the team wrote. A tool nobody thought to list is callable by default, and a name carries no behaviour: `create_page` and `search_pages` look identical to a name-based rule, and one of them writes.
+
+The harness can now invert that default. With **`AI:Governance:ToolBehaviorGating:RequireApprovalForNonReadOnlyTools`** switched on, any tool that has not declared itself read-only requires human approval before it runs. A new mutating tool appearing on an upstream server is gated the moment it appears, with nobody editing a list.
+
+The posture is **off by default**, and applies through the existing tool governor — so it also requires `AI:Governance:EnforceToolInvocation`. Turning one on without the other **fails host startup** rather than silently doing nothing.
+
+## 2. Where the declaration comes from
+
+Two sources, and the difference between them is the whole security argument.
+
+**First-party tools** declare themselves through `ITool.IsReadOnly`, which already existed for concurrency classification and graded autonomy. It defaults to `false` — assume it writes — so a tool that never thought about the question is gated rather than exempt.
+
+**External MCP tools** declare themselves through the protocol's tool annotations: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. These arrive on the definition a server advertises and were previously discarded. They are captured now at discovery by `BehaviorRecordingMcpToolProvider`, a decorator over `IMcpToolProvider` that sits **outside** the security scanner, so only tools that survived the definition scan are recorded.
+
+Discovery is the only moment the information exists. By the time a tool call arrives, all that remains is a name; the annotations are not reachable from it.
+
+## 3. The trust rule, and why it is not simply "believe the annotation"
+
+A tool annotation is supplied by the party the annotation is used to police. The MCP specification says so directly — annotations "are not guaranteed to provide a faithful description of tool behavior", and clients "should never make tool use decisions based on `ToolAnnotations` received from untrusted servers". A server that wants past an approval gate marks its destructive tool read-only.
+
+The reference implementation this feature was modelled on (`CopilotKit/OpenTag`'s `WriteConfirmationInterceptor`) trusts the hint unconditionally. The harness does not. The rule here is:
+
+> **A declaration is believed when it tightens. It is believed when it loosens only from a source entitled to be believed.**
+
+Nobody lies in the strict direction, so `destructiveHint: true` is honoured from every server. Only `readOnlyHint` — the one that removes friction — needs provenance:
+
+| Source | A read-only claim… |
+| --- | --- |
+| First-party tool (`ITool.IsReadOnly`) | Exempts. Authored in the host's own codebase. |
+| MCP server with `TrustToolAnnotations: true` | Exempts. The operator has assessed this publisher. |
+| MCP server without it (**the default**) | Does **not** exempt. Recorded and reported; the tool still needs approval. |
+| Nothing on record | Does not exempt. Unknown is never safe. |
+
+`TrustToolAnnotations` is a per-server setting under `AI:McpServers:Servers:<name>`. Connecting a server is a decision about where its tools come from; this is the separate decision about whether to take its word for what they do.
+
+Two further rules the model enforces:
+
+- **A destructive claim outranks a read-only one.** The combination is incoherent, and an incoherent declaration is a reason to distrust the declarer rather than to pick the convenient half.
+- **When two *different* sources describe the same tool name, the one that does not exempt wins.** A hostile server cannot loosen a tool by shadowing a name a stricter source already claimed, in either arrival order.
+- **A server revising its own tool is always believed, in both directions.** That is what catches a server which advertised a clean read-only tool and later advertises it as a writer — and it is also the only way granting `TrustToolAnnotations` to a server that was already running can take effect. A rule that kept the stricter record unconditionally would pin the earlier untrusted entry forever and the operator's change would silently do nothing until a restart.
+
+## 4. Where the check runs
+
+Inside `IToolInvocationGovernor`, as a third source of "a human must rule on this" alongside the permission layer's `Ask` and the policy engine's `RequireApproval`. It is deliberately **not** a sixth gate on the admission chain.
+
+The governor is stage 2 of `IToolCallAdmissionPipeline`, which every execution path that can reach a tool goes through and which contains the only copy of the admission sequence — so the posture reaches the agent turn, the Execution API, and all three plan step executors without being added anywhere else. Making it a gate of its own would have meant giving it its own route to a human, and two independent approval questions about one call is precisely the failure the governor's single-question design exists to prevent: an approver clears "write tools need sign-off" and thereby silently clears a second question they were never shown.
+
+Reaching a person also requires `AI:Governance:ToolApproval:Enabled` and `AI:Governance:Escalation:Enabled`. Without them the gated call is **refused** rather than asked about — safe, but it will present to users as tools failing for no stated reason.
+
+One consequence worth stating precisely, because the imprecise version is wrong: the governor arms on **either** `EnforceToolInvocation` **or** the presence of a bundle run's capability envelope. So leaving enforcement off does not switch the posture off — it would apply the posture to bundle runs alone while every agent turn and plan step went ungated, which is worse than either consistent answer. That is why the combination fails startup validation rather than being quietly permitted.
+
+## 5. Exemptions
+
+```jsonc
+{
+  "AppConfig": {
+    "AI": {
+      "Governance": {
+        "EnforceToolInvocation": true,
+        "ToolBehaviorGating": {
+          "RequireApprovalForNonReadOnlyTools": true,
+          "Exemptions": [
+            {
+              "Tool": "notion_search",
+              "Server": "notion",
+              "Reason": "POST-based search endpoint; vendor confirmed it does not mutate"
+            }
+          ]
+        }
+      },
+      "McpServers": {
+        "Servers": {
+          "our-own-service": { "TrustToolAnnotations": true }
+        }
+      }
+    }
+  }
+}
+```
+
+The exemption list is a name list, deliberately, and it is the honest part of the design. A hint is sometimes wrong in the direction that costs an operator an approval prompt on every call of a tool that plainly only reads — a search endpoint that uses POST, and is therefore assumed to write. Denying that escape hatch does not make annotations more accurate; it makes operators switch the whole posture off. OpenTag keeps the same list for the same reason.
+
+`Reason` is required and a blank one fails startup validation. This list is the first thing a reviewer reads when asking why a tool was never gated, and an entry with no justification is indistinguishable a year later from one added to silence a prompt.
+
+**`Server` is required whenever the tool comes from a server that is not marked trusted**, and this is the part that is easy to get wrong. A tool name belongs to nobody. An operator exempts `notion_search` after checking one vendor's tool; any other configured server can advertise a destructive tool by that same name tomorrow. The registry already refuses to let a shadowing server loosen a record it did not create — and a name-only exemption applied on top would hand that bypass straight back. Naming the server is a far narrower statement than `TrustToolAnnotations`: that accepts every declaration a server makes, present and future, while this accepts one tool the operator has actually looked at.
+
+An exemption is honoured even for a tool that declares itself destructive, provided it covers that tool's actual source. That is a different question from the destructive-outranks-read-only rule: that rule arbitrates between two claims by the *same* party, while an exemption is the operator overruling that party outright, in writing, with a stated reason.
+
+## 6. Known limits
+
+- **Tool names are the key.** Two MCP servers advertising the same tool name share one behaviour record — resolved stricter-wins, so it fails safe, but collision detection and reporting is a separate concern.
+- **A tool the registry has never seen is `Unknown`, therefore gated.** That is the intended failure mode, but it means a path that invokes a tool without going through discovery gates every call while the posture is on.
+- **The posture asks about a tool, not about a call.** `write_file` needs approval whether it is writing to a scratch directory or to production config. Argument-conditioned rules remain the declarative policy engine's job.
+- **Framework-provided tools have no local declaration, so they gate.** `load_skill` and `read_skill_resource` are unaffected — they bypass the governor entirely, because they are how an agent reads the instructions of skills it was already assigned rather than capabilities it is granted. `run_skill_script` *is* governed, and will require approval under the posture: executing a skill's script is a capability, so that is the intended outcome, but it is worth knowing before switching the posture on in a host that relies on it.
+
+## 7. Where it lives
+
+| Concern | Type |
+| --- | --- |
+| What a tool declared, and who declared it | `Domain.AI.Governance.ToolBehavior` |
+| The exemption rule | `ToolBehavior.IsExemptFromApproval` |
+| Recording and resolving declarations | `IToolBehaviorRegistry` / `ToolBehaviorRegistry` |
+| Capturing MCP annotations at discovery | `BehaviorRecordingMcpToolProvider` |
+| Applying the posture | `ToolInvocationGovernor.RequiresApprovalForDeclaredBehavior` |
+| Refusing an inert configuration at boot | `GovernanceConfigValidator` |
+
+Related: [`mcp-tool-definition-scanning.md`](./mcp-tool-definition-scanning.md) governs what an MCP server is allowed to put in the model's context. This document governs what it is allowed to do once it is there.

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -195,6 +195,13 @@ public static class DependencyInjection
         // graded-autonomy gate and escalation-severity derivation.
         services.AddSingleton<Interfaces.Tools.IToolRiskClassifier, Services.Tools.ToolRiskClassifier>();
 
+        // Tool behaviour registry — what each tool declared it does, and who declared it. Singleton
+        // because an external MCP server's declaration arrives on a discovery call and must still be
+        // there for the tool call it governs, which happens later on a different scope. Registered
+        // unconditionally: recording costs nothing, and only the posture in
+        // GovernanceConfig.ToolBehaviorGating turns the recordings into a decision.
+        services.AddSingleton<Interfaces.Tools.IToolBehaviorRegistry, Services.Tools.ToolBehaviorRegistry>();
+
         // Tool catalog — enumerates the host's keyed ITool registrations for callers that need to
         // discover what they may invoke. Singleton because the registrations cannot change once the
         // container is built, and because resolving every tool per request would be pure waste.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolBehaviorRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolBehaviorRegistry.cs
@@ -1,0 +1,56 @@
+using Domain.AI.Governance;
+
+namespace Application.AI.Common.Interfaces.Tools;
+
+/// <summary>
+/// Holds what each tool has declared about its own behaviour, so governance can decide from what a
+/// tool <em>does</em> rather than from a list of names somebody has to keep correct forever.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why a registry rather than a lookup.</strong> A first-party tool's behaviour can be read on
+/// demand from its keyed-DI registration, but an external MCP tool's cannot: its declaration arrives
+/// once, on the discovery call that publishes it to the model, and the object carrying it is not
+/// reachable from a tool name at invocation time. Recording it at discovery is the only moment the
+/// information exists.
+/// </para>
+/// <para>
+/// <strong>Recording is not admission.</strong> Nothing here decides anything. It answers "what did
+/// this tool say about itself, and who said it", and the governor decides what that is worth. Keeping
+/// the two apart is what lets the decision be tested without a running MCP server.
+/// </para>
+/// </remarks>
+public interface IToolBehaviorRegistry
+{
+    /// <summary>
+    /// Records what an external MCP server advertised about one of its tools.
+    /// </summary>
+    /// <param name="toolName">The advertised tool name, as it will appear on a tool call.</param>
+    /// <param name="behavior">The advertised behaviour, carrying the source's trust level.</param>
+    /// <remarks>
+    /// <para>
+    /// Called on every discovery pass, not once at startup: a server may add tools while running, and
+    /// re-reading the declaration each time is also what catches a server that changes what a tool
+    /// claims after earning its place in the tool surface.
+    /// </para>
+    /// <para>
+    /// <strong>When two servers advertise the same name, the declaration that does not exempt the tool
+    /// wins</strong> — the same tightening-is-believed rule applied to collisions. A hostile server
+    /// cannot loosen a tool by shadowing a name a stricter server already claimed. Detecting and
+    /// reporting the collision itself is a separate concern.
+    /// </para>
+    /// </remarks>
+    void RecordAdvertised(string toolName, ToolBehavior behavior);
+
+    /// <summary>
+    /// Returns the effective behaviour declared for a tool, or <see cref="ToolBehavior.Unknown"/> when
+    /// nothing is known about it.
+    /// </summary>
+    /// <param name="toolName">The tool name being invoked.</param>
+    /// <returns>
+    /// The strictest declaration on record. When a name is both registered in this process and
+    /// advertised externally, the declaration that does <em>not</em> exempt the tool from approval is
+    /// the one returned.
+    /// </returns>
+    ToolBehavior Resolve(string toolName);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -11,6 +11,7 @@ using Domain.AI.Governance;
 using Domain.AI.Permissions;
 using Domain.AI.Sandbox;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
 using Domain.Common.Config.AI.Permissions;
 using Domain.Common.Config.AI.Sandbox;
 using Microsoft.Extensions.Logging;
@@ -63,6 +64,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     private readonly IAgentExecutionContext _executionContext;
     private readonly IToolPermissionService _toolPermissionService;
     private readonly IToolRiskClassifier _toolRiskClassifier;
+    private readonly IToolBehaviorRegistry _toolBehaviorRegistry;
     private readonly IAutonomyDecisionEvaluator _autonomyEvaluator;
     private readonly IGovernancePolicyEngine _policyEngine;
     private readonly IGovernanceAuditService _auditService;
@@ -79,6 +81,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         IAgentExecutionContext executionContext,
         IToolPermissionService toolPermissionService,
         IToolRiskClassifier toolRiskClassifier,
+        IToolBehaviorRegistry toolBehaviorRegistry,
         IAutonomyDecisionEvaluator autonomyEvaluator,
         IGovernancePolicyEngine policyEngine,
         IGovernanceAuditService auditService,
@@ -94,6 +97,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         _executionContext = executionContext;
         _toolPermissionService = toolPermissionService;
         _toolRiskClassifier = toolRiskClassifier;
+        _toolBehaviorRegistry = toolBehaviorRegistry;
         _autonomyEvaluator = autonomyEvaluator;
         _policyEngine = policyEngine;
         _auditService = auditService;
@@ -235,6 +239,11 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         string agentId, string toolName, PermissionDecision permission, ToolRiskProfile profile,
         IReadOnlyDictionary<string, object?>? arguments, CancellationToken cancellationToken)
     {
+        // One snapshot for the whole decision. Two stages read this config, and reading the monitor
+        // twice would let a reload land between them — deciding half the call under one policy and
+        // half under another, which is not a state any operator asked for.
+        var governance = _governanceConfig.CurrentValue;
+
         // Accumulates every reason a human must rule on this call, from whichever gate raised it.
         // Left null until a gate actually asks for one: the overwhelmingly common path is a call no
         // gate wants a human for, and this runs on every authorized tool call.
@@ -260,6 +269,13 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
                     $"unrecognized permission behaviour '{permission.Behavior}'", profile.Radius,
                     requiredApproval: false, agentId);
         }
+
+        // Behaviour posture: what the tool declared it does, rather than whether anyone listed it.
+        // Deliberately a third source of approval reasons rather than a sixth admission gate — a gate
+        // of its own would need its own route to a human, and two independent approval questions about
+        // one call is exactly the shape this method exists to prevent.
+        if (RequiresApprovalForDeclaredBehavior(toolName, governance.ToolBehaviorGating, out var behaviorReason))
+            (approvalReasons ??= []).Add(behaviorReason);
 
         // Independent envelope confirmation. Defence in depth against a resolver arbitration bug —
         // see EnvelopeGrantsToolWhenArmed's remarks for the two occasions that arbitration was wrong.
@@ -291,7 +307,6 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         }
 
         // Declarative policy layer (YAML policies), only when configured.
-        var governance = _governanceConfig.CurrentValue;
         if (governance.Enabled && _policyEngine.HasPolicies)
         {
             // Arguments are forwarded. The policy engine builds its rule-evaluation context from them,
@@ -367,6 +382,86 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         // to the LLM — avoids leaking operator-authored policy detail into model-visible content.
         return ToolInvocationDecision.Deny(GovernanceDenials.NotPermitted(toolName));
     }
+
+    /// <summary>
+    /// Whether the non-read-only approval posture wants a human for this call, and why.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The default is inverted here and nowhere else.</strong> Every other check in this class
+    /// asks whether something forbids the call; this one asks whether anything permits it, and treats
+    /// silence as "no". That is the whole point: a name list can only refuse tools somebody thought of,
+    /// so a tool arriving at runtime from a server nobody on the team wrote is callable until it is
+    /// noticed. Reading the tool's own declaration means a new mutating tool is gated the moment it
+    /// appears, with no list to edit.
+    /// </para>
+    /// <para>
+    /// <strong>Off costs nothing.</strong> The posture is read first and returns immediately when
+    /// disabled, before the registry is consulted, so a host that has not opted in pays one boolean
+    /// read per tool call.
+    /// </para>
+    /// <para>
+    /// <strong>An exemption is honoured even for a self-declared destructive tool.</strong> That looks
+    /// wrong beside the rule that a destructive claim outranks a read-only one, and is a different
+    /// question: that rule arbitrates between two claims by the <em>same</em> party, while an exemption
+    /// is the operator overruling the party outright, in writing, with a reason. Silently ignoring some
+    /// entries in a list an operator maintains is how a control becomes untrustworthy.
+    /// </para>
+    /// </remarks>
+    /// <param name="toolName">The tool being authorized.</param>
+    /// <param name="gating">The posture, from the same config snapshot the rest of the decision uses.</param>
+    /// <param name="reason">The approver-facing reason, when one is needed.</param>
+    /// <returns>True when a human must rule on this call because of what the tool declared.</returns>
+    private bool RequiresApprovalForDeclaredBehavior(
+        string toolName, ToolBehaviorGatingConfig gating, out string reason)
+    {
+        reason = string.Empty;
+
+        if (!gating.RequireApprovalForNonReadOnlyTools)
+            return false;
+
+        var behavior = _toolBehaviorRegistry.Resolve(toolName);
+        if (behavior.NonExemptReason is not { } nonExempt)
+            return false;
+
+        var exemption = gating.Exemptions.FirstOrDefault(
+            entry => string.Equals(entry.Tool, toolName, StringComparison.OrdinalIgnoreCase)
+                     && ExemptionCoversSource(entry, behavior));
+
+        if (exemption is not null)
+        {
+            _logger.LogDebug(
+                "Tool behaviour posture: '{ToolName}' is exempt by configuration — {ExemptionReason} "
+                + "(it would otherwise be gated because {NonExemptReason})",
+                toolName, exemption.Reason, nonExempt);
+            return false;
+        }
+
+        reason = $"declared behaviour: {nonExempt}";
+        return true;
+    }
+
+    /// <summary>
+    /// Whether an exemption written for a tool name may be applied to <em>this</em> declaration of it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A tool name belongs to nobody. An operator exempts a name after checking one vendor's tool, and
+    /// any other configured server can advertise a tool by that name tomorrow. The behaviour registry
+    /// already refuses to let a shadowing server loosen a record it did not create; without this check
+    /// the exemption would hand that bypass straight back, because it matched on the name the attacker
+    /// chose.
+    /// </para>
+    /// <para>
+    /// So a bare name is accepted only for a declaration from somewhere the operator has already
+    /// vouched for — their own code, or a server marked trusted. For anything else the exemption must
+    /// name the server it was written for.
+    /// </para>
+    /// </remarks>
+    private static bool ExemptionCoversSource(ToolBehaviorExemption exemption, ToolBehavior behavior)
+        => behavior.IsVouchedFor
+           || (!string.IsNullOrWhiteSpace(exemption.Server)
+               && string.Equals(exemption.Server, behavior.ServerName, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Applies the graded-autonomy risk gate to an Allow decision. Tightens Allow → Ask/Deny when the

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolBehaviorRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolBehaviorRegistry.cs
@@ -1,0 +1,130 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Governance;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Default <see cref="IToolBehaviorRegistry"/>: holds the declarations external MCP servers advertised
+/// at discovery, and reads a first-party tool's declaration straight off its keyed-DI registration.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a singleton because the advertised half must outlive the discovery scope that
+/// recorded it — the tool call it governs happens later, on a different scope. The dictionary is the
+/// only mutable state and every write is a whole-entry replacement.
+/// </para>
+/// <para>
+/// <strong>The registry is never emptied.</strong> A tool that vanishes from a server keeps its
+/// recorded declaration, which looks like a leak and is deliberate: forgetting an entry can only ever
+/// turn a known behaviour into <see cref="ToolBehavior.Unknown"/>, and the entries are a few dozen
+/// short records. Growth is bounded by how many distinct tool names the configured servers have ever
+/// advertised.
+/// </para>
+/// </remarks>
+public sealed class ToolBehaviorRegistry : IToolBehaviorRegistry
+{
+    private readonly ConcurrentDictionary<string, ToolBehavior> _advertised =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    private readonly IServiceProvider _serviceProvider;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ToolBehaviorRegistry"/> class.
+    /// </summary>
+    /// <param name="serviceProvider">Provider used to resolve keyed <see cref="ITool"/> registrations.</param>
+    public ToolBehaviorRegistry(IServiceProvider serviceProvider)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <inheritdoc />
+    public void RecordAdvertised(string toolName, ToolBehavior behavior)
+    {
+        ArgumentNullException.ThrowIfNull(behavior);
+
+        if (string.IsNullOrWhiteSpace(toolName))
+            return;
+
+        // Two different rules, and conflating them was a defect: a server re-reporting its own tool is
+        // always believed, while a DIFFERENT server may only ever tighten.
+        //
+        // Believing a re-report is what catches a rug-pull — a server that advertised a clean read-only
+        // tool and later advertises it as a writer — and it is also the only way a change to that
+        // server's TrustToolAnnotations setting can ever take effect: the earlier untrusted record is
+        // non-exempt, so a rule that kept the stricter entry unconditionally would pin it forever and
+        // the operator's config change would silently do nothing until the process restarted.
+        //
+        // Evaluated inside the update so two servers advertising the same name concurrently cannot
+        // interleave a read and a write and lose the stricter declaration.
+        _advertised.AddOrUpdate(
+            toolName,
+            behavior,
+            (_, existing) => IsSameSource(existing, behavior) || existing.IsExemptFromApproval
+                ? behavior
+                : existing);
+    }
+
+    /// <inheritdoc />
+    public ToolBehavior Resolve(string toolName)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+            return ToolBehavior.Unknown;
+
+        var advertised = _advertised.GetValueOrDefault(toolName);
+        var registered = ResolveFirstParty(toolName);
+
+        if (advertised is null)
+            return registered ?? ToolBehavior.Unknown;
+
+        if (registered is null)
+            return advertised;
+
+        // Both describe this name. Return whichever does not exempt the tool: the harness resolves a
+        // declared tool from MCP before falling back to keyed DI, so which implementation actually runs
+        // depends on discovery succeeding, and a rule that changes with it would be worse than one that
+        // always answers with the stricter of the two.
+        return advertised.IsExemptFromApproval ? registered : advertised;
+    }
+
+    /// <summary>
+    /// Whether two declarations came from the same MCP server, and may therefore replace one another
+    /// freely.
+    /// </summary>
+    /// <remarks>
+    /// A record with no server name cannot be attributed, so it is never treated as the same source as
+    /// anything — including another unattributed record. That is the fail-closed reading: an
+    /// unattributable declaration must not gain the right to overwrite an attributable one.
+    /// </remarks>
+    private static bool IsSameSource(ToolBehavior existing, ToolBehavior incoming) =>
+        existing.ServerName is { Length: > 0 }
+        && string.Equals(existing.ServerName, incoming.ServerName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Reads the declaration off the tool's own registration, or returns <see langword="null"/> when
+    /// the name is not registered in this process.
+    /// </summary>
+    /// <remarks>
+    /// <strong>This deliberately does not go through <see cref="IToolRiskClassifier"/>,</strong> which
+    /// performs the same keyed-DI lookup and already exposes an <c>IsReadOnly</c>. That type answers
+    /// with a <em>fail-safe default</em> for a name it cannot resolve — a profile that reports
+    /// "not read-only" for an unregistered tool exactly as it does for a registered one that writes.
+    /// Collapsing the two would erase the distinction this registry exists to keep: a tool that said
+    /// it writes and a tool nobody has ever heard of are the same answer for graded autonomy, and
+    /// different facts for anything reporting on which tools still need annotating.
+    /// </remarks>
+    private ToolBehavior? ResolveFirstParty(string toolName)
+    {
+        var tool = _serviceProvider.GetKeyedService<ITool>(toolName);
+        if (tool is null)
+            return null;
+
+        // ITool.IsReadOnly is a bool, not a bool? — a first-party tool always answers, because the
+        // interface's default answers "no" on its behalf. Destructive is left unstated: the harness has
+        // never modelled it locally, and inventing a value here would put a claim in the record that
+        // nobody made.
+        return new ToolBehavior(ToolBehaviorSource.FirstParty, ReadOnly: tool.IsReadOnly);
+    }
+}

--- a/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
@@ -80,5 +80,44 @@ public sealed class GovernanceConfigValidator : AbstractValidator<GovernanceConf
                     "composition root wires the no-op MCP scanner, so tool-registration scanning never " +
                     "runs — enable governance or clear this flag.");
         });
+
+        // The same landmine, for the behaviour posture — but stated precisely, because the imprecise
+        // version of this sentence is wrong. The posture is applied by IToolInvocationGovernor, and
+        // GovernanceEnforcement.IsActive arms that governor on EITHER EnforceToolInvocation OR an
+        // ambient capability envelope. So with enforcement off the posture is not inert everywhere: it
+        // still applies inside a bundle run and nowhere else, which is a worse outcome than either
+        // consistent answer — the same tool is gated or not depending on how the call arrived, and
+        // nothing in the configuration says so.
+        When(x => x.ToolBehaviorGating.RequireApprovalForNonReadOnlyTools, () =>
+        {
+            RuleFor(x => x.EnforceToolInvocation)
+                .Equal(true)
+                .WithMessage(
+                    "ToolBehaviorGating.RequireApprovalForNonReadOnlyTools requires " +
+                    "Governance.EnforceToolInvocation=true. The posture is applied by the tool " +
+                    "governor, which engages either when invocation enforcement is on or when a " +
+                    "bundle run publishes a capability envelope — so leaving enforcement off does not " +
+                    "switch the posture off, it applies it to bundle runs alone while every agent " +
+                    "turn and plan step goes ungated. Note also that reaching a human needs " +
+                    "Governance.ToolApproval.Enabled and Governance.Escalation.Enabled; without them " +
+                    "a gated tool call is refused rather than asked about, which is safe but will " +
+                    "present to users as tools failing for no stated reason.");
+        });
+
+        // Exemptions are checked whether or not the posture is on, because a malformed entry is a typo
+        // in either case and the list is read by operators long before it is read by the governor.
+        RuleForEach(x => x.ToolBehaviorGating.Exemptions)
+            .Must(entry => !string.IsNullOrWhiteSpace(entry.Tool))
+            .WithMessage(
+                "ToolBehaviorGating.Exemptions contains an entry with no tool name. A blank name " +
+                "matches nothing and exempts nothing — remove the entry or name the tool.");
+
+        RuleForEach(x => x.ToolBehaviorGating.Exemptions)
+            .Must(entry => !string.IsNullOrWhiteSpace(entry.Reason))
+            .WithMessage(
+                "ToolBehaviorGating.Exemptions contains an entry with no reason. Every exemption must " +
+                "say why the tool is safe despite not declaring itself read-only: this list is the " +
+                "first thing a reviewer reads when asking why a tool was never gated, and an entry " +
+                "with no justification is indistinguishable from one added to silence a prompt.");
     }
 }

--- a/src/Content/Domain/Domain.AI/Governance/ToolBehavior.cs
+++ b/src/Content/Domain/Domain.AI/Governance/ToolBehavior.cs
@@ -1,0 +1,166 @@
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// Where a tool's declared behaviour came from, which decides how much weight it may carry.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The source matters because a behaviour declaration is an <em>input to a security decision that the
+/// declarer supplies</em>. The MCP specification says so directly: annotations "are not guaranteed to
+/// provide a faithful description of tool behavior", and clients "should never make tool use decisions
+/// based on <c>ToolAnnotations</c> received from untrusted servers". A server that wants to escape an
+/// approval gate simply marks its destructive tool read-only.
+/// </para>
+/// <para>
+/// The rule this enum exists to support: <strong>a declaration is believed when it tightens, and only
+/// from a trusted source when it loosens.</strong> Nobody lies in the strict direction, so
+/// <see cref="ToolBehavior.Destructive"/> can be taken at face value from anyone; only
+/// <see cref="ToolBehavior.ReadOnly"/> — the one that removes friction — needs provenance.
+/// </para>
+/// </remarks>
+public enum ToolBehaviorSource
+{
+    /// <summary>
+    /// Nothing is known about the tool's behaviour. The fail-closed case: an unknown tool is treated as
+    /// one that writes, exactly as an unknown knowledge scope is treated as global rather than private.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// The tool is registered in this process and declared its own behaviour through
+    /// <c>ITool.IsReadOnly</c>. Authored in the host's own codebase, so its declaration is as
+    /// trustworthy as the rest of that codebase.
+    /// </summary>
+    FirstParty = 1,
+
+    /// <summary>
+    /// The tool came from an external MCP server the operator has explicitly marked as trusted via
+    /// <c>McpServerDefinition.TrustToolAnnotations</c>. Its read-only claim may exempt it from approval.
+    /// </summary>
+    TrustedMcpServer = 2,
+
+    /// <summary>
+    /// The tool came from an external MCP server carrying no such marking — the default for every
+    /// configured server. Its claims are recorded and reported, and may tighten the outcome, but a
+    /// read-only claim does <strong>not</strong> exempt it from approval.
+    /// </summary>
+    UntrustedMcpServer = 3,
+}
+
+/// <summary>
+/// What a tool has declared about its own behaviour, together with who declared it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The four hints mirror the MCP tool annotations exactly, including their nullability, because the
+/// distinction between "declared false" and "did not say" is the whole point. A tool that says nothing
+/// is not a tool that says it is safe.
+/// </para>
+/// <para>
+/// The per-hint defaults below are the MCP specification's own, and they are all fail-closed:
+/// unspecified read-only means "assume it writes"; unspecified destructive means "assume it can
+/// destroy"; unspecified open-world means "assume it reaches an unpredictable set of entities".
+/// This type deliberately stores the raw <see langword="null"/> rather than folding the default in, so
+/// that a report can distinguish a server that thought about the question from one that did not.
+/// </para>
+/// <para>
+/// <strong>The destructive default is conditional, and <see cref="IsExemptFromApproval"/> is
+/// deliberately not written as though it were absolute.</strong> The specification scopes
+/// <c>destructiveHint</c> to tools that modify their environment — it is the question "additively, or
+/// destructively?", which only arises once the answer to "does it write at all?" is yes. So an
+/// unspecified destructive hint sitting beside <c>readOnlyHint: true</c> is not a fail-closed
+/// "assume it destroys"; it is a question that was never in scope. Reading it the other way would
+/// make every correctly-annotated read-only tool non-exempt and the whole posture unusable.
+/// </para>
+/// </remarks>
+/// <param name="Source">Who declared this behaviour, and therefore how far it may be believed.</param>
+/// <param name="ReadOnly">
+/// Whether the tool only reads and never changes state. <see langword="null"/> when unspecified, which
+/// the specification says to read as "not read-only".
+/// </param>
+/// <param name="Destructive">
+/// Whether the tool can perform destructive rather than merely additive updates. <see langword="null"/>
+/// when unspecified, which the specification says to read as "destructive".
+/// </param>
+/// <param name="Idempotent">
+/// Whether repeating the call with the same arguments has no further effect. <see langword="null"/>
+/// when unspecified, which the specification says to read as "not idempotent".
+/// </param>
+/// <param name="OpenWorld">
+/// Whether the tool interacts with an open, unpredictable set of external entities (a web search)
+/// rather than a closed and well-defined one (a memory lookup). <see langword="null"/> when
+/// unspecified, which the specification says to read as "open world".
+/// </param>
+/// <param name="ServerName">
+/// The MCP server that advertised this tool, or <see langword="null"/> for a tool registered in this
+/// process. Carried because a tool <em>name</em> is claimable by any configured server, so anything
+/// keyed on the name alone — an operator's exemption, most of all — needs to know which party the
+/// declaration it is acting on actually came from.
+/// </param>
+public sealed record ToolBehavior(
+    ToolBehaviorSource Source,
+    bool? ReadOnly = null,
+    bool? Destructive = null,
+    bool? Idempotent = null,
+    bool? OpenWorld = null,
+    string? ServerName = null)
+{
+    /// <summary>
+    /// The behaviour of a tool nothing is known about: no declaration, no provenance, and therefore
+    /// never exempt from approval.
+    /// </summary>
+    public static ToolBehavior Unknown { get; } = new(ToolBehaviorSource.Unknown);
+
+    /// <summary>
+    /// Whether this declaration is strong enough to let the tool skip human approval under the
+    /// non-read-only approval posture.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Two conditions, both required. The tool must have <em>said</em> it is read-only — silence is not
+    /// a claim — and the claim must come from somewhere entitled to make it: this process's own code, or
+    /// an MCP server the operator marked trusted. A read-only claim from an unmarked server is recorded
+    /// and reported but buys nothing, which is precisely the case the MCP specification warns about.
+    /// </para>
+    /// <para>
+    /// <strong>A destructive claim overrides a read-only one.</strong> The combination is incoherent —
+    /// nothing that only reads can destroy — and an incoherent declaration is a reason to distrust the
+    /// declarer, not to pick the half that is more convenient. This is the tightening direction, so it
+    /// applies regardless of source.
+    /// </para>
+    /// </remarks>
+    public bool IsExemptFromApproval => ReadOnly == true && Destructive != true && IsVouchedFor;
+
+    /// <summary>
+    /// Whether this declaration came from a party the operator has accepted as speaking truthfully
+    /// about tool behaviour: the host's own code, or an MCP server explicitly marked trusted.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="IsExemptFromApproval"/> because provenance and the claim itself are
+    /// different questions, and a caller that overrides the claim — an operator's exemption — must
+    /// still be able to ask about the provenance. Folding the two together is what let a name-matched
+    /// exemption apply to a declaration from a server nobody had vouched for.
+    /// </remarks>
+    public bool IsVouchedFor =>
+        Source is ToolBehaviorSource.FirstParty or ToolBehaviorSource.TrustedMcpServer;
+
+    /// <summary>
+    /// A short operator-facing phrase explaining why this tool is not exempt, for the approval request
+    /// a human actually reads. Returns <see langword="null"/> when the tool is exempt.
+    /// </summary>
+    /// <remarks>
+    /// The three cases are genuinely different actions for whoever is paged: an undeclared tool needs
+    /// someone to find out what it does, a self-declared-destructive tool needs a judgement call, and a
+    /// read-only tool from an unmarked server needs a one-line configuration change if the server is in
+    /// fact trusted. Collapsing them into "not read-only" would hide which one is happening.
+    /// </remarks>
+    public string? NonExemptReason => this switch
+    {
+        { IsExemptFromApproval: true } => null,
+        { Destructive: true } => "the tool declares itself destructive",
+        { ReadOnly: true, Source: ToolBehaviorSource.UntrustedMcpServer } =>
+            "the tool claims to be read-only, but its MCP server is not marked as trusted for tool annotations",
+        { Source: ToolBehaviorSource.Unknown } => "nothing is known about what the tool does",
+        _ => "the tool has not declared itself read-only",
+    };
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/ToolBehaviorGatingConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/ToolBehaviorGatingConfig.cs
@@ -1,0 +1,99 @@
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// Requires human approval for every tool that has not declared itself read-only, rather than for
+/// every tool somebody remembered to put on a list. Bound from
+/// <c>AppConfig:AI:Governance:ToolBehaviorGating</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>What this changes.</strong> Tool governance decides from lists of names — a plugin's
+/// allow and deny lists, per-agent authorization, YAML policy rules. Every one of them requires
+/// somebody to enumerate the dangerous tools correctly, forever, including tools that arrive at
+/// runtime from an MCP server nobody on the team wrote. A tool nobody thought to list is callable by
+/// default, and the lists cannot tell <c>create_page</c> from <c>search_pages</c> because names carry
+/// no behaviour. With this enabled the default inverts: a tool is gated unless its own declaration
+/// says it only reads, so a new mutating tool appearing upstream is gated the moment it appears and
+/// nobody edits anything.
+/// </para>
+/// <para>
+/// <strong>Silence is not a claim.</strong> A tool that declares nothing is treated as one that
+/// writes. This is the same invariant as an unresolved knowledge scope meaning global rather than
+/// private: unknown must never resolve to safe, because every path that fails to establish a fact
+/// then lands on the permissive answer.
+/// </para>
+/// <para>
+/// <strong>Off by default, and it needs company.</strong> The posture is enforced by the tool
+/// governor, so it does nothing unless <see cref="GovernanceConfig.EnforceToolInvocation"/> is also
+/// on; and the resulting verdict only reaches a person when
+/// <see cref="ToolApprovalConfig.Enabled"/> and <see cref="EscalationConfig.Enabled"/> are on too —
+/// without those the call is refused rather than asked about, which is safe but will read to users as
+/// tools mysteriously failing. <c>GovernanceConfigValidator</c> refuses to start a host that switches
+/// this on without enforcement, rather than leaving a switched-on control that does nothing.
+/// </para>
+/// </remarks>
+public sealed class ToolBehaviorGatingConfig
+{
+    /// <summary>
+    /// Whether a tool that has not declared itself read-only requires human approval before it runs.
+    /// Off by default.
+    /// </summary>
+    public bool RequireApprovalForNonReadOnlyTools { get; init; }
+
+    /// <summary>
+    /// Tools exempted from the posture by name, each with the reason it is exempt.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>This is a name list, deliberately, and it is the honest part.</strong> A behaviour
+    /// declaration is a hint, and hints are sometimes wrong in the direction that costs an operator an
+    /// approval prompt on every call of a tool that plainly only reads — a search endpoint that uses
+    /// POST and is therefore assumed to write, for instance. Denying that escape hatch does not make
+    /// the annotations more accurate; it makes operators switch the whole posture off.
+    /// </para>
+    /// <para>
+    /// The reason is required rather than optional, and <c>GovernanceConfigValidator</c> rejects a
+    /// blank one at startup. An exemption whose justification nobody wrote down is indistinguishable a
+    /// year later from one added to silence a prompt, and this list is the first place a reviewer looks
+    /// when asking why a tool was never gated.
+    /// </para>
+    /// </remarks>
+    public List<ToolBehaviorExemption> Exemptions { get; init; } = [];
+}
+
+/// <summary>
+/// One tool exempted from the non-read-only approval posture, and why.
+/// </summary>
+public sealed class ToolBehaviorExemption
+{
+    /// <summary>The tool name, matched case-insensitively against the name on the call.</summary>
+    public string Tool { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The MCP server this exemption is for. Required when the tool comes from a server that is not
+    /// marked trusted; may be omitted for a first-party tool or one from a trusted server.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Without this, an exemption is a bypass any configured server can claim.</strong> A tool
+    /// name is not owned by anyone: an operator exempts <c>notion_search</c> for the vendor server they
+    /// checked, and a second, unvouched-for server advertises a destructive tool by the same name. The
+    /// behaviour registry defends against exactly that — a shadowing server can only ever tighten a
+    /// record it did not create — and a name-only exemption applied on top would hand back the bypass
+    /// the registry had just refused.
+    /// </para>
+    /// <para>
+    /// So an exemption is honoured for an unvouched-for server's tool only when it names that server.
+    /// Naming it is a much narrower statement than
+    /// <c>McpServerDefinition.TrustToolAnnotations</c> — that accepts every declaration a server makes,
+    /// present and future, while this accepts one tool the operator has actually looked at.
+    /// </para>
+    /// </remarks>
+    public string? Server { get; init; }
+
+    /// <summary>
+    /// Why this tool is exempt despite not declaring itself read-only. Required — a blank reason fails
+    /// startup validation.
+    /// </summary>
+    public string Reason { get; init; } = string.Empty;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
@@ -127,4 +127,14 @@ public sealed class GovernanceConfig
     /// the call is blocked, which is safe but silent.
     /// </summary>
     public ToolApprovalConfig ToolApproval { get; init; } = new();
+
+    /// <summary>
+    /// Gates tools by what they have declared they do rather than by name, requiring approval for
+    /// anything not declared read-only. Opt-in via
+    /// <see cref="Governance.ToolBehaviorGatingConfig.RequireApprovalForNonReadOnlyTools"/>; off by
+    /// default, and inert without <see cref="EnforceToolInvocation"/> — which is why a host that
+    /// enables one without the other fails validation rather than starting with a switch that does
+    /// nothing.
+    /// </summary>
+    public ToolBehaviorGatingConfig ToolBehaviorGating { get; init; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerDefinition.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerDefinition.cs
@@ -67,6 +67,34 @@ public class McpServerDefinition
     /// </summary>
     public McpServerAuthConfig? Auth { get; set; }
 
+    /// <summary>
+    /// Whether this server's tool behaviour annotations may be believed when they <em>reduce</em>
+    /// friction — specifically, whether a tool it marks read-only is exempt from the non-read-only
+    /// approval posture. Off by default.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why this is not simply on.</strong> A tool annotation is supplied by the party the
+    /// annotation is used to police. The MCP specification is explicit that annotations "are not
+    /// guaranteed to provide a faithful description of tool behavior" and that clients "should never
+    /// make tool use decisions based on <c>ToolAnnotations</c> received from untrusted servers": a
+    /// server wanting to escape an approval gate marks its destructive tool read-only and walks
+    /// through. Connecting a server is a decision about where its tools come from; this is the
+    /// separate decision about whether to take its word for what they do.
+    /// </para>
+    /// <para>
+    /// <strong>It only ever loosens.</strong> Annotations that make an outcome stricter — a tool
+    /// declaring itself destructive — are honoured from every server regardless of this flag, because
+    /// a server with an incentive to lie has no incentive to lie in that direction.
+    /// </para>
+    /// <para>
+    /// Set this true for servers whose code the operator controls or whose publisher they have
+    /// assessed. Leaving it false on a server means every tool it offers requires approval while the
+    /// posture is on, which is the correct cost of not knowing.
+    /// </para>
+    /// </remarks>
+    public bool TrustToolAnnotations { get; set; }
+
     /// <summary>Gets whether this server requires authentication.</summary>
     public bool RequiresAuth => Auth?.IsConfigured ?? false;
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Tools;
 using Domain.Common.Config.AI;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Resources;
@@ -54,11 +55,18 @@ public static class DependencyInjection
         // throws rather than silently publishing unscanned tool descriptions into the model's context.
         // The governance layer registers a no-op scanner when governance is switched off, so an
         // intentionally ungoverned host still composes.
-        services.AddSingleton<IMcpToolProvider>(sp => new ScanningMcpToolProvider(
-            sp.GetRequiredService<McpToolProvider>(),
-            sp.GetRequiredService<IMcpSecurityScanner>(),
+        // Two decorators, and the order is the argument. Recording sits OUTSIDE screening so only the
+        // tools that survived the definition scan get their declared behaviour put on file — a tool
+        // withheld for a poisoned description is never offered to the model and needs no entry.
+        services.AddSingleton<IMcpToolProvider>(sp => new BehaviorRecordingMcpToolProvider(
+            new ScanningMcpToolProvider(
+                sp.GetRequiredService<McpToolProvider>(),
+                sp.GetRequiredService<IMcpSecurityScanner>(),
+                sp.GetRequiredService<IOptionsMonitor<AIConfig>>(),
+                sp.GetRequiredService<ILogger<ScanningMcpToolProvider>>()),
+            sp.GetRequiredService<IToolBehaviorRegistry>(),
             sp.GetRequiredService<IOptionsMonitor<AIConfig>>(),
-            sp.GetRequiredService<ILogger<ScanningMcpToolProvider>>()));
+            sp.GetRequiredService<ILogger<BehaviorRecordingMcpToolProvider>>()));
 
         // Trace resource provider — exposes optimization run trace files at trace:// URIs.
         // Auth-gated and feature-flagged via MetaHarnessConfig.EnableMcpTraceResources.

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BehaviorRecordingMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BehaviorRecordingMcpToolProvider.cs
@@ -1,0 +1,158 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModelContextProtocol.Client;
+
+namespace Infrastructure.AI.MCP.Services;
+
+/// <summary>
+/// Decorates an <see cref="IMcpToolProvider"/> so that whatever each external MCP server declares about
+/// its tools' behaviour is captured into the <see cref="IToolBehaviorRegistry"/> as the tools are
+/// discovered, together with whether the operator has said that server's word can be taken.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Discovery is the only moment the information exists.</strong> The MCP protocol carries tool
+/// annotations on the definition a server advertises, and the harness converts that definition into an
+/// <c>AITool</c> the model can call. By the time a tool call arrives, all that remains is a name — the
+/// annotations are unreachable from it. Recording them here is not an optimisation; it is the
+/// difference between governing on behaviour and governing on names.
+/// </para>
+/// <para>
+/// <strong>Outside the security scanner, not inside it.</strong> This wraps the screened provider, so
+/// only tools that survived the definition scan are recorded. A tool withheld for a poisoned
+/// description never reaches the model and needs no behaviour on file; recording it would put an entry
+/// in the registry for a name the model was never told about.
+/// </para>
+/// <para>
+/// <strong>The by-name lookup records nothing, deliberately.</strong> That path does not report which
+/// server answered, so the trust decision — which is per server — cannot be made. Recording an
+/// unattributed declaration would mean guessing, and under the registry's stricter-wins rule a guess of
+/// "untrusted" would silently revoke an exemption a trusted server had legitimately earned. A tool the
+/// registry has never heard of resolves to <see cref="ToolBehavior.Unknown"/> and is gated, so
+/// declining to guess fails closed.
+/// </para>
+/// </remarks>
+public sealed class BehaviorRecordingMcpToolProvider : IMcpToolProvider
+{
+    private readonly IMcpToolProvider _inner;
+    private readonly IToolBehaviorRegistry _registry;
+    private readonly IOptionsMonitor<AIConfig> _config;
+    private readonly ILogger<BehaviorRecordingMcpToolProvider> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BehaviorRecordingMcpToolProvider"/> class.
+    /// </summary>
+    /// <param name="inner">The tool provider whose results are recorded.</param>
+    /// <param name="registry">Receives each tool's declared behaviour.</param>
+    /// <param name="config">Supplies per-server trust; read per call so a config reload takes effect.</param>
+    /// <param name="logger">Logger for servers whose declarations are being taken at face value.</param>
+    public BehaviorRecordingMcpToolProvider(
+        IMcpToolProvider inner,
+        IToolBehaviorRegistry registry,
+        IOptionsMonitor<AIConfig> config,
+        ILogger<BehaviorRecordingMcpToolProvider> logger)
+    {
+        _inner = inner;
+        _registry = registry;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IList<AITool>> GetToolsAsync(string serverName, CancellationToken cancellationToken = default)
+    {
+        var tools = await _inner.GetToolsAsync(serverName, cancellationToken);
+        Record(serverName, tools);
+        return tools;
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<string, IList<AITool>>> GetAllToolsAsync(CancellationToken cancellationToken = default)
+    {
+        var discovered = await _inner.GetAllToolsAsync(cancellationToken);
+
+        foreach (var (serverName, tools) in discovered)
+            Record(serverName, tools);
+
+        return discovered;
+    }
+
+    /// <inheritdoc />
+    public Task<AIFunction?> GetToolByNameAsync(string name, CancellationToken cancellationToken = default) =>
+        _inner.GetToolByNameAsync(name, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<bool> IsServerAvailableAsync(string serverName, CancellationToken cancellationToken = default) =>
+        _inner.IsServerAvailableAsync(serverName, cancellationToken);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Does not dispose the decorated provider — the container registers both as singletons and owns
+    /// its lifetime, matching the arrangement the scanning decorator has with the transport provider.
+    /// </remarks>
+    public void Dispose()
+    {
+    }
+
+    /// <summary>
+    /// Records every tool in the batch against the trust level configured for the server that offered it.
+    /// </summary>
+    private void Record(string serverName, IEnumerable<AITool> tools)
+    {
+        var trusted = IsTrusted(serverName);
+
+        if (trusted)
+        {
+            _logger.LogDebug(
+                "MCP server '{ServerName}' is marked as trusted for tool annotations — a tool it declares "
+                + "read-only is exempt from the non-read-only approval posture.",
+                serverName);
+        }
+
+        foreach (var tool in tools)
+            _registry.RecordAdvertised(tool.Name, Describe(tool, serverName, trusted));
+    }
+
+    /// <summary>
+    /// Whether the operator has marked this server's behaviour annotations as believable when they
+    /// loosen. Unknown server names — a server removed from configuration between discovery calls —
+    /// are not trusted.
+    /// </summary>
+    private bool IsTrusted(string serverName)
+    {
+        var servers = _config.CurrentValue.McpServers?.Servers;
+
+        return servers is not null
+               && servers.TryGetValue(serverName, out var definition)
+               && definition.TrustToolAnnotations;
+    }
+
+    /// <summary>
+    /// Translates the SDK's advertised annotations into the harness's behaviour record.
+    /// </summary>
+    /// <remarks>
+    /// A tool that is not an <see cref="McpClientTool"/>, or one whose server sent no annotations at
+    /// all, still gets a record — carrying its source and four unanswered questions. That is not the
+    /// same as no record: it distinguishes "this came from an untrusted server and said nothing" from
+    /// "the harness has never seen this name", and only the first can be reported to an operator as a
+    /// server that should be asked to annotate its tools.
+    /// </remarks>
+    private static ToolBehavior Describe(AITool tool, string serverName, bool trusted)
+    {
+        var source = trusted ? ToolBehaviorSource.TrustedMcpServer : ToolBehaviorSource.UntrustedMcpServer;
+        var annotations = (tool as McpClientTool)?.ProtocolTool.Annotations;
+
+        return new ToolBehavior(
+            source,
+            ReadOnly: annotations?.ReadOnlyHint,
+            Destructive: annotations?.DestructiveHint,
+            Idempotent: annotations?.IdempotentHint,
+            OpenWorld: annotations?.OpenWorldHint,
+            ServerName: serverName);
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/appsettings.json
+++ b/src/Content/Presentation/Presentation.AgentHub/appsettings.json
@@ -43,6 +43,10 @@
           "TimeoutSeconds": null,
           "CriticalAtBlastRadius": "Critical"
         },
+        "ToolBehaviorGating": {
+          "RequireApprovalForNonReadOnlyTools": false,
+          "Exemptions": []
+        },
         "Escalation": {
           "Enabled": true,
           "DefaultTimeoutSeconds": 300,

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
@@ -1,0 +1,352 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Bundles;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.Common;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
+using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// The non-read-only approval posture, exercised through the <em>real</em> admission chain rather than
+/// against the governor in isolation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why the real chain.</strong> The posture's value is that every execution path inherits it,
+/// and every path reaches tools through <see cref="ToolCallAdmissionPipeline"/> and nothing else. A
+/// test that called the governor directly would prove the rule exists; driving the chain proves the
+/// rule is reachable from where calls actually arrive. The per-path tests that prove each caller uses
+/// the chain already exist and are not duplicated here — that property belongs to the chain, not to
+/// this rule, and re-asserting it once per gate is how five copies of a sequence appeared in the first
+/// place.
+/// </para>
+/// <para>
+/// <strong>Approval routing is left off throughout,</strong> which is the shipped default: an approval
+/// verdict with no router degrades to a block. That makes the assertions binary — the call was refused
+/// or it was not — rather than depending on a simulated human.
+/// </para>
+/// </remarks>
+public sealed class ToolBehaviorPostureTests
+{
+    private const string Agent = "test-agent";
+    private const string Tool = "notion_create_page";
+
+    private readonly Mock<IAgentExecutionContext> _context = new();
+    private readonly Mock<IToolPermissionService> _permissions = new();
+    private readonly Mock<IGovernancePolicyEngine> _policyEngine = new();
+    private readonly Mock<ICapabilityEnforcer> _capabilities = new();
+    private readonly Mock<IToolApprovalRouter> _approvalRouter = new();
+    private readonly ToolBehaviorRegistry _behavior;
+
+    private readonly IToolRiskClassifier _riskClassifier =
+        Mock.Of<IToolRiskClassifier>(c =>
+            c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true));
+
+    public ToolBehaviorPostureTests()
+    {
+        _context.Setup(x => x.AgentId).Returns(Agent);
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("allowed by default"));
+        _capabilities
+            .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
+        _approvalRouter
+            .Setup(x => x.RequestApprovalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolApprovalResult.NotRouted("tool approval routing is disabled"));
+
+        // A real registry, not a mock: half the behaviour under test is which declaration wins, and a
+        // mocked registry would let this file assert whatever it liked about that.
+        _behavior = new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider());
+    }
+
+    [Fact]
+    public void PostureDefault_IsOff_OnAConfigWithNothingSet()
+    {
+        // A default is untested unless a test builds the config with nothing set. Every other test here
+        // switches the posture on explicitly, so without this one "off by default" would be a claim in
+        // a comment.
+        var shipped = new GovernanceConfig();
+
+        Assert.False(shipped.ToolBehaviorGating.RequireApprovalForNonReadOnlyTools);
+        Assert.Empty(shipped.ToolBehaviorGating.Exemptions);
+    }
+
+    [Fact]
+    public async Task PostureOff_AToolNobodyHasDescribed_RunsWithoutApproval()
+    {
+        // The control for every refusal below. Without it, a gate that refused everything
+        // unconditionally would pass the whole file.
+        var admission = await Admit(PostureOff);
+
+        Assert.True(admission.IsAllowed);
+    }
+
+    [Fact]
+    public async Task PostureOn_AToolNobodyHasDescribed_IsGated()
+    {
+        var admission = await Admit(PostureOn);
+
+        Assert.False(admission.IsAllowed);
+        AssertApprovalWasSought("nothing is known about what the tool does");
+    }
+
+    [Fact]
+    public async Task PostureOn_AToolDeclaredReadOnlyByATrustedServer_RunsWithoutApproval()
+    {
+        // The pass case, and the reason it is not enough to assert refusals: this is what proves the
+        // gate can tell tools apart rather than simply refusing everything while the posture is on.
+        _behavior.RecordAdvertised(Tool, Advertised("notion", ReadOnly: true, trusted: true));
+
+        var admission = await Admit(PostureOn);
+
+        Assert.True(admission.IsAllowed);
+        AssertNoApprovalWasSought();
+    }
+
+    [Fact]
+    public async Task PostureOn_AToolDeclaredReadOnlyByAnUntrustedServer_IsStillGated()
+    {
+        // The security property the reference implementation does not have. A server that wants past
+        // the gate marks its tool read-only; being unvouched-for is what stops that working.
+        _behavior.RecordAdvertised(Tool, Advertised("marketplace-server", ReadOnly: true));
+
+        var admission = await Admit(PostureOn);
+
+        Assert.False(admission.IsAllowed);
+        AssertApprovalWasSought("not marked as trusted");
+    }
+
+    [Fact]
+    public async Task PostureOn_AToolThatAppearsFromAServerAfterStartup_IsGatedWithNoListEdit()
+    {
+        // The whole point of gating on behaviour. Nothing about this tool exists in any configuration:
+        // it is advertised mid-run, recorded as it is discovered, and gated on what it declared.
+        var pipeline = Pipeline(PostureOn);
+
+        _behavior.RecordAdvertised("newly_appeared_tool", Advertised("marketplace-server", Destructive: true));
+
+        var admission = await pipeline.AdmitAsync(
+            new ToolCallAdmissionRequest("newly_appeared_tool"), CancellationToken.None);
+
+        Assert.False(admission.IsAllowed);
+        AssertApprovalWasSought("declares itself destructive");
+    }
+
+    [Fact]
+    public async Task PostureOn_AnExemptedToolFromTheNamedServer_RunsWithoutApproval()
+    {
+        // The escape hatch for a declaration that is wrong in the direction that costs an approval on
+        // every call — a search endpoint that posts, and is therefore assumed to write.
+        _behavior.RecordAdvertised(Tool, Advertised("notion", ReadOnly: false));
+
+        var admission = await Admit(Exempting(new ToolBehaviorExemption
+        {
+            Tool = Tool,
+            Server = "notion",
+            Reason = "search endpoint that uses POST and does not mutate; verified against the vendor's API docs",
+        }));
+
+        Assert.True(admission.IsAllowed);
+        AssertNoApprovalWasSought();
+    }
+
+    [Fact]
+    public async Task PostureOn_AnExemptionNamingNoServer_DoesNotCoverAnUnvouchedForServersTool()
+    {
+        // The hole this check closes. A tool name belongs to nobody: the operator exempts the name
+        // after checking one vendor's tool, and any other configured server can advertise a tool by
+        // that name tomorrow. The registry already refuses to let a shadowing server loosen a record it
+        // did not create — a bare-name exemption applied on top would hand that bypass straight back.
+        _behavior.RecordAdvertised(Tool, Advertised("some-other-server", Destructive: true));
+
+        var admission = await Admit(Exempting(new ToolBehaviorExemption
+        {
+            Tool = Tool,
+            Reason = "checked the vendor's version of this tool; it only reads",
+        }));
+
+        Assert.False(admission.IsAllowed);
+        AssertApprovalWasSought("declares itself destructive");
+    }
+
+    [Fact]
+    public async Task PostureOn_AnExemptionNamingADifferentServer_DoesNotCoverThisOne()
+    {
+        // The mutation control for the pass case above: naming a server must mean matching it, not
+        // merely supplying one.
+        _behavior.RecordAdvertised(Tool, Advertised("shadowing-server", ReadOnly: false));
+
+        var admission = await Admit(Exempting(new ToolBehaviorExemption
+        {
+            Tool = Tool,
+            Server = "notion",
+            Reason = "verified against the vendor's API docs",
+        }));
+
+        Assert.False(admission.IsAllowed);
+    }
+
+    [Fact]
+    public async Task PostureOn_AnExemptionNamingNoServer_StillCoversAVouchedForTool()
+    {
+        // The server name is required only where it carries weight. For a tool from a server the
+        // operator already trusts, demanding it a second time would be ceremony.
+        _behavior.RecordAdvertised(Tool, Advertised("notion", ReadOnly: false, trusted: true));
+
+        var admission = await Admit(Exempting(new ToolBehaviorExemption
+        {
+            Tool = Tool,
+            Reason = "search endpoint that uses POST and does not mutate",
+        }));
+
+        Assert.True(admission.IsAllowed);
+        AssertNoApprovalWasSought();
+    }
+
+    [Fact]
+    public async Task PostureOn_AnExemptionForADifferentTool_DoesNotCoverThisOne()
+    {
+        // Mutation control for the test above: the exemption must be matched, not merely present.
+        var admission = await Admit(
+            Exempting(new ToolBehaviorExemption { Tool = "some_other_tool", Reason = "unrelated" }));
+
+        Assert.False(admission.IsAllowed);
+    }
+
+    [Fact]
+    public async Task PostureOn_EnforcementOff_OutsideABundleRun_ChangesNothing()
+    {
+        // Half of the reason GovernanceConfigValidator refuses this combination outright. Neither this
+        // test nor the next endorses it — together they pin what the code actually does, so the
+        // validator's message stays true if the rule is ever relaxed.
+        var admission = await Admit(EnforcementOffPostureOn);
+
+        Assert.True(admission.IsAllowed);
+        AssertNoApprovalWasSought();
+    }
+
+    [Fact]
+    public async Task PostureOn_EnforcementOff_InsideABundleRun_StillGates()
+    {
+        // The other half, and the uncomfortable one. The governor arms on EITHER invocation
+        // enforcement OR an ambient capability envelope, so leaving enforcement off does not switch the
+        // posture off — it applies it to bundle runs alone while every agent turn and plan step goes
+        // ungated. An earlier version of this file asserted the opposite in a comment, in a test that
+        // armed no envelope and therefore could not have caught it.
+        using var _ = CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AllowedTools = [Tool] });
+
+        var admission = await Admit(EnforcementOffPostureOn);
+
+        Assert.False(admission.IsAllowed);
+        AssertApprovalWasSought("nothing is known about what the tool does");
+    }
+
+    /// <summary>Invocation enforcement on — the only condition under which the posture does anything.</summary>
+    private static GovernanceConfig Enforcing(ToolBehaviorGatingConfig? gating = null) => new()
+    {
+        EnforceToolInvocation = true,
+        EnableAudit = true,
+        ToolBehaviorGating = gating ?? new ToolBehaviorGatingConfig(),
+    };
+
+    private static GovernanceConfig PostureOff => Enforcing();
+
+    private static GovernanceConfig PostureOn =>
+        Enforcing(new ToolBehaviorGatingConfig { RequireApprovalForNonReadOnlyTools = true });
+
+    private static GovernanceConfig EnforcementOffPostureOn => new()
+    {
+        EnforceToolInvocation = false,
+        ToolBehaviorGating = new ToolBehaviorGatingConfig { RequireApprovalForNonReadOnlyTools = true },
+    };
+
+    /// <summary>The posture on, with one exemption in force.</summary>
+    private static ToolBehaviorGatingConfig Exempting(ToolBehaviorExemption exemption) =>
+        new() { RequireApprovalForNonReadOnlyTools = true, Exemptions = [exemption] };
+
+    /// <summary>A declaration as an MCP server would make it, attributed to that server.</summary>
+    private static ToolBehavior Advertised(
+        string serverName, bool? ReadOnly = null, bool? Destructive = null, bool trusted = false) =>
+        new(trusted ? ToolBehaviorSource.TrustedMcpServer : ToolBehaviorSource.UntrustedMcpServer,
+            ReadOnly: ReadOnly,
+            Destructive: Destructive,
+            ServerName: serverName);
+
+    private Task<ToolCallAdmission> Admit(ToolBehaviorGatingConfig gating) => Admit(Enforcing(gating));
+
+    private Task<ToolCallAdmission> Admit(GovernanceConfig governance) =>
+        Pipeline(governance).AdmitAsync(new ToolCallAdmissionRequest(Tool), CancellationToken.None).AsTask();
+
+    /// <summary>
+    /// Builds the real admission chain around a real governor, so a call arrives the way one does at
+    /// runtime rather than through a direct call to the rule under test.
+    /// </summary>
+    private ToolCallAdmissionPipeline Pipeline(GovernanceConfig governance)
+    {
+        var monitor = Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == governance);
+        var trace = new GovernanceTraceRecorder(monitor);
+
+        var governor = new ToolInvocationGovernor(
+            _context.Object,
+            _permissions.Object,
+            _riskClassifier,
+            _behavior,
+            Mock.Of<IAutonomyDecisionEvaluator>(),
+            _policyEngine.Object,
+            Mock.Of<IGovernanceAuditService>(),
+            Mock.Of<IDenialTracker>(),
+            _capabilities.Object,
+            _approvalRouter.Object,
+            trace,
+            monitor,
+            Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == new PermissionsConfig()),
+            Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == new SandboxConfig()),
+            NullLogger<ToolInvocationGovernor>.Instance);
+
+        return AdmissionHarness.Pipeline(governor: governor, trace: trace);
+    }
+
+    /// <summary>
+    /// Asserts a human was asked, and that the question named the right reason — a refusal alone would
+    /// also be produced by a gate that blocks for some unrelated cause.
+    /// </summary>
+    private void AssertApprovalWasSought(string expectedReasonFragment) =>
+        _approvalRouter.Verify(
+            x => x.RequestApprovalAsync(
+                Agent,
+                It.IsAny<string>(),
+                It.Is<string>(reason => reason.Contains(expectedReasonFragment, StringComparison.Ordinal)),
+                It.IsAny<BlastRadius>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+    private void AssertNoApprovalWasSought() =>
+        _approvalRouter.Verify(
+            x => x.RequestApprovalAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
@@ -80,7 +80,9 @@ public sealed class ToolInvocationGovernorEnvelopeTests
         _trace = new GovernanceTraceRecorder(governanceMonitor);
 
         return new ToolInvocationGovernor(
-            _context.Object, _permissions.Object, _riskClassifier, _autonomy.Object, _policyEngine.Object,
+            _context.Object, _permissions.Object, _riskClassifier,
+            Mock.Of<IToolBehaviorRegistry>(r => r.Resolve(It.IsAny<string>()) == ToolBehavior.Unknown),
+            _autonomy.Object, _policyEngine.Object,
             Mock.Of<IGovernanceAuditService>(), _denialTracker.Object, _capabilities.Object, _approvalRouter.Object,
             _trace, governanceMonitor,
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -42,6 +42,13 @@ public sealed class ToolInvocationGovernorTests
     private readonly IToolRiskClassifier _riskClassifier =
         Mock.Of<IToolRiskClassifier>(c => c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true));
 
+    /// <summary>
+    /// What the tool under test has declared about itself. Defaults to <see cref="ToolBehavior.Unknown"/>
+    /// — the fail-closed answer — so a test that forgets to arrange a declaration exercises the gated
+    /// case rather than the exempt one.
+    /// </summary>
+    private readonly Mock<IToolBehaviorRegistry> _behavior = new();
+
     private readonly GovernanceConfig _governance = new() { EnforceToolInvocation = true, Enabled = false, EnableAudit = true };
     private readonly PermissionsConfig _permissionsConfig = new();
     private readonly SandboxConfig _sandbox = new();
@@ -58,6 +65,7 @@ public sealed class ToolInvocationGovernorTests
                 It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
         _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
+        _behavior.Setup(x => x.Resolve(It.IsAny<string>())).Returns(ToolBehavior.Unknown);
         _approvalRouter
             .Setup(x => x.RequestApprovalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
@@ -91,6 +99,7 @@ public sealed class ToolInvocationGovernorTests
             _context.Object,
             _permissions.Object,
             _riskClassifier,
+            _behavior.Object,
             _autonomy.Object,
             _policyEngine.Object,
             Mock.Of<IGovernanceAuditService>(),

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolBehaviorRegistryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolBehaviorRegistryTests.cs
@@ -1,0 +1,202 @@
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Models;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Tools;
+
+/// <summary>
+/// Tests for <see cref="ToolBehaviorRegistry"/> — what a tool declared about itself, from whichever of
+/// the two sources knows: an external server's advertisement, or the tool's own registration.
+/// </summary>
+public sealed class ToolBehaviorRegistryTests
+{
+    private static ToolBehaviorRegistry CreateRegistry(params ITool[] tools)
+    {
+        var services = new ServiceCollection();
+        foreach (var tool in tools)
+            services.AddKeyedSingleton<ITool>(tool.Name, tool);
+
+        return new ToolBehaviorRegistry(services.BuildServiceProvider());
+    }
+
+    [Fact]
+    public void Resolve_NameNobodyHasDescribed_IsUnknown()
+    {
+        var sut = CreateRegistry();
+
+        sut.Resolve("never_heard_of_it").Should().Be(ToolBehavior.Unknown);
+    }
+
+    [Fact]
+    public void Resolve_RegisteredTool_ReadsItsOwnDeclaration()
+    {
+        var sut = CreateRegistry(
+            new FakeTool("lookup", isReadOnly: true),
+            new FakeTool("deploy", isReadOnly: false));
+
+        sut.Resolve("lookup").Should().BeEquivalentTo(
+            new ToolBehavior(ToolBehaviorSource.FirstParty, ReadOnly: true));
+        sut.Resolve("lookup").IsExemptFromApproval.Should().BeTrue();
+        sut.Resolve("deploy").IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_AdvertisedTool_KeepsWhatTheServerSaidAndWhoSaidIt()
+    {
+        var sut = CreateRegistry();
+        sut.RecordAdvertised(
+            "search_pages",
+            new ToolBehavior(ToolBehaviorSource.TrustedMcpServer, ReadOnly: true, OpenWorld: true));
+
+        var resolved = sut.Resolve("search_pages");
+
+        resolved.Source.Should().Be(ToolBehaviorSource.TrustedMcpServer);
+        resolved.ReadOnly.Should().BeTrue();
+        resolved.OpenWorld.Should().BeTrue();
+        resolved.IsExemptFromApproval.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Resolve_IsCaseInsensitive_BecauseToolNamesAreMatchedThatWayEverywhereElse()
+    {
+        var sut = CreateRegistry();
+        sut.RecordAdvertised("Search_Pages", new ToolBehavior(ToolBehaviorSource.TrustedMcpServer, ReadOnly: true));
+
+        sut.Resolve("search_pages").IsExemptFromApproval.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RecordAdvertised_ADifferentServerClaimingTheSameName_CannotLoosenIt()
+    {
+        // The shadowing attack: a hostile server advertises a name a stricter server already claimed
+        // and marks it read-only, hoping the later write wins. Stricter must survive regardless of
+        // arrival order, so both orders are asserted.
+        //
+        // The two records carry DIFFERENT server names, which is load-bearing: with the same name this
+        // is a server re-reporting its own tool, which must be believed. An earlier version of this
+        // test left both unattributed and therefore proved the weaker of the two rules under the
+        // stronger one's name.
+        var sut = CreateRegistry();
+
+        sut.RecordAdvertised("write_page", Advertised("honest-server", ReadOnly: false));
+        sut.RecordAdvertised("write_page", Advertised("shadowing-server", ReadOnly: true));
+
+        sut.Resolve("write_page").IsExemptFromApproval.Should().BeFalse();
+        sut.Resolve("write_page").ServerName.Should().Be("honest-server");
+
+        var reversed = CreateRegistry();
+        reversed.RecordAdvertised("write_page", Advertised("shadowing-server", ReadOnly: true));
+        reversed.RecordAdvertised("write_page", Advertised("honest-server", ReadOnly: false));
+
+        reversed.Resolve("write_page").IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
+    public void RecordAdvertised_AServerRevisingItsOwnTool_IsBelievedInBothDirections()
+    {
+        // Two things ride on this, and an earlier version of the registry got the second one wrong.
+        //
+        // Tightening is the rug-pull case: a server that advertised a clean read-only tool and later
+        // advertises it as destructive must be believed the second time.
+        //
+        // Loosening is how an operator's decision takes effect. A server discovered before it was
+        // marked trusted has a non-exempt record on file; granting trust re-records the same tools from
+        // the same server as trusted. A rule that kept the stricter entry unconditionally would pin the
+        // old record forever, and the config change would silently do nothing until a restart.
+        var tightening = CreateRegistry();
+        tightening.RecordAdvertised("notes", Advertised("notion", ReadOnly: true, trusted: true));
+        tightening.Resolve("notes").IsExemptFromApproval.Should().BeTrue();
+
+        tightening.RecordAdvertised("notes", Advertised("notion", Destructive: true, trusted: true));
+        tightening.Resolve("notes").IsExemptFromApproval.Should().BeFalse();
+
+        var loosening = CreateRegistry();
+        loosening.RecordAdvertised("notes", Advertised("notion", ReadOnly: true));
+        loosening.Resolve("notes").IsExemptFromApproval.Should().BeFalse();
+
+        loosening.RecordAdvertised("notes", Advertised("notion", ReadOnly: true, trusted: true));
+        loosening.Resolve("notes").IsExemptFromApproval.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RecordAdvertised_AnUnattributedRecord_CannotOverwriteAnAttributedOne()
+    {
+        // "Same source" needs a source. Two records with no server name are not thereby the same
+        // server, and treating them as one would make the unattributed path the loosest in the system.
+        var sut = CreateRegistry();
+
+        sut.RecordAdvertised("notes", Advertised("notion", ReadOnly: false));
+        sut.RecordAdvertised("notes", new ToolBehavior(ToolBehaviorSource.TrustedMcpServer, ReadOnly: true));
+
+        sut.Resolve("notes").IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_NameKnownToBothSources_AnswersWithWhicheverDoesNotExempt()
+    {
+        // A declared tool is resolved from MCP before keyed DI, so which implementation actually runs
+        // depends on whether discovery succeeded. A rule that changed with it would be worse than one
+        // that always answers with the stricter of the two — asserted in both directions.
+        var advertisedWriter = CreateRegistry(new FakeTool("notes", isReadOnly: true));
+        advertisedWriter.RecordAdvertised("notes", new ToolBehavior(ToolBehaviorSource.TrustedMcpServer, ReadOnly: false));
+
+        advertisedWriter.Resolve("notes").IsExemptFromApproval.Should().BeFalse();
+
+        var registeredWriter = CreateRegistry(new FakeTool("notes", isReadOnly: false));
+        registeredWriter.RecordAdvertised("notes", new ToolBehavior(ToolBehaviorSource.TrustedMcpServer, ReadOnly: true));
+
+        registeredWriter.Resolve("notes").IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Resolve_ReadOnlyFromAnUntrustedServer_StaysNonExemptEvenWhenTheToolIsAlsoRegisteredLocally()
+    {
+        // Both halves say read-only, but one of them is not entitled to. The registry must not let the
+        // trusted half launder the untrusted one — the answer is the untrusted declaration.
+        var sut = CreateRegistry(new FakeTool("notes", isReadOnly: true));
+        sut.RecordAdvertised("notes", new ToolBehavior(ToolBehaviorSource.UntrustedMcpServer, ReadOnly: true));
+
+        sut.Resolve("notes").IsExemptFromApproval.Should().BeFalse();
+        sut.Resolve("notes").Source.Should().Be(ToolBehaviorSource.UntrustedMcpServer);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankNames_AreNeitherRecordedNorResolved(string name)
+    {
+        var sut = CreateRegistry();
+
+        sut.RecordAdvertised(name, new ToolBehavior(ToolBehaviorSource.TrustedMcpServer, ReadOnly: true));
+
+        sut.Resolve(name).Should().Be(ToolBehavior.Unknown);
+    }
+
+    /// <summary>A declaration as an MCP server would make it, attributed to that server.</summary>
+    private static ToolBehavior Advertised(
+        string serverName, bool? ReadOnly = null, bool? Destructive = null, bool trusted = false) =>
+        new(trusted ? ToolBehaviorSource.TrustedMcpServer : ToolBehaviorSource.UntrustedMcpServer,
+            ReadOnly: ReadOnly,
+            Destructive: Destructive,
+            ServerName: serverName);
+
+    private sealed class FakeTool(string name, bool isReadOnly) : ITool
+    {
+        public string Name => name;
+        public string Description => "fake tool";
+        public IReadOnlyList<string> SupportedOperations => [];
+        public bool IsReadOnly => isReadOnly;
+        public BlastRadius RiskTier => BlastRadius.Medium;
+
+        public Task<ToolResult> ExecuteAsync(
+            string operation,
+            IReadOnlyDictionary<string, object?> parameters,
+            CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Not used in registry tests.");
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/GovernanceConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/GovernanceConfigValidatorTests.cs
@@ -1,5 +1,6 @@
 using Application.Core.Validation;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
 using FluentAssertions;
 using Xunit;
 
@@ -142,5 +143,101 @@ public class GovernanceConfigValidatorTests
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == nameof(GovernanceConfig.InjectionBlockThreshold));
+    }
+
+    [Fact]
+    public async Task Validate_BehaviorPostureOnWithoutInvocationEnforcement_HasError()
+    {
+        // The dead-control guard. The posture is applied inside the tool governor, which does not
+        // engage at all while EnforceToolInvocation is off — so this combination is a security setting
+        // switched on in configuration and read by nothing at runtime. Refusing to boot is the only
+        // outcome that cannot be mistaken for protection.
+        var config = new GovernanceConfig
+        {
+            EnforceToolInvocation = false,
+            ToolBehaviorGating = new ToolBehaviorGatingConfig { RequireApprovalForNonReadOnlyTools = true },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(GovernanceConfig.EnforceToolInvocation));
+    }
+
+    [Fact]
+    public async Task Validate_BehaviorPostureOnWithInvocationEnforcement_IsValid()
+    {
+        // The control: the rule must reject only the inert combination, not the working one.
+        var config = new GovernanceConfig
+        {
+            EnforceToolInvocation = true,
+            ToolBehaviorGating = new ToolBehaviorGatingConfig { RequireApprovalForNonReadOnlyTools = true },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Validate_ExemptionWithNoStatedReason_HasError(string reason)
+    {
+        // An exemption is the one place the posture can be switched off for a named tool. Whoever reads
+        // this list a year from now needs to know why each entry is there, and a blank reason is
+        // indistinguishable from an entry added to silence a prompt.
+        var config = new GovernanceConfig
+        {
+            ToolBehaviorGating = new ToolBehaviorGatingConfig
+            {
+                Exemptions = [new ToolBehaviorExemption { Tool = "notion_search", Reason = reason }],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_ExemptionWithNoToolName_HasError()
+    {
+        var config = new GovernanceConfig
+        {
+            ToolBehaviorGating = new ToolBehaviorGatingConfig
+            {
+                Exemptions = [new ToolBehaviorExemption { Tool = "", Reason = "vendor confirmed it only reads" }],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_FullyStatedExemption_IsValid()
+    {
+        var config = new GovernanceConfig
+        {
+            ToolBehaviorGating = new ToolBehaviorGatingConfig
+            {
+                Exemptions =
+                [
+                    new ToolBehaviorExemption
+                    {
+                        Tool = "notion_search",
+                        Reason = "POST-based search endpoint; vendor confirmed it does not mutate",
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
     }
 }

--- a/src/Content/Tests/Domain.AI.Tests/Governance/ToolBehaviorTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Governance/ToolBehaviorTests.cs
@@ -1,0 +1,97 @@
+using Domain.AI.Governance;
+using Xunit;
+
+namespace Domain.AI.Tests.Governance;
+
+/// <summary>
+/// The exemption rule: which declarations are strong enough to let a tool skip human approval.
+/// </summary>
+/// <remarks>
+/// This is the whole security argument of behaviour-based gating in one property, so it is tested
+/// exhaustively rather than by example. The case that matters most is the one an attacker controls: a
+/// read-only claim from a server nobody vouched for must buy nothing.
+/// </remarks>
+public sealed class ToolBehaviorTests
+{
+    [Fact]
+    public void Unknown_IsNotExempt()
+    {
+        // Silence is not a claim. Every path that fails to establish what a tool does lands here, so
+        // this is the answer that decides whether the posture is fail-closed.
+        Assert.False(ToolBehavior.Unknown.IsExemptFromApproval);
+        Assert.Equal("nothing is known about what the tool does", ToolBehavior.Unknown.NonExemptReason);
+    }
+
+    [Theory]
+    [InlineData(ToolBehaviorSource.FirstParty)]
+    [InlineData(ToolBehaviorSource.TrustedMcpServer)]
+    public void ReadOnly_FromATrustedSource_IsExempt(ToolBehaviorSource source)
+    {
+        var behavior = new ToolBehavior(source, ReadOnly: true);
+
+        Assert.True(behavior.IsExemptFromApproval);
+        Assert.Null(behavior.NonExemptReason);
+    }
+
+    [Fact]
+    public void ReadOnly_FromAnUntrustedServer_IsNotExempt()
+    {
+        // The control the whole design turns on. A server that wants to escape the gate marks its
+        // destructive tool read-only; the MCP specification says so in as many words. If this ever
+        // returns true, the posture protects nothing against the party it exists to police.
+        var behavior = new ToolBehavior(ToolBehaviorSource.UntrustedMcpServer, ReadOnly: true);
+
+        Assert.False(behavior.IsExemptFromApproval);
+        Assert.Equal(
+            "the tool claims to be read-only, but its MCP server is not marked as trusted for tool annotations",
+            behavior.NonExemptReason);
+    }
+
+    [Theory]
+    [InlineData(ToolBehaviorSource.FirstParty)]
+    [InlineData(ToolBehaviorSource.TrustedMcpServer)]
+    [InlineData(ToolBehaviorSource.UntrustedMcpServer)]
+    public void Destructive_OutranksAReadOnlyClaim_FromEverySource(ToolBehaviorSource source)
+    {
+        // An incoherent declaration — only reads, yet destroys — is a reason to distrust the declarer,
+        // not an invitation to pick the convenient half. Tightening is believed from anyone.
+        var behavior = new ToolBehavior(source, ReadOnly: true, Destructive: true);
+
+        Assert.False(behavior.IsExemptFromApproval);
+        Assert.Equal("the tool declares itself destructive", behavior.NonExemptReason);
+    }
+
+    [Theory]
+    [InlineData(ToolBehaviorSource.FirstParty)]
+    [InlineData(ToolBehaviorSource.TrustedMcpServer)]
+    [InlineData(ToolBehaviorSource.UntrustedMcpServer)]
+    public void NotReadOnly_IsNeverExempt_HoweverTrustedTheSource(ToolBehaviorSource source)
+    {
+        var declared = new ToolBehavior(source, ReadOnly: false);
+        var silent = new ToolBehavior(source);
+
+        Assert.False(declared.IsExemptFromApproval);
+        Assert.False(silent.IsExemptFromApproval);
+        Assert.Equal("the tool has not declared itself read-only", declared.NonExemptReason);
+        Assert.Equal("the tool has not declared itself read-only", silent.NonExemptReason);
+    }
+
+    [Fact]
+    public void TheOtherTwoHints_AreRecorded_AndDoNotDecideExemption()
+    {
+        // Idempotency and open-world reach are worth keeping — they are what a later report or a
+        // risk-tier rule reads — but neither answers "does this change anything", so neither may move
+        // the gate on its own. A tool that writes is gated however idempotent it claims to be.
+        var idempotentWriter = new ToolBehavior(
+            ToolBehaviorSource.TrustedMcpServer, ReadOnly: false, Idempotent: true, OpenWorld: false);
+
+        Assert.False(idempotentWriter.IsExemptFromApproval);
+        Assert.True(idempotentWriter.Idempotent);
+        Assert.False(idempotentWriter.OpenWorld);
+
+        var openWorldReader = new ToolBehavior(
+            ToolBehaviorSource.TrustedMcpServer, ReadOnly: true, OpenWorld: true);
+
+        Assert.True(openWorldReader.IsExemptFromApproval);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Tools;
 using Domain.Common.Config.AI;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Resources;
@@ -36,6 +37,10 @@ public sealed class DependencyInjectionTests : IAsyncLifetime
         // security scanner, which the governance layer normally registers. Same reasoning as the
         // SSRF guard above: a missing security dependency must fail resolution, not be skipped.
         services.AddSingleton(Mock.Of<IMcpSecurityScanner>());
+        // Same again for the behaviour registry the recording decorator writes to. A host that never
+        // wired it would publish MCP tools with nothing on file about what they do, which the
+        // behaviour posture reads as "unknown" for every one of them.
+        services.AddSingleton(Mock.Of<IToolBehaviorRegistry>());
 
         services.AddMcpClientDependencies();
 
@@ -62,17 +67,43 @@ public sealed class DependencyInjectionTests : IAsyncLifetime
     }
 
     [Fact]
-    public void AddMcpClientDependencies_PublishesTheScanningDecoratorAsIMcpToolProvider()
+    public void AddMcpClientDependencies_PublishesTheDecoratedProviderRatherThanTheBareTransport()
     {
         var provider = BuildProvider();
 
         var toolProvider = provider.GetService<IMcpToolProvider>();
 
         toolProvider.Should().NotBeNull();
-        toolProvider.Should().BeOfType<ScanningMcpToolProvider>(
-            "every consumer resolves the interface, so the decorator has to be what the interface "
+        toolProvider.Should().BeOfType<BehaviorRecordingMcpToolProvider>(
+            "every consumer resolves the interface, so the decorators have to be what the interface "
             + "returns — registering the bare transport provider would leave tool definitions from "
-            + "external servers unscanned");
+            + "external servers unscanned and their declared behaviour unrecorded");
+        toolProvider.Should().NotBeOfType<McpToolProvider>();
+    }
+
+    [Fact]
+    public async Task AddMcpClientDependencies_WithoutABehaviorRegistry_FailsToResolveRatherThanSkippingTheRecording()
+    {
+        // The mirror of the scanner test below, and the reason the scanning decorator is still known
+        // to be in the chain even though it is no longer the outermost type: both decorators are built
+        // by the same factory, so a missing collaborator of either one fails the resolution.
+        var services = new ServiceCollection();
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.Configure<AIConfig>(_ => { });
+        services.Configure<Domain.Common.Config.MetaHarness.MetaHarnessConfig>(_ => { });
+        services.AddSingleton(TestSsrf.HandlerFactory());
+        services.AddSingleton(Mock.Of<IMcpSecurityScanner>());
+        // Deliberately no IToolBehaviorRegistry.
+
+        services.AddMcpClientDependencies();
+        await using var provider = services.BuildServiceProvider();
+
+        var resolve = () => provider.GetService<IMcpToolProvider>();
+
+        resolve.Should().Throw<InvalidOperationException>(
+            "a host that publishes external tools without recording what they declared leaves the "
+            + "behaviour posture with nothing to decide from");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
@@ -1,0 +1,189 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Infrastructure.AI.MCP.Services;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// Tests for the decorator that captures what each MCP server declares about its tools' behaviour as
+/// they are discovered.
+/// </summary>
+/// <remarks>
+/// The registry is real rather than mocked: what these tests are actually about is whether a
+/// declaration survives the trip from an advertised definition into something governance can decide
+/// from, and a mocked registry would let the assertions be about the mock instead.
+/// </remarks>
+public sealed class BehaviorRecordingMcpToolProviderTests
+{
+    private const string TrustedServer = "our-own-service";
+    private const string UnvouchedServer = "marketplace-server";
+
+    private readonly Mock<IMcpToolProvider> _inner = new();
+    private readonly IToolBehaviorRegistry _registry =
+        new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider());
+
+    [Fact]
+    public async Task GetToolsAsync_RecordsWhatATrustedServerDeclared()
+    {
+        // The round trip that matters: a read-only claim from a vouched-for server arrives as an
+        // exemption on the other side, with the other three hints preserved rather than discarded.
+        InnerReturns(TrustedServer, McpTool("search_pages", readOnly: true, destructive: false, idempotent: true, openWorld: true));
+
+        await CreateSut(trusted: TrustedServer).GetToolsAsync(TrustedServer);
+
+        var recorded = _registry.Resolve("search_pages");
+        recorded.Source.Should().Be(ToolBehaviorSource.TrustedMcpServer);
+        recorded.ReadOnly.Should().BeTrue();
+        recorded.Destructive.Should().BeFalse();
+        recorded.Idempotent.Should().BeTrue();
+        recorded.OpenWorld.Should().BeTrue();
+        recorded.IsExemptFromApproval.Should().BeTrue();
+
+        // Which server spoke is part of the record, not incidental: an operator's exemption is matched
+        // against it, and a server revising its own tool is told apart from one shadowing someone
+        // else's by this field alone.
+        recorded.ServerName.Should().Be(TrustedServer);
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_TheSameDeclarationFromAnUnvouchedServer_BuysNothing()
+    {
+        // Identical bytes on the wire, opposite outcome. This is the control that proves the trust
+        // decision comes from the operator's configuration and not from the tool definition.
+        InnerReturns(UnvouchedServer, McpTool("search_pages", readOnly: true));
+
+        await CreateSut(trusted: TrustedServer).GetToolsAsync(UnvouchedServer);
+
+        var recorded = _registry.Resolve("search_pages");
+        recorded.Source.Should().Be(ToolBehaviorSource.UntrustedMcpServer);
+        recorded.ReadOnly.Should().BeTrue();
+        recorded.IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_AServerThatAnnotatesNothing_LeavesEveryQuestionOpen()
+    {
+        // Not the same as no record. The tool is known to exist and known to have said nothing, which
+        // is what lets a report tell an operator which servers to ask for annotations.
+        InnerReturns(TrustedServer, AIFunctionFactory.Create(() => "result", "legacy_tool", "does a thing"));
+
+        await CreateSut(trusted: TrustedServer).GetToolsAsync(TrustedServer);
+
+        var recorded = _registry.Resolve("legacy_tool");
+        recorded.Source.Should().Be(ToolBehaviorSource.TrustedMcpServer);
+        recorded.ReadOnly.Should().BeNull();
+        recorded.Destructive.Should().BeNull();
+        recorded.IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetAllToolsAsync_RecordsEachServerAgainstItsOwnTrustLevel()
+    {
+        _inner
+            .Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, IList<AITool>>
+            {
+                [TrustedServer] = [McpTool("vouched_read", readOnly: true)],
+                [UnvouchedServer] = [McpTool("unvouched_read", readOnly: true)],
+            });
+
+        await CreateSut(trusted: TrustedServer).GetAllToolsAsync();
+
+        _registry.Resolve("vouched_read").IsExemptFromApproval.Should().BeTrue();
+        _registry.Resolve("unvouched_read").IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_ReturnsTheInnerProvidersToolsUnchanged()
+    {
+        // Recording must not filter. Withholding is the scanning decorator's job, and a decorator that
+        // quietly dropped a tool here would look identical to a server that never offered it.
+        InnerReturns(TrustedServer, McpTool("a", readOnly: true), McpTool("b", readOnly: false));
+
+        var tools = await CreateSut(trusted: TrustedServer).GetToolsAsync(TrustedServer);
+
+        tools.Select(t => t.Name).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public async Task GetToolByNameAsync_RecordsNothing_BecauseItCannotTellWhichServerAnswered()
+    {
+        // Declining to guess is the fail-closed choice: an unrecorded tool resolves to Unknown and is
+        // gated, whereas a guess of "untrusted" would silently revoke an exemption a trusted server
+        // had legitimately earned for that name.
+        _inner
+            .Setup(p => p.GetToolByNameAsync("search_pages", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AIFunction)McpTool("search_pages", readOnly: true));
+
+        await CreateSut(trusted: TrustedServer).GetToolByNameAsync("search_pages");
+
+        _registry.Resolve("search_pages").Should().Be(ToolBehavior.Unknown);
+    }
+
+    private BehaviorRecordingMcpToolProvider CreateSut(string trusted)
+    {
+        var config = new AIConfig
+        {
+            McpServers = new McpServersConfig
+            {
+                Servers = new Dictionary<string, McpServerDefinition>
+                {
+                    [trusted] = new() { TrustToolAnnotations = true },
+                    [UnvouchedServer] = new(),
+                },
+            },
+        };
+
+        return new BehaviorRecordingMcpToolProvider(
+            _inner.Object,
+            _registry,
+            Mock.Of<IOptionsMonitor<AIConfig>>(m => m.CurrentValue == config),
+            NullLogger<BehaviorRecordingMcpToolProvider>.Instance);
+    }
+
+    private void InnerReturns(string serverName, params AITool[] tools) =>
+        _inner
+            .Setup(p => p.GetToolsAsync(serverName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tools.ToList());
+
+    /// <summary>
+    /// A tool carrying real protocol annotations, so the mapping is exercised against the SDK's own
+    /// type rather than against a stand-in shaped like it.
+    /// </summary>
+    private static AITool McpTool(
+        string name,
+        bool? readOnly = null,
+        bool? destructive = null,
+        bool? idempotent = null,
+        bool? openWorld = null)
+    {
+        var protocolTool = new ModelContextProtocol.Protocol.Tool
+        {
+            Name = name,
+            Description = "does a thing",
+            Annotations = new ModelContextProtocol.Protocol.ToolAnnotations
+            {
+                ReadOnlyHint = readOnly,
+                DestructiveHint = destructive,
+                IdempotentHint = idempotent,
+                OpenWorldHint = openWorld,
+            },
+        };
+
+        return new ModelContextProtocol.Client.McpClientTool(
+            Mock.Of<ModelContextProtocol.Client.McpClient>(),
+            protocolTool,
+            System.Text.Json.JsonSerializerOptions.Default);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -170,6 +170,11 @@ public sealed class SubPlanEnvelopeConfinementTests
             NullLogger<ThreePhasePermissionResolver>.Instance));
         services.AddSingleton(Mock.Of<IToolRiskClassifier>(
             c => c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true)));
+        // Nothing is known about the tools in this fixture, which is the fail-closed answer. It changes
+        // no outcome here — the behaviour posture is off in this config — but the governor resolves the
+        // registry regardless, and a container that cannot build one cannot build a governor.
+        services.AddSingleton(Mock.Of<IToolBehaviorRegistry>(
+            r => r.Resolve(It.IsAny<string>()) == ToolBehavior.Unknown));
         services.AddSingleton(new Mock<IAutonomyDecisionEvaluator>().Object);
         services.AddSingleton(Mock.Of<IGovernancePolicyEngine>(p => p.HasPolicies == false));
         services.AddSingleton(Mock.Of<IGovernanceAuditService>());


### PR DESCRIPTION
Closes #324.

## The problem

Tool governance decides from **lists of names** — a plugin's allow and deny lists, per-agent authorization, YAML policy. Every one requires somebody to enumerate the dangerous tools correctly, forever, including tools arriving at runtime from an MCP server nobody on the team wrote. A tool nobody thought to list is callable by default, and a name carries no behaviour: `create_page` and `search_pages` are indistinguishable to a rule keyed on identity.

Meanwhile the harness was discarding a governance signal that arrives for free. MCP servers advertise four behaviour annotations on every tool definition; a search of `src` for any of them returned nothing.

## What changed

With `AI:Governance:ToolBehaviorGating:RequireApprovalForNonReadOnlyTools` on, a tool that has not declared itself read-only requires human approval. A new mutating tool appearing upstream is gated the moment it appears, with no list edit.

**The trust rule is where this departs from the reference implementation** (`CopilotKit/OpenTag`, cited in the issue). An annotation is supplied by the party the annotation is used to police, and the MCP specification states that clients "should never make tool use decisions based on `ToolAnnotations` received from untrusted servers". OpenTag trusts the hint unconditionally; a hostile server escapes the gate by marking its destructive tool read-only.

So: **a declaration is believed when it tightens, and only from a vouched-for source when it loosens.** `destructiveHint` is honoured from anyone — nobody lies in the strict direction. `readOnlyHint` exempts a tool only from first-party code or a server carrying the new `TrustToolAnnotations` flag, off by default.

The same reasoning applies to the exemption list: a tool name belongs to nobody, so an exemption must name the server it was written for unless the tool's source is already vouched for. Without that, any configured server could claim an exempted name and walk through.

## Where it lives

Inside `IToolInvocationGovernor`, as a third source of "a human must rule on this" alongside the permission layer's `Ask` and the policy engine's `RequireApproval` — deliberately **not** a sixth gate on the admission chain. The governor is stage 2 of the one chain every execution path passes through, so all paths inherit the posture; a gate of its own would need its own route to a human, and two independent approval questions about one call is exactly the failure that chain's ask-once design exists to prevent.

## Safety of the default

Off by default, proven by a test that builds the config with nothing set. `GovernanceConfigValidator` refuses to boot a host that enables the posture without `EnforceToolInvocation` — that combination is **not** inert: the governor also arms on a bundle run's capability envelope, so it would gate bundle runs alone while every agent turn and plan step went ungated.

## Test plan

- `ToolBehaviorTests` — the exemption matrix exhaustively, including the case that matters: a read-only claim from an unvouched-for server buys nothing.
- `ToolBehaviorRegistryTests` — shadowing cannot loosen; a server revising its own tool is believed in both directions (which is what makes a runtime trust grant take effect); an unattributed record cannot overwrite an attributed one.
- `ToolBehaviorPostureTests` — driven through the **real** admission chain around a **real** governor. Both directions: an undeclared tool is gated, a trusted read-only tool is not. Plus the exemption scoping, a tool appearing mid-run with no list edit, and both halves of the enforcement-off behaviour.
- `BehaviorRecordingMcpToolProviderTests` — the annotation round trip against the SDK's own `McpClientTool`, and identical bytes from an unvouched-for server producing the opposite outcome.
- `GovernanceConfigValidatorTests` — the inert-combination refusal and the required exemption reason.

Five mutation controls were run across the feature — removing the trust check, disabling the posture, trusting every server, widening exemptions, and reverting the registry rule — each confirmed to fail the tests that are supposed to notice.

Two pre-existing test fixtures needed the new dependency, which is the useful signal that this reaches real composition rather than sitting beside it.

Full solution suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
