### PR TITLE
Close the approval loop: report execution outcomes, attribute retries (#325)

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -319,6 +319,13 @@ public static class DependencyInjection
         // calls this and nothing else, so a gate added here reaches all of them at once.
         services.TryAddScoped<Interfaces.Governance.IToolCallAdmissionPipeline, Services.Governance.ToolCallAdmissionPipeline>();
 
+        // Closes the approval loop (#325): reports what an approved action actually did, and
+        // attributes a corrected retry to its failed predecessor. Singleton because the failure
+        // memory must outlive any one conversation — that is the entire premise of the feature.
+        // The reporter is scoped, matching the scoped pipeline it is injected into.
+        services.TryAddSingleton<Interfaces.Escalation.IApprovalFailureMemory, Services.Escalation.InProcessApprovalFailureMemory>();
+        services.TryAddScoped<Interfaces.Escalation.IApprovalExecutionReporter, Services.Escalation.DefaultApprovalExecutionReporter>();
+
         return services;
     }
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationRequestInvariants.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/EscalationRequestInvariants.cs
@@ -59,6 +59,15 @@ public static class EscalationRequestInvariants
     public const int MaxTimeoutSeconds = 24 * 24 * 60 * 60;
 
     /// <summary>
+    /// Hard ceiling on <see cref="EscalationRequest.PriorFailureReason"/>, in characters. A second,
+    /// stricter layer against a hand-edited durable row — the soft producer-side truncation lives
+    /// in <c>EscalationConfig.RetryAttribution.MaxPriorFailureLength</c>, which
+    /// <c>EscalationConfigValidator</c> ties to this value so the two can never be configured into
+    /// disagreement.
+    /// </summary>
+    public const int MaxPriorFailureReasonLength = 4096;
+
+    /// <summary>
     /// Validates an escalation request against every creation-time invariant.
     /// </summary>
     /// <param name="request">The request to validate.</param>
@@ -118,6 +127,29 @@ public static class EscalationRequestInvariants
             violation =
                 "the timeout action is Approve at Critical priority — a Critical escalation must " +
                 "never auto-approve on timeout";
+            return false;
+        }
+
+        if (request.AttemptNumber < 1)
+        {
+            violation = $"the attempt number ({request.AttemptNumber}) is less than 1";
+            return false;
+        }
+
+        // Deliberately NOT the mirror check (AttemptNumber > 1 && PriorFailureReason is null) —
+        // that shape is what a legitimate LRU eviction of the failure memory produces, and
+        // rejecting it would fail-close a valid escalation for a benign memory eviction.
+        if (request.AttemptNumber == 1 && request.PriorFailureReason is not null)
+        {
+            violation = "attempt 1 carries a prior failure reason, which never happened";
+            return false;
+        }
+
+        if (request.PriorFailureReason is { Length: > MaxPriorFailureReasonLength })
+        {
+            violation =
+                $"the prior failure reason ({request.PriorFailureReason.Length} chars) exceeds the " +
+                $"maximum of {MaxPriorFailureReasonLength}";
             return false;
         }
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalExecutionReporter.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalExecutionReporter.cs
@@ -1,0 +1,60 @@
+using Domain.AI.Escalation;
+
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Closes the approval loop: reports what happened when an action a human approved was actually
+/// carried out, and updates the bounded failure memory <see cref="IApprovalFailureMemory"/> keeps
+/// so a corrected retry is attributed rather than presented as a fresh ask.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Implementations MUST NOT throw, ever.</strong> This runs strictly after the action it
+/// describes has already completed. An exception escaping here would turn a successful
+/// human-approved tool call into a tool error the model reads as "it didn't work" — whose correct
+/// response is to retry, i.e. perform an approved consequential action a second time. That is
+/// worse than a missing audit line. Same shape as <see cref="IEscalationNotificationChannel"/>'s
+/// own must-not-throw contract, one layer up: audit and notification failures here are logged and
+/// swallowed by the implementation, never surfaced to the caller.
+/// </para>
+/// <para>
+/// This is deliberately not filed under <c>Interfaces/Governance/</c> despite that folder's
+/// source-scanned "every registered contract has a caller" guard: that guard's premise is that a
+/// contract declared there is load-bearing access control, and this reporter cannot refuse
+/// anything — it only describes what already happened. Filing it there to borrow the guard would
+/// be exactly the kind of misplacement that guard exists to catch.
+/// </para>
+/// </remarks>
+public interface IApprovalExecutionReporter
+{
+    /// <summary>Reports that an approved action ran and completed successfully.</summary>
+    /// <param name="reportedBy">
+    /// A stable identifier for the calling site (<c>"direct-invocation"</c>, <c>"agent-turn"</c>,
+    /// or <c>"plan-executor"</c> — the three sites wired to <see cref="IApprovalExecutionReporter"/>
+    /// today), carried onto the audit record so a future auditor can tell which raising sites
+    /// implement execution reporting and which don't.
+    /// </param>
+    ValueTask ReportSucceededAsync(ApprovedCall call, string reportedBy, CancellationToken ct);
+
+    /// <summary>Reports that an approved action ran and failed.</summary>
+    /// <param name="failureReason">A human-readable reason, shown to the approver.</param>
+    /// <param name="reportedBy">See <see cref="ReportSucceededAsync"/>.</param>
+    ValueTask ReportFailedAsync(ApprovedCall call, string failureReason, string reportedBy, CancellationToken ct);
+
+    /// <summary>Reports that an approved action never ran.</summary>
+    /// <param name="reportedBy">See <see cref="ReportSucceededAsync"/>.</param>
+    ValueTask ReportNotExecutedAsync(
+        ApprovedCall call, EscalationNotExecutedReason reason, string reportedBy, CancellationToken ct);
+}
+
+/// <summary>
+/// Identifies one approved call for execution reporting: the escalation that approved it, and the
+/// failure-memory key that reporting a failure or success should update.
+/// </summary>
+/// <param name="EscalationId">The escalation whose approval permitted this call.</param>
+/// <param name="Key">
+/// The failure-memory key for this call. Carried alongside the escalation id rather than
+/// re-derived at report time, because the code path that finally learns the outcome (deep inside
+/// a tool invocation) is not always the code path that raised the escalation.
+/// </param>
+public readonly record struct ApprovedCall(Guid EscalationId, ApprovalFailureKey Key);

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalFailureMemory.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalFailureMemory.cs
@@ -1,0 +1,58 @@
+namespace Application.AI.Common.Interfaces.Escalation;
+
+/// <summary>
+/// Bounded, conversation-scoped memory of failed approved attempts, so a corrected retry can be
+/// attributed to its predecessor instead of presented as a fresh ask. Every operation is a
+/// dictionary hit — deliberately synchronous, unlike the durable escalation stores, because this
+/// has no durable sibling to justify an async signature.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>The key is (conversation, agent, tool) — arguments are deliberately excluded.</strong>
+/// A corrected retry has different arguments by definition, so keying on arguments would
+/// guarantee a miss on the exact case this exists to catch. Keying on conversation and tool alone
+/// risks cross-labeling when a supervisor and a delegated sub-agent both call the same tool in
+/// one conversation, so the agent id is included too. The residual over-breadth — two genuinely
+/// unrelated calls to the same tool by the same agent in one conversation matching — is accepted
+/// on purpose: this field is advisory context on an approval card, not a gate, and a false
+/// positive costs an approver a moment's confusion while a false negative reproduces the exact
+/// rubber-stamp failure this feature exists to prevent.
+/// </para>
+/// <para>
+/// Cleared only on an explicit human denial, never on timeout or escalation — a timeout means
+/// nobody looked, and erasing the context the next approver needs would invert the feature.
+/// </para>
+/// </remarks>
+public interface IApprovalFailureMemory
+{
+    /// <summary>Returns the recalled prior-failure state for this key, or null if none is recorded.</summary>
+    ApprovalFailureRecall? TryRecall(in ApprovalFailureKey key);
+
+    /// <summary>Records a failed approved attempt against this key.</summary>
+    void RecordFailure(in ApprovalFailureKey key, string failureReason, Guid escalationId);
+
+    /// <summary>Clears any recorded failure for this key.</summary>
+    void Clear(in ApprovalFailureKey key);
+}
+
+/// <summary>
+/// The failure-memory key for one action: the conversation it happened in, the agent that
+/// attempted it, and the tool it called. Compared ordinally throughout — this is a machine key,
+/// not a human identity, so it does not use <see cref="Domain.AI.Escalation.ApproverNames"/>'
+/// case-insensitive comparer.
+/// </summary>
+public readonly record struct ApprovalFailureKey(string ConversationId, string AgentId, string ToolName)
+{
+    /// <summary>
+    /// Builds a key, or null when there is no conversation to scope it to. The two production call
+    /// sites (<c>EscalationToolApprovalRouter</c> and <c>ToolInvocationGovernor.BuildApprovedCall</c>)
+    /// both build this key from the same ambient execution context and shared this exact guard
+    /// independently before it was extracted here — sharing it means the "missing conversation
+    /// identity → no key, never a sentinel" rule cannot drift between them.
+    /// </summary>
+    public static ApprovalFailureKey? TryCreate(string? conversationId, string agentId, string toolName) =>
+        string.IsNullOrWhiteSpace(conversationId) ? null : new ApprovalFailureKey(conversationId, agentId, toolName);
+}
+
+/// <summary>A recalled prior failure: how many times it has failed, why, and which escalation last approved it.</summary>
+public readonly record struct ApprovalFailureRecall(int PriorAttemptCount, string FailureReason, Guid EscalationId);

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationAuditStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationAuditStore.cs
@@ -24,6 +24,14 @@ public interface IEscalationAuditStore
     Task RecordOutcomeAsync(EscalationOutcome outcome, CancellationToken ct);
 
     /// <summary>
+    /// Records what happened when an approved escalation's action was actually carried out.
+    /// Same fail-closed throw semantics as the other <c>Record*</c> methods here — whether a
+    /// failure to record should still be reported to the approver is the caller's decision, not
+    /// this store's.
+    /// </summary>
+    Task RecordExecutionAsync(EscalationExecutionRecord record, CancellationToken ct);
+
+    /// <summary>
     /// Returns the full audit history for a specific escalation, ordered chronologically.
     /// Returns an empty list if the escalation ID is unknown.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationNotificationChannel.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationNotificationChannel.cs
@@ -24,4 +24,7 @@ public interface IEscalationNotificationChannel
 
     /// <summary>Warns approvers that an escalation is about to expire.</summary>
     Task NotifyEscalationExpiringAsync(EscalationRequest request, TimeSpan remaining, CancellationToken ct);
+
+    /// <summary>Reports what happened when an approved action was actually carried out.</summary>
+    Task NotifyExecutionReportedAsync(EscalationExecutionRecord record, CancellationToken ct);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationNotifier.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IEscalationNotifier.cs
@@ -25,4 +25,7 @@ public interface IEscalationNotifier
 
     /// <summary>Warns approvers that an escalation is about to expire.</summary>
     Task NotifyEscalationExpiringAsync(EscalationRequest request, TimeSpan remaining, CancellationToken ct);
+
+    /// <summary>Reports what happened when an approved action was actually carried out.</summary>
+    Task NotifyExecutionReportedAsync(EscalationExecutionRecord record, CancellationToken ct);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -1,3 +1,6 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+
 namespace Application.AI.Common.Interfaces.Governance;
 
 /// <summary>
@@ -119,6 +122,29 @@ public interface IToolCallAdmissionPipeline
         ToolCallAdmission admission, string toolName, string? content, out string? result);
 
     /// <summary>
+    /// Reports what happened when a call this pipeline approved was actually carried out, closing
+    /// the approval loop for whichever approver granted it.
+    /// </summary>
+    /// <param name="admission">The verdict returned by <see cref="AdmitAsync"/> for this same call.</param>
+    /// <param name="report">The outcome to report.</param>
+    /// <param name="reportedBy">
+    /// A stable identifier for the calling site (e.g. <c>"direct-invocation"</c>,
+    /// <c>"agent-turn"</c>, <c>"plan-executor"</c>) — the pipeline is one shared, scoped instance
+    /// reached from all three, so it cannot infer this from anything of its own; the caller knows
+    /// which of the three it is and must say so. Carried onto the audit record so a future auditor
+    /// can tell which raising sites implement execution reporting and which don't.
+    /// </param>
+    /// <remarks>
+    /// A no-op when <paramref name="admission"/> carries no <see cref="ToolCallAdmission.ApprovedCall"/>
+    /// — most calls need no human approval, and there is nothing to report a loop closing on.
+    /// Never throws: delegates to <see cref="IApprovalExecutionReporter"/>, whose own contract is
+    /// the same must-not-throw guarantee, for the same reason — this runs after the call already
+    /// completed.
+    /// </remarks>
+    ValueTask ReportExecutionAsync(
+        ToolCallAdmission admission, ToolExecutionReport report, string reportedBy, CancellationToken cancellationToken);
+
+    /// <summary>
     /// The turn's governance trace: every decision the chain's stages recorded, as one record.
     /// </summary>
     /// <remarks>
@@ -181,14 +207,15 @@ public sealed record ToolCallAdmissionRequest(
 /// </remarks>
 public sealed record ToolCallAdmission
 {
-    private static readonly ToolCallAdmission AllowedDecision = new(true, null, false);
-    private static readonly ToolCallAdmission AllowedRedactingDecision = new(true, null, true);
+    private static readonly ToolCallAdmission AllowedDecision = new(true, null, false, null);
+    private static readonly ToolCallAdmission AllowedRedactingDecision = new(true, null, true, null);
 
-    private ToolCallAdmission(bool isAllowed, string? deniedMessage, bool redactsOutput)
+    private ToolCallAdmission(bool isAllowed, string? deniedMessage, bool redactsOutput, ApprovedCall? approvedCall)
     {
         IsAllowed = isAllowed;
         DeniedMessage = deniedMessage;
         RedactsOutput = redactsOutput;
+        ApprovedCall = approvedCall;
     }
 
     /// <summary>Whether the call may proceed to the tool.</summary>
@@ -206,11 +233,31 @@ public sealed record ToolCallAdmission
     /// </summary>
     public bool RedactsOutput { get; }
 
+    /// <summary>
+    /// The approval that permitted this call, when a human approved it. Null on every other allow
+    /// and on every refusal. Set via <see cref="WithApproval"/>, never in the constructor directly,
+    /// so the two cached singletons below never need a variant for every approval.
+    /// </summary>
+    public ApprovedCall? ApprovedCall { get; private init; }
+
     /// <summary>The call may proceed and its output is returned as-is.</summary>
     public static ToolCallAdmission Allow() => AllowedDecision;
 
     /// <summary>The call may proceed, but its output must be scrubbed before it leaves.</summary>
     public static ToolCallAdmission AllowWithOutputRedaction() => AllowedRedactingDecision;
+
+    /// <summary>
+    /// Returns this allow, stamped with the human approval that permitted it. Preserves
+    /// <see cref="RedactsOutput"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">This admission is a refusal.</exception>
+    public ToolCallAdmission WithApproval(ApprovedCall call)
+    {
+        if (!IsAllowed)
+            throw new InvalidOperationException("Cannot attach an approval to a refused admission.");
+
+        return this with { ApprovedCall = call };
+    }
 
     /// <summary>The call is refused, carrying the caller-facing text.</summary>
     /// <param name="deniedMessage">
@@ -220,6 +267,12 @@ public sealed record ToolCallAdmission
     public static ToolCallAdmission Deny(string deniedMessage)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(deniedMessage);
-        return new ToolCallAdmission(false, deniedMessage, false);
+        return new ToolCallAdmission(false, deniedMessage, false, null);
     }
 }
+
+/// <summary>The execution outcome to report for a call the admission chain approved.</summary>
+public readonly record struct ToolExecutionReport(
+    EscalationExecutionStatus Status,
+    string? FailureReason,
+    EscalationNotExecutedReason? NotExecutedReason);

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Domain.AI.Governance;
 
 namespace Application.AI.Common.Interfaces.Governance;
@@ -39,7 +40,7 @@ public interface IToolInvocationGovernor
     /// <returns>
     /// An allow decision, or a deny decision carrying a model-facing message to return in place of
     /// the tool result. When enforcement is disabled the governor records the would-be decision but
-    /// always returns <see cref="ToolInvocationDecision.Allow"/>.
+    /// always returns <see cref="ToolInvocationDecision.Allow()"/>.
     /// </returns>
     /// <remarks>
     /// <paramref name="arguments"/> is optional so the callers that authorize by capability name
@@ -67,8 +68,18 @@ public sealed record ToolInvocationDecision(bool IsAllowed, string? DeniedMessag
     // immutable and indistinguishable between calls.
     private static readonly ToolInvocationDecision AllowedDecision = new(true);
 
+    /// <summary>
+    /// The approval that permitted this call, when it was routed for human approval. Null for an
+    /// allow that needed no approval — the common case, and why <see cref="Allow()"/> keeps
+    /// returning the cached singleton rather than allocating here too.
+    /// </summary>
+    public ApprovedCall? ApprovedCall { get; init; }
+
     /// <summary>An allow decision.</summary>
     public static ToolInvocationDecision Allow() => AllowedDecision;
+
+    /// <summary>An allow decision, stamped with the human approval that permitted it.</summary>
+    public static ToolInvocationDecision Allow(ApprovedCall call) => new(true) { ApprovedCall = call };
 
     /// <summary>A deny decision carrying the model-facing explanation.</summary>
     public static ToolInvocationDecision Deny(string deniedMessage) => new(false, deniedMessage);

--- a/src/Content/Application/Application.AI.Common/Services/Escalation/DefaultApprovalExecutionReporter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Escalation/DefaultApprovalExecutionReporter.cs
@@ -1,0 +1,100 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Escalation;
+
+/// <summary>Default <see cref="IApprovalExecutionReporter"/>: audits, notifies, then updates failure memory.</summary>
+/// <remarks>
+/// <strong>Ordering is deliberate and load-bearing.</strong> Audit before notify, so a
+/// notification-channel outage never produces an approver-visible report with no audit line
+/// behind it. Failure memory last, so a failed audit write never leaves memory claiming an
+/// attempt the audit trail cannot corroborate.
+/// <para>
+/// Every step runs inside one try/catch per this type's own must-not-throw contract (see
+/// <see cref="IApprovalExecutionReporter"/>). The reachable exception set spans a file-backed
+/// hash-chain writer and four notification channels — not enumerable here, same reasoning as
+/// <c>EscalationToolApprovalRouter.Render</c>'s catch-all.
+/// </para>
+/// </remarks>
+public sealed class DefaultApprovalExecutionReporter : IApprovalExecutionReporter
+{
+    private readonly IEscalationAuditStore _auditStore;
+    private readonly IEscalationNotifier _notifier;
+    private readonly IApprovalFailureMemory _failureMemory;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<DefaultApprovalExecutionReporter> _logger;
+
+    /// <summary>Creates the reporter.</summary>
+    public DefaultApprovalExecutionReporter(
+        IEscalationAuditStore auditStore,
+        IEscalationNotifier notifier,
+        IApprovalFailureMemory failureMemory,
+        TimeProvider timeProvider,
+        ILogger<DefaultApprovalExecutionReporter> logger)
+    {
+        _auditStore = auditStore;
+        _notifier = notifier;
+        _failureMemory = failureMemory;
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ReportSucceededAsync(ApprovedCall call, string reportedBy, CancellationToken ct) =>
+        ReportAsync(
+            call,
+            () => EscalationExecutionRecord.Succeeded(call.EscalationId, _timeProvider.GetUtcNow(), reportedBy),
+            onRecorded: () => _failureMemory.Clear(call.Key),
+            ct);
+
+    /// <inheritdoc />
+    public ValueTask ReportFailedAsync(ApprovedCall call, string failureReason, string reportedBy, CancellationToken ct) =>
+        ReportAsync(
+            call,
+            () => EscalationExecutionRecord.Failed(call.EscalationId, failureReason, _timeProvider.GetUtcNow(), reportedBy),
+            onRecorded: () => _failureMemory.RecordFailure(call.Key, failureReason, call.EscalationId),
+            ct);
+
+    /// <inheritdoc />
+    public ValueTask ReportNotExecutedAsync(
+        ApprovedCall call, EscalationNotExecutedReason reason, string reportedBy, CancellationToken ct) =>
+        ReportAsync(
+            call,
+            () => EscalationExecutionRecord.NeverExecuted(call.EscalationId, reason, _timeProvider.GetUtcNow(), reportedBy),
+            // Nothing ran, so there is no new failure to cite and the prior sequence (if any) is
+            // still live — neither cleared nor recorded as a further failure.
+            onRecorded: null,
+            ct);
+
+    /// <summary>
+    /// Builds and reports the record. <paramref name="buildRecord"/> is a factory rather than an
+    /// already-built record so a caller-supplied bad value (a blank failure reason) throws
+    /// <em>inside</em> this method's try/catch rather than while the caller is still evaluating
+    /// arguments — the whole point of this type is that nothing it does escapes as an exception.
+    /// </summary>
+    private async ValueTask ReportAsync(
+        ApprovedCall call, Func<EscalationExecutionRecord> buildRecord, Action? onRecorded, CancellationToken ct)
+    {
+        try
+        {
+            var record = buildRecord();
+            await _auditStore.RecordExecutionAsync(record, ct).ConfigureAwait(false);
+            await _notifier.NotifyExecutionReportedAsync(record, ct).ConfigureAwait(false);
+            onRecorded?.Invoke();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            _logger.LogInformation(
+                "Execution report for escalation {EscalationId} was cancelled with the turn.",
+                call.EscalationId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to report execution result for escalation {EscalationId} — the approver may " +
+                "never learn what this approved action did.",
+                call.EscalationId);
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Escalation/InProcessApprovalFailureMemory.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Escalation/InProcessApprovalFailureMemory.cs
@@ -1,0 +1,146 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Escalation;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Escalation;
+
+/// <summary>
+/// Thread-safe singleton implementation of <see cref="IApprovalFailureMemory"/>. Follows the same
+/// bounded-LRU shape as <c>InProcessConversationBudgetTracker</c>.
+/// </summary>
+/// <remarks>
+/// <strong>Cap is 2,000, not the 64 a single-user editor extension would use.</strong> This is a
+/// singleton in a multi-tenant server process, not a per-user client — the property that makes
+/// this feature useful (the interceptor outliving any one conversation) is exactly why a small
+/// cap is wrong here: on a host with 100 concurrent conversations, a 64-entry LRU would evict a
+/// conversation's memory within seconds and the feature would silently stop working with no
+/// signal beyond an eviction warning nobody expected to need. 2,000 entries of a few short strings,
+/// an int, and a Guid is a few hundred KB — cheap insurance against exactly that.
+/// </remarks>
+public sealed class InProcessApprovalFailureMemory : IApprovalFailureMemory
+{
+    /// <summary>Maximum number of keys tracked before least-recently-used eviction kicks in.</summary>
+    internal const int MaxTrackedActions = 2_000;
+
+    private readonly ConcurrentDictionary<ApprovalFailureKey, Entry> _entries = new();
+    private readonly object _evictionLock = new();
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<InProcessApprovalFailureMemory> _logger;
+
+    /// <summary>Creates the memory.</summary>
+    /// <param name="timeProvider">Supplies the access timestamps that drive LRU eviction.</param>
+    /// <param name="logger">Receives eviction warnings.</param>
+    public InProcessApprovalFailureMemory(TimeProvider timeProvider, ILogger<InProcessApprovalFailureMemory> logger)
+    {
+        _timeProvider = timeProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public ApprovalFailureRecall? TryRecall(in ApprovalFailureKey key)
+    {
+        if (!_entries.TryGetValue(key, out var entry))
+            return null;
+
+        entry.LastAccessTicks = _timeProvider.GetUtcNow().UtcTicks;
+        var (attemptCount, failureReason, escalationId) = entry.Snapshot();
+        return new ApprovalFailureRecall(attemptCount, failureReason, escalationId);
+    }
+
+    /// <inheritdoc />
+    public void RecordFailure(in ApprovalFailureKey key, string failureReason, Guid escalationId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(failureReason);
+
+        var now = _timeProvider.GetUtcNow().UtcTicks;
+        // Stamp the access time at creation so a brand-new entry is never rank-0 (oldest) for a
+        // concurrent eviction running before this thread updates the timestamp.
+        var entry = _entries.GetOrAdd(key, _ => new Entry { LastAccessTicks = now });
+        entry.RecordFailure(failureReason, escalationId);
+        entry.LastAccessTicks = now;
+        // Deliberately not folded into the entry's own lock: LastAccessTicks is a pure ranking
+        // signal, and two concurrent writers each stamping "now" in whichever order is a benign
+        // race (LRU eviction only needs an approximate ordering, not one serialized with the
+        // attempt data below).
+
+        EvictIfOverCapacity();
+    }
+
+    /// <inheritdoc />
+    public void Clear(in ApprovalFailureKey key) => _entries.TryRemove(key, out _);
+
+    /// <summary>
+    /// When the entry count exceeds the cap, evicts the least-recently-touched entries back down to
+    /// ~90% of the cap in a single guarded pass, so concurrent writers don't each scan.
+    /// </summary>
+    private void EvictIfOverCapacity()
+    {
+        if (_entries.Count <= MaxTrackedActions)
+            return;
+
+        lock (_evictionLock)
+        {
+            if (_entries.Count <= MaxTrackedActions)
+                return;
+
+            var target = (int)(MaxTrackedActions * 0.9);
+            var toRemove = _entries.Count - target;
+
+            var oldest = _entries
+                .OrderBy(kvp => kvp.Value.LastAccessTicks)
+                .Take(toRemove)
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var key in oldest)
+                _entries.TryRemove(key, out _);
+
+            _logger.LogWarning(
+                "Approval failure memory evicted {Count} least-recently-used entries (cap {Cap})",
+                oldest.Count, MaxTrackedActions);
+        }
+    }
+
+    /// <summary>One key's recorded failure. <see cref="LastAccessTicks"/> drives LRU eviction.</summary>
+    private sealed class Entry
+    {
+        // Guards AttemptCount/FailureReason/EscalationId as one unit — Snapshot() must never
+        // return a mix of one RecordFailure call's count with another's reason or id, and Guid
+        // is larger than a machine word so a lock-free write of it is not atomic on any runtime.
+        // A per-entry lock is cheap here: this path is touched only when a human-approved call
+        // fails, never on the hot tool-call path.
+        private readonly object _gate = new();
+        private long _lastAccessTicks;
+        private int _attemptCount;
+        private string _failureReason = string.Empty;
+        private Guid _escalationId;
+
+        /// <summary>
+        /// Last access time in UTC ticks. Read/written via <see cref="Volatile"/>, independently of
+        /// <see cref="_gate"/> — it is a pure LRU ranking signal, and eviction only needs an
+        /// approximate ordering, not one serialized with the attempt data <see cref="_gate"/> guards.
+        /// </summary>
+        public long LastAccessTicks
+        {
+            get => Volatile.Read(ref _lastAccessTicks);
+            set => Volatile.Write(ref _lastAccessTicks, value);
+        }
+
+        /// <summary>A coherent snapshot of the attempt count, failure reason, and escalation id together.</summary>
+        public (int AttemptCount, string FailureReason, Guid EscalationId) Snapshot()
+        {
+            lock (_gate)
+                return (_attemptCount, _failureReason, _escalationId);
+        }
+
+        public void RecordFailure(string failureReason, Guid escalationId)
+        {
+            lock (_gate)
+            {
+                _attemptCount++;
+                _failureReason = failureReason;
+                _escalationId = escalationId;
+            }
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Domain.Common.Helpers;
@@ -40,6 +41,8 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
     private readonly IEscalationService _escalationService;
     private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
+    private readonly IAgentExecutionContext _executionContext;
+    private readonly IApprovalFailureMemory _failureMemory;
     private readonly ILogger<EscalationToolApprovalRouter> _logger;
 
     // A misconfigured roster is a standing condition, not a per-call event. Warning once keeps the
@@ -56,16 +59,22 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
         IEscalationService escalationService,
         ICompositeResponseSanitizer sanitizer,
         IOptionsMonitor<GovernanceConfig> governanceConfig,
+        IAgentExecutionContext executionContext,
+        IApprovalFailureMemory failureMemory,
         ILogger<EscalationToolApprovalRouter> logger)
     {
         ArgumentNullException.ThrowIfNull(escalationService);
         ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(governanceConfig);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(failureMemory);
         ArgumentNullException.ThrowIfNull(logger);
 
         _escalationService = escalationService;
         _sanitizer = sanitizer;
         _governanceConfig = governanceConfig;
+        _executionContext = executionContext;
+        _failureMemory = failureMemory;
         _logger = logger;
     }
 
@@ -132,6 +141,13 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
             return ToolApprovalResult.NotRouted("no approvers configured");
         }
 
+        // Computed once and reused for both the recall (below) and the clear-on-explicit-denial
+        // (in Interpret) — the two must agree on identity, or a retry could recall under one key
+        // and clear under another. Null when the turn has no known conversation (e.g. a
+        // console-hosted run with no durable identity); attempt attribution then simply
+        // degrades to "always attempt 1", the same behaviour as before this feature existed.
+        var failureKey = ApprovalFailureKey.TryCreate(_executionContext.ConversationId, agentId, toolName);
+
         EscalationRequest request;
         try
         {
@@ -140,7 +156,7 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
             // the JSON writer's depth limit, and a host sanitizer may throw for its own reasons. The
             // class promises to fail closed at every exit; leaving construction outside the try made
             // that promise false for exactly the inputs an adversarial turn would choose.
-            request = BuildRequest(agentId, toolName, reason, radius, arguments, governance, roster);
+            request = BuildRequest(agentId, toolName, reason, radius, arguments, governance, roster, failureKey);
         }
         catch (Exception ex)
         {
@@ -155,7 +171,7 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
                 .RequestEscalationAsync(request, cancellationToken)
                 .ConfigureAwait(false);
 
-            return Interpret(outcome, toolName, request.EscalationId);
+            return Interpret(outcome, toolName, request.EscalationId, failureKey);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -184,7 +200,8 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
         BlastRadius radius,
         IReadOnlyDictionary<string, object?>? arguments,
         GovernanceConfig governance,
-        IReadOnlyList<string> roster)
+        IReadOnlyList<string> roster,
+        ApprovalFailureKey? failureKey)
     {
         var approval = governance.ToolApproval;
         var escalation = governance.Escalation;
@@ -194,6 +211,12 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
         var priority = radius >= ParseCriticalThreshold(approval.CriticalAtBlastRadius)
             ? EscalationPriority.Critical
             : EscalationPriority.Blocking;
+
+        // #325 retry attribution: recall a prior failed attempt at this exact (conversation, agent,
+        // tool) so the next approver sees "this failed last time, here's why" instead of asking the
+        // same question cold. No recall — no known conversation, first attempt, or an LRU eviction —
+        // leaves the request at its record defaults (attempt 1, no prior failure).
+        var recall = failureKey is { } key ? _failureMemory.TryRecall(key) : null;
 
         return new EscalationRequest
         {
@@ -209,11 +232,28 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
             Approvers = [.. roster],
             TimeoutSeconds = approval.TimeoutSeconds ?? escalation.DefaultTimeoutSeconds,
             TimeoutAction = TimeoutAction,
-            RequestedAt = DateTimeOffset.UtcNow
+            RequestedAt = DateTimeOffset.UtcNow,
+            AttemptNumber = recall is { } r ? r.PriorAttemptCount + 1 : 1,
+            PriorFailureReason = recall is { } r2
+                ? TruncatePriorFailureReason(r2.FailureReason, escalation.RetryAttribution.MaxPriorFailureLength)
+                : null,
+            PredecessorEscalationId = recall?.EscalationId
         };
     }
 
-    private ToolApprovalResult Interpret(EscalationOutcome outcome, string toolName, Guid escalationId)
+    /// <summary>
+    /// Interprets an escalation outcome as a routed result, and — for an explicit human denial only
+    /// — clears the retry-attribution memory for this action.
+    /// </summary>
+    /// <remarks>
+    /// Cleared on <see cref="EscalationResolutionType.Denied"/> alone, never on
+    /// <see cref="EscalationResolutionType.TimedOut"/> or <see cref="EscalationResolutionType.Escalated"/>.
+    /// "The reviewer ended this line of retries" presupposes a reviewer actually looked; a timeout
+    /// means nobody did, and erasing the context the next approver needs on a mere timeout would
+    /// invert the feature this memory exists for.
+    /// </remarks>
+    private ToolApprovalResult Interpret(
+        EscalationOutcome outcome, string toolName, Guid escalationId, ApprovalFailureKey? failureKey)
     {
         if (outcome.IsApproved)
         {
@@ -243,7 +283,35 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
             _ => "an approver refused the call"
         };
 
+        if (outcome.ResolutionType == EscalationResolutionType.Denied && failureKey is { } key)
+            _failureMemory.Clear(key);
+
         return ToolApprovalResult.Denied(why, escalationId);
+    }
+
+    /// <summary>
+    /// Truncates a recalled failure reason to the configured display bound, defensively re-clamped
+    /// to always stay under <see cref="EscalationRequestInvariants.MaxPriorFailureReasonLength"/>
+    /// even including the truncation suffix.
+    /// </summary>
+    /// <remarks>
+    /// The soft cap is operator config (<c>EscalationConfig.RetryAttribution.MaxPriorFailureLength</c>,
+    /// default 512) and the hard cap is the invariant (4096). <c>GovernanceConfigValidator</c> ties
+    /// the two together at boot so they cannot be configured into disagreement — but this clamp does
+    /// not trust that validator to have run: a misconfigured soft cap above the hard cap must
+    /// degrade to a shorter card, never to a request that fails <see cref="EscalationRequestInvariants"/>
+    /// and gets fail-closed at the top of <see cref="RequestApprovalAsync"/> for reasons an operator
+    /// would have no way to connect to this setting.
+    /// </remarks>
+    private static string TruncatePriorFailureReason(string reason, int configuredMaxLength)
+    {
+        const string suffix = "… (truncated)";
+        var cap = Math.Clamp(
+            configuredMaxLength, 1, EscalationRequestInvariants.MaxPriorFailureReasonLength - suffix.Length);
+
+        return reason.Length > cap
+            ? string.Concat(reason.AsSpan(0, cap), suffix)
+            : reason;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
 using System.Text.Json;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Microsoft.Extensions.Logging;
 
@@ -49,6 +51,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     private readonly IToolCallObserverChain _observers;
     private readonly IProgressEvaluator _progressEvaluator;
     private readonly IGovernanceTraceRecorder _trace;
+    private readonly IApprovalExecutionReporter _executionReporter;
     private readonly ILogger<ToolCallAdmissionPipeline> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="ToolCallAdmissionPipeline"/> class.</summary>
@@ -69,6 +72,9 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// </param>
     /// <param name="progressEvaluator">Stage 5 — the loop guard.</param>
     /// <param name="trace">The turn's governance trail, which the stages write to and this type snapshots.</param>
+    /// <param name="executionReporter">
+    /// Closes the approval loop for a call this pipeline approved — see <see cref="ReportExecutionAsync"/>.
+    /// </param>
     /// <param name="logger">Records a redaction that could not be applied.</param>
     public ToolCallAdmissionPipeline(
         IAgentToolAuthorizationGate authorizationGate,
@@ -77,6 +83,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         IToolCallObserverChain observers,
         IProgressEvaluator progressEvaluator,
         IGovernanceTraceRecorder trace,
+        IApprovalExecutionReporter executionReporter,
         ILogger<ToolCallAdmissionPipeline> logger)
     {
         ArgumentNullException.ThrowIfNull(authorizationGate);
@@ -85,6 +92,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         ArgumentNullException.ThrowIfNull(observers);
         ArgumentNullException.ThrowIfNull(progressEvaluator);
         ArgumentNullException.ThrowIfNull(trace);
+        ArgumentNullException.ThrowIfNull(executionReporter);
         ArgumentNullException.ThrowIfNull(logger);
 
         _authorizationGate = authorizationGate;
@@ -93,6 +101,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         _observers = observers;
         _progressEvaluator = progressEvaluator;
         _trace = trace;
+        _executionReporter = executionReporter;
         _logger = logger;
     }
 
@@ -185,9 +194,15 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 return Refuse(verdict.HaltMessage, toolName);
         }
 
-        return classification.Outcome == ClassificationGateOutcome.RedactOutput
+        var admission = classification.Outcome == ClassificationGateOutcome.RedactOutput
             ? ToolCallAdmission.AllowWithOutputRedaction()
             : ToolCallAdmission.Allow();
+
+        // Stamp the approval that permitted this call, when there was one, so the caller can
+        // close the loop on it after the tool runs. An approval only ever loosens THIS gate — a
+        // later gate above still refused the call outright above, so a call that reaches here
+        // with an approval genuinely proceeded because a human said yes.
+        return decision.ApprovedCall is { } call ? admission.WithApproval(call) : admission;
     }
 
     /// <inheritdoc />
@@ -231,6 +246,35 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
 
         result = null;
         return false;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ReportExecutionAsync(
+        ToolCallAdmission admission, ToolExecutionReport report, string reportedBy, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(admission);
+
+        // Not validated eagerly with a throw: this method's own contract is "never throws" (see
+        // the interface doc), matching the must-not-throw guarantee of everything it delegates
+        // to. A blank reportedBy from a broken caller is a caller bug — EscalationExecutionRecord's
+        // factories still reject it, but inside DefaultApprovalExecutionReporter's own try/catch,
+        // where it is logged rather than thrown, consistent with every other failure on this path.
+        if (admission.ApprovedCall is not { } call)
+            return ValueTask.CompletedTask;
+
+        return report switch
+        {
+            { Status: EscalationExecutionStatus.Succeeded } =>
+                _executionReporter.ReportSucceededAsync(call, reportedBy, cancellationToken),
+            { Status: EscalationExecutionStatus.Failed, FailureReason: { } reason } =>
+                _executionReporter.ReportFailedAsync(call, reason, reportedBy, cancellationToken),
+            { Status: EscalationExecutionStatus.NeverExecuted, NotExecutedReason: { } notExecuted } =>
+                _executionReporter.ReportNotExecutedAsync(call, notExecuted, reportedBy, cancellationToken),
+            // An incoherent report (Failed with no reason, NeverExecuted with no reason) is a
+            // caller bug, not something to guess at or throw over — this is the one place in the
+            // execution-reporting path with no must-not-throw contract protecting it yet.
+            _ => ValueTask.CompletedTask
+        };
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.Approval.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.Approval.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Governance;
@@ -29,9 +30,15 @@ public sealed partial class ToolInvocationGovernor
     /// call site.
     /// </param>
     /// <param name="Reason">Approver attribution, carried onto the final trace record.</param>
+    /// <param name="Call">
+    /// The approval, for execution reporting, when the call was approved by a routed escalation
+    /// with a known conversation. Null on a block, and null on an approval this governor cannot
+    /// attribute to a conversation.
+    /// </param>
     private readonly record struct ApprovalGate(
         ToolInvocationDecision? Block,
-        string Reason);
+        string Reason,
+        ApprovedCall? Call = null);
 
     /// <summary>
     /// Puts an approval-required verdict to a human and reports whether they allowed it.
@@ -58,7 +65,7 @@ public sealed partial class ToolInvocationGovernor
             .ConfigureAwait(false);
 
         if (approval.Outcome == ToolApprovalOutcome.Approved)
-            return new ApprovalGate(Block: null, approval.Reason);
+            return new ApprovalGate(Block: null, approval.Reason, BuildApprovedCall(agentId, toolName, approval));
 
         // Not approved. Count it against the agent exactly as an unrouted approval verdict always
         // has, so repeated attempts at a tool nobody will approve still trip the denial tracker.
@@ -68,5 +75,25 @@ public sealed partial class ToolInvocationGovernor
             requiredApproval: true, agentId);
 
         return new ApprovalGate(block, approval.Reason);
+    }
+
+    /// <summary>
+    /// Builds the execution-reporting handle for an approved call, or null when it cannot be
+    /// attributed to a conversation.
+    /// </summary>
+    /// <remarks>
+    /// A defensive check on <see cref="ToolApprovalResult.EscalationId"/>, not a null-forgiving
+    /// <c>!</c> — <see cref="ApprovalGate"/>'s own doc explains why that matters here: an approval
+    /// this governor cannot attribute must degrade to no execution report, not throw.
+    /// </remarks>
+    private ApprovedCall? BuildApprovedCall(string agentId, string toolName, ToolApprovalResult approval)
+    {
+        if (approval.EscalationId is not { } escalationId)
+            return null;
+
+        if (ApprovalFailureKey.TryCreate(_executionContext.ConversationId, agentId, toolName) is not { } key)
+            return null;
+
+        return new ApprovedCall(escalationId, key);
     }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Sandbox;
@@ -335,6 +336,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
 
         // Nothing deterministic refuses this call. If any gate wants a human, this is the moment.
         string? approvedBy = null;
+        ApprovedCall? approvedCall = null;
         if (approvalReasons is not null)
         {
             var gate = await RequestApprovalAsync(agentId, toolName,
@@ -345,6 +347,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
                 return block;
 
             approvedBy = gate.Reason;
+            approvedCall = gate.Call;
         }
 
         _trace.Record(new ToolDecisionRecord(toolName, ToolDecisionOutcome.Allowed,
@@ -357,7 +360,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         if (governance.EnableAudit)
             _auditService.Log(agentId, toolName, ToolDecisionOutcome.Allowed.ToString());
 
-        return ToolInvocationDecision.Allow();
+        return approvedCall is { } call ? ToolInvocationDecision.Allow(call) : ToolInvocationDecision.Allow();
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ApprovalExecutionReporting.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ApprovalExecutionReporting.cs
@@ -1,0 +1,32 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Escalation;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// The one "the call threw before it could report its own outcome" shape shared by every governed
+/// tool-execution surface that closes the #325 approval loop on a catch-and-rethrow path.
+/// </summary>
+/// <remarks>
+/// Extracted because <see cref="DirectToolInvoker"/> and <see cref="GovernedAIFunction"/> each
+/// independently arrived at the identical shape — literal reason string included — for the one
+/// outcome neither can describe more specifically: the call started, threw, and neither the tool
+/// result shape nor a caught exception says anything more useful than "it didn't finish."
+/// </remarks>
+internal static class ApprovalExecutionReporting
+{
+    /// <summary>The reason text reported when a tool call throws before it can report its own outcome.</summary>
+    internal const string CallDidNotComplete = "the tool call did not complete";
+
+    /// <summary>
+    /// Reports the call Failed with <see cref="CallDidNotComplete"/>, on
+    /// <see cref="CancellationToken.None"/> so the report cannot itself be why an approver never
+    /// learns the call failed. Callers use this immediately before rethrowing — it never throws.
+    /// </summary>
+    internal static ValueTask ReportCallDidNotCompleteAsync(
+        IToolCallAdmissionPipeline pipeline, ToolCallAdmission admission, string reportedBy) =>
+        pipeline.ReportExecutionAsync(
+            admission,
+            new ToolExecutionReport(EscalationExecutionStatus.Failed, CallDidNotComplete, null),
+            reportedBy, CancellationToken.None);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -3,7 +3,9 @@ using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Escalation;
 using Domain.AI.Governance;
+using Domain.AI.Models;
 using Domain.Common.Config.AI.DirectToolInvocation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -131,8 +133,19 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         {
             // Identity and envelope. Both must be in place before AuthorizeAsync — see the type
             // remarks for what the governor reads, and when.
+            //
+            // The conversation id is deliberately NOT agentId. #325's retry-attribution memory is
+            // keyed on (conversation, agent, tool) precisely so it expires — but agentId here is
+            // the caller's stable synthetic identity, reused for every direct invocation that
+            // caller ever makes. Passing it as the conversation id too would give the failure-memory
+            // key no expiry at all: two calls to the same tool by the same caller, hours apart and
+            // sharing nothing else, would be mislabeled as the same retry sequence forever. A direct
+            // invocation is a single, standalone call with no request-level session concept to key
+            // on, so each one mints its own one-shot id — TryRecall can then never find a match for
+            // it, which is the correct behaviour (retry attribution genuinely does not apply here),
+            // achieved without a special case rather than through an accidental permanent one.
             var executionContext = scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
-            executionContext.Initialize(agentId, agentId, turnNumber: 1);
+            executionContext.Initialize(agentId, conversationId: Guid.NewGuid().ToString(), turnNumber: 1);
 
             // Required, not GetService: the chain is registered unconditionally, and an absent one is
             // indistinguishable at runtime from a host whose gates all happen to be off — so tolerating
@@ -234,13 +247,53 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
             return Refused(DirectToolInvocationStatus.NotFound, DirectToolInvocationErrors.NoSuchTool, sw);
         }
 
-        var result = await tool
-            .ExecuteAsync(armed.Request.Operation, armed.Request.Parameters, deadline.Token)
+        ToolResult result;
+        try
+        {
+            result = await tool
+                .ExecuteAsync(armed.Request.Operation, armed.Request.Parameters, deadline.Token)
+                .ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Reported before rethrowing so the deadline/cancellation/fault handling in
+            // RunArmedAsync is unchanged — this only adds the approval-loop close, never
+            // replaces the caller-facing outcome.
+            await ApprovalExecutionReporting
+                .ReportCallDidNotCompleteAsync(armed.AdmissionPipeline, admission, ReportedBy)
+                .ConfigureAwait(false);
+            throw;
+        }
+
+        await ReportExecutionAsync(
+            armed.AdmissionPipeline, admission,
+            result.Success
+                ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
+                : new ToolExecutionReport(
+                    EscalationExecutionStatus.Failed,
+                    result.Error ?? "the tool reported failure with no message", null))
             .ConfigureAwait(false);
 
         sw.Stop();
         return Shape(result, armed, admission, sw.Elapsed);
     }
+
+    /// <summary>
+    /// Closes the approval loop for this call, when it was one a human approved.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately reported on <see cref="CancellationToken.None"/>, not the deadline or caller
+    /// token — both are typically already fired by the time this runs (a fault means the deadline
+    /// elapsed, or the caller went away), and a report cancelled by the same token that caused the
+    /// failure would silently drop exactly the report that failure needs to reach the approver.
+    /// <see cref="IToolCallAdmissionPipeline.ReportExecutionAsync"/> never throws — see its own
+    /// must-not-throw contract — so this is not itself a new fault surface.
+    /// </remarks>
+    private const string ReportedBy = "direct-invocation";
+
+    private static ValueTask ReportExecutionAsync(
+        IToolCallAdmissionPipeline pipeline, ToolCallAdmission admission, ToolExecutionReport report) =>
+        pipeline.ReportExecutionAsync(admission, report, ReportedBy, CancellationToken.None);
 
     /// <summary>
     /// Builds a refusal and stops the clock. This method owns stopping it, so callers must not — a

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Escalation;
 using Microsoft.Extensions.AI;
 
 namespace Application.AI.Common.Services.Tools;
@@ -31,6 +32,8 @@ namespace Application.AI.Common.Services.Tools;
 /// </remarks>
 internal sealed class GovernedAIFunction : DelegatingAIFunction
 {
+    private const string ReportedBy = "agent-turn";
+
     public GovernedAIFunction(AIFunction innerFunction)
         : base(innerFunction)
     {
@@ -53,7 +56,31 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
         if (!admission.IsAllowed)
             return admission.DeniedMessage;
 
-        var result = await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false);
+        object? result;
+        try
+        {
+            result = await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            await ApprovalExecutionReporting
+                .ReportCallDidNotCompleteAsync(admissionPipeline, admission, ReportedBy)
+                .ConfigureAwait(false);
+            throw;
+        }
+
+        // A no-throw return is reported Succeeded. This is an imprecise signal for an ITool-backed
+        // function specifically: the generic converter (AIToolConverter) flattens ToolResult.Fail
+        // into a returned "Error: ..." string rather than throwing, which this layer cannot tell
+        // apart from a genuinely successful string result — it has no structured ToolResult to
+        // inspect, only whatever object the wrapped AIFunction returns, and that wrapped function is
+        // just as often MCP- or skill-provided as ITool-backed. Fixing that precisely would mean
+        // changing what every tool converter returns on failure, which is out of scope for wiring an
+        // existing report call into this path. Documented as a known limitation rather than guessed at.
+        await admissionPipeline.ReportExecutionAsync(
+            admission,
+            new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null),
+            ReportedBy, CancellationToken.None).ConfigureAwait(false);
 
         return admissionPipeline.ApplyOutputPolicy(admission, Name, result);
     }

--- a/src/Content/Application/Application.Core/CQRS/Escalation/EscalationSummary.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/EscalationSummary.cs
@@ -53,6 +53,27 @@ public sealed record EscalationSummary
     /// <summary>Action the service takes if the escalation times out undecided.</summary>
     public required EscalationTimeoutAction TimeoutAction { get; init; }
 
+    /// <summary>
+    /// 1 for a first attempt; N for the Nth time this exact (conversation, agent, tool) action has
+    /// been asked, per <c>EscalationRequest.AttemptNumber</c>. The retry-attribution card (#325)
+    /// this and the two fields below carry only renders when this is greater than 1 — an approver
+    /// reading a first attempt sees nothing different from before this feature existed.
+    /// </summary>
+    public required int AttemptNumber { get; init; }
+
+    /// <summary>
+    /// Why the prior attempt at this action failed, truncated to
+    /// <c>EscalationConfig.RetryAttribution.MaxPriorFailureLength</c>. Null on a first attempt or
+    /// when the failure memory that would have supplied it was evicted or never recorded.
+    /// </summary>
+    public string? PriorFailureReason { get; init; }
+
+    /// <summary>
+    /// The escalation that approved the prior attempt this one retries, letting an approver open
+    /// the earlier record for full context. Null on a first attempt.
+    /// </summary>
+    public Guid? PredecessorEscalationId { get; init; }
+
     /// <summary>Projects a domain <see cref="EscalationRequest"/> to the wire-safe shape.</summary>
     /// <param name="request">The pending escalation request to project. Must not be null.</param>
     public static EscalationSummary FromRequest(EscalationRequest request)
@@ -72,7 +93,10 @@ public sealed record EscalationSummary
             Approvers = request.Approvers,
             RequestedAt = request.RequestedAt,
             TimeoutSeconds = request.TimeoutSeconds,
-            TimeoutAction = request.TimeoutAction
+            TimeoutAction = request.TimeoutAction,
+            AttemptNumber = request.AttemptNumber,
+            PriorFailureReason = request.PriorFailureReason,
+            PredecessorEscalationId = request.PredecessorEscalationId
         };
     }
 }

--- a/src/Content/Application/Application.Core/Validation/EscalationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/EscalationConfigValidator.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Domain.AI.Escalation;
 using Domain.Common.Config.AI.Governance;
 using FluentValidation;
@@ -95,6 +96,20 @@ public sealed class EscalationConfigValidator : AbstractValidator<EscalationConf
                 "Critical escalation must never auto-approve on timeout. Change DefaultTimeoutAction " +
                 "or remove the Critical entry.")
             .WithName("DefaultTimeoutAction");
+
+        // Ties the #325 retry-attribution card's soft, operator-configured display cap to
+        // EscalationRequestInvariants' hard runtime ceiling, so the two can never disagree. A soft
+        // cap above the hard ceiling is not a display-only mistake: EscalationToolApprovalRouter
+        // truncates defensively to the hard ceiling regardless (see
+        // EscalationToolApprovalRouter.TruncatePriorFailureReason), so the practical effect of a
+        // misconfigured value here is a silently shorter card, not a broken one — but it is still a
+        // configuration error worth surfacing at boot rather than masking behind that fallback.
+        RuleFor(x => x.RetryAttribution.MaxPriorFailureLength)
+            .InclusiveBetween(1, EscalationRequestInvariants.MaxPriorFailureReasonLength)
+            .WithMessage(
+                "RetryAttribution.MaxPriorFailureLength must be between 1 and " +
+                $"{EscalationRequestInvariants.MaxPriorFailureReasonLength} — " +
+                "EscalationRequestInvariants' hard ceiling on EscalationRequest.PriorFailureReason.");
     }
 
     private static bool CriticalPriorityAutoApprovesOnTimeout(EscalationConfig config) =>

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationAuditRecord.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationAuditRecord.cs
@@ -26,6 +26,7 @@ public sealed record EscalationAuditRecord
     /// <item><see cref="EscalationAuditRecordType.Request"/> → <see cref="EscalationRequest"/></item>
     /// <item><see cref="EscalationAuditRecordType.Decision"/> → <see cref="ApproverDecision"/></item>
     /// <item><see cref="EscalationAuditRecordType.Outcome"/> → <see cref="EscalationOutcome"/></item>
+    /// <item><see cref="EscalationAuditRecordType.Execution"/> → <see cref="EscalationExecutionRecord"/></item>
     /// </list>
     /// </remarks>
     public required string Payload { get; init; }

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationAuditRecordType.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationAuditRecordType.cs
@@ -11,5 +11,7 @@ public enum EscalationAuditRecordType
     /// <summary>An approver submitted a decision.</summary>
     Decision,
     /// <summary>The escalation was resolved (approved, denied, timed out, or escalated).</summary>
-    Outcome
+    Outcome,
+    /// <summary>An approved action's execution result was reported: succeeded, failed, or never ran.</summary>
+    Execution
 }

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationExecutionRecord.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationExecutionRecord.cs
@@ -1,0 +1,95 @@
+namespace Domain.AI.Escalation;
+
+/// <summary>
+/// What happened when an approved escalation's action was actually carried out — the record
+/// pushed to the approver so a failed action and a completed one no longer look identical.
+/// </summary>
+/// <remarks>
+/// Constructible only through the factories below, mirroring
+/// <c>Application.AI.Common.Interfaces.Governance.ToolCallAdmission</c>: a <see cref="Failed"/>
+/// record with a blank <see cref="FailureReason"/> would read to an approver as "no reason
+/// given", which is indistinguishable from success, so the shape that could produce one is kept
+/// unreachable rather than defended against at every reader.
+/// </remarks>
+public sealed record EscalationExecutionRecord
+{
+    private EscalationExecutionRecord(
+        Guid escalationId,
+        EscalationExecutionStatus status,
+        string? failureReason,
+        EscalationNotExecutedReason? notExecutedReason,
+        DateTimeOffset reportedAt,
+        string reportedBy)
+    {
+        EscalationId = escalationId;
+        Status = status;
+        FailureReason = failureReason;
+        NotExecutedReason = notExecutedReason;
+        ReportedAt = reportedAt;
+        ReportedBy = reportedBy;
+    }
+
+    /// <summary>Correlates back to the originating escalation.</summary>
+    public Guid EscalationId { get; }
+
+    /// <summary>Whether the action succeeded, failed, or never ran.</summary>
+    public EscalationExecutionStatus Status { get; }
+
+    /// <summary>
+    /// Why the action failed. Non-null if and only if <see cref="Status"/> is
+    /// <see cref="EscalationExecutionStatus.Failed"/>.
+    /// </summary>
+    public string? FailureReason { get; }
+
+    /// <summary>
+    /// Why the action never ran. Non-null if and only if <see cref="Status"/> is
+    /// <see cref="EscalationExecutionStatus.NeverExecuted"/>.
+    /// </summary>
+    public EscalationNotExecutedReason? NotExecutedReason { get; }
+
+    /// <summary>When this record was produced.</summary>
+    public DateTimeOffset ReportedAt { get; }
+
+    /// <summary>
+    /// A stable identifier for the site that produced this record (<c>"direct-invocation"</c>,
+    /// <c>"agent-turn"</c>, or <c>"plan-executor"</c>). Never blank — this is what makes "nobody
+    /// reported" distinguishable from "this site reported" when auditing which raising sites
+    /// implement execution reporting.
+    /// </summary>
+    public string ReportedBy { get; }
+
+    /// <summary>The action ran and completed successfully.</summary>
+    public static EscalationExecutionRecord Succeeded(
+        Guid escalationId, DateTimeOffset reportedAt, string reportedBy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reportedBy);
+        return new EscalationExecutionRecord(
+            escalationId, EscalationExecutionStatus.Succeeded, null, null, reportedAt, reportedBy);
+    }
+
+    /// <summary>The action ran and failed.</summary>
+    /// <param name="failureReason">
+    /// Why it failed. Must contain something an approver can read — blank is rejected as well as
+    /// null, for the same reason as <see cref="FailureReason"/>'s own doc.
+    /// </param>
+    public static EscalationExecutionRecord Failed(
+        Guid escalationId, string failureReason, DateTimeOffset reportedAt, string reportedBy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(failureReason);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reportedBy);
+        return new EscalationExecutionRecord(
+            escalationId, EscalationExecutionStatus.Failed, failureReason, null, reportedAt, reportedBy);
+    }
+
+    /// <summary>The action never ran.</summary>
+    public static EscalationExecutionRecord NeverExecuted(
+        Guid escalationId,
+        EscalationNotExecutedReason reason,
+        DateTimeOffset reportedAt,
+        string reportedBy)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reportedBy);
+        return new EscalationExecutionRecord(
+            escalationId, EscalationExecutionStatus.NeverExecuted, null, reason, reportedAt, reportedBy);
+    }
+}

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationExecutionStatus.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationExecutionStatus.cs
@@ -1,0 +1,18 @@
+namespace Domain.AI.Escalation;
+
+/// <summary>
+/// What happened when an approved action was actually carried out. Reported after
+/// <see cref="EscalationOutcome.IsApproved"/> is true, closing the gap where an approver learns
+/// they approved something but never learns whether it then worked.
+/// </summary>
+public enum EscalationExecutionStatus
+{
+    /// <summary>The approved action ran and completed successfully.</summary>
+    Succeeded,
+    /// <summary>The approved action ran and failed. See the record's failure reason.</summary>
+    Failed,
+    /// <summary>
+    /// The approved action never ran — see the record's not-executed reason for why.
+    /// </summary>
+    NeverExecuted
+}

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationNotExecutedReason.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationNotExecutedReason.cs
@@ -1,0 +1,18 @@
+namespace Domain.AI.Escalation;
+
+/// <summary>
+/// Why an approved action was never carried out. Every member names a concrete producer in this
+/// codebase — a reason with nothing that reports it is dead surface an approver can never
+/// actually see.
+/// </summary>
+public enum EscalationNotExecutedReason
+{
+    /// <summary>
+    /// The approved action was cancelled before or during execution — e.g. a plan run was
+    /// cancelled or torn down after a tool call was approved but before it completed. Broad by
+    /// design: it covers an operator cancel, a caller-token cancel, and a host shutdown alike,
+    /// because none of those are distinguishable from the one place this is reported —
+    /// see <c>ToolUseStepExecutor</c>.
+    /// </summary>
+    RunCancelled
+}

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationRequest.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationRequest.cs
@@ -53,4 +53,26 @@ public sealed record EscalationRequest
     /// by an <see cref="AutonomyExceededResult"/> from the supervisor.
     /// </summary>
     public GovernanceDecision? OriginatingDecision { get; init; }
+
+    /// <summary>
+    /// Which attempt at this action this is, 1-based. Greater than 1 means a prior
+    /// <em>approved</em> attempt at the same action in the same conversation ran and failed —
+    /// not a revision, not a resubmission of an unresolved request. Defaults to 1 so every
+    /// existing caller is unaffected; only <c>EscalationToolApprovalRouter</c> currently
+    /// populates a higher value, from bounded conversation-scoped failure memory.
+    /// </summary>
+    public int AttemptNumber { get; init; } = 1;
+
+    /// <summary>
+    /// Why the previous attempt at this action failed, shown to the approver so a corrected
+    /// retry is never indistinguishable from being asked the same question twice. Null on a
+    /// first attempt. Approver-facing only — never relayed to the model.
+    /// </summary>
+    public string? PriorFailureReason { get; init; }
+
+    /// <summary>
+    /// The escalation id of the failed prior attempt this one follows, when
+    /// <see cref="AttemptNumber"/> is greater than 1. Null on a first attempt.
+    /// </summary>
+    public Guid? PredecessorEscalationId { get; init; }
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/EscalationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/EscalationConfig.cs
@@ -14,6 +14,8 @@ namespace Domain.Common.Config.AI.Governance;
 /// ├── DefaultTimeoutAction     — Deny / DenyAndEscalate / Approve / Escalate
 /// ├── DefaultApprovalStrategy  — AnyOf / AllOf / Quorum
 /// ├── AuditStoragePath          — Directory for JSONL audit log
+/// ├── RetryAttribution          — Retry-attribution card sizing (#325)
+/// │   └── MaxPriorFailureLength — Soft producer-side cap on the prior-failure text
 /// └── PriorityLevels{}         — Per-priority overrides keyed by EscalationPriority name
 ///     ├── TimeoutSeconds       — Override timeout for this level
 ///     ├── Async                — Non-blocking mode (informational)
@@ -88,4 +90,21 @@ public class EscalationConfig
     /// </para>
     /// </remarks>
     public string ApproverClaimType { get; set; } = "preferred_username";
+
+    /// <summary>
+    /// Sizing for the retry-attribution card (#325): when a corrected retry follows a failed
+    /// approved attempt, how much of the prior failure's text is shown to the next approver.
+    /// </summary>
+    public EscalationRetryAttributionConfig RetryAttribution { get; set; } = new();
+}
+
+/// <summary>Sizing for the retry-attribution text shown on a second-or-later approval attempt.</summary>
+public sealed class EscalationRetryAttributionConfig
+{
+    /// <summary>
+    /// Soft producer-side cap, in characters, on <c>EscalationRequest.PriorFailureReason</c>. Tied
+    /// by <c>EscalationConfigValidator</c> to <c>EscalationRequestInvariants.MaxPriorFailureReasonLength</c>
+    /// (the hard runtime ceiling) so the two can never be configured into disagreement.
+    /// </summary>
+    public int MaxPriorFailureLength { get; set; } = 512;
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/DriftEscalationBridge.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DriftDetection/DriftEscalationBridge.cs
@@ -91,6 +91,20 @@ public sealed class DriftEscalationBridge : IEscalationNotificationChannel
         return Task.CompletedTask;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// No-op by design, not an oversight. This bridge's tracking dictionary is populated at
+    /// request time and already removed by <see cref="NotifyEscalationResolvedAsync"/> the
+    /// moment an escalation resolves — before execution ever happens — so there is no reliable
+    /// way to re-derive "was this originally drift-tagged?" from here. It doesn't need one: no
+    /// drift-remediation call site reports execution results in this codebase today, so this
+    /// method is never actually invoked for a real drift escalation. Wiring drift remediation
+    /// into execution reporting is a deferred follow-up, not something this method should guess
+    /// at.
+    /// </remarks>
+    public Task NotifyExecutionReportedAsync(EscalationExecutionRecord record, CancellationToken ct) =>
+        Task.CompletedTask;
+
     private async Task NotifyDriftResolvedAsync(
         EscalationRequest request, EscalationOutcome outcome, CancellationToken ct)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/CompositeEscalationNotifier.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/CompositeEscalationNotifier.cs
@@ -52,6 +52,13 @@ public sealed class CompositeEscalationNotifier : IEscalationNotifier
             channel => channel.NotifyEscalationExpiringAsync(request, remaining, ct));
     }
 
+    /// <inheritdoc />
+    public Task NotifyExecutionReportedAsync(EscalationExecutionRecord record, CancellationToken ct)
+    {
+        return FanOutAsync(
+            channel => channel.NotifyExecutionReportedAsync(record, ct));
+    }
+
     private Task FanOutAsync(Func<IEscalationNotificationChannel, Task> action)
     {
         var tasks = _channels.Select(channel => SafeNotifyAsync(action, channel));

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/JsonlEscalationAuditStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/JsonlEscalationAuditStore.cs
@@ -111,6 +111,22 @@ public sealed class JsonlEscalationAuditStore : IEscalationAuditStore, IVerifiab
     }
 
     /// <inheritdoc />
+    public async Task RecordExecutionAsync(EscalationExecutionRecord record, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        var auditRecord = new EscalationAuditRecord
+        {
+            RecordType = EscalationAuditRecordType.Execution,
+            EscalationId = record.EscalationId,
+            Timestamp = DateTimeOffset.UtcNow,
+            Payload = JsonSerializer.Serialize(record, SerializeOptions)
+        };
+
+        await AppendRecordAsync(auditRecord, ct);
+    }
+
+    /// <inheritdoc />
     public async Task<IReadOnlyList<EscalationAuditRecord>> GetHistoryAsync(
         Guid escalationId,
         CancellationToken ct)

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/NoOpSlackNotifier.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/NoOpSlackNotifier.cs
@@ -46,4 +46,11 @@ public sealed class NoOpSlackNotifier : IEscalationNotificationChannel
         _logger.LogDebug("Slack: would notify escalation expiring for {EscalationId} ({Remaining} remaining)", request.EscalationId, remaining);
         return Task.CompletedTask;
     }
+
+    /// <inheritdoc />
+    public Task NotifyExecutionReportedAsync(EscalationExecutionRecord record, CancellationToken ct)
+    {
+        _logger.LogDebug("Slack: would notify execution {Status} for {EscalationId}", record.Status, record.EscalationId);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Escalation/NoOpTeamsNotifier.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Escalation/NoOpTeamsNotifier.cs
@@ -47,4 +47,11 @@ public sealed class NoOpTeamsNotifier : IEscalationNotificationChannel
         _logger.LogDebug("Teams: would notify escalation expiring for {EscalationId} ({Remaining} remaining)", request.EscalationId, remaining);
         return Task.CompletedTask;
     }
+
+    /// <inheritdoc />
+    public Task NotifyExecutionReportedAsync(EscalationExecutionRecord record, CancellationToken ct)
+    {
+        _logger.LogDebug("Teams: would notify execution {Status} for {EscalationId}", record.Status, record.EscalationId);
+        return Task.CompletedTask;
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -5,6 +5,7 @@ using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Interfaces.Sandbox;
+using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.AI.Planner;
 using Domain.AI.Sandbox;
@@ -28,6 +29,8 @@ namespace Infrastructure.AI.Planner.StepExecutors;
 /// </remarks>
 public sealed class ToolUseStepExecutor : IPlanStepExecutor
 {
+    private const string ReportedBy = "plan-executor";
+
     private readonly ICapabilityEnforcer _capabilityEnforcer;
     // Required, not optional-with-a-null-default, and deliberately so. An omitted admission chain is
     // indistinguishable at runtime from a host whose gates are all off, so a default would let a
@@ -91,21 +94,67 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         var profile = await _capabilityEnforcer.ResolveProfileAsync(config.ToolName, ct);
         var isolationLevel = DetermineIsolation(config, profile, step);
 
-        var input = JsonSerializer.Serialize(arguments);
+        var (sandboxResult, sandboxFailure) = await RunSandboxAsync(
+            config, step, profile, isolationLevel, arguments, admission, sw, ct);
+        if (sandboxFailure is not null)
+            return sandboxFailure;
+
+        var attestationFailure = await VerifyAttestationAsync(sandboxResult!, admission, config, step, sw, ct);
+        if (attestationFailure is not null)
+            return attestationFailure;
+
+        sw.Stop();
+
+        await _notifier.NotifySandboxStatusAsync(
+            _executionContext.CurrentPlanId ?? new PlanId(Guid.Empty), step.Id, config.ToolName, isolationLevel,
+            sandboxResult!.ResourceUsage ?? new ResourceUsage(),
+            sandboxResult.Attestation?.Signature, ct);
+
+        return sandboxResult.Success
+            ? await HandleSuccessAsync(admission, config, sandboxResult, sw)
+            : await HandleFailureAsync(admission, config, step, sandboxResult, sw);
+    }
+
+    /// <summary>
+    /// Runs the tool in its sandbox. Returns the result, or — on a thrown fault — a failed step
+    /// result and no sandbox result. A cancellation is neither: it rethrows after reporting
+    /// <see cref="EscalationExecutionStatus.NeverExecuted"/>, so it is not shaped as either tuple case.
+    /// </summary>
+    private async Task<(SandboxExecutionResult? Result, StepExecutionResult? Failure)> RunSandboxAsync(
+        ToolUseConfig config,
+        PlanStep step,
+        ToolPermissionProfile profile,
+        SandboxIsolationLevel isolationLevel,
+        IReadOnlyDictionary<string, object?> arguments,
+        ToolCallAdmission admission,
+        Stopwatch sw,
+        CancellationToken ct)
+    {
         var request = new SandboxExecutionRequest
         {
             ToolName = config.ToolName,
-            Input = input,
+            Input = JsonSerializer.Serialize(arguments),
             Limits = new ResourceLimits(),
             PermissionProfile = profile,
             Timeout = step.Timeout
         };
 
         var executor = _serviceProvider.GetRequiredKeyedService<ISandboxExecutor>(isolationLevel);
-        SandboxExecutionResult sandboxResult;
         try
         {
-            sandboxResult = await executor.ExecuteAsync(request, ct);
+            return (await executor.ExecuteAsync(request, ct), null);
+        }
+        catch (OperationCanceledException)
+        {
+            // The one place #325 execution reporting needs a third outcome, not two. A plan run is
+            // checkpointed and resumable, so "cancelled mid-call" is not the same claim as "failed" —
+            // the step may still succeed when the plan resumes and re-admits it, and telling the
+            // approver it failed would be a false report the resume then contradicts. Reported before
+            // rethrowing so ExecuteStepAsync's own Cancelled/Failed step-status decision is untouched.
+            await ReportExecutionAsync(
+                admission, EscalationExecutionStatus.NeverExecuted, failureReason: null,
+                notExecutedReason: EscalationNotExecutedReason.RunCancelled);
+            throw;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -114,84 +163,108 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
             // because step error state is returned to callers and sandbox exceptions carry host paths,
             // container ids, and mount configuration.
             _logger.LogError(ex, "Sandbox execution threw for tool {Tool} in step {Step}", config.ToolName, step.Name);
-            return new StepExecutionResult
+            await ReportExecutionAsync(
+                admission, EscalationExecutionStatus.Failed, PlanStepErrors.SandboxFailed);
+            return (null, new StepExecutionResult
             {
                 Status = StepExecutionStatus.Failed,
                 ErrorMessage = PlanStepErrors.SandboxFailed,
                 Duration = sw.Elapsed
-            };
+            });
         }
+    }
 
-        if (sandboxResult.Attestation is not null)
-        {
-            // When the attestation carries an output hash, verify BOUND to the actual
-            // returned output — signature-only verification cannot detect a result whose
-            // Output was tampered after signing. Legacy/output-less attestations (timeouts,
-            // spawn refusals) have nothing to bind and fall back to signature verification.
-            var verified = sandboxResult.Attestation.OutputHash is not null
-                ? await _attestationService.VerifyBoundAsync(
-                    sandboxResult.Attestation, sandboxResult.Output ?? string.Empty, ct)
-                : await _attestationService.VerifyAsync(sandboxResult.Attestation, ct);
-            if (!verified)
-            {
-                sw.Stop();
-                _logger.LogWarning("Attestation verification failed for tool {Tool} in step {Step}",
-                    config.ToolName, step.Name);
-                return new StepExecutionResult
-                {
-                    Status = StepExecutionStatus.Failed,
-                    ErrorMessage = "Attestation verification failed: possible tampering detected.",
-                    Duration = sw.Elapsed,
-                    Attestation = sandboxResult.Attestation
-                };
-            }
-        }
+    /// <summary>
+    /// Verifies the sandbox result's attestation, when it carries one. Returns null when verification
+    /// passed (or nothing needed verifying); otherwise the failed step result to return.
+    /// </summary>
+    private async Task<StepExecutionResult?> VerifyAttestationAsync(
+        SandboxExecutionResult sandboxResult,
+        ToolCallAdmission admission,
+        ToolUseConfig config,
+        PlanStep step,
+        Stopwatch sw,
+        CancellationToken ct)
+    {
+        if (sandboxResult.Attestation is null)
+            return null;
+
+        // When the attestation carries an output hash, verify BOUND to the actual returned output —
+        // signature-only verification cannot detect a result whose Output was tampered after signing.
+        // Legacy/output-less attestations (timeouts, spawn refusals) have nothing to bind and fall
+        // back to signature verification.
+        var verified = sandboxResult.Attestation.OutputHash is not null
+            ? await _attestationService.VerifyBoundAsync(
+                sandboxResult.Attestation, sandboxResult.Output ?? string.Empty, ct)
+            : await _attestationService.VerifyAsync(sandboxResult.Attestation, ct);
+        if (verified)
+            return null;
 
         sw.Stop();
-
-        await _notifier.NotifySandboxStatusAsync(
-            _executionContext.CurrentPlanId ?? new PlanId(Guid.Empty), step.Id, config.ToolName, isolationLevel,
-            sandboxResult.ResourceUsage ?? new ResourceUsage(),
-            sandboxResult.Attestation?.Signature, ct);
-
-        if (sandboxResult.Success)
+        _logger.LogWarning("Attestation verification failed for tool {Tool} in step {Step}",
+            config.ToolName, step.Name);
+        await ReportExecutionAsync(
+            admission, EscalationExecutionStatus.Failed,
+            "attestation verification failed: possible tampering detected");
+        return new StepExecutionResult
         {
-            // Admission is not finished when the tool returns: a classified asset can be allowed
-            // through and have its output scrubbed instead of being refused outright. Skipping this
-            // would leave the gate's audit line and metric asserting a redaction that never happened,
-            // while the raw content went back to the caller — a worse failure than not classifying at
-            // all, because it reports itself as safe.
-            if (!_admissionPipeline.TryApplyTextOutputPolicy(
-                    admission, config.ToolName, sandboxResult.Output, out var content))
-            {
-                return new StepExecutionResult
-                {
-                    Status = StepExecutionStatus.Failed,
-                    ErrorMessage = GovernanceDenials.NotPermitted(config.ToolName),
-                    Duration = sw.Elapsed,
-                    IsPolicyDenial = true,
-                    Attestation = sandboxResult.Attestation
-                };
-            }
+            Status = StepExecutionStatus.Failed,
+            ErrorMessage = "Attestation verification failed: possible tampering detected.",
+            Duration = sw.Elapsed,
+            Attestation = sandboxResult.Attestation
+        };
+    }
 
-            if (!string.IsNullOrEmpty(content))
-                content = _responseSanitizer.Sanitize(content, config.ToolName).SanitizedContent;
-
+    /// <summary>Shapes a successful sandbox result into the step's completed (or policy-denied) outcome.</summary>
+    private async Task<StepExecutionResult> HandleSuccessAsync(
+        ToolCallAdmission admission, ToolUseConfig config, SandboxExecutionResult sandboxResult, Stopwatch sw)
+    {
+        // Admission is not finished when the tool returns: a classified asset can be allowed through
+        // and have its output scrubbed instead of being refused outright. Skipping this would leave
+        // the gate's audit line and metric asserting a redaction that never happened, while the raw
+        // content went back to the caller — a worse failure than not classifying at all, because it
+        // reports itself as safe.
+        if (!_admissionPipeline.TryApplyTextOutputPolicy(
+                admission, config.ToolName, sandboxResult.Output, out var content))
+        {
+            await ReportExecutionAsync(
+                admission, EscalationExecutionStatus.Failed, GovernanceDenials.NotPermitted(config.ToolName));
             return new StepExecutionResult
             {
-                Status = StepExecutionStatus.Completed,
-                Output = content,
+                Status = StepExecutionStatus.Failed,
+                ErrorMessage = GovernanceDenials.NotPermitted(config.ToolName),
                 Duration = sw.Elapsed,
+                IsPolicyDenial = true,
                 Attestation = sandboxResult.Attestation
             };
         }
 
-        // Same treatment as the throw path above: the sandbox's failure text is raw process stderr, a
-        // raw exception message, or raw container logs, and step error state is persisted and returned to
-        // callers. Log it in full, persist only the stable code.
+        if (!string.IsNullOrEmpty(content))
+            content = _responseSanitizer.Sanitize(content, config.ToolName).SanitizedContent;
+
+        await ReportExecutionAsync(admission, EscalationExecutionStatus.Succeeded, failureReason: null);
+
+        return new StepExecutionResult
+        {
+            Status = StepExecutionStatus.Completed,
+            Output = content,
+            Duration = sw.Elapsed,
+            Attestation = sandboxResult.Attestation
+        };
+    }
+
+    /// <summary>Shapes a failed sandbox result into the step's failed outcome.</summary>
+    private async Task<StepExecutionResult> HandleFailureAsync(
+        ToolCallAdmission admission, ToolUseConfig config, PlanStep step, SandboxExecutionResult sandboxResult, Stopwatch sw)
+    {
+        // Same treatment as the throw path in RunSandboxAsync: the sandbox's failure text is raw
+        // process stderr, a raw exception message, or raw container logs, and step error state is
+        // persisted and returned to callers. Log it in full, persist only the stable code.
         _logger.LogWarning(
             "Tool {Tool} in step {Step} failed in the sandbox: {SandboxError}",
             config.ToolName, step.Name, sandboxResult.ErrorMessage ?? "(no detail reported)");
+
+        await ReportExecutionAsync(admission, EscalationExecutionStatus.Failed, PlanStepErrors.ToolFailed);
 
         return new StepExecutionResult
         {
@@ -201,6 +274,24 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
             Attestation = sandboxResult.Attestation
         };
     }
+
+    /// <summary>
+    /// Closes the approval loop for this step's call, when it was one a human approved. A no-op for
+    /// every other call — see <see cref="IToolCallAdmissionPipeline.ReportExecutionAsync"/>.
+    /// </summary>
+    /// <remarks>
+    /// Reported on <see cref="CancellationToken.None"/>, not the step's own token: by the time this
+    /// runs the outcome is already known, and a plan-level cancellation racing the report must not be
+    /// the reason an approver never learns whether their approved action actually ran.
+    /// </remarks>
+    private ValueTask ReportExecutionAsync(
+        ToolCallAdmission admission,
+        EscalationExecutionStatus status,
+        string? failureReason,
+        EscalationNotExecutedReason? notExecutedReason = null) =>
+        _admissionPipeline.ReportExecutionAsync(
+            admission, new ToolExecutionReport(status, failureReason, notExecutedReason),
+            ReportedBy, CancellationToken.None);
 
     /// <summary>
     /// Runs the tool call through the admission chain and, when refused, produces the failed step

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEscalationEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEscalationEvents.cs
@@ -39,6 +39,18 @@ public sealed record EscalationRequestedEvent : AgUiEvent
     /// <summary>Tool arguments (sanitized for display). Null when omitted.</summary>
     [JsonPropertyName("arguments")]
     public IReadOnlyDictionary<string, string>? Arguments { get; init; }
+
+    /// <summary>
+    /// Which attempt at this action this is, 1-based. Greater than 1 means a prior approved
+    /// attempt ran and failed. Optional (not required) so this event's shape stays additive
+    /// for any client that predates this field.
+    /// </summary>
+    [JsonPropertyName("attemptNumber")]
+    public int? AttemptNumber { get; init; }
+
+    /// <summary>Why the previous attempt at this action failed. Null on a first attempt.</summary>
+    [JsonPropertyName("priorFailureReason")]
+    public string? PriorFailureReason { get; init; }
 }
 
 /// <summary>
@@ -98,4 +110,42 @@ public sealed record EscalationExpiringEvent : AgUiEvent
     /// <summary>Seconds remaining before the escalation times out.</summary>
     [JsonPropertyName("remainingSeconds")]
     public required int RemainingSeconds { get; init; }
+}
+
+/// <summary>
+/// Reports what happened when an approved escalation's action was actually carried out —
+/// closes the approval loop so a failed action and a completed one no longer look identical to
+/// the approver.
+/// </summary>
+/// <remarks>
+/// Emitted inline within the same turn for a tool-call approval, so this reaches the UI live.
+/// For a plan-executor approval the plan resumes with no AG-UI run active, so this event reaches
+/// only the audit trail — the loop still closes, just not on this surface. See
+/// <c>AgUiEscalationNotifier</c>.
+/// </remarks>
+public sealed record EscalationExecutedEvent : AgUiEvent
+{
+    /// <summary>Correlates back to the originating escalation.</summary>
+    [JsonPropertyName("escalationId")]
+    public required string EscalationId { get; init; }
+
+    /// <summary>Whether the action succeeded, failed, or never ran (e.g. "Succeeded", "Failed", "NeverExecuted").</summary>
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    /// <summary>Why the action failed. Present only when <see cref="Status"/> is "Failed".</summary>
+    [JsonPropertyName("failureReason")]
+    public string? FailureReason { get; init; }
+
+    /// <summary>Why the action never ran. Present only when <see cref="Status"/> is "NeverExecuted".</summary>
+    [JsonPropertyName("notExecutedReason")]
+    public string? NotExecutedReason { get; init; }
+
+    /// <summary>When this report was produced.</summary>
+    [JsonPropertyName("reportedAt")]
+    public required DateTimeOffset ReportedAt { get; init; }
+
+    /// <summary>A stable identifier for the site that produced this report (e.g. "plan-executor").</summary>
+    [JsonPropertyName("reportedBy")]
+    public required string ReportedBy { get; init; }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventType.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEventType.cs
@@ -68,6 +68,9 @@ public static class AgUiEventType
     /// <summary>Warns that a pending escalation is approaching its timeout deadline.</summary>
     public const string EscalationExpiring = "ESCALATION_EXPIRING";
 
+    /// <summary>Reports what happened when an approved escalation's action was actually carried out.</summary>
+    public const string EscalationExecuted = "ESCALATION_EXECUTED";
+
     /// <summary>Signals that drift was detected at warn severity.</summary>
     public const string DriftWarn = "DRIFT_WARN";
 

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
@@ -15,7 +15,7 @@ namespace Presentation.AgentHub.AgUi;
 /// <list type="bullet">
 ///   <item><description><c>AgUiRunEvents.cs</c> — Run lifecycle and text message streaming</description></item>
 ///   <item><description><c>AgUiPlanEvents.cs</c> — Plan execution, steps, state deltas, sandbox</description></item>
-///   <item><description><c>AgUiEscalationEvents.cs</c> — Escalation request/resolve/expiry</description></item>
+///   <item><description><c>AgUiEscalationEvents.cs</c> — Escalation request/resolve/expiry/execution</description></item>
 ///   <item><description><c>AgUiDriftEvents.cs</c> — Quality drift detection and resolution</description></item>
 ///   <item><description><c>AgUiLearningEvents.cs</c> — Learning capture, application, forgetting</description></item>
 /// </list>
@@ -37,6 +37,7 @@ namespace Presentation.AgentHub.AgUi;
 [JsonDerivedType(typeof(EscalationRequestedEvent), AgUiEventType.EscalationRequested)]
 [JsonDerivedType(typeof(EscalationResolvedEvent), AgUiEventType.EscalationResolved)]
 [JsonDerivedType(typeof(EscalationExpiringEvent), AgUiEventType.EscalationExpiring)]
+[JsonDerivedType(typeof(EscalationExecutedEvent), AgUiEventType.EscalationExecuted)]
 // Drift detection
 [JsonDerivedType(typeof(DriftWarnEvent), AgUiEventType.DriftWarn)]
 [JsonDerivedType(typeof(DriftAlertEvent), AgUiEventType.DriftAlert)]

--- a/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiEscalationNotifier.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiEscalationNotifier.cs
@@ -53,6 +53,8 @@ public sealed class AgUiEscalationNotifier : IEscalationNotificationChannel
             Arguments = request.Arguments.Count > 0
                 ? request.Arguments
                 : null,
+            AttemptNumber = request.AttemptNumber,
+            PriorFailureReason = request.PriorFailureReason,
         };
 
         try
@@ -131,6 +133,44 @@ public sealed class AgUiEscalationNotifier : IEscalationNotificationChannel
         {
             _logger.LogWarning(ex, "Failed to write escalation-expiring event for {EscalationId}.",
                 request.EscalationId);
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// This channel no-ops when no AG-UI run is active — the honest limitation documented on
+    /// <see cref="EscalationExecutedEvent"/>: a tool-call approval's report fires inline within
+    /// the same turn, so this reaches the UI live, but a plan-executor approval resumes with no
+    /// run active, so that report reaches only the audit trail.
+    /// </remarks>
+    public async Task NotifyExecutionReportedAsync(EscalationExecutionRecord record, CancellationToken ct)
+    {
+        var writer = _writerAccessor.Writer;
+        if (writer is null)
+        {
+            _logger.LogDebug("No AG-UI writer active; skipping execution-reported event for {EscalationId}.",
+                record.EscalationId);
+            return;
+        }
+
+        var evt = new EscalationExecutedEvent
+        {
+            EscalationId = record.EscalationId.ToString(),
+            Status = record.Status.ToString(),
+            FailureReason = record.FailureReason,
+            NotExecutedReason = record.NotExecutedReason?.ToString(),
+            ReportedAt = record.ReportedAt,
+            ReportedBy = record.ReportedBy,
+        };
+
+        try
+        {
+            await writer.WriteAsync(evt, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Failed to write execution-reported event for {EscalationId}.",
+                record.EscalationId);
         }
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Escalation/EscalationRequestInvariantsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Escalation/EscalationRequestInvariantsTests.cs
@@ -139,4 +139,114 @@ public sealed class EscalationRequestInvariantsTests
         isValid.Should().BeTrue();
         violation.Should().BeNull();
     }
+
+    // ===== #325 retry attribution: AttemptNumber / PriorFailureReason =====
+
+    [Fact]
+    public void TryValidate_AttemptNumberZero_IsRejected()
+    {
+        var request = CreateValidRequest() with { AttemptNumber = 0 };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeFalse();
+        violation.Should().Contain("attempt number");
+    }
+
+    [Fact]
+    public void TryValidate_AttemptNumberNegative_IsRejected()
+    {
+        var request = CreateValidRequest() with { AttemptNumber = -1 };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeFalse();
+        violation.Should().Contain("attempt number");
+    }
+
+    [Fact]
+    public void TryValidate_AttemptNumberOneWithNoPriorFailureReason_IsAccepted()
+    {
+        // Mutation control: a first attempt (the default shape) must not be rejected by the
+        // attempt-number floor.
+        var request = CreateValidRequest() with { AttemptNumber = 1, PriorFailureReason = null };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeTrue();
+        violation.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryValidate_AttemptOneWithPriorFailureReason_IsRejected()
+    {
+        // A first attempt cannot have failed before — a prior failure reason on attempt 1 is
+        // internally incoherent, reachable only via a hand-edited or corrupted durable row.
+        var request = CreateValidRequest() with { AttemptNumber = 1, PriorFailureReason = "boom" };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeFalse();
+        violation.Should().Contain("attempt 1");
+    }
+
+    [Fact]
+    public void TryValidate_AttemptTwoWithPriorFailureReason_IsAccepted()
+    {
+        // Mutation control: the coherent retry shape (attempt > 1, reason present) must pass.
+        var request = CreateValidRequest() with { AttemptNumber = 2, PriorFailureReason = "boom" };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeTrue();
+        violation.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryValidate_AttemptTwoWithNoPriorFailureReason_IsAccepted()
+    {
+        // The deliberately-NOT-rejected shape: an attempt count above 1 with no prior failure
+        // reason is what a benign LRU eviction of the failure memory produces (the recall came
+        // back null, so AttemptNumber stayed effectively re-derivable as "still a retry" while
+        // the reason itself was gone). Rejecting this would fail-close a valid escalation purely
+        // because the bounded memory it depends on evicted an entry.
+        var request = CreateValidRequest() with { AttemptNumber = 2, PriorFailureReason = null };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeTrue();
+        violation.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryValidate_PriorFailureReasonExceedsMaxLength_IsRejected()
+    {
+        var request = CreateValidRequest() with
+        {
+            AttemptNumber = 2,
+            PriorFailureReason = new string('x', EscalationRequestInvariants.MaxPriorFailureReasonLength + 1)
+        };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeFalse();
+        violation.Should().Contain("exceeds the");
+    }
+
+    [Fact]
+    public void TryValidate_PriorFailureReasonAtMaxLength_IsAccepted()
+    {
+        // Boundary control: exactly at the ceiling must still pass — only exceeding it is a
+        // violation.
+        var request = CreateValidRequest() with
+        {
+            AttemptNumber = 2,
+            PriorFailureReason = new string('x', EscalationRequestInvariants.MaxPriorFailureReasonLength)
+        };
+
+        var isValid = EscalationRequestInvariants.TryValidate(request, out var violation);
+
+        isValid.Should().BeTrue();
+        violation.Should().BeNull();
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
@@ -34,6 +35,7 @@ internal static class AdmissionHarness
             observers ?? Mock.Of<IToolCallObserverChain>(),
             progressEvaluator ?? PermissiveProgressEvaluator(),
             trace ?? TraceRecorder(),
+            Mock.Of<IApprovalExecutionReporter>(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
 
     /// <summary>

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/EscalationToolApprovalRouterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/EscalationToolApprovalRouterTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
@@ -32,6 +33,11 @@ public sealed class EscalationToolApprovalRouterTests
     private readonly ICompositeResponseSanitizer _sanitizer =
         Mock.Of<ICompositeResponseSanitizer>(s =>
             s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()) == SanitizationResult.Clean("scrubbed"));
+    private readonly Mock<IAgentExecutionContext> _executionContext = new();
+    private readonly Mock<IApprovalFailureMemory> _failureMemory = new();
+
+    public EscalationToolApprovalRouterTests() =>
+        _executionContext.SetupGet(c => c.ConversationId).Returns("test-conversation");
 
     private static GovernanceConfig Config(
         bool approvalEnabled = true,
@@ -57,6 +63,8 @@ public sealed class EscalationToolApprovalRouterTests
         _escalation.Object,
         _sanitizer,
         Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == config),
+        _executionContext.Object,
+        _failureMemory.Object,
         NullLogger<EscalationToolApprovalRouter>.Instance);
 
     private static EscalationOutcome Outcome(
@@ -438,5 +446,176 @@ public sealed class EscalationToolApprovalRouterTests
 
         Assert.NotNull(captured);
         Assert.Equal(120, captured.TimeoutSeconds);
+    }
+
+    // ===== #325 retry attribution: recall on build, clear on explicit denial =====
+
+    private void CaptureRequest(out Func<EscalationRequest?> captured)
+    {
+        EscalationRequest? request = null;
+        _escalation
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationRequest, CancellationToken>((r, _) => request = r)
+            .ReturnsAsync(Outcome(approved: true, EscalationResolutionType.Approved));
+        captured = () => request;
+    }
+
+    // Moq's argument matcher does not bind It.IsAny<T>() through an `in` parameter in this
+    // version, so every TryRecall setup below matches the literal key the router is expected to
+    // build rather than a wildcard — that literal match doubles as the assertion that the router
+    // built the right key (a wrong key would fall through to the loose mock's default null).
+    private static readonly ApprovalFailureKey ExpectedKey = new("test-conversation", Agent, Tool);
+
+    [Fact]
+    public async Task RequestApprovalAsync_NoRecall_IsAttemptOneWithNoPriorFailure()
+    {
+        CaptureRequest(out var captured);
+        // No setup for ExpectedKey: the loose mock's default (null) is exactly the "nothing
+        // recorded" case this test exists to pin.
+
+        await Route(Config());
+
+        Assert.NotNull(captured());
+        Assert.Equal(1, captured()!.AttemptNumber);
+        Assert.Null(captured()!.PriorFailureReason);
+        Assert.Null(captured()!.PredecessorEscalationId);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_RecallExists_PopulatesAttemptAttributionFields()
+    {
+        CaptureRequest(out var captured);
+        var predecessorId = Guid.NewGuid();
+        _failureMemory
+            .Setup(m => m.TryRecall(ExpectedKey))
+            .Returns(new ApprovalFailureRecall(PriorAttemptCount: 1, FailureReason: "permission denied", predecessorId));
+
+        await Route(Config());
+
+        Assert.NotNull(captured());
+        Assert.Equal(2, captured()!.AttemptNumber);
+        Assert.Equal("permission denied", captured()!.PriorFailureReason);
+        Assert.Equal(predecessorId, captured()!.PredecessorEscalationId);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_RecallLookup_UsesConversationAgentAndToolAsTheKey()
+    {
+        // Pinned deliberately: arguments are excluded from the key by design (a corrected retry
+        // has different arguments by definition), and this is the test that would catch a
+        // regression back toward keying on them — a key built any other way (e.g. including
+        // arguments) would miss this setup and TryRecall would return the loose mock's default
+        // null, which the assertion below would catch.
+        var predecessorId = Guid.NewGuid();
+        _failureMemory
+            .Setup(m => m.TryRecall(ExpectedKey))
+            .Returns(new ApprovalFailureRecall(1, "boom", predecessorId));
+        CaptureRequest(out var captured);
+
+        await Route(Config());
+
+        Assert.NotNull(captured());
+        Assert.Equal(predecessorId, captured()!.PredecessorEscalationId);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_NoKnownConversation_SkipsRecallEntirely()
+    {
+        // Missing conversation identity must degrade to "always attempt 1, recall nothing" — never
+        // a shared sentinel key that would let one caller's failure label another's card.
+        _executionContext.SetupGet(c => c.ConversationId).Returns((string?)null);
+        CaptureRequest(out var captured);
+
+        await Route(Config());
+
+        _failureMemory.Verify(m => m.TryRecall(ExpectedKey), Times.Never);
+        Assert.NotNull(captured());
+        Assert.Equal(1, captured()!.AttemptNumber);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_RecalledReasonExceedsConfiguredCap_IsTruncated()
+    {
+        CaptureRequest(out var captured);
+        _failureMemory
+            .Setup(m => m.TryRecall(ExpectedKey))
+            .Returns(new ApprovalFailureRecall(1, new string('x', 1000), Guid.NewGuid()));
+
+        var config = Config();
+        var narrowCap = new GovernanceConfig
+        {
+            Escalation = new EscalationConfig
+            {
+                Enabled = config.Escalation.Enabled,
+                DefaultTimeoutSeconds = config.Escalation.DefaultTimeoutSeconds,
+                DefaultTimeoutAction = config.Escalation.DefaultTimeoutAction,
+                RetryAttribution = new EscalationRetryAttributionConfig { MaxPriorFailureLength = 20 }
+            },
+            ToolApproval = config.ToolApproval
+        };
+
+        await Route(narrowCap);
+
+        Assert.NotNull(captured());
+        Assert.True(captured()!.PriorFailureReason!.Length <= 20 + "… (truncated)".Length);
+        Assert.Contains("truncated", captured()!.PriorFailureReason);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_RecalledReasonWithinCap_IsNotTruncated()
+    {
+        // Mutation control: a reason already under the configured cap must survive unchanged.
+        CaptureRequest(out var captured);
+        _failureMemory
+            .Setup(m => m.TryRecall(ExpectedKey))
+            .Returns(new ApprovalFailureRecall(1, "short reason", Guid.NewGuid()));
+
+        await Route(Config());
+
+        Assert.NotNull(captured());
+        Assert.Equal("short reason", captured()!.PriorFailureReason);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_ExplicitDenial_ClearsFailureMemory()
+    {
+        _escalation
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Outcome(approved: false, EscalationResolutionType.Denied));
+
+        await Route(Config());
+
+        _failureMemory.Verify(
+            m => m.Clear(new ApprovalFailureKey("test-conversation", Agent, Tool)), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(EscalationResolutionType.TimedOut)]
+    [InlineData(EscalationResolutionType.Escalated)]
+    public async Task RequestApprovalAsync_NonDenialRefusal_DoesNotClearFailureMemory(
+        EscalationResolutionType resolution)
+    {
+        // "The user ended that sequence" presupposes a user; a timeout means nobody looked, and an
+        // escalation is still in flight elsewhere — erasing the next approver's context on either
+        // would invert the feature.
+        _escalation
+            .Setup(x => x.RequestEscalationAsync(It.IsAny<EscalationRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Outcome(approved: false, resolution));
+
+        await Route(Config());
+
+        _failureMemory.Verify(m => m.Clear(It.IsAny<ApprovalFailureKey>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RequestApprovalAsync_Approved_DoesNotClearFailureMemory()
+    {
+        // Clearing on success is DefaultApprovalExecutionReporter's job, once the approved action
+        // actually runs — not the router's, which only knows the call was approved, not executed.
+        SetupEscalation(Outcome(approved: true, EscalationResolutionType.Approved));
+
+        await Route(Config());
+
+        _failureMemory.Verify(m => m.Clear(It.IsAny<ApprovalFailureKey>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
@@ -1,6 +1,8 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
+using Domain.AI.Escalation;
 using Microsoft.Extensions.AI;
 using Moq;
 using Xunit;
@@ -86,6 +88,68 @@ public sealed class GovernedAIFunctionTests
         Assert.NotNull(seen);
         Assert.True(seen!.CountsTowardLoopDetection);
         Assert.Equal("file_system", seen.ToolName);
+    }
+
+    // ===== #325 execution reporting =====
+
+    private static ApprovedCall ApprovedCall() =>
+        new(Guid.NewGuid(), new ApprovalFailureKey("conv-1", "agent-1", "file_system"));
+
+    private static Mock<IToolCallAdmissionPipeline> ApprovingPipeline(ApprovedCall call)
+    {
+        var pipeline = new Mock<IToolCallAdmissionPipeline>();
+        pipeline
+            .Setup(p => p.AdmitAsync(It.IsAny<ToolCallAdmissionRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.FromResult(ToolCallAdmission.Allow().WithApproval(call)));
+        pipeline
+            .Setup(p => p.ApplyOutputPolicy(It.IsAny<ToolCallAdmission>(), It.IsAny<string>(), It.IsAny<object?>()))
+            .Returns<ToolCallAdmission, string, object?>((_, _, result) => result);
+        return pipeline;
+    }
+
+    // GovernedAIFunction does not itself decide whether an approval exists to report against —
+    // that no-op belongs to IToolCallAdmissionPipeline.ReportExecutionAsync (pinned in
+    // ToolCallAdmissionPipelineTests), so this layer's contract is simply "always ask" on every
+    // admitted call. The two tests below, against a raw mocked pipeline that has no such no-op
+    // built in, are what prove the call happens on every path (success and failure).
+
+    [Fact]
+    public async Task InvokeAsync_ToolSucceeds_WithApproval_ReportsSucceeded()
+    {
+        var (inner, _) = MakeInner();
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        await InvokeUnder(pipeline.Object, inner);
+
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r => r.Status == EscalationExecutionStatus.Succeeded),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ToolThrows_WithApproval_ReportsFailedAndStillRethrows()
+    {
+        Func<string> throwing = () => throw new InvalidOperationException("boom");
+        var inner = AIFunctionFactory.Create(
+            throwing, new AIFunctionFactoryOptions { Name = "file_system", Description = "test tool" });
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        Func<Task> act = () => InvokeUnder(pipeline.Object, inner);
+
+        // MEAI's AIFunctionFactory wraps the delegate's throw in an AIFunctionArgumentException; the
+        // wiring under test only needs to prove the report happened and something still escaped.
+        await Assert.ThrowsAnyAsync<Exception>(act);
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r => r.Status == EscalationExecutionStatus.Failed),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -1,6 +1,8 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Changes;
+using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Microsoft.Extensions.Logging.Abstractions;
 using FluentAssertions;
@@ -383,6 +385,104 @@ public sealed class ToolCallAdmissionPipelineTests
         return new ToolCallAdmissionPipeline(
             authorizationGate.Object, governor.Object, classificationGate.Object, observers.Object,
             progress.Object, AdmissionHarness.TraceRecorder(),
+            new Mock<IApprovalExecutionReporter>().Object,
             NullLogger<ToolCallAdmissionPipeline>.Instance);
+    }
+
+    // ===== ReportExecutionAsync: #325 execution reporting dispatch =====
+
+    private static ToolCallAdmissionPipeline WithReporter(Mock<IApprovalExecutionReporter> reporter) => new(
+        Mock.Of<IAgentToolAuthorizationGate>(), Mock.Of<IToolInvocationGovernor>(),
+        Mock.Of<IToolClassificationGate>(), Mock.Of<IToolCallObserverChain>(), Mock.Of<IProgressEvaluator>(),
+        AdmissionHarness.TraceRecorder(), reporter.Object, NullLogger<ToolCallAdmissionPipeline>.Instance);
+
+    private static ApprovedCall Call() =>
+        new(Guid.NewGuid(), new ApprovalFailureKey("conv-1", "agent-1", Tool));
+
+    [Fact]
+    public async Task ReportExecutionAsync_NoApprovedCall_IsANoOp()
+    {
+        // Most calls need no human approval — nothing to report a loop closing on.
+        var reporter = new Mock<IApprovalExecutionReporter>();
+        var admission = ToolCallAdmission.Allow();
+
+        await WithReporter(reporter).ReportExecutionAsync(
+            admission, new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null), "test-site", CancellationToken.None);
+
+        reporter.Verify(r => r.ReportSucceededAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        reporter.Verify(r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        reporter.Verify(r => r.ReportNotExecutedAsync(It.IsAny<ApprovedCall>(), It.IsAny<EscalationNotExecutedReason>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReportExecutionAsync_Succeeded_DispatchesToReportSucceededAsync()
+    {
+        var reporter = new Mock<IApprovalExecutionReporter>();
+        var call = Call();
+        var admission = ToolCallAdmission.Allow().WithApproval(call);
+
+        await WithReporter(reporter).ReportExecutionAsync(
+            admission, new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null), "test-site", CancellationToken.None);
+
+        reporter.Verify(r => r.ReportSucceededAsync(call, It.IsAny<string>(), CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReportExecutionAsync_FailedWithReason_DispatchesToReportFailedAsync()
+    {
+        var reporter = new Mock<IApprovalExecutionReporter>();
+        var call = Call();
+        var admission = ToolCallAdmission.Allow().WithApproval(call);
+
+        await WithReporter(reporter).ReportExecutionAsync(
+            admission, new ToolExecutionReport(EscalationExecutionStatus.Failed, "permission denied", null), "test-site", CancellationToken.None);
+
+        reporter.Verify(r => r.ReportFailedAsync(call, "permission denied", It.IsAny<string>(), CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReportExecutionAsync_FailedWithNoReason_IsANoOp()
+    {
+        // An incoherent report (Failed with no reason) is a caller bug, not something to guess at —
+        // this is the one place in the reporting path with no must-not-throw contract protecting it,
+        // so it must not throw either; it simply reports nothing.
+        var reporter = new Mock<IApprovalExecutionReporter>();
+        var admission = ToolCallAdmission.Allow().WithApproval(Call());
+
+        await WithReporter(reporter).ReportExecutionAsync(
+            admission, new ToolExecutionReport(EscalationExecutionStatus.Failed, null, null), "test-site", CancellationToken.None);
+
+        reporter.Verify(r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReportExecutionAsync_NeverExecutedWithReason_DispatchesToReportNotExecutedAsync()
+    {
+        var reporter = new Mock<IApprovalExecutionReporter>();
+        var call = Call();
+        var admission = ToolCallAdmission.Allow().WithApproval(call);
+
+        await WithReporter(reporter).ReportExecutionAsync(
+            admission,
+            new ToolExecutionReport(EscalationExecutionStatus.NeverExecuted, null, EscalationNotExecutedReason.RunCancelled),
+            "test-site", CancellationToken.None);
+
+        reporter.Verify(
+            r => r.ReportNotExecutedAsync(call, EscalationNotExecutedReason.RunCancelled, It.IsAny<string>(), CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ReportExecutionAsync_NeverExecutedWithNoReason_IsANoOp()
+    {
+        var reporter = new Mock<IApprovalExecutionReporter>();
+        var admission = ToolCallAdmission.Allow().WithApproval(Call());
+
+        await WithReporter(reporter).ReportExecutionAsync(
+            admission, new ToolExecutionReport(EscalationExecutionStatus.NeverExecuted, null, null), "test-site", CancellationToken.None);
+
+        reporter.Verify(
+            r => r.ReportNotExecutedAsync(It.IsAny<ApprovedCall>(), It.IsAny<EscalationNotExecutedReason>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/DefaultApprovalExecutionReporterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/DefaultApprovalExecutionReporterTests.cs
@@ -1,0 +1,190 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Services.Escalation;
+using Domain.AI.Escalation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Escalation;
+
+/// <summary>
+/// Tests for <see cref="DefaultApprovalExecutionReporter"/> — the #325 execution-reporting path,
+/// whose two defining properties are the audit-then-notify-then-memory ordering and a
+/// must-not-throw contract that holds regardless of which dependency fails.
+/// </summary>
+public sealed class DefaultApprovalExecutionReporterTests
+{
+    private readonly Mock<IEscalationAuditStore> _auditStore = new();
+    private readonly Mock<IEscalationNotifier> _notifier = new();
+    private readonly Mock<IApprovalFailureMemory> _failureMemory = new();
+    private readonly FakeTimeProvider _timeProvider = new();
+
+    private DefaultApprovalExecutionReporter Create() => new(
+        _auditStore.Object, _notifier.Object, _failureMemory.Object, _timeProvider,
+        NullLogger<DefaultApprovalExecutionReporter>.Instance);
+
+    private static ApprovedCall Call() =>
+        new(Guid.NewGuid(), new ApprovalFailureKey("conv-1", "agent-1", "file_system"));
+
+    [Fact]
+    public async Task ReportSucceededAsync_WritesAuditBeforeNotify()
+    {
+        var order = new List<string>();
+        _auditStore.Setup(s => s.RecordExecutionAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("audit")).Returns(Task.CompletedTask);
+        _notifier.Setup(n => n.NotifyExecutionReportedAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("notify")).Returns(Task.CompletedTask);
+
+        var call = Call();
+        await Create().ReportSucceededAsync(call, "tool-invocation", CancellationToken.None);
+
+        Assert.Equal(["audit", "notify"], order);
+        _failureMemory.Verify(m => m.Clear(call.Key), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReportSucceededAsync_WritesTheExpectedAuditRecord()
+    {
+        EscalationExecutionRecord? recorded = null;
+        _auditStore.Setup(s => s.RecordExecutionAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationExecutionRecord, CancellationToken>((r, _) => recorded = r)
+            .Returns(Task.CompletedTask);
+
+        var call = Call();
+        await Create().ReportSucceededAsync(call, "tool-invocation", CancellationToken.None);
+
+        Assert.NotNull(recorded);
+        Assert.Equal(call.EscalationId, recorded!.EscalationId);
+        Assert.Equal(EscalationExecutionStatus.Succeeded, recorded.Status);
+        Assert.Null(recorded.FailureReason);
+        Assert.Equal("tool-invocation", recorded.ReportedBy);
+    }
+
+    [Fact]
+    public async Task ReportFailedAsync_RecordsFailureAgainstMemory_NotClear()
+    {
+        var call = Call();
+        await Create().ReportFailedAsync(call, "permission denied", "tool-invocation", CancellationToken.None);
+
+        _failureMemory.Verify(
+            m => m.RecordFailure(call.Key, "permission denied", call.EscalationId), Times.Once);
+        _failureMemory.Verify(m => m.Clear(It.IsAny<ApprovalFailureKey>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReportFailedAsync_WritesTheExpectedAuditRecord()
+    {
+        EscalationExecutionRecord? recorded = null;
+        _auditStore.Setup(s => s.RecordExecutionAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationExecutionRecord, CancellationToken>((r, _) => recorded = r)
+            .Returns(Task.CompletedTask);
+
+        var call = Call();
+        await Create().ReportFailedAsync(call, "permission denied", "tool-invocation", CancellationToken.None);
+
+        Assert.NotNull(recorded);
+        Assert.Equal(EscalationExecutionStatus.Failed, recorded!.Status);
+        Assert.Equal("permission denied", recorded.FailureReason);
+    }
+
+    [Fact]
+    public async Task ReportNotExecutedAsync_TouchesNeitherClearNorRecordFailure()
+    {
+        // Nothing ran, so there is no new failure to cite and any prior sequence must stay live —
+        // neither cleared nor recorded as a further failure.
+        var call = Call();
+        await Create().ReportNotExecutedAsync(
+            call, EscalationNotExecutedReason.RunCancelled, "plan-executor", CancellationToken.None);
+
+        _failureMemory.Verify(m => m.Clear(It.IsAny<ApprovalFailureKey>()), Times.Never);
+        _failureMemory.Verify(
+            m => m.RecordFailure(It.IsAny<ApprovalFailureKey>(), It.IsAny<string>(), It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReportNotExecutedAsync_WritesTheExpectedAuditRecord()
+    {
+        EscalationExecutionRecord? recorded = null;
+        _auditStore.Setup(s => s.RecordExecutionAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .Callback<EscalationExecutionRecord, CancellationToken>((r, _) => recorded = r)
+            .Returns(Task.CompletedTask);
+
+        var call = Call();
+        await Create().ReportNotExecutedAsync(
+            call, EscalationNotExecutedReason.RunCancelled, "plan-executor", CancellationToken.None);
+
+        Assert.NotNull(recorded);
+        Assert.Equal(EscalationExecutionStatus.NeverExecuted, recorded!.Status);
+        Assert.Equal(EscalationNotExecutedReason.RunCancelled, recorded.NotExecutedReason);
+    }
+
+    // ===== Must-not-throw contract: a failure in any single dependency must not escape =====
+
+    [Fact]
+    public async Task ReportSucceededAsync_AuditStoreThrows_DoesNotThrow()
+    {
+        _auditStore.Setup(s => s.RecordExecutionAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("disk full"));
+
+        var exception = await Record.ExceptionAsync(
+            () => Create().ReportSucceededAsync(Call(), "tool-invocation", CancellationToken.None).AsTask());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ReportSucceededAsync_NotifierThrows_DoesNotThrow()
+    {
+        _notifier.Setup(n => n.NotifyExecutionReportedAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("channel unreachable"));
+
+        var exception = await Record.ExceptionAsync(
+            () => Create().ReportSucceededAsync(Call(), "tool-invocation", CancellationToken.None).AsTask());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ReportSucceededAsync_NotifierThrows_MemoryIsNeverUpdated()
+    {
+        // Ordering's other half: a failed notify must not let a stale memory update slip through
+        // behind it, because the notify failure means the approver never received this report and
+        // clearing "solves" a loop that, from the approver's side, is still open.
+        _notifier.Setup(n => n.NotifyExecutionReportedAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("channel unreachable"));
+
+        await Create().ReportSucceededAsync(Call(), "tool-invocation", CancellationToken.None);
+
+        _failureMemory.Verify(m => m.Clear(It.IsAny<ApprovalFailureKey>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReportFailedAsync_MemoryThrows_DoesNotThrow()
+    {
+        _failureMemory
+            .Setup(m => m.RecordFailure(It.IsAny<ApprovalFailureKey>(), It.IsAny<string>(), It.IsAny<Guid>()))
+            .Throws(new InvalidOperationException("memory corrupted"));
+
+        var exception = await Record.ExceptionAsync(
+            () => Create().ReportFailedAsync(Call(), "boom", "tool-invocation", CancellationToken.None).AsTask());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task ReportFailedAsync_OperationCanceled_MutationControl_DoesNotThrow()
+    {
+        // The turn was abandoned while the report was in flight. This is not the caller's fault and
+        // must not surface as an exception any more than a genuine infrastructure fault does.
+        var cts = new CancellationTokenSource();
+        _auditStore.Setup(s => s.RecordExecutionAsync(It.IsAny<EscalationExecutionRecord>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        cts.Cancel();
+
+        var exception = await Record.ExceptionAsync(
+            () => Create().ReportFailedAsync(Call(), "boom", "tool-invocation", cts.Token).AsTask());
+
+        Assert.Null(exception);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/InProcessApprovalFailureMemoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/InProcessApprovalFailureMemoryTests.cs
@@ -1,0 +1,149 @@
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Services.Escalation;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Escalation;
+
+/// <summary>
+/// Tests for <see cref="InProcessApprovalFailureMemory"/> — the bounded, conversation-scoped
+/// record of failed approved attempts that #325 retry attribution reads from and writes to.
+/// </summary>
+public sealed class InProcessApprovalFailureMemoryTests
+{
+    private static InProcessApprovalFailureMemory Create() =>
+        new(TimeProvider.System, NullLogger<InProcessApprovalFailureMemory>.Instance);
+
+    private static ApprovalFailureKey Key(string conversationId = "conv-1", string agentId = "agent-1", string toolName = "file_system") =>
+        new(conversationId, agentId, toolName);
+
+    [Fact]
+    public void TryRecall_NothingRecorded_ReturnsNull()
+    {
+        var memory = Create();
+
+        var recall = memory.TryRecall(Key());
+
+        Assert.Null(recall);
+    }
+
+    [Fact]
+    public void RecordFailure_ThenTryRecall_ReturnsWhatWasRecorded()
+    {
+        var memory = Create();
+        var key = Key();
+        var escalationId = Guid.NewGuid();
+
+        memory.RecordFailure(key, "permission denied", escalationId);
+        var recall = memory.TryRecall(key);
+
+        Assert.NotNull(recall);
+        Assert.Equal(1, recall!.Value.PriorAttemptCount);
+        Assert.Equal("permission denied", recall.Value.FailureReason);
+        Assert.Equal(escalationId, recall.Value.EscalationId);
+    }
+
+    [Fact]
+    public void RecordFailure_TwiceForSameKey_IncrementsAttemptCountAndKeepsLatestReason()
+    {
+        var memory = Create();
+        var key = Key();
+
+        memory.RecordFailure(key, "first failure", Guid.NewGuid());
+        var secondEscalationId = Guid.NewGuid();
+        memory.RecordFailure(key, "second failure", secondEscalationId);
+
+        var recall = memory.TryRecall(key);
+
+        Assert.NotNull(recall);
+        Assert.Equal(2, recall!.Value.PriorAttemptCount);
+        Assert.Equal("second failure", recall.Value.FailureReason);
+        Assert.Equal(secondEscalationId, recall.Value.EscalationId);
+    }
+
+    [Fact]
+    public void RecordFailure_BlankFailureReason_Throws()
+    {
+        var memory = Create();
+
+        Assert.ThrowsAny<ArgumentException>(() => memory.RecordFailure(Key(), "", Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Clear_RemovesTheRecordedEntry()
+    {
+        var memory = Create();
+        var key = Key();
+        memory.RecordFailure(key, "boom", Guid.NewGuid());
+
+        memory.Clear(key);
+
+        Assert.Null(memory.TryRecall(key));
+    }
+
+    [Fact]
+    public void Clear_UnknownKey_MutationControl_DoesNotThrow()
+    {
+        var memory = Create();
+
+        var exception = Record.Exception(() => memory.Clear(Key("never-recorded")));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void DifferentConversationIds_AreIsolated()
+    {
+        // The key is (conversation, agent, tool) precisely so one conversation's retry history can
+        // never label another's approval card.
+        var memory = Create();
+        memory.RecordFailure(Key(conversationId: "conv-a"), "boom", Guid.NewGuid());
+
+        var recall = memory.TryRecall(Key(conversationId: "conv-b"));
+
+        Assert.Null(recall);
+    }
+
+    [Fact]
+    public void DifferentAgentIds_InSameConversation_AreIsolated()
+    {
+        // A supervisor and a delegated sub-agent calling the same tool in one conversation must not
+        // cross-label each other's retry history.
+        var memory = Create();
+        memory.RecordFailure(Key(agentId: "supervisor"), "boom", Guid.NewGuid());
+
+        var recall = memory.TryRecall(Key(agentId: "sub-agent"));
+
+        Assert.Null(recall);
+    }
+
+    [Fact]
+    public void EvictsLeastRecentlyUsed_WhenOverCapacity()
+    {
+        var memory = Create();
+
+        for (var i = 0; i <= InProcessApprovalFailureMemory.MaxTrackedActions; i++)
+            memory.RecordFailure(Key(conversationId: $"conv-{i}"), "boom", Guid.NewGuid());
+
+        // The most recently recorded entry must survive — the cap is respected, not exceeded.
+        var survivor = Key(conversationId: $"conv-{InProcessApprovalFailureMemory.MaxTrackedActions}");
+        Assert.NotNull(memory.TryRecall(survivor));
+    }
+
+    [Fact]
+    public void EvictedEntry_TryRecallReturnsNull_WhichIsTheDocumentedTradeOff()
+    {
+        // Recorded first and never touched again, so it is the least-recently-used entry once the
+        // cap is crossed. Pinned so the eviction trade-off (a benign miss, not a crash) is visible
+        // — EscalationRequestInvariants explicitly accepts the resulting "attempt > 1 with no prior
+        // failure reason" shape as valid rather than treating it as corruption.
+        var memory = Create();
+        var evicted = Key(conversationId: "first");
+        memory.RecordFailure(evicted, "boom", Guid.NewGuid());
+
+        for (var i = 0; i <= InProcessApprovalFailureMemory.MaxTrackedActions; i++)
+            memory.RecordFailure(Key(conversationId: $"conv-{i}"), "boom", Guid.NewGuid());
+
+        Assert.Null(memory.TryRecall(evicted));
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common;
 using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Agent;
@@ -16,6 +17,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Moq;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Services.Tools;
@@ -58,6 +60,7 @@ public sealed class DirectToolInvokerTests
     private readonly GovernorRecord _governor = new();
     private readonly RecordingSanitizer _sanitizer = new();
     private readonly DirectToolInvocationConfig _config = new() { Enabled = true };
+    private readonly Mock<IApprovalExecutionReporter> _executionReporter = new();
     private FakeClassificationGate? _classificationGate;
     private FakeObserverChain? _observerChain;
 
@@ -641,6 +644,62 @@ public sealed class DirectToolInvokerTests
         }
     }
 
+    // ---- #325 execution reporting ----------------------------------------------------------------
+
+    private static ApprovedCall ApprovedCall() =>
+        new(Guid.NewGuid(), new ApprovalFailureKey("conv-1", Caller, "alpha"));
+
+    [Fact]
+    public async Task ToolSucceeds_WithNoApproval_ReportsNothing()
+    {
+        // Most calls need no human approval — nothing to report a loop closing on.
+        await Invoke(Request("alpha"), Tool("alpha"));
+
+        _executionReporter.Verify(r => r.ReportSucceededAsync(
+            It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ToolSucceeds_WithApproval_ReportsSucceeded()
+    {
+        var call = ApprovedCall();
+        _governor.Decision = ToolInvocationDecision.Allow(call);
+
+        await Invoke(Request("alpha"), Tool("alpha"));
+
+        _executionReporter.Verify(
+            r => r.ReportSucceededAsync(call, "direct-invocation", CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToolReturnsFailure_WithApproval_ReportsFailedWithTheToolsError()
+    {
+        var call = ApprovedCall();
+        _governor.Decision = ToolInvocationDecision.Allow(call);
+
+        await Invoke(Request("alpha"), Tool("alpha", result: ToolResult.Fail("permission denied")));
+
+        _executionReporter.Verify(
+            r => r.ReportFailedAsync(call, "permission denied", "direct-invocation", CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task ToolThrows_WithApproval_ReportsFailedAndStillRethrows()
+    {
+        var call = ApprovedCall();
+        _governor.Decision = ToolInvocationDecision.Allow(call);
+
+        var outcome = await Invoke(
+            Request("alpha"),
+            Tool("alpha", onExecuteAsync: _ => throw new InvalidOperationException("boom")));
+
+        // The fault is reported (approval loop closed) but still surfaces as the invoker's own
+        // faulted outcome — reporting must never swallow or replace the caller-facing result.
+        _executionReporter.Verify(r => r.ReportFailedAsync(
+            call, It.IsAny<string>(), "direct-invocation", CancellationToken.None), Times.Once);
+        outcome.Status.Should().Be(DirectToolInvocationStatus.Faulted);
+    }
+
     // ---- fixture --------------------------------------------------------------------------------
 
     private DirectToolInvocationRequest Request(
@@ -699,6 +758,13 @@ public sealed class DirectToolInvokerTests
         // which is this fixture's composition. Registered because the chain requires it: an absent
         // gate and a switched-off one must never be confusable at runtime.
         services.AddSingleton(AdmissionHarness.PermissiveAuthorizationGate());
+
+        // Closes the approval loop for whichever call this chain approves. Substituted here for the
+        // same reason RecordingGovernor substitutes the real governor above: the real implementation
+        // needs the escalation subsystem's Infrastructure registrations, which this Application-layer
+        // fixture does not build — the chain still requires SOME registration, an absent one and a
+        // no-op one must never be confusable at runtime.
+        services.AddSingleton(_executionReporter.Object);
 
         // The real chain, not a mock of it, built the same way the production root builds it. This
         // suite's whole subject is what the Execution API does before, during and after a tool call,

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -98,6 +98,10 @@ public class AgentPipelineIntegrationTests
             .ReturnsAsync(Application.AI.Common.Interfaces.Governance.ToolInvocationDecision.Allow());
         services.AddScoped(_ => authorizationMock.Object);
 
+        // Closes the approval loop for whichever call this chain approves — not under test here;
+        // permissive mock so the handler resolves.
+        services.AddScoped(_ => Mock.Of<Application.AI.Common.Interfaces.Escalation.IApprovalExecutionReporter>());
+
         // The REAL admission chain over the five permissive gates above, not a mock of it, built the
         // same way the production root builds it. The handler depends only on the chain now, and
         // registering the real one keeps this an end-to-end proof that the five gates are reachable

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/EscalationSummaryTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/EscalationSummaryTests.cs
@@ -1,0 +1,66 @@
+using Application.Core.CQRS.Escalation;
+using Domain.AI.Escalation;
+using Domain.AI.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS.Escalation;
+
+/// <summary>
+/// Tests for <see cref="EscalationSummary.FromRequest"/> — the wire-safe projection an approver's
+/// dashboard actually reads, including the #325 retry-attribution fields.
+/// </summary>
+public sealed class EscalationSummaryTests
+{
+    private static EscalationRequest CreateRequest(
+        int attemptNumber = 1, string? priorFailureReason = null, Guid? predecessorEscalationId = null) =>
+        new()
+        {
+            EscalationId = Guid.NewGuid(),
+            AgentId = "agent-1",
+            ToolName = "file_system",
+            Arguments = new Dictionary<string, string>(),
+            Description = "test escalation",
+            RiskLevel = RiskLevel.High,
+            Priority = EscalationPriority.Blocking,
+            Approvers = ["alice"],
+            RequestedAt = DateTimeOffset.UtcNow,
+            AttemptNumber = attemptNumber,
+            PriorFailureReason = priorFailureReason,
+            PredecessorEscalationId = predecessorEscalationId
+        };
+
+    [Fact]
+    public void FromRequest_FirstAttempt_CarriesNoRetryAttribution()
+    {
+        var summary = EscalationSummary.FromRequest(CreateRequest());
+
+        summary.AttemptNumber.Should().Be(1);
+        summary.PriorFailureReason.Should().BeNull();
+        summary.PredecessorEscalationId.Should().BeNull();
+    }
+
+    [Fact]
+    public void FromRequest_RetryAttempt_CarriesTheRetryAttributionCard()
+    {
+        // This is the field set the whole #325 feature exists to surface — an approver reading
+        // only EscalationSummary (the list and detail read surfaces) must see it, not just the
+        // real-time notification channels.
+        var predecessorId = Guid.NewGuid();
+        var request = CreateRequest(attemptNumber: 2, priorFailureReason: "permission denied", predecessorEscalationId: predecessorId);
+
+        var summary = EscalationSummary.FromRequest(request);
+
+        summary.AttemptNumber.Should().Be(2);
+        summary.PriorFailureReason.Should().Be("permission denied");
+        summary.PredecessorEscalationId.Should().Be(predecessorId);
+    }
+
+    [Fact]
+    public void FromRequest_NullRequest_Throws()
+    {
+        var act = () => EscalationSummary.FromRequest(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/EscalationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/EscalationConfigValidatorTests.cs
@@ -206,6 +206,57 @@ public class EscalationConfigValidatorTests
         result.IsValid.Should().BeTrue();
     }
 
+    [Fact]
+    public async Task Validate_DefaultRetryAttributionCap_NoErrors()
+    {
+        // Mutation control: the class default (512) must pass without the test having to know its
+        // exact value — a default (or omitted) section always passes.
+        var config = CreateValidConfig();
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_RetryAttributionCapZero_HasError()
+    {
+        var config = CreateValidConfig();
+        config.RetryAttribution.MaxPriorFailureLength = 0;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "RetryAttribution.MaxPriorFailureLength");
+    }
+
+    [Fact]
+    public async Task Validate_RetryAttributionCapAboveTheHardCeiling_HasError()
+    {
+        // A soft cap above EscalationRequestInvariants.MaxPriorFailureReasonLength (4096) could
+        // never be honoured — every retry-attribution request would fail that invariant instead
+        // of showing a shorter card.
+        var config = CreateValidConfig();
+        config.RetryAttribution.MaxPriorFailureLength = 5000;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "RetryAttribution.MaxPriorFailureLength");
+    }
+
+    [Fact]
+    public async Task Validate_RetryAttributionCapAtTheHardCeiling_NoErrors()
+    {
+        // Boundary control: exactly at the ceiling must still pass.
+        var config = CreateValidConfig();
+        config.RetryAttribution.MaxPriorFailureLength = 4096;
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
     private static EscalationConfig CreateValidConfig() => new()
     {
         Enabled = true,

--- a/src/Content/Tests/Domain.AI.Tests/Escalation/EscalationExecutionRecordTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Escalation/EscalationExecutionRecordTests.cs
@@ -1,0 +1,93 @@
+using Domain.AI.Escalation;
+using Xunit;
+
+namespace Domain.AI.Tests.Escalation;
+
+/// <summary>
+/// Tests for <see cref="EscalationExecutionRecord"/>'s factories — the shape that makes a failure
+/// with no reason, or a never-executed record with no reason, unconstructable rather than merely
+/// discouraged.
+/// </summary>
+public sealed class EscalationExecutionRecordTests
+{
+    private static readonly Guid EscalationId = Guid.NewGuid();
+    private static readonly DateTimeOffset ReportedAt = DateTimeOffset.UtcNow;
+    private const string ReportedBy = "tool-invocation";
+
+    [Fact]
+    public void Succeeded_SetsExpectedShape()
+    {
+        var record = EscalationExecutionRecord.Succeeded(EscalationId, ReportedAt, ReportedBy);
+
+        Assert.Equal(EscalationId, record.EscalationId);
+        Assert.Equal(EscalationExecutionStatus.Succeeded, record.Status);
+        Assert.Null(record.FailureReason);
+        Assert.Null(record.NotExecutedReason);
+        Assert.Equal(ReportedAt, record.ReportedAt);
+        Assert.Equal(ReportedBy, record.ReportedBy);
+    }
+
+    [Fact]
+    public void Failed_SetsExpectedShape()
+    {
+        var record = EscalationExecutionRecord.Failed(EscalationId, "permission denied", ReportedAt, ReportedBy);
+
+        Assert.Equal(EscalationExecutionStatus.Failed, record.Status);
+        Assert.Equal("permission denied", record.FailureReason);
+        Assert.Null(record.NotExecutedReason);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Failed_BlankFailureReason_Throws(string? failureReason)
+    {
+        // The whole point of the private constructor: a Failed record with nothing an approver can
+        // read is indistinguishable from success, so this shape must never exist rather than be
+        // guarded against at every reader.
+        Assert.ThrowsAny<ArgumentException>(
+            () => EscalationExecutionRecord.Failed(EscalationId, failureReason!, ReportedAt, ReportedBy));
+    }
+
+    [Fact]
+    public void Failed_NonBlankFailureReason_MutationControl_DoesNotThrow()
+    {
+        var exception = Record.Exception(
+            () => EscalationExecutionRecord.Failed(EscalationId, "boom", ReportedAt, ReportedBy));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void NeverExecuted_SetsExpectedShape()
+    {
+        var record = EscalationExecutionRecord.NeverExecuted(
+            EscalationId, EscalationNotExecutedReason.RunCancelled, ReportedAt, ReportedBy);
+
+        Assert.Equal(EscalationExecutionStatus.NeverExecuted, record.Status);
+        Assert.Null(record.FailureReason);
+        Assert.Equal(EscalationNotExecutedReason.RunCancelled, record.NotExecutedReason);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public void Succeeded_BlankReportedBy_Throws(string? reportedBy)
+    {
+        // ReportedBy is what makes "nobody reported" distinguishable from "this site reported" when
+        // auditing which raising sites implement execution reporting — a blank value defeats that.
+        Assert.ThrowsAny<ArgumentException>(
+            () => EscalationExecutionRecord.Succeeded(EscalationId, ReportedAt, reportedBy!));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NeverExecuted_BlankReportedBy_Throws(string? reportedBy)
+    {
+        Assert.ThrowsAny<ArgumentException>(() => EscalationExecutionRecord.NeverExecuted(
+            EscalationId, EscalationNotExecutedReason.RunCancelled, ReportedAt, reportedBy!));
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
@@ -64,6 +65,7 @@ internal static class PermissiveAdmission
             Mock.Of<IToolCallObserverChain>(),
             progress.Object,
             trace,
+            Mock.Of<IApprovalExecutionReporter>(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common;
 using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Services.AI;
@@ -156,6 +157,7 @@ public sealed class PlanRunLlmCallScopeTests
         services.AddSingleton(StepExecutors.PermissiveAdmission.AuthorizationGate());
         services.AddSingleton(StepExecutors.PermissiveAdmission.ProgressGuard());
         services.AddSingleton(StepExecutors.PermissiveAdmission.TraceRecorder());
+        services.AddSingleton(Mock.Of<IApprovalExecutionReporter>());
         // Step executors require the admission chain rather than defaulting it to null, so that a
         // composition which forgets it fails at resolution instead of running unguarded. The real
         // chain over the gates above, built the same way the production root builds it — a mock of

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Sandbox;
@@ -266,6 +267,7 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         services.AddScoped(_ => StepExecutors.PermissiveAdmission.ProgressGuard());
         services.AddScoped(_ => StepExecutors.PermissiveAdmission.TraceRecorder());
         services.AddScoped(_ => new Mock<IAgentToolAuthorizationGate>().Object);
+        services.AddScoped(_ => new Mock<IApprovalExecutionReporter>().Object);
         // Step executors take the admission chain as a required dependency, deliberately: an omitted
         // chain is indistinguishable at runtime from a host whose gates are all off, so a nullable
         // default would let a composition silently run the plan path unguarded. The real composition

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
@@ -52,6 +53,7 @@ internal static class PermissiveAdmission
             observers ?? Mock.Of<IToolCallObserverChain>(),
             ProgressGuard(),
             TraceRecorder(),
+            Mock.Of<IApprovalExecutionReporter>(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
 
     /// <summary>A loop guard that never halts — what the real one answers while switched off.</summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -1,9 +1,11 @@
 using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Attestation;
+using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.AI.Planner;
 using Domain.Common.Config.AI;
@@ -25,6 +27,7 @@ public sealed class ToolUseStepExecutorTests
     private readonly Mock<ICompositeResponseSanitizer> _responseSanitizer = new();
     private readonly Mock<IPlanProgressNotifier> _notifier = new();
     private readonly Mock<ISandboxExecutor> _sandboxExecutor = new();
+    private readonly Mock<IApprovalExecutionReporter> _executionReporter = new();
     private readonly PlanExecutionContext _context = new() { CurrentPlanId = new PlanId(Guid.NewGuid()) };
     private readonly ToolUseStepExecutor _sut;
 
@@ -482,6 +485,7 @@ public sealed class ToolUseStepExecutorTests
             observers,
             PermissiveAdmission.ProgressGuard(),
             PermissiveAdmission.TraceRecorder(),
+            _executionReporter.Object,
             NullLogger<ToolCallAdmissionPipeline>.Instance);
 
     /// <summary>
@@ -535,5 +539,93 @@ public sealed class ToolUseStepExecutorTests
         Assert.Contains("\"op\"", captured!.Input);
         Assert.Contains("5", captured.Input);
         Assert.Contains("3", captured.Input);
+    }
+
+    // ===== #325 execution reporting =====
+
+    private static readonly ApprovedCall Call = new(
+        Guid.NewGuid(), new ApprovalFailureKey("conv-1", "plan-executor", "file_system"));
+
+    private void GovernorApproves() =>
+        _toolGovernor
+            .Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<IReadOnlyDictionary<string, object?>?>()))
+            .Returns(ValueTask.FromResult(ToolInvocationDecision.Allow(Call)));
+
+    [Fact]
+    public async Task ExecuteAsync_NoApproval_ReportsNothing()
+    {
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
+
+        await _sut.ExecuteAsync(CreateStep(new ToolUseConfig { ToolName = "file_system" }),
+            new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        _executionReporter.Verify(
+            r => r.ReportSucceededAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ApprovedCallSucceeds_ReportsSucceeded()
+    {
+        GovernorApproves();
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
+
+        await _sut.ExecuteAsync(CreateStep(new ToolUseConfig { ToolName = "file_system" }),
+            new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        _executionReporter.Verify(
+            r => r.ReportSucceededAsync(Call, "plan-executor", CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ApprovedCallSandboxReportsFailure_ReportsFailed()
+    {
+        GovernorApproves();
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult { Success = false, ErrorMessage = "container OOM-killed" });
+
+        await _sut.ExecuteAsync(CreateStep(new ToolUseConfig { ToolName = "file_system" }),
+            new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        _executionReporter.Verify(
+            r => r.ReportFailedAsync(Call, It.IsAny<string>(), "plan-executor", CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ApprovedCallSandboxThrows_ReportsFailedAndStillFailsTheStep()
+    {
+        GovernorApproves();
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("sandbox host unreachable"));
+
+        var result = await _sut.ExecuteAsync(CreateStep(new ToolUseConfig { ToolName = "file_system" }),
+            new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Failed, result.Status);
+        _executionReporter.Verify(
+            r => r.ReportFailedAsync(Call, It.IsAny<string>(), "plan-executor", CancellationToken.None), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ApprovedCallCancelledDuringSandbox_ReportsNeverExecuted_NotFailed()
+    {
+        // The #325 gap only the plan-executor path has a producer for: a plan run is checkpointed
+        // and resumable, so "cancelled mid-call" must not be reported as "failed" — the step may
+        // still succeed once the plan resumes and re-admits it.
+        GovernorApproves();
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => _sut.ExecuteAsync(
+            CreateStep(new ToolUseConfig { ToolName = "file_system" }),
+            new Dictionary<PlanStepId, string>(), CancellationToken.None));
+
+        _executionReporter.Verify(
+            r => r.ReportNotExecutedAsync(Call, EscalationNotExecutedReason.RunCancelled, "plan-executor", CancellationToken.None),
+            Times.Once);
+        _executionReporter.Verify(
+            r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
## Summary

Closes #325. An approver could see they approved a tool call but never learn whether it actually succeeded, failed, or ran at all — a failed action and a completed one looked identical in the audit trail. A corrected retry was also indistinguishable from being asked the same question twice.

- **Reports the executed outcome.** `IApprovalExecutionReporter` closes the loop from all three live execution paths — direct HTTP invocation (`DirectToolInvoker`), a live agent conversation (`GovernedAIFunction`), and an automated plan step (`ToolUseStepExecutor`) — through the existing `IToolCallAdmissionPipeline`, which now threads an `ApprovedCall` value from the moment of approval through to execution. The plan-executor path also reports `NeverExecuted` when a plan run is cancelled mid-call, since a checkpointed/resumable plan can't honestly claim "failed" for a call that may still succeed on resume.
- **Attributes retries.** A bounded, conversation-scoped failure memory (`InProcessApprovalFailureMemory`, cap 2,000, LRU) lets `EscalationToolApprovalRouter` show the next approver "this failed last time, here's why" instead of asking cold. Keyed on (conversation, agent, tool) — deliberately excluding arguments, since a corrected retry has different arguments by definition. Cleared only on an explicit human denial, never on timeout.
- Ships the boot-time config tie (`EscalationConfigValidator`) between the display truncation cap and the hard runtime ceiling, and surfaces the retry-attribution fields on the HTTP read path (`EscalationSummary`).

## Review history

Three passes on the committed diff, receipts recorded:
1. **`/code-review`** found 4 real issues, all fixed: every execution report was mislabeled with one hardcoded call-site tag regardless of which of the three paths actually produced it; the direct-invocation surface reused a stable per-caller identity as the retry-attribution conversation key, so unrelated calls hours apart could be shown as retries of each other; a rare concurrent-write race could corrupt a cached retry record's escalation id; and `ToolUseStepExecutor.ExecuteAsync` had grown past the repo's method-length convention (split into 5 focused methods — caught and fixed a self-introduced fire-and-forget bug while doing so, before it ever shipped).
2. **`/simplify`** (4 parallel angles) found two real duplications, both fixed: a key-construction guard independently reimplemented in two files (extracted a factory), and a catch-and-report pattern triplicated across two call sites sharing a literal string verbatim (extracted a shared helper). Flagged but deliberately not fixed this round: a shared bounded-LRU cache abstraction (would touch an unrelated existing file outside this diff) and making the call-site label a closed enum instead of a string convention (larger, wire-format-sensitive refactor) — both noted as follow-ups.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 errors
- [x] `dotnet test src/AgenticHarness.slnx` — all 22 test projects pass, 0 failures (run twice: once before review fixes, once after)
- [x] New/extended test coverage: `InProcessApprovalFailureMemoryTests`, `DefaultApprovalExecutionReporterTests`, `EscalationExecutionRecordTests`, extended `EscalationRequestInvariantsTests`, `EscalationToolApprovalRouterTests` (recall/truncation/clear-on-denial-only), `ToolCallAdmissionPipelineTests` (dispatch), `DirectToolInvokerTests`/`GovernedAIFunctionTests`/`ToolUseStepExecutorTests` (all three reporting call sites, including the plan-executor cancellation → `NeverExecuted` path), `EscalationConfigValidatorTests`, `EscalationSummaryTests`
- [x] Every new guard has a mutation control per repo convention

## Known, documented gap (not fixed here — out of scope)

An approved call can still be refused by a later admission gate, so the tool never runs and no execution record is written — distinguishing "refused after approval" from "refused before one" needs more design than this PR's scope. Also: for an `ITool`-backed function reached via the agent-turn path, a tool-level failure that returns an error string (rather than throwing) is currently reported as `Succeeded`, because the generic tool→AIFunction converter flattens `ToolResult.Fail` into a string before this layer ever sees it — fixing that precisely means changing what every tool converter returns on failure, out of scope for wiring an existing report call into this path. Both are documented in code comments at their exact location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgyekFt9vVUfL75GP1HL7d