### PR TITLE
feat: wire a bundle's own MCP servers into its run (#368)

### DIFF
--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -116,7 +116,7 @@ public sealed class RunBundleCommandHandler
             UserMessages = request.UserMessages,
             MaxTurns = request.MaxTurns,
             ConversationId = request.ConversationId,
-            Envelope = request.Envelope,
+            Envelope = WithBundleOwnedMcpServers(request.Envelope, staged),
             Status = BundleRunStatus.Queued,
             Streaming = request.Stream,
             CreatedAt = _time.GetUtcNow()
@@ -137,6 +137,22 @@ public sealed class RunBundleCommandHandler
 
         return Result<RunBundleResult>.Success(new RunBundleResult { JobId = record.JobId });
     }
+
+    /// <summary>
+    /// Additively unions the bundle's own registered MCP server names (<see cref="StagedBundle.McpServerNames"/>)
+    /// into the caller's resolved envelope's <see cref="CapabilityEnvelope.AllowedMcpServers"/> — union
+    /// only, never replace, so the caller's own configured grant is never narrowed by running a bundle.
+    /// A bundle with no MCP servers (the common case) returns the envelope unchanged. The tool NAMES a
+    /// bundle-owned server publishes are granted separately, once the server is actually reachable — see
+    /// <c>BundleRunExecutor.RunConversationAsync</c>.
+    /// </summary>
+    private static CapabilityEnvelope WithBundleOwnedMcpServers(CapabilityEnvelope envelope, StagedBundle staged)
+        => staged.McpServerNames.Count == 0
+            ? envelope
+            : envelope with
+            {
+                AllowedMcpServers = [.. envelope.AllowedMcpServers, .. staged.McpServerNames]
+            };
 
     /// <summary>
     /// True when this caller may run against the requested conversation — either because it is theirs,

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -142,8 +142,12 @@ public sealed class RunBundleCommandHandler
     /// Additively unions the bundle's own registered MCP server names (<see cref="StagedBundle.McpServerNames"/>)
     /// into the caller's resolved envelope's <see cref="CapabilityEnvelope.AllowedMcpServers"/> — union
     /// only, never replace, so the caller's own configured grant is never narrowed by running a bundle.
-    /// A bundle with no MCP servers (the common case) returns the envelope unchanged. The tool NAMES a
-    /// bundle-owned server publishes are granted separately, once the server is actually reachable — see
+    /// Also stamps the SAME names into <see cref="CapabilityEnvelope.BundleOwnedMcpServers"/> — the only
+    /// place that field is ever populated, so "is this granted server bundle-owned" is answered from this
+    /// run's own provenance, never re-derived downstream from a server name's shape (which a host-plugin
+    /// server can share, since <c>PluginLoader</c> namespaces those identically). A bundle with no MCP
+    /// servers (the common case) returns the envelope unchanged. The tool NAMES a bundle-owned server
+    /// publishes are granted separately, once the server is actually reachable — see
     /// <c>BundleRunExecutor.RunConversationAsync</c>.
     /// </summary>
     private static CapabilityEnvelope WithBundleOwnedMcpServers(CapabilityEnvelope envelope, StagedBundle staged)
@@ -151,7 +155,8 @@ public sealed class RunBundleCommandHandler
             ? envelope
             : envelope with
             {
-                AllowedMcpServers = [.. envelope.AllowedMcpServers, .. staged.McpServerNames]
+                AllowedMcpServers = [.. envelope.AllowedMcpServers, .. staged.McpServerNames],
+                BundleOwnedMcpServers = [.. envelope.BundleOwnedMcpServers, .. staged.McpServerNames]
             };
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleMcpServerRegistrar.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleMcpServerRegistrar.cs
@@ -1,0 +1,21 @@
+namespace Application.AI.Common.Interfaces.Bundles;
+
+/// <summary>
+/// Tears down a bundle's own MCP server registrations when its handle is evicted — the deregistration
+/// counterpart to the registration <c>BundleStagingService</c> performs at staging time. A bundle's
+/// servers are registered under a bundle-scoped, namespaced key
+/// (<c>StagedBundle.McpServerNames</c>) that no other bundle or host server shares, so deregistering
+/// them can never affect anything outside the one bundle whose handle was removed.
+/// </summary>
+public interface IBundleMcpServerRegistrar
+{
+    /// <summary>
+    /// Removes each of <paramref name="serverNames"/> from the shared MCP server configuration and
+    /// disconnects any live client connected under that name. Idempotent — a name that was never
+    /// registered, or was already deregistered, is a no-op for that name. Never throws for a bad or
+    /// already-gone name; a connection-level failure while disconnecting is logged and swallowed, not
+    /// propagated, since this runs on cleanup paths that must not fail the caller.
+    /// </summary>
+    /// <param name="serverNames">The bundle-scoped, namespaced server names to deregister.</param>
+    Task DeregisterAsync(IReadOnlyList<string> serverNames);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
@@ -42,6 +42,17 @@ public static class BundleOwnedMcpToolNaming
     public static string BuildToolName(string namespacedServerName, string rawToolName)
         => $"{Sanitize(namespacedServerName)}{Separator}{rawToolName}";
 
+    /// <summary>
+    /// Whether <paramref name="serverName"/> is a bundle-owned, namespaced server key
+    /// (<c>{BundleId}:{serverName}</c>, per <see cref="Domain.AI.Bundles.StagedBundle.McpServerNames"/>)
+    /// rather than a plain, host-configured server name. Host-configured names never contain a colon —
+    /// <c>BundleStagingService.RegisterBundleMcpServers</c> is the only producer of a colon-bearing
+    /// server key in this codebase — so this is a reliable, non-heuristic test everywhere a caller
+    /// holds an already-resolved server name (as opposed to <c>ToolChainBuilder.ResolveEffectiveMcpServerName</c>,
+    /// which instead suffix-matches a skill's bare declared name against the granted list).
+    /// </summary>
+    public static bool IsNamespacedServerName(string serverName) => serverName.Contains(':');
+
     private static string Sanitize(string value)
     {
         var chars = new char[value.Length];

--- a/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
@@ -1,0 +1,55 @@
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Computes the collision-proof, model-facing name for a tool resolved via a bundle's own (bundle-
+/// authored, untrusted) MCP server.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists.</strong> Making a bundle's own MCP server usable requires granting the
+/// tool names it publishes into the run's <c>CapabilityEnvelope.AllowedTools</c> — but the invocation-
+/// time governance gate (<c>ToolInvocationGovernor.EnvelopeGrantsToolWhenArmed</c>) authorizes purely
+/// by NAME, with no notion of which server a call actually resolves through. Granting a bundle's
+/// self-reported tool name verbatim would let a malicious bundle advertise a tool literally named
+/// after a real, more privileged host tool (reachable via keyed DI or a host-configured MCP server)
+/// and get that unrelated tool auto-granted by name coincidence — a privilege escalation that costs
+/// the attacker nothing but picking a string.
+/// </para>
+/// <para>
+/// Namespacing the tool's own callable name to its originating server — not just internal bookkeeping,
+/// but the actual name published to the model and checked at invocation — closes this by construction:
+/// the granted name can only ever have come from this one server, for this one bundle, because the
+/// namespace prefix is derived from the host-generated, attacker-uncontrolled bundle id, never from
+/// anything the bundle author chooses.
+/// </para>
+/// <para>
+/// Both the publisher (<c>ToolChainBuilder</c>, which wraps the tool the model calls) and the granter
+/// (<c>BundleRunExecutor</c>, which populates <c>AllowedTools</c>) call this SAME function, so the
+/// published name and the granted name can never drift apart.
+/// </para>
+/// </remarks>
+public static class BundleOwnedMcpToolNaming
+{
+    private const string Separator = "__";
+
+    /// <summary>
+    /// Builds the namespaced tool name for <paramref name="rawToolName"/> as published by
+    /// <paramref name="namespacedServerName"/> (the bundle-scoped <c>{bundleId}:{serverName}</c> key
+    /// under which the server itself is registered). The server portion is sanitized to the character
+    /// set most LLM providers require for a function name; the tool's own name is left exactly as the
+    /// server declared it, matching how any other MCP tool name is trusted today.
+    /// </summary>
+    public static string BuildToolName(string namespacedServerName, string rawToolName)
+        => $"{Sanitize(namespacedServerName)}{Separator}{rawToolName}";
+
+    private static string Sanitize(string value)
+    {
+        var chars = new char[value.Length];
+        for (var i = 0; i < value.Length; i++)
+        {
+            var c = value[i];
+            chars[i] = char.IsAsciiLetterOrDigit(c) || c is '_' or '-' ? c : '_';
+        }
+        return new string(chars);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+
 namespace Application.AI.Common.Services.Tools;
 
 /// <summary>
@@ -33,14 +36,78 @@ public static class BundleOwnedMcpToolNaming
     private const string Separator = "__";
 
     /// <summary>
+    /// The hard cap OpenAI and Azure OpenAI both enforce on a function/tool name
+    /// (<c>^[a-zA-Z0-9_-]{1,64}$</c>). A name that exceeds this is rejected outright, failing every turn
+    /// of the run — see <see cref="Shorten"/>.
+    /// </summary>
+    private const int MaxToolNameLength = 64;
+
+    /// <summary>Bytes of the content hash kept in a disambiguating suffix, rendered as hex (twice this many characters).</summary>
+    private const int HashSuffixByteCount = 5;
+
+    /// <summary>
     /// Builds the namespaced tool name for <paramref name="rawToolName"/> as published by
     /// <paramref name="namespacedServerName"/> (the bundle-scoped <c>{bundleId}:{serverName}</c> key
-    /// under which the server itself is registered). The server portion is sanitized to the character
-    /// set most LLM providers require for a function name; the tool's own name is left exactly as the
-    /// server declared it, matching how any other MCP tool name is trusted today.
+    /// under which the server itself is registered). The server portion is sanitized to the character set
+    /// OpenAI and Azure OpenAI both require for a function name (<c>^[a-zA-Z0-9_-]{1,64}$</c>); the tool's
+    /// own (untrusted, bundle-server-declared) name goes through the same sanitization via
+    /// <see cref="SanitizeToolName"/> — a bundle-authored MCP server can name its tool anything, including
+    /// spaces or punctuation no provider's function-calling API accepts, and an unsanitized name fails
+    /// every turn of the run exactly like an over-length one does. When the sanitized concatenation would
+    /// still exceed <see cref="MaxToolNameLength"/> — routine, not just adversarial, for an ordinary bundle
+    /// id + server name + tool name — the result is deterministically shortened by <see cref="Shorten"/>
+    /// instead, so the published name always stays within the limit every provider enforces.
     /// </summary>
     public static string BuildToolName(string namespacedServerName, string rawToolName)
-        => $"{Sanitize(namespacedServerName)}{Separator}{rawToolName}";
+    {
+        var full = $"{Sanitize(namespacedServerName)}{Separator}{SanitizeToolName(rawToolName)}";
+        return full.Length <= MaxToolNameLength ? full : Shorten(full);
+    }
+
+    /// <summary>
+    /// Sanitizes <paramref name="rawToolName"/> to the provider charset. When the raw name was already
+    /// clean, <see cref="Sanitize"/> is a no-op and the result is returned as-is — preserving a short,
+    /// readable name for the overwhelmingly common case. When sanitization actually changes the name, it
+    /// necessarily collapses information (multiple distinct raw characters all map to <c>'_'</c>), so two
+    /// different raw tool names from the same server can sanitize to the identical string (e.g. "get user"
+    /// and "get.user" both become "get_user") — silently merging two different tools into one published
+    /// name, which the tool-chain's dedup-by-name step would then drop one of without any signal. A content
+    /// hash of the ORIGINAL raw name is appended whenever sanitization was non-trivial, so distinct raw
+    /// names stay distinct after sanitizing; two raw names that are already letter-for-letter identical
+    /// correctly still produce the same result, since they name the same tool.
+    /// </summary>
+    private static string SanitizeToolName(string rawToolName)
+    {
+        var sanitized = Sanitize(rawToolName);
+        return sanitized == rawToolName ? sanitized : $"{sanitized}_{HexHashPrefix(rawToolName)}";
+    }
+
+    /// <summary>
+    /// Fits an over-length namespaced name into <see cref="MaxToolNameLength"/> characters by keeping a
+    /// leading slice of it (long enough to always retain the host-generated bundle-id prefix, since that
+    /// prefix — never the server or tool name — is what the security property in
+    /// <see cref="BundleOwnedMcpToolNaming"/>'s class remarks relies on being attacker-uncontrolled) and
+    /// replacing the rest with a content hash of the FULL untruncated name. The hash is computed over
+    /// everything, so two different (server, tool) pairs that share the same truncated head — including
+    /// two pairs whose head is empty because the server prefix alone already overflows the budget — still
+    /// diverge in the appended hash almost certainly, keeping the scheme collision-resistant without
+    /// depending on how much of the head survives. Only called once <paramref name="full"/> is already
+    /// confirmed to exceed <see cref="MaxToolNameLength"/>, so the head slice never runs past the end of
+    /// <paramref name="full"/>.
+    /// </summary>
+    private static string Shorten(string full)
+    {
+        var suffix = $"{Separator}{HexHashPrefix(full)}";
+        var head = full[..(MaxToolNameLength - suffix.Length)];
+        return $"{head}{suffix}";
+    }
+
+    /// <summary>The first <see cref="HashSuffixByteCount"/> bytes of <paramref name="value"/>'s SHA-256 digest, as lowercase hex.</summary>
+    private static string HexHashPrefix(string value)
+    {
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexStringLower(digest.AsSpan(0, HashSuffixByteCount));
+    }
 
     private static string Sanitize(string value)
     {

--- a/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
@@ -42,17 +42,6 @@ public static class BundleOwnedMcpToolNaming
     public static string BuildToolName(string namespacedServerName, string rawToolName)
         => $"{Sanitize(namespacedServerName)}{Separator}{rawToolName}";
 
-    /// <summary>
-    /// Whether <paramref name="serverName"/> is a bundle-owned, namespaced server key
-    /// (<c>{BundleId}:{serverName}</c>, per <see cref="Domain.AI.Bundles.StagedBundle.McpServerNames"/>)
-    /// rather than a plain, host-configured server name. Host-configured names never contain a colon —
-    /// <c>BundleStagingService.RegisterBundleMcpServers</c> is the only producer of a colon-bearing
-    /// server key in this codebase — so this is a reliable, non-heuristic test everywhere a caller
-    /// holds an already-resolved server name (as opposed to <c>ToolChainBuilder.ResolveEffectiveMcpServerName</c>,
-    /// which instead suffix-matches a skill's bare declared name against the granted list).
-    /// </summary>
-    public static bool IsNamespacedServerName(string serverName) => serverName.Contains(':');
-
     private static string Sanitize(string value)
     {
         var chars = new char[value.Length];

--- a/src/Content/Application/Application.AI.Common/Services/Tools/McpToolFetch.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/McpToolFetch.cs
@@ -1,0 +1,35 @@
+using Application.AI.Common.Interfaces;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Fetches one MCP server's tools, treating an unreachable server as "contributes nothing" rather than
+/// a failed operation. Shared by <see cref="ToolChainBuilder"/> (fetching tools to publish) and
+/// <c>BundleRunExecutor</c> (fetching tools to discover grant names) so both apply the exact same
+/// fail-soft policy instead of maintaining independent copies of the same try/catch.
+/// </summary>
+public static class McpToolFetch
+{
+    /// <summary>
+    /// Fetches <paramref name="serverName"/>'s tools via <paramref name="mcpToolProvider"/>. Returns
+    /// <see langword="null"/> — logged, never thrown — when the server could not be reached, so a single
+    /// unreachable server never fails the caller's larger operation (a tool build, or a run's grant
+    /// discovery).
+    /// </summary>
+    /// <param name="context">Short caller-identifying prefix for the log message, e.g. <c>"Capability envelope"</c>.</param>
+    public static async Task<IList<AITool>?> TryGetToolsAsync(
+        IMcpToolProvider mcpToolProvider, string serverName, string context, ILogger logger, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await mcpToolProvider.GetToolsAsync(serverName, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "{Context}: MCP server '{Server}' could not be reached — skipped", context, serverName);
+            return null;
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/NamespacedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/NamespacedAIFunction.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Wraps a tool resolved via a bundle's own MCP server so it is published to the model and governed
+/// under its namespaced name (<see cref="BundleOwnedMcpToolNaming"/>) rather than the bare name the
+/// (untrusted, bundle-authored) server itself declared. Derives from <see cref="DelegatingAIFunction"/>
+/// so invocation, description, and schema all still delegate to the inner function — only the name
+/// changes, which is exactly what the invocation-time governance gate matches on.
+/// </summary>
+internal sealed class NamespacedAIFunction : DelegatingAIFunction
+{
+    /// <summary>Wraps <paramref name="innerFunction"/> under <paramref name="namespacedName"/>.</summary>
+    public NamespacedAIFunction(AIFunction innerFunction, string namespacedName)
+        : base(innerFunction)
+    {
+        Name = namespacedName;
+    }
+
+    /// <inheritdoc />
+    public override string Name { get; }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -94,21 +94,9 @@ public partial class ToolChainBuilder : IToolChainBuilder
         var injected = new List<ProvisionedTool>();
         foreach (var (serverName, serverTools) in await ResolveInjectedMcpToolsAsync(cancellationToken))
         {
-            // Mirrors ProvisionToolAsync's Managed-mode wrapping: a bundle-owned server's tools must be
-            // published under a namespaced name (never the bare, bundle-chosen one a malicious bundle
-            // controls), because that published name is exactly what gets checked against
-            // CapabilityEnvelope.AllowedTools at invocation time. BundleRunExecutor grants the namespaced
-            // name via this same BundleOwnedMcpToolNaming.BuildToolName; publishing the bare name here
-            // would both deny every legitimate call (never in AllowedTools) and reopen the name-collision
-            // privilege escalation ProvisionToolAsync already closes on the Managed path.
             var isBundleOwned = BundleOwnedMcpToolNaming.IsNamespacedServerName(serverName);
             foreach (var t in serverTools)
-            {
-                var published = isBundleOwned && t is AIFunction fn
-                    ? (AITool)new NamespacedAIFunction(fn, BundleOwnedMcpToolNaming.BuildToolName(serverName, t.Name))
-                    : t;
-                injected.Add(new ProvisionedTool(published, serverName));
-            }
+                injected.Add(new ProvisionedTool(PublishServerTool(t, serverName, isBundleOwned), serverName));
         }
 
         if (options.AdditionalTools?.Count > 0)
@@ -204,6 +192,23 @@ public partial class ToolChainBuilder : IToolChainBuilder
         var survivorSet = new HashSet<AITool>(survivors, ReferenceEqualityComparer.Instance);
         return provisioned.Where(p => survivorSet.Contains(p.Tool)).ToList();
     }
+
+    /// <summary>
+    /// Publishes one server-resolved tool under its governed name. A bundle-owned server's
+    /// <see cref="AIFunction"/> tools are wrapped in <see cref="NamespacedAIFunction"/> under
+    /// <see cref="BundleOwnedMcpToolNaming.BuildToolName"/> — never the bare, bundle-chosen name a
+    /// malicious bundle controls — because that published name is exactly what gets checked against
+    /// <c>CapabilityEnvelope.AllowedTools</c> at invocation time; <c>BundleRunExecutor</c> grants the
+    /// SAME namespaced name via this same function, so the two can never drift apart. Everything else
+    /// (a non-bundle-owned server, or a non-<see cref="AIFunction"/> tool) passes through unchanged.
+    /// Shared by both MCP resolution paths — <see cref="BuildInjectedModeToolsAsync"/> and
+    /// <see cref="ProvisionToolAsync"/> — so this decision is made in exactly one place, never
+    /// independently re-decided (and potentially missed) per call site.
+    /// </summary>
+    private static AITool PublishServerTool(AITool tool, string serverName, bool isBundleOwned) =>
+        isBundleOwned && tool is AIFunction fn
+            ? new NamespacedAIFunction(fn, BundleOwnedMcpToolNaming.BuildToolName(serverName, tool.Name))
+            : tool;
 
     /// <summary>
     /// The single exit every resolution path in <em>this builder</em> returns through: drops tools whose
@@ -377,14 +382,9 @@ public partial class ToolChainBuilder : IToolChainBuilder
                     // tools are published and governed under a namespaced name (never the bare,
                     // bundle-chosen one) so a malicious bundle cannot get a real host tool auto-granted
                     // by advertising a same-named tool of its own. See BundleOwnedMcpToolNaming.
-                    var published = isBundleOwned
-                        ? mcpTools.Select(t => t is AIFunction fn
-                            ? (AITool)new NamespacedAIFunction(
-                                fn, BundleOwnedMcpToolNaming.BuildToolName(effectiveServerName, t.Name))
-                            : t)
-                        : mcpTools;
-
-                    return published.Select(t => new ProvisionedTool(t, effectiveServerName)).ToList();
+                    return mcpTools
+                        .Select(t => new ProvisionedTool(PublishServerTool(t, effectiveServerName, isBundleOwned), effectiveServerName))
+                        .ToList();
                 }
             }
             catch (Exception ex)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -93,8 +93,23 @@ public partial class ToolChainBuilder : IToolChainBuilder
     {
         var injected = new List<ProvisionedTool>();
         foreach (var (serverName, serverTools) in await ResolveInjectedMcpToolsAsync(cancellationToken))
+        {
+            // Mirrors ProvisionToolAsync's Managed-mode wrapping: a bundle-owned server's tools must be
+            // published under a namespaced name (never the bare, bundle-chosen one a malicious bundle
+            // controls), because that published name is exactly what gets checked against
+            // CapabilityEnvelope.AllowedTools at invocation time. BundleRunExecutor grants the namespaced
+            // name via this same BundleOwnedMcpToolNaming.BuildToolName; publishing the bare name here
+            // would both deny every legitimate call (never in AllowedTools) and reopen the name-collision
+            // privilege escalation ProvisionToolAsync already closes on the Managed path.
+            var isBundleOwned = BundleOwnedMcpToolNaming.IsNamespacedServerName(serverName);
             foreach (var t in serverTools)
-                injected.Add(new ProvisionedTool(t, serverName));
+            {
+                var published = isBundleOwned && t is AIFunction fn
+                    ? (AITool)new NamespacedAIFunction(fn, BundleOwnedMcpToolNaming.BuildToolName(serverName, t.Name))
+                    : t;
+                injected.Add(new ProvisionedTool(published, serverName));
+            }
+        }
 
         if (options.AdditionalTools?.Count > 0)
             foreach (var t in options.AdditionalTools)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -485,13 +485,17 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// fallback below. A skill author cannot know their bundle's future id at authoring time, so a
     /// bundle's own server is granted under a namespaced key (<c>{bundleId}:{declaredName}</c>) that never
     /// exact-matches the declaration; when the armed envelope contains exactly one grant ending in
-    /// <c>:{declaredName}</c>, that full namespaced name is resolved to contact. Two or more matching
-    /// suffixes is ambiguous and denied rather than guessed. <c>IsBundleOwned</c> is decided from
-    /// <see cref="Domain.AI.Bundles.CapabilityEnvelope.IsBundleOwnedMcpServer"/> — the run's own authoritative record —
+    /// <c>:{declaredName}</c>, that full namespaced name is resolved to contact. When more than one grant
+    /// shares the suffix, the bundle-owned one wins if exactly one of the matches is bundle-owned
+    /// (safe only because every skill resolved during a bundle run is one of that bundle's own — see the
+    /// resolution-time comment below); any other multi-match shape is still ambiguous and denied rather
+    /// than guessed. <c>IsBundleOwned</c> is decided from
+    /// <see cref="Domain.AI.Bundles.CapabilityEnvelope.IsBundleOwnedMcpServer"/> — the run's own authoritative record,
+    /// itself populated by a single writer (<c>RunBundleCommandHandler.WithBundleOwnedMcpServers</c>) —
     /// never from the suffix match alone: a host-installed plugin's own MCP server is namespaced under
     /// the identical <c>{Prefix}:{ServerName}</c> shape, so a suffix match can legitimately resolve to an
     /// explicitly-granted plugin server that is NOT bundle-owned and must NOT be renamed. Returns a
-    /// <see langword="null"/> server name when neither resolves, logged and never contacted — a bundle can
+    /// <see langword="null"/> server name when nothing resolves, logged and never contacted — a bundle can
     /// never reach a host MCP server it was not granted.
     /// </remarks>
     private (string? ServerName, bool IsBundleOwned) ResolveEffectiveMcpServerName(string declaredName)
@@ -507,6 +511,22 @@ public partial class ToolChainBuilder : IToolChainBuilder
 
         if (matches.Count == 1)
             return (matches[0], envelope.IsBundleOwnedMcpServer(matches[0]));
+
+        // More than one namespaced grant shares this bare server name — an unrelated host- or
+        // plugin-granted server (see CapabilityEnvelope.BundleOwnedMcpServers remarks: both use the
+        // identical {Prefix}:{ServerName} shape) coincidentally ends in the same suffix as THIS run's own
+        // bundle-owned server. Every skill resolved while running a bundle is one of that bundle's OWN
+        // OwnedSkills — OverlayAwareAgentOwnedSkillStore is authoritative for the ephemeral agent and never
+        // falls through to a caller's other skills — so a declaredName reaching this method during a
+        // bundle run can only ever mean the bundle's own server, never the unrelated grant it happens to
+        // collide with. Preferring the bundle-owned candidate therefore only makes the bundle's own
+        // already-granted access reliable against an incidental name clash; it can never resolve to the
+        // caller's separate grant instead, so it cannot escalate what this run can reach. Staging rejects
+        // duplicate server names within one bundle's own manifest set, so at most one match here is ever
+        // bundle-owned.
+        var bundleOwnedMatches = matches.Where(envelope.IsBundleOwnedMcpServer).ToList();
+        if (bundleOwnedMatches.Count == 1)
+            return (bundleOwnedMatches[0], true);
 
         _logger.LogInformation(
             "Capability envelope: MCP server '{Server}' is outside the bundle run's grant — not contacted and its tools excluded",

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -91,10 +91,16 @@ public partial class ToolChainBuilder : IToolChainBuilder
         SkillAgentOptions options,
         CancellationToken cancellationToken)
     {
+        // The authoritative source for "is this granted server bundle-owned": CapabilityEnvelope.BundleOwnedMcpServers,
+        // stamped once by RunBundleCommandHandler from the staged bundle's own registration. A server
+        // name's SHAPE cannot answer this — PluginLoader namespaces a host-installed plugin's own MCP
+        // servers under the identical "{Prefix}:{ServerName}" convention, into the same shared server
+        // config a bundle registers into, so a colon in the name is not evidence of bundle ownership.
+        var envelope = CapabilityEnvelopeAccessor.Current;
         var injected = new List<ProvisionedTool>();
         foreach (var (serverName, serverTools) in await ResolveInjectedMcpToolsAsync(cancellationToken))
         {
-            var isBundleOwned = BundleOwnedMcpToolNaming.IsNamespacedServerName(serverName);
+            var isBundleOwned = envelope?.IsBundleOwnedMcpServer(serverName) ?? false;
             foreach (var t in serverTools)
                 injected.Add(new ProvisionedTool(PublishServerTool(t, serverName, isBundleOwned), serverName));
         }
@@ -378,10 +384,10 @@ public partial class ToolChainBuilder : IToolChainBuilder
                     _logger.LogDebug(
                         "Resolved tool {ToolName} from MCP server {ServerName}", declaration.Name, effectiveServerName);
 
-                    // A bundle-owned server was reached only via the namespaced suffix fallback — its
-                    // tools are published and governed under a namespaced name (never the bare,
-                    // bundle-chosen one) so a malicious bundle cannot get a real host tool auto-granted
-                    // by advertising a same-named tool of its own. See BundleOwnedMcpToolNaming.
+                    // A bundle-owned server's tools are published and governed under a namespaced name
+                    // (never the bare, bundle-chosen one) so a malicious bundle cannot get a real host
+                    // tool auto-granted by advertising a same-named tool of its own. See
+                    // CapabilityEnvelope.IsBundleOwnedMcpServer and BundleOwnedMcpToolNaming.
                     return mcpTools
                         .Select(t => new ProvisionedTool(PublishServerTool(t, effectiveServerName, isBundleOwned), effectiveServerName))
                         .ToList();
@@ -464,24 +470,27 @@ public partial class ToolChainBuilder : IToolChainBuilder
 
     /// <summary>
     /// Resolves the MCP server name to actually contact for a skill's declared, bundle-agnostic server
-    /// name (e.g. <c>"epr-mcp"</c>) on the managed resolution path, and whether that resolution went
-    /// through the namespaced (bundle-owned) fallback rather than an exact grant — the caller uses that
-    /// flag to decide whether the resolved tools must be published under a namespaced name (see
-    /// <see cref="BundleOwnedMcpToolNaming"/>).
+    /// name (e.g. <c>"epr-mcp"</c>) on the managed resolution path, and whether that resolved server is
+    /// this run's own bundle-owned one — the caller uses that flag to decide whether the resolved tools
+    /// must be published under a namespaced name (see <see cref="BundleOwnedMcpToolNaming"/>).
     /// </summary>
     /// <remarks>
     /// Off the bundle path no envelope is published, so the declared name passes through unchanged
-    /// (<c>IsBundleOwnedFallback: false</c>) and every server is permitted. On a bundle run, an exact
-    /// grant for the declared name wins outright — a host-configured, non-namespaced server is unaffected
-    /// by the fallback below. A skill author cannot know their bundle's future id at authoring time, so a
+    /// (<c>IsBundleOwned: false</c>) and every server is permitted. On a bundle run, an exact grant for
+    /// the declared name wins outright — a host-configured, non-namespaced server is unaffected by the
+    /// fallback below. A skill author cannot know their bundle's future id at authoring time, so a
     /// bundle's own server is granted under a namespaced key (<c>{bundleId}:{declaredName}</c>) that never
     /// exact-matches the declaration; when the armed envelope contains exactly one grant ending in
-    /// <c>:{declaredName}</c>, that full namespaced name is resolved instead, flagged
-    /// <c>IsBundleOwnedFallback: true</c>. Two or more matching suffixes is ambiguous and denied rather
-    /// than guessed. Returns a <see langword="null"/> server name when neither resolves, logged and never
-    /// contacted — a bundle can never reach a host MCP server it was not granted.
+    /// <c>:{declaredName}</c>, that full namespaced name is resolved to contact. Two or more matching
+    /// suffixes is ambiguous and denied rather than guessed. <c>IsBundleOwned</c> is decided from
+    /// <see cref="Domain.AI.Bundles.CapabilityEnvelope.IsBundleOwnedMcpServer"/> — the run's own authoritative record —
+    /// never from the suffix match alone: a host-installed plugin's own MCP server is namespaced under
+    /// the identical <c>{Prefix}:{ServerName}</c> shape, so a suffix match can legitimately resolve to an
+    /// explicitly-granted plugin server that is NOT bundle-owned and must NOT be renamed. Returns a
+    /// <see langword="null"/> server name when neither resolves, logged and never contacted — a bundle can
+    /// never reach a host MCP server it was not granted.
     /// </remarks>
-    private (string? ServerName, bool IsBundleOwnedFallback) ResolveEffectiveMcpServerName(string declaredName)
+    private (string? ServerName, bool IsBundleOwned) ResolveEffectiveMcpServerName(string declaredName)
     {
         var envelope = CapabilityEnvelopeAccessor.Current;
         if (envelope is null || envelope.GrantsMcpServer(declaredName))
@@ -493,7 +502,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
             .ToList();
 
         if (matches.Count == 1)
-            return (matches[0], true);
+            return (matches[0], envelope.IsBundleOwnedMcpServer(matches[0]));
 
         _logger.LogInformation(
             "Capability envelope: MCP server '{Server}' is outside the bundle run's grant — not contacted and its tools excluded",

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -343,18 +343,33 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // Reference-only MCP: a bundle run resolves a tool from an MCP server only when the caller's
         // envelope grants that server; otherwise the MCP attempt is skipped and resolution falls through
         // to keyed DI (itself governed at invocation time). Off the bundle path every server is permitted.
-        if (_mcpToolProvider != null && IsMcpServerAllowed(declaration.Name))
+        var (effectiveServerName, isBundleOwned) = ResolveEffectiveMcpServerName(declaration.Name);
+        if (_mcpToolProvider != null && effectiveServerName is not null)
         {
             try
             {
-                // In managed mode, a ToolDeclaration's Name is the MCP server name — GetToolsAsync
-                // returns that server's whole tool list, which is why every tool it returns is
-                // attributed to declaration.Name below.
-                var mcpTools = await _mcpToolProvider.GetToolsAsync(declaration.Name, cancellationToken);
+                // In managed mode, a ToolDeclaration's Name is the MCP server name (or, on a bundle run,
+                // the bundle-agnostic name a namespaced grant resolved to) — GetToolsAsync returns that
+                // server's whole tool list, which is why every tool it returns is attributed to
+                // effectiveServerName below.
+                var mcpTools = await _mcpToolProvider.GetToolsAsync(effectiveServerName, cancellationToken);
                 if (mcpTools?.Count > 0)
                 {
-                    _logger.LogDebug("Resolved tool {ToolName} from MCP server", declaration.Name);
-                    return mcpTools.Select(t => new ProvisionedTool(t, declaration.Name)).ToList();
+                    _logger.LogDebug(
+                        "Resolved tool {ToolName} from MCP server {ServerName}", declaration.Name, effectiveServerName);
+
+                    // A bundle-owned server was reached only via the namespaced suffix fallback — its
+                    // tools are published and governed under a namespaced name (never the bare,
+                    // bundle-chosen one) so a malicious bundle cannot get a real host tool auto-granted
+                    // by advertising a same-named tool of its own. See BundleOwnedMcpToolNaming.
+                    var published = isBundleOwned
+                        ? mcpTools.Select(t => t is AIFunction fn
+                            ? (AITool)new NamespacedAIFunction(
+                                fn, BundleOwnedMcpToolNaming.BuildToolName(effectiveServerName, t.Name))
+                            : t)
+                        : mcpTools;
+
+                    return published.Select(t => new ProvisionedTool(t, effectiveServerName)).ToList();
                 }
             }
             catch (Exception ex)
@@ -430,35 +445,45 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// from the first return, which silently mistypes the failure branch's <see langword="null"/>.
     /// </summary>
     private async Task<(string Server, IList<AITool>? Tools)> FetchServerToolsAsync(string server, CancellationToken cancellationToken)
-    {
-        try
-        {
-            return (server, await _mcpToolProvider!.GetToolsAsync(server, cancellationToken));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Capability envelope: granted MCP server '{Server}' could not be reached — skipped", server);
-            return (server, null);
-        }
-    }
+        => (server, await McpToolFetch.TryGetToolsAsync(_mcpToolProvider!, server, "Capability envelope", _logger, cancellationToken));
 
     /// <summary>
-    /// Whether the ambient capability envelope permits reaching the named MCP server on the managed
-    /// resolution path. Off the bundle path no envelope is published, so this returns
-    /// <see langword="true"/> and every server passes through unchanged. On a bundle run only servers named
-    /// in the caller's envelope are permitted; a denied server is logged and never contacted, so a bundle
-    /// can never reach a host MCP server it was not granted.
+    /// Resolves the MCP server name to actually contact for a skill's declared, bundle-agnostic server
+    /// name (e.g. <c>"epr-mcp"</c>) on the managed resolution path, and whether that resolution went
+    /// through the namespaced (bundle-owned) fallback rather than an exact grant — the caller uses that
+    /// flag to decide whether the resolved tools must be published under a namespaced name (see
+    /// <see cref="BundleOwnedMcpToolNaming"/>).
     /// </summary>
-    private bool IsMcpServerAllowed(string serverName)
+    /// <remarks>
+    /// Off the bundle path no envelope is published, so the declared name passes through unchanged
+    /// (<c>IsBundleOwnedFallback: false</c>) and every server is permitted. On a bundle run, an exact
+    /// grant for the declared name wins outright — a host-configured, non-namespaced server is unaffected
+    /// by the fallback below. A skill author cannot know their bundle's future id at authoring time, so a
+    /// bundle's own server is granted under a namespaced key (<c>{bundleId}:{declaredName}</c>) that never
+    /// exact-matches the declaration; when the armed envelope contains exactly one grant ending in
+    /// <c>:{declaredName}</c>, that full namespaced name is resolved instead, flagged
+    /// <c>IsBundleOwnedFallback: true</c>. Two or more matching suffixes is ambiguous and denied rather
+    /// than guessed. Returns a <see langword="null"/> server name when neither resolves, logged and never
+    /// contacted — a bundle can never reach a host MCP server it was not granted.
+    /// </remarks>
+    private (string? ServerName, bool IsBundleOwnedFallback) ResolveEffectiveMcpServerName(string declaredName)
     {
         var envelope = CapabilityEnvelopeAccessor.Current;
-        if (envelope is null || envelope.GrantsMcpServer(serverName))
-            return true;
+        if (envelope is null || envelope.GrantsMcpServer(declaredName))
+            return (declaredName, false);
+
+        var suffix = ":" + declaredName;
+        var matches = envelope.AllowedMcpServers
+            .Where(name => name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        if (matches.Count == 1)
+            return (matches[0], true);
 
         _logger.LogInformation(
             "Capability envelope: MCP server '{Server}' is outside the bundle run's grant — not contacted and its tools excluded",
-            serverName);
-        return false;
+            declaredName);
+        return (null, false);
     }
 
     private IEnumerable<AITool>? ResolveToolByName(string toolName)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -91,15 +91,15 @@ public partial class ToolChainBuilder : IToolChainBuilder
         SkillAgentOptions options,
         CancellationToken cancellationToken)
     {
-        // The authoritative source for "is this granted server bundle-owned": CapabilityEnvelope.BundleOwnedMcpServers,
-        // stamped once by RunBundleCommandHandler from the staged bundle's own registration. A server
-        // name's SHAPE cannot answer this — PluginLoader namespaces a host-installed plugin's own MCP
-        // servers under the identical "{Prefix}:{ServerName}" convention, into the same shared server
-        // config a bundle registers into, so a colon in the name is not evidence of bundle ownership.
         var envelope = CapabilityEnvelopeAccessor.Current;
         var injected = new List<ProvisionedTool>();
-        foreach (var (serverName, serverTools) in await ResolveInjectedMcpToolsAsync(cancellationToken))
+        foreach (var (serverName, serverTools) in await ResolveInjectedMcpToolsAsync(envelope, cancellationToken))
         {
+            // The authoritative source for "is this granted server bundle-owned": CapabilityEnvelope.BundleOwnedMcpServers,
+            // stamped once by RunBundleCommandHandler from the staged bundle's own registration. A server
+            // name's SHAPE cannot answer this — PluginLoader namespaces a host-installed plugin's own MCP
+            // servers under the identical "{Prefix}:{ServerName}" convention, into the same shared server
+            // config a bundle registers into, so a colon in the name is not evidence of bundle ownership.
             var isBundleOwned = envelope?.IsBundleOwnedMcpServer(serverName) ?? false;
             foreach (var t in serverTools)
                 injected.Add(new ProvisionedTool(PublishServerTool(t, serverName, isBundleOwned), serverName));
@@ -433,9 +433,13 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// is never reached at all (no side-effect connection, no tool-schema disclosure), closing
     /// SSRF-by-construction. An empty grant yields no MCP tools.
     /// </summary>
-    private async Task<IReadOnlyList<(string ServerName, IList<AITool> Tools)>> ResolveInjectedMcpToolsAsync(CancellationToken cancellationToken)
+    /// <param name="envelope">
+    /// The ambient <see cref="CapabilityEnvelopeAccessor.Current"/>, read once by the caller and passed in
+    /// rather than re-read here — both this method and the caller's own bundle-ownership check need it.
+    /// </param>
+    private async Task<IReadOnlyList<(string ServerName, IList<AITool> Tools)>> ResolveInjectedMcpToolsAsync(
+        Domain.AI.Bundles.CapabilityEnvelope? envelope, CancellationToken cancellationToken)
     {
-        var envelope = CapabilityEnvelopeAccessor.Current;
         if (envelope is null)
         {
             var allByServer = await _mcpToolProvider!.GetAllToolsAsync(cancellationToken);

--- a/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
@@ -65,6 +65,19 @@ public sealed record CapabilityEnvelope
     /// envelope is built from the staged bundle, and never re-derived downstream from string shape.
     /// Empty (the default) means no bundle-owned server is granted this run.
     /// </summary>
+    /// <remarks>
+    /// <strong>Invariant callers must preserve:</strong> this list is always a subset of
+    /// <see cref="AllowedMcpServers"/>, and the two are kept in sync by a SINGLE writer today
+    /// (<c>RunBundleCommandHandler.WithBundleOwnedMcpServers</c>), which unions the same
+    /// <c>staged.McpServerNames</c> into both in one <c>with</c> expression. Nothing in the type system
+    /// enforces this — a future call site that adds a bundle-owned name to <see cref="AllowedMcpServers"/>
+    /// without adding it here as well would silently make that server's tools resolve as NOT bundle-owned
+    /// (falling through to <see cref="IsBundleOwnedMcpServer"/> returning <see langword="false"/>), which
+    /// is fail-closed on the namespacing decision but reintroduces the exact "trust a server based on
+    /// incomplete provenance" defect this field exists to prevent. Any new writer of
+    /// <see cref="AllowedMcpServers"/> for a bundle-owned server MUST update this list in the same
+    /// operation.
+    /// </remarks>
     public IReadOnlyList<string> BundleOwnedMcpServers { get; init; } = [];
 
     /// <summary>
@@ -90,14 +103,14 @@ public sealed record CapabilityEnvelope
     /// resolver and tool-chain builder match tool names.
     /// </summary>
     /// <param name="toolName">The tool name being checked.</param>
-    public bool GrantsTool(string toolName) => AllowedTools.Contains(toolName, StringComparer.OrdinalIgnoreCase);
+    public bool GrantsTool(string toolName) => Contains(AllowedTools, toolName);
 
     /// <summary>
     /// Whether this envelope grants access to the named MCP server. Case-insensitive, mirroring how the
     /// MCP tool provider keys servers by name.
     /// </summary>
     /// <param name="serverName">The MCP server name being checked.</param>
-    public bool GrantsMcpServer(string serverName) => AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
+    public bool GrantsMcpServer(string serverName) => Contains(AllowedMcpServers, serverName);
 
     /// <summary>
     /// Whether the named, already-resolved MCP server is this run's own bundle-owned server (see
@@ -106,6 +119,13 @@ public sealed record CapabilityEnvelope
     /// of inferring ownership from the server name's shape.
     /// </summary>
     /// <param name="serverName">The MCP server name being checked.</param>
-    public bool IsBundleOwnedMcpServer(string serverName) =>
-        BundleOwnedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
+    public bool IsBundleOwnedMcpServer(string serverName) => Contains(BundleOwnedMcpServers, serverName);
+
+    /// <summary>
+    /// Shared case-insensitive membership check backing every <c>Grants*</c>/<c>Is*</c> predicate on this
+    /// envelope, so the comparison rule (ordinal, case-insensitive) is expressed once rather than
+    /// independently re-typed on every grant list this record accumulates.
+    /// </summary>
+    private static bool Contains(IReadOnlyList<string> names, string name) =>
+        names.Contains(name, StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
@@ -56,6 +56,18 @@ public sealed record CapabilityEnvelope
     public IReadOnlyList<string> AllowedMcpServers { get; init; } = [];
 
     /// <summary>
+    /// The subset of <see cref="AllowedMcpServers"/> that are this run's OWN bundle-owned servers (i.e.
+    /// <c>StagedBundle.McpServerNames</c>) rather than a host-configured or plugin-configured server the
+    /// envelope separately grants. Both use the identical <c>{Prefix}:{ServerName}</c> namespaced-key
+    /// shape (plugins are namespaced by <c>PluginLoader</c> under <c>{PluginName}:{ServerName}</c>, into
+    /// the SAME shared server config bundles register into), so a server name's shape alone can never
+    /// distinguish the two — only the run's own provenance can. Populated once, at the point the run's
+    /// envelope is built from the staged bundle, and never re-derived downstream from string shape.
+    /// Empty (the default) means no bundle-owned server is granted this run.
+    /// </summary>
+    public IReadOnlyList<string> BundleOwnedMcpServers { get; init; } = [];
+
+    /// <summary>
     /// The highest autonomy tier this caller's bundle run may act under. Enforced as a ceiling: the
     /// effective autonomy is the most restrictive of this value, the host's own graded-autonomy gate, and
     /// each tool's blast radius — this can only tighten, never loosen. Defaults to the most restrictive
@@ -86,4 +98,14 @@ public sealed record CapabilityEnvelope
     /// </summary>
     /// <param name="serverName">The MCP server name being checked.</param>
     public bool GrantsMcpServer(string serverName) => AllowedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Whether the named, already-resolved MCP server is this run's own bundle-owned server (see
+    /// <see cref="BundleOwnedMcpServers"/>) rather than a host- or plugin-granted one — the authoritative
+    /// check callers must use to decide whether a resolved tool needs bundle-owned namespacing, instead
+    /// of inferring ownership from the server name's shape.
+    /// </summary>
+    /// <param name="serverName">The MCP server name being checked.</param>
+    public bool IsBundleOwnedMcpServer(string serverName) =>
+        BundleOwnedMcpServers.Contains(serverName, StringComparer.OrdinalIgnoreCase);
 }

--- a/src/Content/Domain/Domain.AI/Bundles/StagedBundle.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/StagedBundle.cs
@@ -53,8 +53,16 @@ public sealed record StagedBundle
 
     /// <summary>
     /// The plugin manifests parsed from any <c>plugin.json</c> files in the bundle. Empty when the
-    /// bundle ships no plugins. Carried through staging for completeness; wiring a bundle's plugins into
-    /// its ephemeral agent is a later concern.
+    /// bundle ships no plugins.
     /// </summary>
     public IReadOnlyList<PluginManifest> PluginManifests { get; init; } = [];
+
+    /// <summary>
+    /// The bundle-scoped, namespaced keys (<c>{BundleId}:{serverName}</c>) this bundle's own MCP
+    /// servers were registered under in the host's <c>McpServersConfig.Servers</c> during staging.
+    /// Empty when the bundle declares no MCP servers. A run unions these into its
+    /// <see cref="CapabilityEnvelope"/> so the bundle can reach the servers it shipped;
+    /// eviction of this bundle's handle deregisters exactly these names and nothing else.
+    /// </summary>
+    public IReadOnlyList<string> McpServerNames { get; init; } = [];
 }

--- a/src/Content/Domain/Domain.AI/Bundles/StagedBundle.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/StagedBundle.cs
@@ -59,10 +59,11 @@ public sealed record StagedBundle
 
     /// <summary>
     /// The bundle-scoped, namespaced keys (<c>{BundleId}:{serverName}</c>) this bundle's own MCP
-    /// servers were registered under in the host's <c>McpServersConfig.Servers</c> during staging.
-    /// Empty when the bundle declares no MCP servers. A run unions these into its
-    /// <see cref="CapabilityEnvelope"/> so the bundle can reach the servers it shipped;
-    /// eviction of this bundle's handle deregisters exactly these names and nothing else.
+    /// servers were registered under in the untrusted <c>BundleOwnedMcpServerRegistry</c> — deliberately
+    /// NOT the host's trusted <c>McpServersConfig.Servers</c> — during staging. Empty when the bundle
+    /// declares no MCP servers. A run unions these into its <see cref="CapabilityEnvelope"/> so the
+    /// bundle can reach the servers it shipped; eviction of this bundle's handle deregisters exactly
+    /// these names and nothing else.
     /// </summary>
     public IReadOnlyList<string> McpServerNames { get; init; } = [];
 }

--- a/src/Content/Domain/Domain.AI/Identity/AgentIdentityKind.cs
+++ b/src/Content/Domain/Domain.AI/Identity/AgentIdentityKind.cs
@@ -51,5 +51,14 @@ public enum AgentIdentityKind
     /// Development/test escape hatch. Returns a fixture identity without contacting
     /// Entra. Never resolved when the host environment is not Development.
     /// </summary>
-    Development = 5
+    Development = 5,
+
+    /// <summary>
+    /// Not backed by any Entra credential and never resolved by <c>IAgentIdentityResolver</c> — used for
+    /// internal, host-generated attribution where there is no live agent turn to derive an identity from
+    /// (e.g. a bundle's own outbound MCP connections, attributed to the bundle itself so egress allowlist
+    /// decisions and the audit trail have something real to key on). Carries no token and acquires
+    /// nothing from a credential provider.
+    /// </summary>
+    System = 6
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -138,4 +138,17 @@ public class BundleExecutionConfig
     /// anonymous serving is explicitly opted into. Only consulted by the bundle API host.
     /// </summary>
     public BundleApiAuthConfig Auth { get; set; } = new();
+
+    /// <summary>
+    /// Whether a bundle's own manifest may declare a remote (http/sse) MCP server that the host will connect
+    /// to on the bundle's behalf. Off by default: a bundle is untrusted, externally-authored input, and
+    /// honouring its own declared network endpoints means the host makes outbound requests a caller's
+    /// <c>CapabilityEnvelope</c> never authorized. When disabled, a bundle's declared <c>mcp.json</c> is
+    /// ignored entirely at staging time — the bundle registers no MCP servers, staging does not fail. Even
+    /// when enabled, a declared server's URL must still match <c>AppConfig.AI.Egress.DefaultAllowlist</c>
+    /// (checked at registration) and every connection is attributed and audited like any other outbound
+    /// request (checked live, on every call) — this flag only controls whether the capability exists at all.
+    /// </summary>
+    /// <value>Default: false</value>
+    public bool AllowBundleDeclaredMcpServers { get; set; }
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+
+namespace Domain.Common.Config.AI.MCP;
+
+/// <summary>
+/// Runtime-only store for a bundle's own MCP server definitions — deliberately a distinct type from
+/// <see cref="McpServersConfig"/>, not a second instance of it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists.</strong> A bundle (untrusted, user-uploaded content) can declare its own MCP
+/// server. Registering that definition into the shared, singleton <see cref="McpServersConfig"/> — the
+/// same dictionary trusted, host-admin-configured servers live in — let it leak into every consumer that
+/// enumerates that dictionary (<c>McpConnectionManager.GetConfiguredServerNames</c> and everything built
+/// on it: <c>McpToolProvider.GetAllToolsAsync</c>/<c>GetToolByNameAsync</c>, the MCP REST endpoints), with
+/// no bundle-provenance filter and no <c>CapabilityEnvelope</c> check — so an ordinary, non-bundle agent
+/// conversation would pull in an attacker's tools under their bare, attacker-chosen names. This registry
+/// closes that by construction: a bundle-owned definition is never reachable from
+/// <c>GetConfiguredServerNames()</c> at all, because it is never IN <see cref="McpServersConfig.Servers"/>.
+/// Only an exact-name lookup (<c>McpConnectionManager</c>'s connect path) consults this registry, as a
+/// fallback after the host dictionary misses — the path <c>ToolChainBuilder</c>'s already envelope-gated,
+/// name-keyed bundle-run resolution uses.
+/// </para>
+/// <para>
+/// <strong>Deliberately not <c>: McpServersConfig</c>.</strong> Inheriting would let a parameter typed
+/// <see cref="McpServersConfig"/> still accept an instance of this type — the exact ambiguity a distinct,
+/// unrelated type rules out at the compiler level. A same-typed second instance distinguished only by a
+/// DI key was considered and rejected for the same reason: two adjacent same-typed constructor parameters
+/// invite a silent swap in a future refactor.
+/// </para>
+/// <para>
+/// <strong>Never config-bound.</strong> <see cref="Servers"/> is get-only and starts empty — unlike
+/// <see cref="McpServersConfig"/>, which doubles as both an <c>appsettings.json</c>-bound options object
+/// and a runtime-mutated registry, this type has exactly one role.
+/// </para>
+/// </remarks>
+public sealed class BundleOwnedMcpServerRegistry
+{
+    /// <summary>
+    /// The dictionary of bundle-owned MCP server definitions, keyed by their bundle-scoped namespaced
+    /// name (<c>{BundleId}:{ServerName}</c>). Never enumerated by anything that publishes tools to an
+    /// ordinary, non-bundle conversation — only resolved by exact name from an envelope-gated caller.
+    /// </summary>
+    public ConcurrentDictionary<string, McpServerDefinition> Servers { get; } = new();
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Domain.Common.Config.AI.MCP;
 
@@ -7,41 +8,17 @@ namespace Domain.Common.Config.AI.MCP;
 /// <see cref="McpServersConfig"/>, not a second instance of it.
 /// </summary>
 /// <remarks>
-/// <para>
-/// <strong>Why this exists.</strong> A bundle (untrusted, user-uploaded content) can declare its own MCP
-/// server. Registering that definition into the shared, singleton <see cref="McpServersConfig"/> — the
-/// same dictionary trusted, host-admin-configured servers live in — let it leak into every consumer that
-/// enumerates that dictionary (<c>McpConnectionManager.GetConfiguredServerNames</c> and everything built
-/// on it: <c>McpToolProvider.GetAllToolsAsync</c>/<c>GetToolByNameAsync</c>, the MCP REST endpoints), with
-/// no bundle-provenance filter and no <c>CapabilityEnvelope</c> check — so an ordinary, non-bundle agent
-/// conversation would pull in an attacker's tools under their bare, attacker-chosen names. This registry
-/// closes that by construction: a bundle-owned definition is never reachable from
-/// <c>GetConfiguredServerNames()</c> at all, because it is never IN <see cref="McpServersConfig.Servers"/>.
-/// Only an exact-name lookup (<c>McpConnectionManager</c>'s connect path) consults this registry, as a
-/// fallback after the host dictionary misses — the path <c>ToolChainBuilder</c>'s already envelope-gated,
-/// name-keyed bundle-run resolution uses.
-/// </para>
-/// <para>
-/// <strong>Deliberately not <c>: McpServersConfig</c>.</strong> Inheriting would let a parameter typed
-/// <see cref="McpServersConfig"/> still accept an instance of this type — the exact ambiguity a distinct,
-/// unrelated type rules out at the compiler level. A same-typed second instance distinguished only by a
-/// DI key was considered and rejected for the same reason: two adjacent same-typed constructor parameters
-/// invite a silent swap in a future refactor.
-/// </para>
-/// <para>
-/// <strong>No enumeration surface, deliberately.</strong> Unlike <see cref="McpServersConfig.Servers"/>
-/// (a public, directly-enumerable <see cref="ConcurrentDictionary{TKey,TValue}"/>), this type exposes only
-/// <see cref="TryAdd"/>/<see cref="TryRemove"/>/<see cref="TryGetValue"/> — no <c>Keys</c>, <c>Values</c>,
-/// or enumerator. "Never reachable from an enumeration chokepoint" must hold for every future consumer
-/// this registry is ever injected into, not just the ones reviewed today; a raw dictionary property would
-/// make that merely a documented promise a future caller could break with a casual <c>foreach</c>. A
-/// narrow, name-only API makes it true by type instead.
-/// </para>
-/// <para>
-/// <strong>Never config-bound.</strong> Starts empty and is never touched by the options binder — unlike
-/// <see cref="McpServersConfig"/>, which doubles as both an <c>appsettings.json</c>-bound options object
-/// and a runtime-mutated registry, this type has exactly one role.
-/// </para>
+/// A bundle (untrusted, user-uploaded content) can declare its own MCP server; registering it into the
+/// shared, enumerable <see cref="McpServersConfig"/> would leak it into every consumer that enumerates
+/// that dictionary (<c>McpConnectionManager.GetConfiguredServerNames</c> and everything built on it) with
+/// no bundle-provenance check. This type closes that two ways at once: it is a distinct type — not
+/// inheritance, not a DI-keyed second <see cref="McpServersConfig"/> instance — so a bundle-owned
+/// definition can never be type- or key-confused with a trusted entry; and it exposes no enumeration API
+/// at all (<see cref="TryAdd"/>/<see cref="TryRemove"/>/<see cref="TryGetValue"/> only), so it can never
+/// become a second <c>GetConfiguredServerNames</c>-style chokepoint for any future consumer it's injected
+/// into. Only an exact-name lookup (<c>McpConnectionManager</c>'s connect path) consults this registry,
+/// as a fallback after the host dictionary misses — the path <c>ToolChainBuilder</c>'s already
+/// envelope-gated, name-keyed bundle-run resolution uses. Never config-bound; starts empty.
 /// </remarks>
 public sealed class BundleOwnedMcpServerRegistry
 {
@@ -67,6 +44,6 @@ public sealed class BundleOwnedMcpServerRegistry
     /// Resolves <paramref name="namespacedName"/> to its registered definition, if any — the ONLY way to
     /// read from this registry. There is no enumeration method by design; see this type's own remarks.
     /// </summary>
-    public bool TryGetValue(string namespacedName, out McpServerDefinition? definition) =>
+    public bool TryGetValue(string namespacedName, [NotNullWhen(true)] out McpServerDefinition? definition) =>
         _servers.TryGetValue(namespacedName, out definition);
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
@@ -29,17 +29,43 @@ namespace Domain.Common.Config.AI.MCP;
 /// invite a silent swap in a future refactor.
 /// </para>
 /// <para>
-/// <strong>Never config-bound.</strong> <see cref="Servers"/> is get-only and starts empty — unlike
+/// <strong>No enumeration surface, deliberately.</strong> Unlike <see cref="McpServersConfig.Servers"/>
+/// (a public, directly-enumerable <see cref="ConcurrentDictionary{TKey,TValue}"/>), this type exposes only
+/// <see cref="TryAdd"/>/<see cref="TryRemove"/>/<see cref="TryGetValue"/> — no <c>Keys</c>, <c>Values</c>,
+/// or enumerator. "Never reachable from an enumeration chokepoint" must hold for every future consumer
+/// this registry is ever injected into, not just the ones reviewed today; a raw dictionary property would
+/// make that merely a documented promise a future caller could break with a casual <c>foreach</c>. A
+/// narrow, name-only API makes it true by type instead.
+/// </para>
+/// <para>
+/// <strong>Never config-bound.</strong> Starts empty and is never touched by the options binder — unlike
 /// <see cref="McpServersConfig"/>, which doubles as both an <c>appsettings.json</c>-bound options object
 /// and a runtime-mutated registry, this type has exactly one role.
 /// </para>
 /// </remarks>
 public sealed class BundleOwnedMcpServerRegistry
 {
+    private readonly ConcurrentDictionary<string, McpServerDefinition> _servers = new();
+
     /// <summary>
-    /// The dictionary of bundle-owned MCP server definitions, keyed by their bundle-scoped namespaced
-    /// name (<c>{BundleId}:{ServerName}</c>). Never enumerated by anything that publishes tools to an
-    /// ordinary, non-bundle conversation — only resolved by exact name from an envelope-gated caller.
+    /// Registers <paramref name="definition"/> under <paramref name="namespacedName"/>
+    /// (<c>{BundleId}:{ServerName}</c>). Returns <see langword="false"/> without replacing anything if
+    /// that name is already registered — the caller decides how to report a duplicate.
     /// </summary>
-    public ConcurrentDictionary<string, McpServerDefinition> Servers { get; } = new();
+    public bool TryAdd(string namespacedName, McpServerDefinition definition) =>
+        _servers.TryAdd(namespacedName, definition);
+
+    /// <summary>
+    /// Removes the entry registered under <paramref name="namespacedName"/>, if any. Idempotent: removing
+    /// an unregistered name is a no-op that returns <see langword="false"/>, never an error.
+    /// </summary>
+    public bool TryRemove(string namespacedName, out McpServerDefinition? definition) =>
+        _servers.TryRemove(namespacedName, out definition);
+
+    /// <summary>
+    /// Resolves <paramref name="namespacedName"/> to its registered definition, if any — the ONLY way to
+    /// read from this registry. There is no enumeration method by design; see this type's own remarks.
+    /// </summary>
+    public bool TryGetValue(string namespacedName, out McpServerDefinition? definition) =>
+        _servers.TryGetValue(namespacedName, out definition);
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/BundleOwnedMcpServerRegistry.cs
@@ -57,10 +57,11 @@ public sealed class BundleOwnedMcpServerRegistry
 
     /// <summary>
     /// Removes the entry registered under <paramref name="namespacedName"/>, if any. Idempotent: removing
-    /// an unregistered name is a no-op that returns <see langword="false"/>, never an error.
+    /// an unregistered name is a no-op that returns <see langword="false"/>, never an error. No caller
+    /// needs the removed definition, so this returns only whether an entry was removed — not the value
+    /// itself, matching this type's stated goal of exposing the narrowest usable surface.
     /// </summary>
-    public bool TryRemove(string namespacedName, out McpServerDefinition? definition) =>
-        _servers.TryRemove(namespacedName, out definition);
+    public bool TryRemove(string namespacedName) => _servers.TryRemove(namespacedName, out _);
 
     /// <summary>
     /// Resolves <paramref name="namespacedName"/> to its registered definition, if any — the ONLY way to

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServersConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServersConfig.cs
@@ -1,3 +1,5 @@
+using System.Collections.Concurrent;
+
 namespace Domain.Common.Config.AI.MCP;
 
 /// <summary>
@@ -9,11 +11,20 @@ namespace Domain.Common.Config.AI.MCP;
 /// Keyed by server name (e.g., "filesystem", "github", "remote-tools").
 /// The key becomes the server identifier used in <c>IMcpToolProvider.GetToolsAsync(serverName)</c>.
 /// </para>
+/// <para>
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> rather than a plain dictionary: server registration
+/// is no longer a startup-only write. A staged bundle registers its own namespaced servers at request
+/// time (<c>BundleStagingService</c>), concurrently with reads that hold an enumerator open across
+/// network I/O (<c>McpToolProvider.GetToolByNameAsync</c>) — a plain <see cref="Dictionary{TKey,TValue}"/>
+/// is unsafe under that mix of concurrent read/write. Confirmed to bind identically to a plain dictionary
+/// from real <c>IConfiguration</c> (<c>McpServersConfigBindingTests.Bind_JsonConfiguredServers_AlsoPopulatesConcurrentDictionary</c>)
+/// — an earlier, incorrectly-shaped binding test wrongly suggested otherwise; see that test's remarks.
+/// </para>
 /// </remarks>
 public class McpServersConfig
 {
     /// <summary>
     /// Gets or sets the dictionary of MCP server definitions keyed by server name.
     /// </summary>
-    public Dictionary<string, McpServerDefinition> Servers { get; set; } = new();
+    public ConcurrentDictionary<string, McpServerDefinition> Servers { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServersConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServersConfig.cs
@@ -13,11 +13,13 @@ namespace Domain.Common.Config.AI.MCP;
 /// </para>
 /// <para>
 /// <see cref="ConcurrentDictionary{TKey,TValue}"/> rather than a plain dictionary: server registration
-/// is no longer a startup-only write. A staged bundle registers its own namespaced servers at request
-/// time (<c>BundleStagingService</c>), concurrently with reads that hold an enumerator open across
-/// network I/O (<c>McpToolProvider.GetToolByNameAsync</c>) — a plain <see cref="Dictionary{TKey,TValue}"/>
-/// is unsafe under that mix of concurrent read/write. Confirmed to bind identically to a plain dictionary
-/// from real <c>IConfiguration</c> (<c>McpServersConfigBindingTests.Bind_JsonConfiguredServers_AlsoPopulatesConcurrentDictionary</c>)
+/// is no longer a startup-only write. A host-installed plugin registers its own namespaced servers at
+/// load time (<c>PluginLoader</c>), concurrently with reads that hold an enumerator open across network
+/// I/O (<c>McpToolProvider.GetToolByNameAsync</c>) — a plain <see cref="Dictionary{TKey,TValue}"/> is
+/// unsafe under that mix of concurrent read/write. (A staged bundle's own servers are registered into
+/// the separate <c>BundleOwnedMcpServerRegistry</c> instead, not here — see its own doc comment.)
+/// Confirmed to bind identically to a plain dictionary from real <c>IConfiguration</c>
+/// (<c>McpServersConfigBindingTests.Bind_JsonConfiguredServers_AlsoPopulatesConcurrentDictionary</c>)
 /// — an earlier, incorrectly-shaped binding test wrongly suggested otherwise; see that test's remarks.
 /// </para>
 /// </remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.MCP;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Resources;
 using Infrastructure.AI.MCP.Services;
@@ -33,6 +34,11 @@ public static class DependencyInjection
     /// <returns>The service collection for chaining.</returns>
     public static IServiceCollection AddMcpClientDependencies(this IServiceCollection services)
     {
+        // The runtime-only store for a bundle's own (untrusted, uploaded) MCP server definitions —
+        // deliberately never the AIConfig-bound McpServersConfig below. See its own doc comment for why
+        // this is a distinct type rather than a second McpServersConfig instance.
+        services.AddSingleton<BundleOwnedMcpServerRegistry>();
+
         // Connection manager — singleton, manages MCP client lifecycles.
         // Resolving AntiSsrfHandlerFactory makes the SSRF guard a mandatory dependency:
         // if the egress layer (Infrastructure.AI RegisterEgressServices) was not wired,
@@ -43,7 +49,9 @@ public static class DependencyInjection
             var logger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<McpConnectionManager>>();
             var loggerFactory = sp.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
             var antiSsrfHandlerFactory = sp.GetRequiredService<AntiSsrfHandlerFactory>();
-            return new McpConnectionManager(logger, loggerFactory, antiSsrfHandlerFactory, aiConfig.CurrentValue.McpServers);
+            var bundleOwnedServers = sp.GetRequiredService<BundleOwnedMcpServerRegistry>();
+            return new McpConnectionManager(
+                logger, loggerFactory, antiSsrfHandlerFactory, aiConfig.CurrentValue.McpServers, bundleOwnedServers);
         });
 
         // Tool provider — singleton wrapping connection manager. Only the scanning decorator is
@@ -75,10 +83,11 @@ public static class DependencyInjection
         services.AddSingleton<IMcpResourceProvider>(sp => sp.GetRequiredService<TraceResourceProvider>());
 
         // Deregisters a bundle's own MCP servers (and disconnects any live client for them) when its
-        // handle is evicted. Wired to the SAME McpServersConfig instance McpConnectionManager (above) and
-        // BundleStagingService's registration use, so a removal here is visible to both (issue #368).
+        // handle is evicted. Wired to the SAME BundleOwnedMcpServerRegistry instance McpConnectionManager
+        // (above) and BundleStagingService's registration use, so a removal here is visible to both
+        // (issue #368; isolated from the trusted registry per the security fix in #370).
         services.AddSingleton<IBundleMcpServerRegistrar>(sp => new BundleMcpServerRegistrar(
-            sp.GetRequiredService<IOptionsMonitor<AIConfig>>().CurrentValue.McpServers,
+            sp.GetRequiredService<BundleOwnedMcpServerRegistry>(),
             sp.GetRequiredService<McpConnectionManager>(),
             sp.GetRequiredService<ILogger<BundleMcpServerRegistrar>>()));
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -8,6 +8,7 @@ using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Resources;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -37,7 +38,11 @@ public static class DependencyInjection
         // The runtime-only store for a bundle's own (untrusted, uploaded) MCP server definitions —
         // deliberately never the AIConfig-bound McpServersConfig below. See its own doc comment for why
         // this is a distinct type rather than a second McpServersConfig instance.
-        services.AddSingleton<BundleOwnedMcpServerRegistry>();
+        // TryAddSingleton, not AddSingleton: BundleStagingService (Infrastructure.AI) also needs this
+        // instance and registers it the same idempotent way, so whichever of AddInfrastructureAIDependencies
+        // / AddMcpClientDependencies runs first wins and both layers share the one instance regardless of
+        // call order — neither extension method depends on the other having run first.
+        services.TryAddSingleton<BundleOwnedMcpServerRegistry>();
 
         // Connection manager — singleton, manages MCP client lifecycles.
         // Resolving AntiSsrfHandlerFactory makes the SSRF guard a mandatory dependency:

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -36,12 +36,9 @@ public static class DependencyInjection
     public static IServiceCollection AddMcpClientDependencies(this IServiceCollection services)
     {
         // The runtime-only store for a bundle's own (untrusted, uploaded) MCP server definitions —
-        // deliberately never the AIConfig-bound McpServersConfig below. See its own doc comment for why
-        // this is a distinct type rather than a second McpServersConfig instance.
-        // TryAddSingleton, not AddSingleton: BundleStagingService (Infrastructure.AI) also needs this
-        // instance and registers it the same idempotent way, so whichever of AddInfrastructureAIDependencies
-        // / AddMcpClientDependencies runs first wins and both layers share the one instance regardless of
-        // call order — neither extension method depends on the other having run first.
+        // deliberately never the AIConfig-bound McpServersConfig below. See its own doc comment for why.
+        // TryAddSingleton (not AddSingleton) — also registered by AddInfrastructureAIDependencies, so
+        // call order between the two extension methods is irrelevant.
         services.TryAddSingleton<BundleOwnedMcpServerRegistry>();
 
         // Connection manager — singleton, manages MCP client lifecycles.

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -52,8 +52,16 @@ public static class DependencyInjection
             var loggerFactory = sp.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
             var antiSsrfHandlerFactory = sp.GetRequiredService<AntiSsrfHandlerFactory>();
             var bundleOwnedServers = sp.GetRequiredService<BundleOwnedMcpServerRegistry>();
+            // The bundle-owned egress-attribution chain (see McpConnectionManager.ResolveBundleEgressClient)
+            // resolves the SAME registered EgressPolicyDelegatingHandler the "egress" named HttpClient uses
+            // (Infrastructure.AI/DependencyInjection.Egress.cs) from the root provider it is handed below —
+            // making an unwired egress layer a startup failure, on the same reasoning as AntiSsrfHandlerFactory
+            // above, rather than a silently unattributed bundle connection.
+            var scopeFactory = sp.GetRequiredService<IServiceScopeFactory>();
+            var ambientScope = sp.GetRequiredService<IAmbientRequestScope>();
             return new McpConnectionManager(
-                logger, loggerFactory, antiSsrfHandlerFactory, aiConfig.CurrentValue.McpServers, bundleOwnedServers);
+                logger, loggerFactory, antiSsrfHandlerFactory, aiConfig.CurrentValue.McpServers, bundleOwnedServers,
+                scopeFactory, ambientScope, sp);
         });
 
         // Tool provider — singleton wrapping connection manager. Only the scanning decorator is

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.Common.Config.AI;
@@ -72,6 +73,14 @@ public static class DependencyInjection
         // Auth-gated and feature-flagged via MetaHarnessConfig.EnableMcpTraceResources.
         services.AddSingleton<TraceResourceProvider>();
         services.AddSingleton<IMcpResourceProvider>(sp => sp.GetRequiredService<TraceResourceProvider>());
+
+        // Deregisters a bundle's own MCP servers (and disconnects any live client for them) when its
+        // handle is evicted. Wired to the SAME McpServersConfig instance McpConnectionManager (above) and
+        // BundleStagingService's registration use, so a removal here is visible to both (issue #368).
+        services.AddSingleton<IBundleMcpServerRegistrar>(sp => new BundleMcpServerRegistrar(
+            sp.GetRequiredService<IOptionsMonitor<AIConfig>>().CurrentValue.McpServers,
+            sp.GetRequiredService<McpConnectionManager>(),
+            sp.GetRequiredService<ILogger<BundleMcpServerRegistrar>>()));
 
         return services;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Egress/BundleMcpEgressAttributionHandler.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Egress/BundleMcpEgressAttributionHandler.cs
@@ -1,0 +1,93 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Domain.AI.Identity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.AI.MCP.Egress;
+
+/// <summary>
+/// Outermost handler in a bundle-owned MCP server's HTTP pipeline. Establishes a fresh, self-contained
+/// agent identity for the duration of exactly one outbound request, then delegates down to the shared
+/// egress-policy and SSRF rings — so every request over a bundle-owned connection is attributed and
+/// audited, regardless of whatever ambient context (or lack of one) the calling code happens to have.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists.</strong> <c>EgressPolicyDelegatingHandler</c> (the shared allowlist + audit
+/// ring every other outbound path in the harness goes through) refuses to act without an agent identity
+/// pulled from <see cref="IAmbientRequestScope.Current"/> — by design, an unattributable request is
+/// denied rather than silently permitted. A bundle-owned MCP connection is contacted from two places
+/// with two different ambient states: <c>BundleRunExecutor</c>'s tool-discovery pass, which runs before
+/// any DI scope exists at all, and <c>ToolChainBuilder</c>'s later tool resolution, which runs inside a
+/// real request scope but only carries a resolved identity when the separate, opt-in identity subsystem
+/// (<c>AppConfig.AI.Identity.Enabled</c>) happens to be on. Relying on whatever identity is ambient at
+/// each call site would make the connection's behaviour depend on unrelated configuration and calling
+/// context; instead, this handler gives the connection its own identity, asserted fresh on every single
+/// request, so the egress ring always has something real to evaluate — the bundle itself.
+/// </para>
+/// <para>
+/// This does not weaken attribution: the identity used here (<see cref="AgentIdentityKind.System"/>,
+/// <c>Id</c> = the bundle-scoped server name) is never a real Entra principal and is scoped to exactly
+/// the one bundle whose server this client was built for — see
+/// <see cref="Infrastructure.AI.MCP.Services.McpConnectionManager"/>, which constructs one of these per
+/// bundle-owned server name, never shared across bundles.
+/// </para>
+/// </remarks>
+public sealed class BundleMcpEgressAttributionHandler : DelegatingHandler
+{
+    private readonly string _attributionId;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IAmbientRequestScope _ambientScope;
+
+    /// <summary>
+    /// Initializes a new <see cref="BundleMcpEgressAttributionHandler"/> attributing every request it
+    /// sends to <paramref name="attributionId"/>.
+    /// </summary>
+    /// <param name="attributionId">
+    /// The identity id every request through this handler is attributed to — the bundle-scoped,
+    /// namespaced MCP server name, so the audit trail and any allowlist decision can be traced back to
+    /// exactly which bundle's server made the call.
+    /// </param>
+    /// <param name="scopeFactory">Used to create a short-lived DI scope per request.</param>
+    /// <param name="ambientScope">The ambient request-scope holder <c>EgressPolicyDelegatingHandler</c> reads identity from.</param>
+    public BundleMcpEgressAttributionHandler(
+        string attributionId, IServiceScopeFactory scopeFactory, IAmbientRequestScope ambientScope)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(attributionId);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(ambientScope);
+
+        _attributionId = attributionId;
+        _scopeFactory = scopeFactory;
+        _ambientScope = ambientScope;
+    }
+
+    /// <inheritdoc />
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // A fresh scope per request, not one captured once at construction: this handler instance is
+        // cached and reused for the connection's entire lifetime (McpConnectionManager.ResolveBundleEgressClient),
+        // and HttpClient.SendAsync is explicitly safe to call concurrently — so two overlapping requests
+        // over the SAME cached client (e.g. two simultaneous tool calls against one bundle-owned server)
+        // must each get their own scope. IAmbientRequestScope.BeginScope pushes onto an AsyncLocal, which
+        // is per-async-flow, not shared state a single push could cover for every future caller: pushing
+        // once at construction would only affect whichever flow happened to build the handler, leaving
+        // every other concurrent flow's ambient identity untouched (or, if a naively shared scope were
+        // reused, IAgentExecutionContext.SetIdentity would throw on the second call within it). The scope
+        // is cheap and this handler is not on a hot per-token path — it fires once per MCP request, not
+        // per model token.
+        await using var scope = _scopeFactory.CreateAsyncScope();
+
+        var executionContext = scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
+        executionContext.SetIdentity(new AgentIdentity { Id = _attributionId, Kind = AgentIdentityKind.System });
+
+        // Overwrites whatever ambient scope (if any) the caller had for the lifetime of this one
+        // request, then restores it on disposal (IAmbientRequestScope.BeginScope's documented
+        // contract) — so this request is always attributed to the bundle, never to whatever else is
+        // running around it, and the caller's own context is never disturbed beyond this one call.
+        using var _ = _ambientScope.BeginScope(scope.ServiceProvider);
+
+        return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -6,27 +6,28 @@ namespace Infrastructure.AI.MCP.Services;
 
 /// <summary>
 /// Default <see cref="IBundleMcpServerRegistrar"/>. Removes a bundle's namespaced entries from the
-/// shared <see cref="McpServersConfig"/> and disconnects any live <see cref="McpConnectionManager"/>
-/// client for each — the deregistration counterpart to the registration <c>BundleStagingService</c>
-/// performs at staging time, against the SAME <see cref="McpServersConfig"/> instance.
+/// shared <see cref="BundleOwnedMcpServerRegistry"/> and disconnects any live
+/// <see cref="McpConnectionManager"/> client for each — the deregistration counterpart to the
+/// registration <c>BundleStagingService</c> performs at staging time, against the SAME
+/// <see cref="BundleOwnedMcpServerRegistry"/> instance.
 /// </summary>
 public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
 {
-    private readonly McpServersConfig _mcpServersConfig;
+    private readonly BundleOwnedMcpServerRegistry _bundleOwnedMcpServers;
     private readonly McpConnectionManager _connectionManager;
     private readonly ILogger<BundleMcpServerRegistrar> _logger;
 
     /// <summary>Initializes a new <see cref="BundleMcpServerRegistrar"/>.</summary>
     public BundleMcpServerRegistrar(
-        McpServersConfig mcpServersConfig,
+        BundleOwnedMcpServerRegistry bundleOwnedMcpServers,
         McpConnectionManager connectionManager,
         ILogger<BundleMcpServerRegistrar> logger)
     {
-        ArgumentNullException.ThrowIfNull(mcpServersConfig);
+        ArgumentNullException.ThrowIfNull(bundleOwnedMcpServers);
         ArgumentNullException.ThrowIfNull(connectionManager);
         ArgumentNullException.ThrowIfNull(logger);
 
-        _mcpServersConfig = mcpServersConfig;
+        _bundleOwnedMcpServers = bundleOwnedMcpServers;
         _connectionManager = connectionManager;
         _logger = logger;
     }
@@ -36,7 +37,7 @@ public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
     {
         foreach (var serverName in serverNames)
         {
-            _mcpServersConfig.Servers.TryRemove(serverName, out _);
+            _bundleOwnedMcpServers.Servers.TryRemove(serverName, out _);
 
             try
             {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Application.AI.Common.Interfaces.Bundles;
 using Domain.Common.Config.AI.MCP;
 using Microsoft.Extensions.Logging;
@@ -35,24 +36,31 @@ public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
     /// <inheritdoc />
     public async Task DeregisterAsync(IReadOnlyList<string> serverNames)
     {
-        foreach (var serverName in serverNames)
-        {
-            _bundleOwnedMcpServers.TryRemove(serverName);
+        // Independent per-server teardown (each disconnect is real network/process I/O against a
+        // distinct entry) — fanned out with Task.WhenAll rather than paid cumulatively one server at a
+        // time, mirroring BundleRunExecutor.WithBundleOwnedToolGrantsAsync's discovery fan-out for the
+        // same reason. Each task catches its own failure, so one server's teardown error can never stop
+        // another's from running or from being cleaned up from the registry.
+        await Task.WhenAll(serverNames.Select(DeregisterOneAsync)).ConfigureAwait(false);
+    }
 
-            try
-            {
-                // Idempotent for a name with no active client (McpConnectionManager.DisconnectAsync is a
-                // no-op TryRemove) — safe to call even if this bundle's server was never actually
-                // contacted during its run.
-                await _connectionManager.DisconnectAsync(serverName).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex,
-                    "Failed to disconnect MCP client for deregistered bundle server '{Server}'; " +
-                    "the connection will be cleaned up on host shutdown",
-                    serverName);
-            }
+    private async Task DeregisterOneAsync(string serverName)
+    {
+        _bundleOwnedMcpServers.TryRemove(serverName);
+
+        try
+        {
+            // Idempotent for a name with no active client (McpConnectionManager.DisconnectAsync is a
+            // no-op TryRemove) — safe to call even if this bundle's server was never actually
+            // contacted during its run.
+            await _connectionManager.DisconnectAsync(serverName).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to disconnect MCP client for deregistered bundle server '{Server}'; " +
+                "the connection will be cleaned up on host shutdown",
+                serverName);
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -1,0 +1,57 @@
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common.Config.AI.MCP;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.MCP.Services;
+
+/// <summary>
+/// Default <see cref="IBundleMcpServerRegistrar"/>. Removes a bundle's namespaced entries from the
+/// shared <see cref="McpServersConfig"/> and disconnects any live <see cref="McpConnectionManager"/>
+/// client for each — the deregistration counterpart to the registration <c>BundleStagingService</c>
+/// performs at staging time, against the SAME <see cref="McpServersConfig"/> instance.
+/// </summary>
+public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
+{
+    private readonly McpServersConfig _mcpServersConfig;
+    private readonly McpConnectionManager _connectionManager;
+    private readonly ILogger<BundleMcpServerRegistrar> _logger;
+
+    /// <summary>Initializes a new <see cref="BundleMcpServerRegistrar"/>.</summary>
+    public BundleMcpServerRegistrar(
+        McpServersConfig mcpServersConfig,
+        McpConnectionManager connectionManager,
+        ILogger<BundleMcpServerRegistrar> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mcpServersConfig);
+        ArgumentNullException.ThrowIfNull(connectionManager);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _mcpServersConfig = mcpServersConfig;
+        _connectionManager = connectionManager;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task DeregisterAsync(IReadOnlyList<string> serverNames)
+    {
+        foreach (var serverName in serverNames)
+        {
+            _mcpServersConfig.Servers.TryRemove(serverName, out _);
+
+            try
+            {
+                // Idempotent for a name with no active client (McpConnectionManager.DisconnectAsync is a
+                // no-op TryRemove) — safe to call even if this bundle's server was never actually
+                // contacted during its run.
+                await _connectionManager.DisconnectAsync(serverName).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to disconnect MCP client for deregistered bundle server '{Server}'; " +
+                    "the connection will be cleaned up on host shutdown",
+                    serverName);
+            }
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -37,7 +37,7 @@ public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
     {
         foreach (var serverName in serverNames)
         {
-            _bundleOwnedMcpServers.Servers.TryRemove(serverName, out _);
+            _bundleOwnedMcpServers.TryRemove(serverName, out _);
 
             try
             {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -37,7 +37,7 @@ public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
     {
         foreach (var serverName in serverNames)
         {
-            _bundleOwnedMcpServers.TryRemove(serverName, out _);
+            _bundleOwnedMcpServers.TryRemove(serverName);
 
             try
             {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -27,6 +27,11 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private readonly HttpClient _httpClient;
     private readonly McpServersConfig _config;
     private readonly BundleOwnedMcpServerRegistry _bundleOwnedServers;
+
+    // A single flat cache keyed by bare serverName, shared across BOTH _config and _bundleOwnedServers —
+    // safe today because the two namespacing schemes never collide (host names are plain or
+    // {pluginName}:{name}; bundle names are {bundleId GUID}:{name}). A future change that restructures
+    // these into per-source caches should preserve that invariant, not merely mirror the field shapes.
     private readonly ConcurrentDictionary<string, McpClient> _clients = new();
     private readonly ConcurrentDictionary<string, HttpClient> _entraClients = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionLocks = new();
@@ -138,14 +143,9 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// <strong>Deliberately host-only.</strong> This enumerates <em>only</em> <see cref="_config"/> —
-    /// never <see cref="_bundleOwnedServers"/>. Every consumer built on this method
-    /// (<c>McpToolProvider.GetAllToolsAsync</c>/<c>GetToolByNameAsync</c>, and through them the MCP REST
-    /// endpoints, and <c>ToolChainBuilder</c>'s no-envelope resolution path — i.e. every ORDINARY,
-    /// non-bundle agent conversation) publishes whatever this returns with no further bundle-provenance
-    /// check. If a bundle-owned server were ever enumerable here, its tools would reach every other
-    /// conversation on the host under their bare, attacker-chosen names. Do not add
-    /// <see cref="_bundleOwnedServers"/> to this method; see <see cref="BundleOwnedMcpServerRegistry"/>'s
-    /// own doc comment for why it is a separate type instead of a filtered flag on this one.
+    /// never <see cref="_bundleOwnedServers"/>. Do not add it here; see
+    /// <see cref="BundleOwnedMcpServerRegistry"/>'s own doc comment for why a bundle-owned server must
+    /// never be reachable from this method.
     /// </remarks>
     public IEnumerable<string> GetConfiguredServerNames()
     {
@@ -161,10 +161,6 @@ public sealed class McpConnectionManager : IAsyncDisposable
         // a bundle run's own already-envelope-gated resolution (ToolChainBuilder.ProvisionToolAsync,
         // ResolveInjectedMcpToolsAsync's envelope-armed branch, BundleRunExecutor.DiscoverToolNamesAsync)
         // reaches its own server; without it, a bundle run could never use its own registered tools.
-        // _clients/_connectionLocks/_entraClients below are a single flat cache keyed by bare serverName
-        // across BOTH sources — safe today because the two namespacing schemes never collide (host names
-        // are plain or {pluginName}:{name}; bundle names are {bundleId GUID}:{name}), documented here
-        // rather than restructured into per-source caches.
         if (!_config.Servers.TryGetValue(serverName, out var definition)
             && !_bundleOwnedServers.Servers.TryGetValue(serverName, out definition))
             throw new McpConnectionException($"MCP server '{serverName}' is not configured.");

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -1,8 +1,12 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Exceptions;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Egress;
 using Domain.Common.Config.AI.MCP;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.Identity;
+using Infrastructure.AI.MCP.Egress;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Client;
 
@@ -27,6 +31,12 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private readonly HttpClient _httpClient;
     private readonly McpServersConfig _config;
     private readonly BundleOwnedMcpServerRegistry _bundleOwnedServers;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IAmbientRequestScope _ambientScope;
+    private readonly IServiceProvider _rootServices;
+    private readonly IEgressAuditWriter _egressAuditWriter;
+    private readonly ILogger<EgressPolicyDelegatingHandler> _egressHandlerLogger;
+    private readonly TimeProvider _timeProvider;
 
     // A single flat cache keyed by bare serverName, shared across BOTH _config and _bundleOwnedServers —
     // safe today because the two namespacing schemes never collide (host names are plain or
@@ -34,6 +44,18 @@ public sealed class McpConnectionManager : IAsyncDisposable
     // these into per-source caches should preserve that invariant, not merely mirror the field shapes.
     private readonly ConcurrentDictionary<string, McpClient> _clients = new();
     private readonly ConcurrentDictionary<string, HttpClient> _entraClients = new();
+
+    /// <summary>
+    /// Per-bundle-server clients whose handler chain is <see cref="BundleMcpEgressAttributionHandler"/> →
+    /// a dedicated <see cref="EgressPolicyDelegatingHandler"/> → the shared <see cref="_antiSsrfHandler"/>
+    /// — see <see cref="ResolveBundleEgressClient"/>. Kept separate from <see cref="_entraClients"/> even
+    /// though both are per-server client caches: an Entra client wraps only a lightweight token handler
+    /// around the SAME shared terminal handler, while a bundle-egress client owns two additional handler
+    /// instances of its own (still never the shared AntiSSRF handler itself — see the disposal remarks on
+    /// <see cref="DisposeAsync"/>).
+    /// </summary>
+    private readonly ConcurrentDictionary<string, HttpClient> _bundleEgressClients = new();
+
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionLocks = new();
     private bool _disposed;
 
@@ -41,20 +63,21 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// Initializes a new instance of the <see cref="McpConnectionManager"/> class.
     /// </summary>
     /// <remarks>
-    /// The SSRF defense is a hard dependency, not a configuration option: the single
-    /// shared <see cref="HttpClient"/> used for every HTTP/SSE transport is built on the
-    /// <c>AntiSSRFHandler</c> produced by <paramref name="antiSsrfHandlerFactory"/>, which
-    /// performs connect-time IP filtering (RFC 1918, loopback, link-local, IMDS, IPv6 ULA)
-    /// and redirect re-validation. There is no code path that constructs an unguarded
-    /// client, so SSRF protection cannot be silently omitted by misconfiguration.
+    /// The SSRF defense is a hard dependency, not a configuration option: every HTTP/SSE transport this
+    /// manager builds — host-configured or bundle-owned — is built on the <c>AntiSSRFHandler</c> produced
+    /// by <paramref name="antiSsrfHandlerFactory"/>, which performs connect-time IP filtering (RFC 1918,
+    /// loopback, link-local, IMDS, IPv6 ULA) and redirect re-validation. There is no code path that
+    /// constructs an unguarded client, so SSRF protection cannot be silently omitted by misconfiguration.
     /// <para>
-    /// This deliberately applies only the AntiSSRF ring, NOT the outer
-    /// <c>EgressPolicyDelegatingHandler</c> (per-skill hostname allowlist + JSONL audit)
-    /// that the general egress <see cref="HttpClient"/> composes. MCP servers are
-    /// explicitly admin-configured, and connections are established outside an agent turn
-    /// (e.g. startup tool discovery) where that handler's required agent identity is
-    /// absent — it would deny every connection. SSRF filtering, the security-critical
-    /// ring, applies unconditionally.
+    /// A host-configured server's shared client applies only the AntiSSRF ring, not the outer
+    /// <c>EgressPolicyDelegatingHandler</c> (hostname allowlist + JSONL audit) the general egress
+    /// <see cref="HttpClient"/> composes — those servers are explicitly admin-configured, and connections
+    /// are established outside an agent turn (e.g. startup tool discovery) where that handler's required
+    /// agent identity would be absent. A <strong>bundle-owned</strong> server is different: it is
+    /// untrusted, uploader-declared input, so its connections go through a dedicated, per-server chain
+    /// (<see cref="ResolveBundleEgressClient"/>) that applies BOTH rings on every request, attributing
+    /// each one to the owning bundle via <see cref="BundleMcpEgressAttributionHandler"/> rather than
+    /// depending on whatever ambient identity the calling code happens to have.
     /// </para>
     /// </remarks>
     public McpConnectionManager(
@@ -62,12 +85,15 @@ public sealed class McpConnectionManager : IAsyncDisposable
         ILoggerFactory loggerFactory,
         AntiSsrfHandlerFactory antiSsrfHandlerFactory,
         McpServersConfig config,
-        BundleOwnedMcpServerRegistry bundleOwnedServers)
+        BundleOwnedMcpServerRegistry bundleOwnedServers,
+        IServiceScopeFactory scopeFactory,
+        IAmbientRequestScope ambientScope,
+        IServiceProvider rootServices)
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
-        // The shared SSRF-guard terminal handler. Captured so Entra connections can wrap
-        // it with a per-server token-injecting handler while still routing through the
+        // The shared SSRF-guard terminal handler. Captured so Entra connections and bundle-egress
+        // connections can each wrap it with their own outer handler(s) while still routing through the
         // same connect-time IP filter.
         _antiSsrfHandler = antiSsrfHandlerFactory.GetOrCreate();
         // disposeHandler: false — the AntiSSRF handler is a shared singleton owned by
@@ -75,6 +101,22 @@ public sealed class McpConnectionManager : IAsyncDisposable
         _httpClient = new HttpClient(_antiSsrfHandler, disposeHandler: false);
         _config = config;
         _bundleOwnedServers = bundleOwnedServers;
+        _scopeFactory = scopeFactory;
+        _ambientScope = ambientScope;
+        _rootServices = rootServices;
+        // Resolved ONCE here — all three are singleton registrations, so the container returns the SAME
+        // cached instance on every call and this costs nothing beyond construction. This is deliberately
+        // NOT done by resolving EgressPolicyDelegatingHandler itself from rootServices per bundle-owned
+        // server in ResolveBundleEgressClient: that type is registered transient, and a transient
+        // IDisposable resolved directly from the ROOT container (not a scope) is tracked by the container
+        // and never released until process shutdown — the container leaks one handler per distinct
+        // bundle-owned server name for the remainder of the host's lifetime. Resolving these three
+        // singleton dependencies here and constructing EgressPolicyDelegatingHandler by hand keeps this
+        // manager the sole owner of every instance it builds, exactly like the pre-existing Entra client
+        // cache below.
+        _egressAuditWriter = rootServices.GetRequiredService<IEgressAuditWriter>();
+        _egressHandlerLogger = rootServices.GetRequiredService<ILogger<EgressPolicyDelegatingHandler>>();
+        _timeProvider = rootServices.GetService<TimeProvider>() ?? TimeProvider.System;
     }
 
     /// <summary>
@@ -128,14 +170,30 @@ public sealed class McpConnectionManager : IAsyncDisposable
             _logger.LogInformation("Disconnected from MCP server '{ServerName}'", serverName);
         }
 
-        // Release the per-server Entra client (and its pooled sockets) on explicit
-        // disconnect, mirroring the cleanup of _clients above. disposeHandler:false leaves
-        // the shared AntiSSRF handler intact; a later reconnect recreates a fresh
-        // token-injecting client.
-        if (_entraClients.TryRemove(serverName, out var entraClient))
+        // Release the per-server Entra and bundle-egress clients (and their pooled sockets) on explicit
+        // disconnect, mirroring the cleanup of _clients above. Both caches were built with
+        // disposeHandler:false, so this leaves the shared AntiSSRF handler intact; a later reconnect
+        // recreates a fresh token-injecting or attribution+egress-policy handler pair as needed.
+        TryDisposeCachedClient(_entraClients, serverName);
+        TryDisposeCachedClient(_bundleEgressClients, serverName);
+    }
+
+    private static void TryDisposeCachedClient(ConcurrentDictionary<string, HttpClient> cache, string serverName)
+    {
+        if (cache.TryRemove(serverName, out var client))
         {
-            entraClient.Dispose();
+            client.Dispose();
         }
+    }
+
+    private static void DisposeCachedClients(ConcurrentDictionary<string, HttpClient> cache)
+    {
+        foreach (var kvp in cache)
+        {
+            kvp.Value.Dispose();
+        }
+
+        cache.Clear();
     }
 
     /// <summary>
@@ -161,9 +219,14 @@ public sealed class McpConnectionManager : IAsyncDisposable
         // a bundle run's own already-envelope-gated resolution (ToolChainBuilder.ProvisionToolAsync,
         // ResolveInjectedMcpToolsAsync's envelope-armed branch, BundleRunExecutor.DiscoverToolNamesAsync)
         // reaches its own server; without it, a bundle run could never use its own registered tools.
-        if (!_config.Servers.TryGetValue(serverName, out var definition)
-            && !_bundleOwnedServers.TryGetValue(serverName, out definition))
-            throw new McpConnectionException($"MCP server '{serverName}' is not configured.");
+        // Whichever branch resolves the definition also tells us which egress treatment it gets below.
+        var isBundleOwned = false;
+        if (!_config.Servers.TryGetValue(serverName, out var definition))
+        {
+            if (!_bundleOwnedServers.TryGetValue(serverName, out definition))
+                throw new McpConnectionException($"MCP server '{serverName}' is not configured.");
+            isBundleOwned = true;
+        }
 
         if (!definition.Enabled)
             throw new McpConnectionException($"MCP server '{serverName}' is disabled.");
@@ -174,7 +237,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
         try
         {
-            var transport = CreateTransport(serverName, definition);
+            var transport = CreateTransport(serverName, definition, isBundleOwned);
 
             var client = await McpClient.CreateAsync(
                 transport,
@@ -195,7 +258,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         }
     }
 
-    private IClientTransport CreateTransport(string serverName, McpServerDefinition definition)
+    private IClientTransport CreateTransport(string serverName, McpServerDefinition definition, bool isBundleOwned)
     {
         return definition.Type switch
         {
@@ -209,12 +272,12 @@ public sealed class McpConnectionManager : IAsyncDisposable
                     ? definition.Env.ToDictionary(kvp => kvp.Key, kvp => (string?)kvp.Value)
                     : null
             }),
-            McpServerType.Http or McpServerType.Sse => CreateHttpTransport(serverName, definition),
+            McpServerType.Http or McpServerType.Sse => CreateHttpTransport(serverName, definition, isBundleOwned),
             _ => throw new McpConnectionException($"Unsupported MCP transport type: {definition.Type}")
         };
     }
 
-    private HttpClientTransport CreateHttpTransport(string serverName, McpServerDefinition definition)
+    private HttpClientTransport CreateHttpTransport(string serverName, McpServerDefinition definition, bool isBundleOwned)
     {
         var uri = new Uri(definition.Url ?? throw new McpConnectionException(
             $"MCP server '{serverName}' is configured as {definition.Type} but has no URL."));
@@ -233,21 +296,53 @@ public sealed class McpConnectionManager : IAsyncDisposable
         // token in front of the same SSRF guard. All paths still route through the
         // connect-time IP filter, so a URL resolving to an internal/metadata address is
         // refused at the socket. The transport does not own the supplied client.
-        var httpClient = ResolveTransportHttpClient(serverName, definition.Auth, options);
+        var httpClient = ResolveTransportHttpClient(serverName, definition.Auth, options, isBundleOwned);
 
         return new HttpClientTransport(options, httpClient, _loggerFactory);
     }
 
     /// <summary>
-    /// Resolves the <see cref="HttpClient"/> for a server's transport and applies any
-    /// static auth headers to <paramref name="options"/>. Throws when auth is configured
-    /// but incomplete — a half-configured server must fail loudly rather than connect
-    /// with no credential.
+    /// Thin dispatcher to the host-configured or bundle-owned resolution path — the two share no logic
+    /// (different credential model, different handler chain), so each gets its own method rather than
+    /// one method with two unrelated bodies stitched together by an <c>if</c>.
     /// </summary>
     private HttpClient ResolveTransportHttpClient(
         string serverName,
         McpServerAuthConfig? auth,
-        HttpClientTransportOptions options)
+        HttpClientTransportOptions options,
+        bool isBundleOwned)
+    {
+        return isBundleOwned
+            ? ResolveBundleOwnedTransportHttpClient(serverName, auth)
+            : ResolveHostConfiguredTransportHttpClient(serverName, auth, options);
+    }
+
+    /// <summary>
+    /// Resolves the client for a bundle-owned server. Bundle manifests can never populate <c>Auth</c>
+    /// (see the guard below), so there are no static headers to apply — the credential-free,
+    /// egress-attributed handler chain lives entirely in <see cref="ResolveBundleEgressClient"/>.
+    /// </summary>
+    private HttpClient ResolveBundleOwnedTransportHttpClient(string serverName, McpServerAuthConfig? auth)
+    {
+        // A bundle's own MCP server definition never carries Auth — McpServerDefinitionBuilder does
+        // not populate it for bundle-declared servers, so a bundle cannot induce the host to attach
+        // a credential to its own endpoint. Fail loudly rather than silently skip the egress-attributed
+        // path below if that invariant is ever violated by a future change.
+        if (auth is { IsConfigured: true })
+            throw new McpConnectionException(
+                $"Bundle-owned MCP server '{serverName}' has auth configured, which bundle-declared " +
+                "servers do not support.");
+
+        return ResolveBundleEgressClient(serverName);
+    }
+
+    /// <summary>
+    /// Resolves the client for a host-configured (admin-declared) server and applies any static auth
+    /// headers to <paramref name="options"/>. Throws when auth is configured but incomplete — a
+    /// half-configured server must fail loudly rather than connect with no credential.
+    /// </summary>
+    private HttpClient ResolveHostConfiguredTransportHttpClient(
+        string serverName, McpServerAuthConfig? auth, HttpClientTransportOptions options)
     {
         if (auth is not { IsConfigured: true })
             return _httpClient;
@@ -282,6 +377,44 @@ public sealed class McpConnectionManager : IAsyncDisposable
                 throw new McpConnectionException(
                     $"MCP server '{serverName}' uses unsupported auth type '{auth.Type}'.");
         }
+    }
+
+    /// <summary>
+    /// Builds (or returns the cached) egress-attributed client for one bundle-owned server. The handler
+    /// chain is <see cref="BundleMcpEgressAttributionHandler"/> (outer — stamps every request with a
+    /// synthetic identity scoped to this exact server) → a dedicated <see cref="EgressPolicyDelegatingHandler"/>
+    /// built from the SAME singleton dependencies (<see cref="_egressAuditWriter"/>, <see cref="_egressHandlerLogger"/>,
+    /// <see cref="_timeProvider"/>) production's own "egress" named <see cref="HttpClient"/> registration
+    /// (<c>Infrastructure.AI/DependencyInjection.Egress.cs</c>) resolves its handler from — wrapping
+    /// <see cref="_antiSsrfHandler"/> (inner/terminal, the SAME shared singleton every other path uses —
+    /// SSRF protection is never weakened or duplicated).
+    /// <c>disposeHandler</c> is deliberately <see langword="false"/>, mirroring the Entra client cache:
+    /// <see cref="DelegatingHandler"/>'s own disposal cascades into its
+    /// <see cref="DelegatingHandler.InnerHandler"/>, so <see langword="true"/> here would eventually
+    /// dispose the SHARED AntiSSRF handler out from under every other connection this manager owns.
+    /// <c>EgressPolicyDelegatingHandler</c> is built with <see langword="new"/> rather than resolved from
+    /// <see cref="_rootServices"/>, deliberately: that type is registered transient, and a transient
+    /// <see cref="IDisposable"/> resolved directly from the ROOT container is tracked and never released
+    /// by the container until process shutdown — one handler would leak per distinct bundle-owned server
+    /// name for the life of the host. Manually constructing it keeps this manager the sole owner of every
+    /// instance it builds, so the two handler instances this method allocates hold no unmanaged resources
+    /// and are safe to leave to the GC once the cache entry is dropped, exactly as before.
+    /// </summary>
+    private HttpClient ResolveBundleEgressClient(string serverName)
+    {
+        return _bundleEgressClients.GetOrAdd(serverName, name =>
+        {
+            var egressHandler = new EgressPolicyDelegatingHandler(
+                _rootServices, _ambientScope, _egressAuditWriter, _egressHandlerLogger, _timeProvider)
+            {
+                InnerHandler = _antiSsrfHandler
+            };
+            var attributionHandler = new BundleMcpEgressAttributionHandler(name, _scopeFactory, _ambientScope)
+            {
+                InnerHandler = egressHandler
+            };
+            return new HttpClient(attributionHandler, disposeHandler: false);
+        });
     }
 
     private static readonly HashSet<string> BlockedHosts = new(StringComparer.OrdinalIgnoreCase)
@@ -319,16 +452,12 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
         _clients.Clear();
 
-        // Per-server Entra clients were built with disposeHandler:false, so disposing them
-        // releases the client wrapper without touching the shared AntiSSRF handler their
-        // token handlers wrap. The token handlers hold only a managed TokenCredential and
-        // are reclaimed by the GC.
-        foreach (var kvp in _entraClients)
-        {
-            kvp.Value.Dispose();
-        }
-
-        _entraClients.Clear();
+        // Both per-server client caches were built with disposeHandler:false, so disposing each client
+        // releases the wrapper only, without touching the shared AntiSSRF handler its own handler(s)
+        // wrap — the credential/attribution handlers each one owns hold no unmanaged resources and are
+        // reclaimed by the GC.
+        DisposeCachedClients(_entraClients);
+        DisposeCachedClients(_bundleEgressClients);
 
         foreach (var kvp in _connectionLocks)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -26,6 +26,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private readonly HttpMessageHandler _antiSsrfHandler;
     private readonly HttpClient _httpClient;
     private readonly McpServersConfig _config;
+    private readonly BundleOwnedMcpServerRegistry _bundleOwnedServers;
     private readonly ConcurrentDictionary<string, McpClient> _clients = new();
     private readonly ConcurrentDictionary<string, HttpClient> _entraClients = new();
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionLocks = new();
@@ -55,7 +56,8 @@ public sealed class McpConnectionManager : IAsyncDisposable
         ILogger<McpConnectionManager> logger,
         ILoggerFactory loggerFactory,
         AntiSsrfHandlerFactory antiSsrfHandlerFactory,
-        McpServersConfig config)
+        McpServersConfig config,
+        BundleOwnedMcpServerRegistry bundleOwnedServers)
     {
         _logger = logger;
         _loggerFactory = loggerFactory;
@@ -67,6 +69,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         // the factory; this client must not dispose it.
         _httpClient = new HttpClient(_antiSsrfHandler, disposeHandler: false);
         _config = config;
+        _bundleOwnedServers = bundleOwnedServers;
     }
 
     /// <summary>
@@ -133,6 +136,17 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// <summary>
     /// Gets the names of all configured and enabled servers.
     /// </summary>
+    /// <remarks>
+    /// <strong>Deliberately host-only.</strong> This enumerates <em>only</em> <see cref="_config"/> —
+    /// never <see cref="_bundleOwnedServers"/>. Every consumer built on this method
+    /// (<c>McpToolProvider.GetAllToolsAsync</c>/<c>GetToolByNameAsync</c>, and through them the MCP REST
+    /// endpoints, and <c>ToolChainBuilder</c>'s no-envelope resolution path — i.e. every ORDINARY,
+    /// non-bundle agent conversation) publishes whatever this returns with no further bundle-provenance
+    /// check. If a bundle-owned server were ever enumerable here, its tools would reach every other
+    /// conversation on the host under their bare, attacker-chosen names. Do not add
+    /// <see cref="_bundleOwnedServers"/> to this method; see <see cref="BundleOwnedMcpServerRegistry"/>'s
+    /// own doc comment for why it is a separate type instead of a filtered flag on this one.
+    /// </remarks>
     public IEnumerable<string> GetConfiguredServerNames()
     {
         return _config.Servers
@@ -142,7 +156,17 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
     private async Task<McpClient> CreateClientAsync(string serverName, CancellationToken cancellationToken)
     {
-        if (!_config.Servers.TryGetValue(serverName, out var definition))
+        // Host dictionary first (trusted source wins outright), then the bundle-owned registry as a
+        // fallback for an exact-name lookup only — never enumerated, only resolved by name. This is how
+        // a bundle run's own already-envelope-gated resolution (ToolChainBuilder.ProvisionToolAsync,
+        // ResolveInjectedMcpToolsAsync's envelope-armed branch, BundleRunExecutor.DiscoverToolNamesAsync)
+        // reaches its own server; without it, a bundle run could never use its own registered tools.
+        // _clients/_connectionLocks/_entraClients below are a single flat cache keyed by bare serverName
+        // across BOTH sources — safe today because the two namespacing schemes never collide (host names
+        // are plain or {pluginName}:{name}; bundle names are {bundleId GUID}:{name}), documented here
+        // rather than restructured into per-source caches.
+        if (!_config.Servers.TryGetValue(serverName, out var definition)
+            && !_bundleOwnedServers.Servers.TryGetValue(serverName, out definition))
             throw new McpConnectionException($"MCP server '{serverName}' is not configured.");
 
         if (!definition.Enabled)

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -162,7 +162,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         // ResolveInjectedMcpToolsAsync's envelope-armed branch, BundleRunExecutor.DiscoverToolNamesAsync)
         // reaches its own server; without it, a bundle run could never use its own registered tools.
         if (!_config.Servers.TryGetValue(serverName, out var definition)
-            && !_bundleOwnedServers.Servers.TryGetValue(serverName, out definition))
+            && !_bundleOwnedServers.TryGetValue(serverName, out definition))
             throw new McpConnectionException($"MCP server '{serverName}' is not configured.");
 
         if (!definition.Enabled)

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
@@ -1,6 +1,8 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Application.Core.CQRS.Agents.RunConversation;
 using Domain.AI.Bundles;
 using MediatR;
@@ -40,15 +42,22 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
     private readonly IBundleHandleStore _handleStore;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly TimeProvider _time;
+    private readonly IMcpToolProvider? _mcpToolProvider;
     private readonly ILogger<BundleRunExecutor> _logger;
 
     /// <summary>Initializes a new <see cref="BundleRunExecutor"/>.</summary>
+    /// <param name="mcpToolProvider">
+    /// Optional — null on a host with no MCP client dependencies registered. Used only to discover the
+    /// tool names a bundle's own registered MCP servers publish, so they can be additively granted for
+    /// invocation; see <see cref="WithBundleOwnedToolGrantsAsync"/>.
+    /// </param>
     public BundleRunExecutor(
         IBundleRunJobStore jobStore,
         IBundleHandleStore handleStore,
         IServiceScopeFactory scopeFactory,
         TimeProvider time,
-        ILogger<BundleRunExecutor> logger)
+        ILogger<BundleRunExecutor> logger,
+        IMcpToolProvider? mcpToolProvider = null)
     {
         ArgumentNullException.ThrowIfNull(jobStore);
         ArgumentNullException.ThrowIfNull(handleStore);
@@ -61,6 +70,7 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         _scopeFactory = scopeFactory;
         _time = time;
         _logger = logger;
+        _mcpToolProvider = mcpToolProvider;
     }
 
     /// <inheritdoc />
@@ -164,6 +174,9 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
             OwnedSkills = staged.OwnedSkills
         };
 
+        var envelope = await WithBundleOwnedToolGrantsAsync(record.Envelope, staged, cancellationToken)
+            .ConfigureAwait(false);
+
         await using var scope = _scopeFactory.CreateAsyncScope();
         var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
 
@@ -171,7 +184,7 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         // resolve, and the envelope so the governor enforces the per-caller grant. Disposed in reverse when the
         // (materialised) conversation returns.
         using (EphemeralAgentOverlayAccessor.Begin(overlay))
-        using (CapabilityEnvelopeAccessor.Begin(record.Envelope))
+        using (CapabilityEnvelopeAccessor.Begin(envelope))
         {
             // A run that names a conversation continues it; one that does not gets an id of its own so
             // its budget and telemetry still have somewhere to accumulate. The owner rides along only in
@@ -188,6 +201,60 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
 
             return await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Additively grants the NAMESPACED tool names a bundle's own MCP servers actually publish, so
+    /// <c>ToolInvocationGovernor</c>'s invocation-time check — which matches a call against
+    /// <see cref="CapabilityEnvelope.AllowedTools"/> by name, not by originating server — does not deny
+    /// a call to a server the run's envelope already permits reaching. Contacts ONLY the bundle's own
+    /// registered servers (<see cref="StagedBundle.McpServerNames"/>), never a host-shared server, once
+    /// per run, before the envelope is armed. The stored <paramref name="envelope"/> (also used for
+    /// status reporting elsewhere) is never mutated — a new value is returned for this run's ambient
+    /// scope only. A server that fails to connect contributes zero tools this run — consistent with how
+    /// <c>ToolChainBuilder</c> already treats an unreachable granted server — rather than failing the run.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Namespaced, not the bare server-declared name.</strong> Granting a bundle's self-reported
+    /// tool name verbatim would let a malicious bundle advertise a tool literally named after a real,
+    /// more privileged host tool and get it auto-granted by name coincidence — the invocation gate has
+    /// no notion of which server a call resolves through, only the name. <see cref="BundleOwnedMcpToolNaming"/>
+    /// namespaces the grant to this run's own server key, which only <c>ToolChainBuilder</c> ever
+    /// publishes a tool under (via <c>NamespacedAIFunction</c>) for a bundle-owned resolution — so the
+    /// granted name and the model-callable name always agree, and neither can ever collide with an
+    /// unrelated host tool's bare name.
+    /// </remarks>
+    private async Task<CapabilityEnvelope> WithBundleOwnedToolGrantsAsync(
+        CapabilityEnvelope envelope, StagedBundle staged, CancellationToken cancellationToken)
+    {
+        if (_mcpToolProvider is null || staged.McpServerNames.Count == 0)
+            return envelope;
+
+        // Concurrent, not sequential — a bundle that owns several servers must not pay their connect
+        // latency cumulatively at the start of every run. Mirrors ToolChainBuilder.ResolveInjectedMcpToolsAsync's
+        // Task.WhenAll fan-out over granted servers.
+        var perServerNames = await Task.WhenAll(
+            staged.McpServerNames.Select(serverName => DiscoverToolNamesAsync(serverName, cancellationToken)));
+
+        var discoveredToolNames = perServerNames.SelectMany(names => names).ToList();
+
+        return discoveredToolNames.Count == 0
+            ? envelope
+            : envelope with { AllowedTools = [.. envelope.AllowedTools, .. discoveredToolNames] };
+    }
+
+    /// <summary>
+    /// Discovers one bundle-owned server's namespaced tool names, or an empty list if the server could
+    /// not be reached — a failed server contributes zero tools rather than failing the whole run.
+    /// </summary>
+    private async Task<IReadOnlyList<string>> DiscoverToolNamesAsync(string serverName, CancellationToken cancellationToken)
+    {
+        var tools = await McpToolFetch.TryGetToolsAsync(
+            _mcpToolProvider!, serverName, "Bundle run tool discovery", _logger, cancellationToken).ConfigureAwait(false);
+
+        return tools is null
+            ? []
+            : tools.Select(tool => BundleOwnedMcpToolNaming.BuildToolName(serverName, tool.Name)).ToList();
     }
 
     private static BundleRunOutcome MapOutcome(ConversationResult result) => new()

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -473,7 +473,7 @@ public sealed class BundleStagingService : IBundleStagingService
             // (PluginLoader) are a different trust tier and are unaffected: only this bundle path rejects
             // Stdio. Tracked follow-up to run a bundle's stdio server inside the existing process/Docker
             // sandbox instead of rejecting it outright: #371.
-            if (definition.Type == McpServerType.Stdio)
+            if (!definition.IsRemoteServer)
             {
                 _logger.LogWarning(
                     "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio (local command) " +

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -495,9 +495,9 @@ public sealed class BundleStagingService : IBundleStagingService
             // for both cases, not assert an explicit stdio declaration that may not exist.
             _logger.LogWarning(
                 "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) " +
-                "transport — either explicitly declared, or its 'type' was missing/unrecognized (only " +
-                "'http' and 'sse' are supported) and defaulted to stdio — which is not permitted for " +
-                "bundle-owned servers; rejected, not registered.",
+                "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
+                "The transport was either explicitly declared, or defaulted to stdio because 'type' was " +
+                "missing or unrecognized (only 'http'/'sse' are supported).",
                 bundleId, serverProp.Name);
             return false;
         }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -42,6 +42,13 @@ public sealed class BundleStagingService : IBundleStagingService
     /// </summary>
     private const long RatioGuardFloorBytes = 1024 * 1024;
 
+    /// <summary>
+    /// A bundle (unlike a host-installed plugin) has no declaration-level env overrides — this empty,
+    /// read-only instance is reused across every server built for every bundle upload rather than
+    /// allocating a fresh empty dictionary per server.
+    /// </summary>
+    private static readonly Dictionary<string, string> NoDeclarationEnv = [];
+
     private readonly IOptionsMonitor<AppConfig> _appConfig;
     private readonly AgentMetadataParser _agentParser;
     private readonly SkillMetadataParser _skillParser;
@@ -470,7 +477,7 @@ public sealed class BundleStagingService : IBundleStagingService
         {
             definition = McpServerDefinitionBuilder.Build(
                 // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
-                serverProp.Value, new Dictionary<string, string>(), $"[Bundle: {bundleId}]", serverProp.Name);
+                serverProp.Value, NoDeclarationEnv, $"[Bundle: {bundleId}]", serverProp.Name);
         }
         catch (Exception ex)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -450,53 +450,60 @@ public sealed class BundleStagingService : IBundleStagingService
         foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
         {
             var namespacedName = $"{bundleId}:{serverProp.Name}";
-
-            McpServerDefinition definition;
-            try
-            {
-                definition = McpServerDefinitionBuilder.Build(
-                    // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
-                    serverProp.Value, new Dictionary<string, string>(), $"[Bundle: {bundleId}]", serverProp.Name);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex,
-                    "Bundle {BundleId}: failed to build MCP server definition for '{ServerName}', skipping",
-                    bundleId, serverProp.Name);
-                continue;
-            }
-
-            // A bundle is untrusted, uploader-supplied content. A stdio server's Command/Args/Env come
-            // straight from the bundle's own manifest, and connecting to it launches that command as a
-            // real host process (via McpConnectionManager -> StdioClientTransport) — arbitrary command
-            // execution on the harness host, gated only by upload permission. Host-installed plugins
-            // (PluginLoader) are a different trust tier and are unaffected: only this bundle path rejects
-            // Stdio. Tracked follow-up to run a bundle's stdio server inside the existing process/Docker
-            // sandbox instead of rejecting it outright: #371.
-            if (!definition.IsRemoteServer)
-            {
-                _logger.LogWarning(
-                    "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio (local command) " +
-                    "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
-                    "Only http/sse (remote) MCP servers are permitted in a bundle's own manifest.",
-                    bundleId, serverProp.Name);
-                continue;
-            }
-
-            if (_mcpServersConfig.Servers.TryAdd(namespacedName, definition))
-            {
+            if (TryBuildAndRegisterOneServer(bundleId, namespacedName, serverProp))
                 registered.Add(namespacedName);
-            }
-            else
-            {
-                _logger.LogWarning(
-                    "Bundle {BundleId}: duplicate MCP server name '{ServerName}' declared across " +
-                    "more than one plugin manifest; keeping the first",
-                    bundleId, serverProp.Name);
-            }
         }
 
         return registered;
+    }
+
+    /// <summary>
+    /// Builds one manifest-declared server and registers it under <paramref name="namespacedName"/>,
+    /// rejecting a stdio (local-command) transport and a duplicate name — see
+    /// <see cref="RegisterBundleMcpServers"/>. Returns whether registration succeeded.
+    /// </summary>
+    private bool TryBuildAndRegisterOneServer(string bundleId, string namespacedName, System.Text.Json.JsonProperty serverProp)
+    {
+        McpServerDefinition definition;
+        try
+        {
+            definition = McpServerDefinitionBuilder.Build(
+                // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
+                serverProp.Value, new Dictionary<string, string>(), $"[Bundle: {bundleId}]", serverProp.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Bundle {BundleId}: failed to build MCP server definition for '{ServerName}', skipping",
+                bundleId, serverProp.Name);
+            return false;
+        }
+
+        // A bundle is untrusted, uploader-supplied content. A stdio server's Command/Args/Env come
+        // straight from the bundle's own manifest, and connecting to it launches that command as a
+        // real host process (via McpConnectionManager -> StdioClientTransport) — arbitrary command
+        // execution on the harness host, gated only by upload permission. Host-installed plugins
+        // (PluginLoader) are a different trust tier and are unaffected: only this bundle path rejects
+        // Stdio. Tracked follow-up to run a bundle's stdio server inside the existing process/Docker
+        // sandbox instead of rejecting it outright: #371.
+        if (!definition.IsRemoteServer)
+        {
+            _logger.LogWarning(
+                "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio (local command) " +
+                "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
+                "Only http/sse (remote) MCP servers are permitted in a bundle's own manifest.",
+                bundleId, serverProp.Name);
+            return false;
+        }
+
+        if (_mcpServersConfig.Servers.TryAdd(namespacedName, definition))
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: duplicate MCP server name '{ServerName}' declared across " +
+            "more than one plugin manifest; keeping the first",
+            bundleId, serverProp.Name);
+        return false;
     }
 
     private Result<StagedBundle> CleanupAndFail(string bundleDir, params string[] errors)

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -489,10 +489,15 @@ public sealed class BundleStagingService : IBundleStagingService
         // sandbox instead of rejecting it outright: #371.
         if (!definition.IsRemoteServer)
         {
+            // "resolved to", not "declares": McpServerDefinitionBuilder.ParseType defaults an ABSENT or
+            // UNRECOGNIZED 'type' value to Stdio too (only "http"/"sse" are matched), so a bundle author
+            // who misspells a real remote transport lands here as well — this message must stay accurate
+            // for both cases, not assert an explicit stdio declaration that may not exist.
             _logger.LogWarning(
-                "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio (local command) " +
-                "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
-                "Only http/sse (remote) MCP servers are permitted in a bundle's own manifest.",
+                "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) " +
+                "transport — either explicitly declared, or its 'type' was missing/unrecognized (only " +
+                "'http' and 'sse' are supported) and defaulted to stdio — which is not permitted for " +
+                "bundle-owned servers; rejected, not registered.",
                 bundleId, serverProp.Name);
             return false;
         }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -1,4 +1,5 @@
 using System.IO.Compression;
+using System.Text.Json;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
@@ -462,7 +463,7 @@ public sealed class BundleStagingService : IBundleStagingService
     /// rejecting a stdio (local-command) transport and a duplicate name — see
     /// <see cref="RegisterBundleMcpServers"/>. Returns whether registration succeeded.
     /// </summary>
-    private bool TryBuildAndRegisterOneServer(string bundleId, string namespacedName, System.Text.Json.JsonProperty serverProp)
+    private bool TryBuildAndRegisterOneServer(string bundleId, string namespacedName, JsonProperty serverProp)
     {
         McpServerDefinition definition;
         try

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -54,7 +54,7 @@ public sealed class BundleStagingService : IBundleStagingService
     private readonly SkillMetadataParser _skillParser;
     private readonly ISkillFileReader _skillFileReader;
     private readonly IPluginManifestReader _pluginReader;
-    private readonly McpServersConfig _mcpServersConfig;
+    private readonly BundleOwnedMcpServerRegistry _bundleOwnedMcpServers;
     private readonly ILogger<BundleStagingService> _logger;
 
     /// <summary>Initialises the staging service with its parsers, configuration, and logger.</summary>
@@ -67,12 +67,13 @@ public sealed class BundleStagingService : IBundleStagingService
     /// (issue #247).
     /// </param>
     /// <param name="pluginReader">Reader for a staged bundle's plugin manifest.</param>
-    /// <param name="mcpServersConfig">
-    /// The same live <see cref="McpServersConfig"/> instance <c>McpConnectionManager</c> reads (the
-    /// <c>AIConfig</c>-bound one, not the <c>AppConfig</c>-bound one — they are independent object
-    /// graphs; see the composition-root comment next to <c>PluginLoader</c>'s registration). A staged
-    /// bundle's own MCP servers are merged into it under a bundle-scoped namespaced key, mirroring how
-    /// <see cref="Infrastructure.AI.Plugins.PluginLoader"/> merges a host plugin's servers.
+    /// <param name="bundleOwnedMcpServers">
+    /// The shared, singleton <see cref="BundleOwnedMcpServerRegistry"/> — a bundle's own MCP servers are
+    /// merged into it under a bundle-scoped namespaced key, deliberately NOT into the trusted, host-admin
+    /// <c>McpServersConfig</c> <c>McpConnectionManager</c> enumerates: an uploaded bundle is untrusted
+    /// content, and registering it into the same dictionary the host enumerates would let it leak into
+    /// every ordinary, non-bundle conversation. <c>McpConnectionManager</c> consults this registry only
+    /// by exact name, as a fallback after its host dictionary misses — never by enumeration.
     /// </param>
     /// <param name="logger">Logger for staging diagnostics.</param>
     public BundleStagingService(
@@ -81,18 +82,18 @@ public sealed class BundleStagingService : IBundleStagingService
         SkillMetadataParser skillParser,
         ISkillFileReader skillFileReader,
         IPluginManifestReader pluginReader,
-        McpServersConfig mcpServersConfig,
+        BundleOwnedMcpServerRegistry bundleOwnedMcpServers,
         ILogger<BundleStagingService> logger)
     {
         ArgumentNullException.ThrowIfNull(skillFileReader);
-        ArgumentNullException.ThrowIfNull(mcpServersConfig);
+        ArgumentNullException.ThrowIfNull(bundleOwnedMcpServers);
 
         _appConfig = appConfig;
         _agentParser = agentParser;
         _skillParser = skillParser;
         _skillFileReader = skillFileReader;
         _pluginReader = pluginReader;
-        _mcpServersConfig = mcpServersConfig;
+        _bundleOwnedMcpServers = bundleOwnedMcpServers;
         _logger = logger;
     }
 
@@ -435,9 +436,10 @@ public sealed class BundleStagingService : IBundleStagingService
     }
 
     /// <summary>
-    /// Merges one manifest's declared MCP servers into the shared <see cref="McpServersConfig"/> under
-    /// a bundle-scoped key (<c>{bundleId}:{serverName}</c>) and returns each registered key — the values
-    /// that become <see cref="StagedBundle.McpServerNames"/>, later unioned into the run's
+    /// Merges one manifest's declared MCP servers into the shared <see cref="BundleOwnedMcpServerRegistry"/>
+    /// — deliberately NOT the trusted, host-admin <c>McpServersConfig</c> — under a bundle-scoped key
+    /// (<c>{bundleId}:{serverName}</c>) and returns each registered key — the values that become
+    /// <see cref="StagedBundle.McpServerNames"/>, later unioned into the run's
     /// <see cref="Domain.AI.Bundles.CapabilityEnvelope"/>. <paramref name="bundleId"/> alone (not the
     /// manifest's own name) is the namespace, because <see cref="Domain.AI.Bundles.StagedBundle.BundleId"/>
     /// is a fresh GUID per staging — two bundles can never collide — while a manifest's <c>Name</c> is
@@ -509,7 +511,7 @@ public sealed class BundleStagingService : IBundleStagingService
             return false;
         }
 
-        if (_mcpServersConfig.Servers.TryAdd(namespacedName, definition))
+        if (_bundleOwnedMcpServers.Servers.TryAdd(namespacedName, definition))
             return true;
 
         _logger.LogWarning(

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -68,12 +68,9 @@ public sealed class BundleStagingService : IBundleStagingService
     /// </param>
     /// <param name="pluginReader">Reader for a staged bundle's plugin manifest.</param>
     /// <param name="bundleOwnedMcpServers">
-    /// The shared, singleton <see cref="BundleOwnedMcpServerRegistry"/> — a bundle's own MCP servers are
-    /// merged into it under a bundle-scoped namespaced key, deliberately NOT into the trusted, host-admin
-    /// <c>McpServersConfig</c> <c>McpConnectionManager</c> enumerates: an uploaded bundle is untrusted
-    /// content, and registering it into the same dictionary the host enumerates would let it leak into
-    /// every ordinary, non-bundle conversation. <c>McpConnectionManager</c> consults this registry only
-    /// by exact name, as a fallback after its host dictionary misses — never by enumeration.
+    /// The shared, singleton <see cref="BundleOwnedMcpServerRegistry"/> a bundle's own MCP servers are
+    /// merged into under a bundle-scoped namespaced key — deliberately NOT the trusted, host-admin
+    /// <c>McpServersConfig</c>; see <see cref="BundleOwnedMcpServerRegistry"/>'s own doc comment for why.
     /// </param>
     /// <param name="logger">Logger for staging diagnostics.</param>
     public BundleStagingService(

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -466,6 +466,23 @@ public sealed class BundleStagingService : IBundleStagingService
                 continue;
             }
 
+            // A bundle is untrusted, uploader-supplied content. A stdio server's Command/Args/Env come
+            // straight from the bundle's own manifest, and connecting to it launches that command as a
+            // real host process (via McpConnectionManager -> StdioClientTransport) — arbitrary command
+            // execution on the harness host, gated only by upload permission. Host-installed plugins
+            // (PluginLoader) are a different trust tier and are unaffected: only this bundle path rejects
+            // Stdio. Tracked follow-up to run a bundle's stdio server inside the existing process/Docker
+            // sandbox instead of rejecting it outright: #371.
+            if (definition.Type == McpServerType.Stdio)
+            {
+                _logger.LogWarning(
+                    "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio (local command) " +
+                    "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
+                    "Only http/sse (remote) MCP servers are permitted in a bundle's own manifest.",
+                    bundleId, serverProp.Name);
+                continue;
+            }
+
             if (_mcpServersConfig.Servers.TryAdd(namespacedName, definition))
             {
                 registered.Add(namespacedName);

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -7,9 +7,11 @@ using Domain.AI.Skills;
 using Domain.Common;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.BundleExecution;
+using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Plugins;
 using Domain.Common.Helpers;
 using Infrastructure.AI.Agents;
+using Infrastructure.AI.Plugins;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -44,6 +46,7 @@ public sealed class BundleStagingService : IBundleStagingService
     private readonly SkillMetadataParser _skillParser;
     private readonly ISkillFileReader _skillFileReader;
     private readonly IPluginManifestReader _pluginReader;
+    private readonly McpServersConfig _mcpServersConfig;
     private readonly ILogger<BundleStagingService> _logger;
 
     /// <summary>Initialises the staging service with its parsers, configuration, and logger.</summary>
@@ -56,6 +59,13 @@ public sealed class BundleStagingService : IBundleStagingService
     /// (issue #247).
     /// </param>
     /// <param name="pluginReader">Reader for a staged bundle's plugin manifest.</param>
+    /// <param name="mcpServersConfig">
+    /// The same live <see cref="McpServersConfig"/> instance <c>McpConnectionManager</c> reads (the
+    /// <c>AIConfig</c>-bound one, not the <c>AppConfig</c>-bound one — they are independent object
+    /// graphs; see the composition-root comment next to <c>PluginLoader</c>'s registration). A staged
+    /// bundle's own MCP servers are merged into it under a bundle-scoped namespaced key, mirroring how
+    /// <see cref="Infrastructure.AI.Plugins.PluginLoader"/> merges a host plugin's servers.
+    /// </param>
     /// <param name="logger">Logger for staging diagnostics.</param>
     public BundleStagingService(
         IOptionsMonitor<AppConfig> appConfig,
@@ -63,15 +73,18 @@ public sealed class BundleStagingService : IBundleStagingService
         SkillMetadataParser skillParser,
         ISkillFileReader skillFileReader,
         IPluginManifestReader pluginReader,
+        McpServersConfig mcpServersConfig,
         ILogger<BundleStagingService> logger)
     {
         ArgumentNullException.ThrowIfNull(skillFileReader);
+        ArgumentNullException.ThrowIfNull(mcpServersConfig);
 
         _appConfig = appConfig;
         _agentParser = agentParser;
         _skillParser = skillParser;
         _skillFileReader = skillFileReader;
         _pluginReader = pluginReader;
+        _mcpServersConfig = mcpServersConfig;
         _logger = logger;
     }
 
@@ -351,7 +364,7 @@ public sealed class BundleStagingService : IBundleStagingService
             return CleanupAndFail(bundleDir, "Bundle AGENT.md has no resolvable id.");
 
         var ownedSkills = ParseNestedSkills(bundleDir);
-        var manifests = ParsePluginManifests(bundleDir);
+        var (manifests, mcpServerNames) = ParsePluginManifests(bundleDir, bundleId);
 
         return Result<StagedBundle>.Success(new StagedBundle
         {
@@ -360,6 +373,7 @@ public sealed class BundleStagingService : IBundleStagingService
             Agent = agent,
             OwnedSkills = ownedSkills,
             PluginManifests = manifests,
+            McpServerNames = mcpServerNames,
         });
     }
 
@@ -382,13 +396,18 @@ public sealed class BundleStagingService : IBundleStagingService
         return [.. byId.Values];
     }
 
-    private IReadOnlyList<PluginManifest> ParsePluginManifests(string bundleDir)
+    private (IReadOnlyList<PluginManifest> Manifests, IReadOnlyList<string> McpServerNames) ParsePluginManifests(
+        string bundleDir, string bundleId)
     {
         var manifests = new List<PluginManifest>();
+        var mcpServerNames = new List<string>();
 
         var rootManifest = _pluginReader.Read(bundleDir);
         if (rootManifest is not null)
+        {
             manifests.Add(rootManifest);
+            mcpServerNames.AddRange(RegisterBundleMcpServers(bundleDir, bundleId, rootManifest));
+        }
 
         var pluginsRoot = Path.Combine(bundleDir, "plugins");
         if (Directory.Exists(pluginsRoot))
@@ -397,11 +416,70 @@ public sealed class BundleStagingService : IBundleStagingService
             {
                 var manifest = _pluginReader.Read(pluginDir);
                 if (manifest is not null)
+                {
                     manifests.Add(manifest);
+                    mcpServerNames.AddRange(RegisterBundleMcpServers(pluginDir, bundleId, manifest));
+                }
             }
         }
 
-        return manifests;
+        return (manifests, mcpServerNames);
+    }
+
+    /// <summary>
+    /// Merges one manifest's declared MCP servers into the shared <see cref="McpServersConfig"/> under
+    /// a bundle-scoped key (<c>{bundleId}:{serverName}</c>) and returns each registered key — the values
+    /// that become <see cref="StagedBundle.McpServerNames"/>, later unioned into the run's
+    /// <see cref="Domain.AI.Bundles.CapabilityEnvelope"/>. <paramref name="bundleId"/> alone (not the
+    /// manifest's own name) is the namespace, because <see cref="Domain.AI.Bundles.StagedBundle.BundleId"/>
+    /// is a fresh GUID per staging — two bundles can never collide — while a manifest's <c>Name</c> is
+    /// free text and not guaranteed unique. A malformed or missing <c>mcp.json</c> is skipped and logged,
+    /// never fails staging.
+    /// </summary>
+    private IReadOnlyList<string> RegisterBundleMcpServers(string manifestBaseDir, string bundleId, PluginManifest manifest)
+    {
+        var registered = new List<string>();
+        if (string.IsNullOrEmpty(manifest.McpServers))
+            return registered;
+
+        using var block = Infrastructure.AI.Plugins.McpManifestReader.ReadMcpServersBlock(
+            manifestBaseDir, manifest.McpServers, $"Bundle {bundleId}", _logger);
+        if (block is null)
+            return registered;
+
+        foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
+        {
+            var namespacedName = $"{bundleId}:{serverProp.Name}";
+
+            McpServerDefinition definition;
+            try
+            {
+                definition = McpServerDefinitionBuilder.Build(
+                    // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
+                    serverProp.Value, new Dictionary<string, string>(), $"[Bundle: {bundleId}]", serverProp.Name);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Bundle {BundleId}: failed to build MCP server definition for '{ServerName}', skipping",
+                    bundleId, serverProp.Name);
+                continue;
+            }
+
+            if (_mcpServersConfig.Servers.TryAdd(namespacedName, definition))
+            {
+                registered.Add(namespacedName);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Bundle {BundleId}: duplicate MCP server name '{ServerName}' declared across " +
+                    "more than one plugin manifest; keeping the first",
+                    bundleId, serverProp.Name);
+            }
+        }
+
+        return registered;
     }
 
     private Result<StagedBundle> CleanupAndFail(string bundleDir, params string[] errors)

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
 using Domain.AI.Bundles;
+using Domain.AI.Egress;
 using Domain.AI.Skills;
 using Domain.Common;
 using Domain.Common.Config;
@@ -12,6 +13,7 @@ using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Plugins;
 using Domain.Common.Helpers;
 using Infrastructure.AI.Agents;
+using Infrastructure.AI.Egress;
 using Infrastructure.AI.Plugins;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging;
@@ -449,15 +451,33 @@ public sealed class BundleStagingService : IBundleStagingService
         if (string.IsNullOrEmpty(manifest.McpServers))
             return registered;
 
+        // A bundle is untrusted, externally-authored input. Honouring its own declared MCP servers means
+        // the host makes outbound connections a caller's CapabilityEnvelope never authorized — off by
+        // default until an operator opts in. The manifest is never even opened when off, so a disabled
+        // host pays no parsing cost for a capability it doesn't have.
+        if (!_appConfig.CurrentValue.AI.BundleExecution.AllowBundleDeclaredMcpServers)
+        {
+            _logger.LogInformation(
+                "Bundle {BundleId}: declares MCP servers but AllowBundleDeclaredMcpServers is disabled — " +
+                "skipping, none registered. Set AppConfig:AI:BundleExecution:AllowBundleDeclaredMcpServers " +
+                "= true to enable this capability.",
+                bundleId);
+            return registered;
+        }
+
         using var block = Infrastructure.AI.Plugins.McpManifestReader.ReadMcpServersBlock(
             manifestBaseDir, manifest.McpServers, $"Bundle {bundleId}", _logger);
         if (block is null)
             return registered;
 
+        // Loop-invariant: every server this manifest declares is checked against the SAME harness-wide
+        // allowlist, so it is mapped from config once here rather than re-derived on every iteration.
+        var allowlist = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
+
         foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
         {
             var namespacedName = $"{bundleId}:{serverProp.Name}";
-            if (TryBuildAndRegisterOneServer(bundleId, namespacedName, serverProp))
+            if (TryBuildAndRegisterOneServer(bundleId, namespacedName, serverProp, allowlist))
                 registered.Add(namespacedName);
         }
 
@@ -466,10 +486,11 @@ public sealed class BundleStagingService : IBundleStagingService
 
     /// <summary>
     /// Builds one manifest-declared server and registers it under <paramref name="namespacedName"/>,
-    /// rejecting a stdio (local-command) transport and a duplicate name — see
+    /// rejecting a stdio (local-command) transport, a disallowed destination, and a duplicate name — see
     /// <see cref="RegisterBundleMcpServers"/>. Returns whether registration succeeded.
     /// </summary>
-    private bool TryBuildAndRegisterOneServer(string bundleId, string namespacedName, JsonProperty serverProp)
+    private bool TryBuildAndRegisterOneServer(
+        string bundleId, string namespacedName, JsonProperty serverProp, IReadOnlyList<EgressAllowlistEntry> allowlist)
     {
         McpServerDefinition definition;
         try
@@ -486,27 +507,14 @@ public sealed class BundleStagingService : IBundleStagingService
             return false;
         }
 
-        // A bundle is untrusted, uploader-supplied content. A stdio server's Command/Args/Env come
-        // straight from the bundle's own manifest, and connecting to it launches that command as a
-        // real host process (via McpConnectionManager -> StdioClientTransport) — arbitrary command
-        // execution on the harness host, gated only by upload permission. Host-installed plugins
-        // (PluginLoader) are a different trust tier and are unaffected: only this bundle path rejects
-        // Stdio. Tracked follow-up to run a bundle's stdio server inside the existing process/Docker
-        // sandbox instead of rejecting it outright: #371.
         if (!definition.IsRemoteServer)
         {
-            // "resolved to", not "declares": McpServerDefinitionBuilder.ParseType defaults an ABSENT or
-            // UNRECOGNIZED 'type' value to Stdio too (only "http"/"sse" are matched), so a bundle author
-            // who misspells a real remote transport lands here as well — this message must stay accurate
-            // for both cases, not assert an explicit stdio declaration that may not exist.
-            _logger.LogWarning(
-                "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) " +
-                "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
-                "The transport was either explicitly declared, or defaulted to stdio because 'type' was " +
-                "missing or unrecognized (only 'http'/'sse' are supported).",
-                bundleId, serverProp.Name);
+            LogStdioRejected(bundleId, serverProp.Name);
             return false;
         }
+
+        if (!IsUrlAllowlisted(bundleId, serverProp.Name, definition.Url, allowlist))
+            return false;
 
         if (_bundleOwnedMcpServers.TryAdd(namespacedName, definition))
             return true;
@@ -515,6 +523,65 @@ public sealed class BundleStagingService : IBundleStagingService
             "Bundle {BundleId}: duplicate MCP server name '{ServerName}' declared across " +
             "more than one plugin manifest; keeping the first",
             bundleId, serverProp.Name);
+        return false;
+    }
+
+    // A bundle is untrusted, uploader-supplied content. A stdio server's Command/Args/Env come
+    // straight from the bundle's own manifest, and connecting to it launches that command as a
+    // real host process (via McpConnectionManager -> StdioClientTransport) — arbitrary command
+    // execution on the harness host, gated only by upload permission. Host-installed plugins
+    // (PluginLoader) are a different trust tier and are unaffected: only this bundle path rejects
+    // Stdio. Tracked follow-up to run a bundle's stdio server inside the existing process/Docker
+    // sandbox instead of rejecting it outright: #371.
+    private void LogStdioRejected(string bundleId, string serverName)
+    {
+        // "resolved to", not "declares": McpServerDefinitionBuilder.ParseType defaults an ABSENT or
+        // UNRECOGNIZED 'type' value to Stdio too (only "http"/"sse" are matched), so a bundle author
+        // who misspells a real remote transport lands here as well — this message must stay accurate
+        // for both cases, not assert an explicit stdio declaration that may not exist.
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) " +
+            "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
+            "The transport was either explicitly declared, or defaulted to stdio because 'type' was " +
+            "missing or unrecognized (only 'http'/'sse' are supported).",
+            bundleId, serverName);
+    }
+
+    /// <summary>
+    /// Registration-time pre-check against the SAME harness-wide allowlist a bundle-owned server's live
+    /// connections are evaluated against (<c>McpConnectionManager</c>'s per-request egress policy —
+    /// Infrastructure.AI.MCP, a different project this one does not reference), sharing
+    /// <see cref="DefaultEgressPolicy.MatchesAnyEntry"/>'s matching loop directly with the live decision
+    /// (<see cref="DefaultEgressPolicy.AllowAsync"/>) so the two matching primitives can never
+    /// independently drift on what "host/scheme/port matches THIS list" means. This is deliberately NOT a
+    /// claim that this check and the live decision always agree: the live path resolves its policy
+    /// per-identity via <c>IEgressPolicyResolver</c>, which can source a different, wider, or differently
+    /// cached allowlist than the one read fresh from config here — the two can diverge on WHICH list
+    /// applies, even though they never diverge on what matching against a given list means. This is a
+    /// fast, synchronous, no-DNS gate at upload time so an obviously-disallowed (or unparsable)
+    /// destination is rejected before a bundle handle ever exists — not a replacement for the audited,
+    /// per-request enforcement every actual connection still goes through, and not a guarantee that
+    /// passing this gate implies the live connection will also be allowed.
+    /// </summary>
+    private bool IsUrlAllowlisted(
+        string bundleId, string serverName, string? url, IReadOnlyList<EgressAllowlistEntry> allowlist)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            _logger.LogWarning(
+                "Bundle {BundleId}: MCP server '{ServerName}' declares an unparsable or missing URL " +
+                "'{Url}' — rejected, not registered.",
+                bundleId, serverName, url);
+            return false;
+        }
+
+        if (DefaultEgressPolicy.MatchesAnyEntry(allowlist, uri))
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' declares URL '{Url}', whose host is not on " +
+            "AppConfig:AI:Egress:DefaultAllowlist — rejected, not registered.",
+            bundleId, serverName, url);
         return false;
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -508,7 +508,7 @@ public sealed class BundleStagingService : IBundleStagingService
             return false;
         }
 
-        if (_bundleOwnedMcpServers.Servers.TryAdd(namespacedName, definition))
+        if (_bundleOwnedMcpServers.TryAdd(namespacedName, definition))
             return true;
 
         _logger.LogWarning(

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleHandleStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleHandleStore.cs
@@ -43,14 +43,21 @@ public sealed class InMemoryBundleHandleStore : IBundleHandleStore, IDisposable
     private readonly ConcurrentDictionary<string, HandleEntry> _entries = new(StringComparer.Ordinal);
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
+    private readonly IBundleMcpServerRegistrar? _mcpServerRegistrar;
     private readonly ILogger<InMemoryBundleHandleStore> _logger;
     private bool _disposed;
 
     /// <summary>Initializes a new <see cref="InMemoryBundleHandleStore"/>.</summary>
+    /// <param name="mcpServerRegistrar">
+    /// Optional — null on a host with no MCP client dependencies registered. Deregisters a bundle's own
+    /// MCP servers (registered by <c>BundleStagingService</c> at staging time) whenever its handle is
+    /// evicted, so a removed/expired bundle's servers and connections do not linger (issue #368).
+    /// </param>
     public InMemoryBundleHandleStore(
         IOptionsMonitor<AppConfig> config,
         TimeProvider time,
-        ILogger<InMemoryBundleHandleStore> logger)
+        ILogger<InMemoryBundleHandleStore> logger,
+        IBundleMcpServerRegistrar? mcpServerRegistrar = null)
     {
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(time);
@@ -59,6 +66,7 @@ public sealed class InMemoryBundleHandleStore : IBundleHandleStore, IDisposable
         _config = config;
         _time = time;
         _logger = logger;
+        _mcpServerRegistrar = mcpServerRegistrar;
     }
 
     private TimeSpan Ttl => _config.CurrentValue.AI.BundleExecution.HandleTtl;
@@ -201,8 +209,38 @@ public sealed class InMemoryBundleHandleStore : IBundleHandleStore, IDisposable
         if (!_entries.TryRemove(new KeyValuePair<string, HandleEntry>(handle, entry)))
             return false;
 
+        FireAndForgetMcpDeregistration(entry.Bundle.McpServerNames);
         DeleteDirectorySafely(stagedRootDirectory);
         return true;
+    }
+
+    /// <summary>
+    /// Deregisters a bundle's own MCP servers without blocking the caller — every path into
+    /// <see cref="EvictAndDelete"/> is either already synchronous-only by contract
+    /// (<see cref="Remove"/>, <see cref="SweepExpired"/>) or runs inside <c>lock (entry)</c>
+    /// (<see cref="ReleaseLease"/>), so an awaited deregistration is not an option here. A failure is
+    /// logged and swallowed — matches this store's existing posture that cleanup must never crash the
+    /// sweeper or a caller (see <see cref="DeleteDirectorySafely"/>).
+    /// </summary>
+    private void FireAndForgetMcpDeregistration(IReadOnlyList<string> mcpServerNames)
+    {
+        if (_mcpServerRegistrar is null || mcpServerNames.Count == 0)
+            return;
+
+        _ = DeregisterMcpServersSafelyAsync(mcpServerNames);
+    }
+
+    private async Task DeregisterMcpServersSafelyAsync(IReadOnlyList<string> mcpServerNames)
+    {
+        try
+        {
+            await _mcpServerRegistrar!.DeregisterAsync(mcpServerNames).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to deregister bundle MCP servers {ServerNames} during handle eviction",
+                string.Join(", ", mcpServerNames));
+        }
     }
 
     private void DeleteDirectorySafely(string path)
@@ -242,7 +280,14 @@ public sealed class InMemoryBundleHandleStore : IBundleHandleStore, IDisposable
             lock (entry)
             {
                 if (entry.LeaseCount == 0)
+                {
+                    // Best-effort only, same as the directory delete below: the process is exiting
+                    // regardless, so an MCP client's underlying process/socket is torn down by the OS
+                    // either way. This still removes the config entries and attempts a clean disconnect
+                    // for the (likely) case that shutdown is not instantaneous.
+                    FireAndForgetMcpDeregistration(entry.Bundle.McpServerNames);
                     DeleteDirectorySafely(entry.Bundle.StagedRootDirectory);
+                }
             }
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -190,11 +190,8 @@ public static partial class DependencyInjection
         // until an ingest call reaches it — so it is registered unconditionally; the run/API surface that
         // invokes it is gated in a later layer. Wired to the SAME BundleOwnedMcpServerRegistry instance
         // McpConnectionManager (Infrastructure.AI.MCP) reads — deliberately NOT the trusted, AIConfig-bound
-        // McpServersConfig PluginLoader (below) writes into: a staged bundle's own MCP servers are
-        // untrusted, uploader-supplied content and must never land in the same registry the host
-        // enumerates for an ordinary conversation (issue #368's original design; isolated in #370 after a
-        // security review found the shared-registry version let a bundle's tools leak into every
-        // non-bundle conversation on the host).
+        // McpServersConfig PluginLoader (below) writes into; see BundleOwnedMcpServerRegistry's own doc
+        // comment for why.
         services.AddSingleton<IBundleStagingService>(sp => new BundleStagingService(
             sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
             sp.GetRequiredService<AgentMetadataParser>(),

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -188,18 +188,20 @@ public static partial class DependencyInjection
         // --- Bundle execution (staging) ---
         // Off by default (AI:BundleExecution:Enabled). The staging service is passive — it does nothing
         // until an ingest call reaches it — so it is registered unconditionally; the run/API surface that
-        // invokes it is gated in a later layer. Wired to the SAME McpServersConfig instance PluginLoader
-        // (below) and McpConnectionManager read — the AIConfig-bound one, not the AppConfig-bound one;
-        // see the comment on the PluginLoader registration for why that distinction matters. A staged
-        // bundle's own MCP servers are merged into that instance under a bundle-scoped key at staging
-        // time (issue #368).
+        // invokes it is gated in a later layer. Wired to the SAME BundleOwnedMcpServerRegistry instance
+        // McpConnectionManager (Infrastructure.AI.MCP) reads — deliberately NOT the trusted, AIConfig-bound
+        // McpServersConfig PluginLoader (below) writes into: a staged bundle's own MCP servers are
+        // untrusted, uploader-supplied content and must never land in the same registry the host
+        // enumerates for an ordinary conversation (issue #368's original design; isolated in #370 after a
+        // security review found the shared-registry version let a bundle's tools leak into every
+        // non-bundle conversation on the host).
         services.AddSingleton<IBundleStagingService>(sp => new BundleStagingService(
             sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
             sp.GetRequiredService<AgentMetadataParser>(),
             sp.GetRequiredService<SkillMetadataParser>(),
             sp.GetRequiredService<ISkillFileReader>(),
             sp.GetRequiredService<IPluginManifestReader>(),
-            sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.AIConfig>>().CurrentValue.McpServers,
+            sp.GetRequiredService<Domain.Common.Config.AI.MCP.BundleOwnedMcpServerRegistry>(),
             sp.GetRequiredService<ILogger<BundleStagingService>>()));
 
         // Capability-envelope resolver — maps the calling credential to its configured per-caller grant.

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -49,6 +49,7 @@ using Infrastructure.AI.Tools;
 using Infrastructure.AI.Traces;
 using Domain.Common.Config.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -192,6 +193,11 @@ public static partial class DependencyInjection
         // McpConnectionManager (Infrastructure.AI.MCP) reads — deliberately NOT the trusted, AIConfig-bound
         // McpServersConfig PluginLoader (below) writes into; see BundleOwnedMcpServerRegistry's own doc
         // comment for why.
+        // TryAddSingleton (not AddSingleton), and this layer registers it too, not just
+        // Infrastructure.AI.MCP: BundleStagingService needs this instance regardless of whether
+        // AddMcpClientDependencies has run, so AddInfrastructureAIDependencies must not silently depend
+        // on registration order between the two layers to resolve IBundleStagingService.
+        services.TryAddSingleton<Domain.Common.Config.AI.MCP.BundleOwnedMcpServerRegistry>();
         services.AddSingleton<IBundleStagingService>(sp => new BundleStagingService(
             sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
             sp.GetRequiredService<AgentMetadataParser>(),

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -193,10 +193,8 @@ public static partial class DependencyInjection
         // McpConnectionManager (Infrastructure.AI.MCP) reads — deliberately NOT the trusted, AIConfig-bound
         // McpServersConfig PluginLoader (below) writes into; see BundleOwnedMcpServerRegistry's own doc
         // comment for why.
-        // TryAddSingleton (not AddSingleton), and this layer registers it too, not just
-        // Infrastructure.AI.MCP: BundleStagingService needs this instance regardless of whether
-        // AddMcpClientDependencies has run, so AddInfrastructureAIDependencies must not silently depend
-        // on registration order between the two layers to resolve IBundleStagingService.
+        // TryAddSingleton (not AddSingleton) — also registered by AddMcpClientDependencies, so call order
+        // between the two extension methods is irrelevant.
         services.TryAddSingleton<Domain.Common.Config.AI.MCP.BundleOwnedMcpServerRegistry>();
         services.AddSingleton<IBundleStagingService>(sp => new BundleStagingService(
             sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -188,8 +188,19 @@ public static partial class DependencyInjection
         // --- Bundle execution (staging) ---
         // Off by default (AI:BundleExecution:Enabled). The staging service is passive — it does nothing
         // until an ingest call reaches it — so it is registered unconditionally; the run/API surface that
-        // invokes it is gated in a later layer.
-        services.AddSingleton<IBundleStagingService, BundleStagingService>();
+        // invokes it is gated in a later layer. Wired to the SAME McpServersConfig instance PluginLoader
+        // (below) and McpConnectionManager read — the AIConfig-bound one, not the AppConfig-bound one;
+        // see the comment on the PluginLoader registration for why that distinction matters. A staged
+        // bundle's own MCP servers are merged into that instance under a bundle-scoped key at staging
+        // time (issue #368).
+        services.AddSingleton<IBundleStagingService>(sp => new BundleStagingService(
+            sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+            sp.GetRequiredService<AgentMetadataParser>(),
+            sp.GetRequiredService<SkillMetadataParser>(),
+            sp.GetRequiredService<ISkillFileReader>(),
+            sp.GetRequiredService<IPluginManifestReader>(),
+            sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.AIConfig>>().CurrentValue.McpServers,
+            sp.GetRequiredService<ILogger<BundleStagingService>>()));
 
         // Capability-envelope resolver — maps the calling credential to its configured per-caller grant.
         // Passive like staging: it only reads config when asked, so it is registered unconditionally and

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/DefaultEgressPolicy.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/DefaultEgressPolicy.cs
@@ -98,24 +98,10 @@ public sealed class DefaultEgressPolicy : IEgressPolicy
             };
         }
 
-        foreach (var entry in _entries)
+        var match = FindMatch(_entries, target);
+        if (match is not null)
         {
-            if (!HostMatches(entry, target.Host))
-            {
-                continue;
-            }
-
-            if (!SchemeMatches(entry, target.Scheme))
-            {
-                continue;
-            }
-
-            if (!PortMatches(entry, target.Port))
-            {
-                continue;
-            }
-
-            var matched = entry.Host ?? entry.HostPattern ?? "(unknown)";
+            var matched = match.Host ?? match.HostPattern ?? "(unknown)";
             var resolvedIp = await TryResolveAsync(target.Host, cancellationToken).ConfigureAwait(false);
 
             return new EgressDecision
@@ -141,6 +127,36 @@ public sealed class DefaultEgressPolicy : IEgressPolicy
     private static bool IsHttpScheme(string scheme) =>
         string.Equals(scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
         || string.Equals(scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Pure, synchronous "does any entry match this target" check — no DNS resolution, no audit, no
+    /// identity. Used by <see cref="AllowAsync"/> for the live decision, and reused directly by
+    /// <c>BundleStagingService</c> as an early, registration-time pre-check against the same allowlist a
+    /// bundle-declared server's live connections will be evaluated against, through the SAME
+    /// <see cref="FindMatch"/> loop <see cref="AllowAsync"/> itself calls — so the two checks are provably
+    /// the same host/scheme/port decision, not two independently-maintained copies of it.
+    /// </summary>
+    internal static bool MatchesAnyEntry(IReadOnlyList<EgressAllowlistEntry> entries, Uri target)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(target);
+
+        if (!target.IsAbsoluteUri || !IsHttpScheme(target.Scheme))
+            return false;
+
+        return FindMatch(entries, target) is not null;
+    }
+
+    private static EgressAllowlistEntry? FindMatch(IReadOnlyList<EgressAllowlistEntry> entries, Uri target)
+    {
+        foreach (var entry in entries)
+        {
+            if (HostMatches(entry, target.Host) && SchemeMatches(entry, target.Scheme) && PortMatches(entry, target.Port))
+                return entry;
+        }
+
+        return null;
+    }
 
     private static bool HostMatches(EgressAllowlistEntry entry, string requestHost)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using Domain.Common.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Plugins;
+
+/// <summary>
+/// Locates, path-guards, and parses a manifest's <c>mcpServers</c> JSON block. Shared by
+/// <see cref="PluginLoader"/> (host plugins) and <c>BundleStagingService</c> (bundle-declared servers)
+/// so the two never independently decide how that file is found, guarded against escaping its owning
+/// directory, or parsed — and so a malformed or missing file degrades identically (skip, log, never
+/// fail the caller's larger operation) everywhere it's read.
+/// </summary>
+public static class McpManifestReader
+{
+    /// <summary>
+    /// The parsed <c>mcpServers</c> object plus the <see cref="System.Text.Json.JsonDocument"/> that
+    /// owns its underlying buffer. Callers must dispose this (via <c>using</c>) once done enumerating
+    /// <see cref="ServersElement"/> — the element is only valid while the owning document is alive.
+    /// </summary>
+    public readonly struct McpServersBlock(JsonDocument document, JsonElement serversElement) : IDisposable
+    {
+        /// <summary>The <c>mcpServers</c> object's entries.</summary>
+        public JsonElement ServersElement { get; } = serversElement;
+
+        /// <inheritdoc />
+        public void Dispose() => document.Dispose();
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="mcpServersRelativePath"/> against <paramref name="baseDir"/>, verifies it
+    /// does not escape that directory, and parses its <c>mcpServers</c> object. Returns
+    /// <see langword="null"/> when the path escapes, the file is missing, the JSON is malformed, or it
+    /// has no <c>mcpServers</c> property.
+    /// </summary>
+    /// <param name="baseDir">The directory the manifest declaring <paramref name="mcpServersRelativePath"/> lives in.</param>
+    /// <param name="mcpServersRelativePath">The manifest's own <c>mcpServers</c> path (e.g. <c>"./mcp.json"</c>).</param>
+    /// <param name="ownerDescription">Human-readable owner for log messages, e.g. <c>"Plugin azure"</c> or <c>"Bundle b1"</c>.</param>
+    /// <param name="logger">Logger for the skip/failure cases.</param>
+    public static McpServersBlock? ReadMcpServersBlock(
+        string baseDir, string mcpServersRelativePath, string ownerDescription, ILogger logger)
+    {
+        var mcpPath = Path.GetFullPath(Path.Combine(baseDir, mcpServersRelativePath));
+        var normalizedBase = PathScope.Normalize(baseDir);
+        if (!PathScope.IsSameOrUnderNormalized(PathScope.Normalize(mcpPath), normalizedBase))
+        {
+            logger.LogWarning(
+                "{Owner}: MCP config path {Path} escapes its base directory, skipping", ownerDescription, mcpPath);
+            return null;
+        }
+
+        if (!File.Exists(mcpPath))
+            return null;
+
+        JsonDocument doc;
+        try
+        {
+            var json = File.ReadAllText(mcpPath);
+            doc = JsonDocument.Parse(json, new JsonDocumentOptions
+            {
+                CommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            });
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "{Owner}: failed to parse MCP config at {Path}", ownerDescription, mcpPath);
+            return null;
+        }
+
+        if (doc.RootElement.TryGetProperty("mcpServers", out var serversElement))
+            return new McpServersBlock(doc, serversElement);
+
+        doc.Dispose();
+        return null;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
@@ -49,8 +49,12 @@ public static class McpManifestReader
         {
             mcpPath = Path.GetFullPath(Path.Combine(baseDir, mcpServersRelativePath));
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        catch (Exception ex)
         {
+            // Broad catch, matching this method's own JSON-parse guard below and the sibling
+            // PluginManifestReader.Read's path-resolution guard: a narrower filter here would silently
+            // diverge from both if a future runtime version throws a different exception type for a
+            // malformed path than the ones known today.
             logger.LogWarning(ex,
                 "{Owner}: MCP config path '{RelativePath}' is invalid, skipping",
                 ownerDescription, mcpServersRelativePath);

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
@@ -30,8 +30,12 @@ public static class McpManifestReader
     /// <summary>
     /// Resolves <paramref name="mcpServersRelativePath"/> against <paramref name="baseDir"/>, verifies it
     /// does not escape that directory, and parses its <c>mcpServers</c> object. Returns
-    /// <see langword="null"/> when the path escapes, the file is missing, the JSON is malformed, or it
-    /// has no <c>mcpServers</c> property.
+    /// <see langword="null"/> when the path escapes, the file is missing, the JSON is malformed, it has no
+    /// <c>mcpServers</c> property, or that property is not a JSON object (e.g. a string, array, or number)
+    /// — every caller enumerates <see cref="McpServersBlock.ServersElement"/> as an object's properties,
+    /// which throws <see cref="InvalidOperationException"/> on any other <see cref="JsonValueKind"/>; that
+    /// exception must never propagate out of a manifest-parsing path this type exists to make degrade
+    /// gracefully.
     /// </summary>
     /// <param name="baseDir">The directory the manifest declaring <paramref name="mcpServersRelativePath"/> lives in.</param>
     /// <param name="mcpServersRelativePath">The manifest's own <c>mcpServers</c> path (e.g. <c>"./mcp.json"</c>).</param>
@@ -40,7 +44,19 @@ public static class McpManifestReader
     public static McpServersBlock? ReadMcpServersBlock(
         string baseDir, string mcpServersRelativePath, string ownerDescription, ILogger logger)
     {
-        var mcpPath = Path.GetFullPath(Path.Combine(baseDir, mcpServersRelativePath));
+        string mcpPath;
+        try
+        {
+            mcpPath = Path.GetFullPath(Path.Combine(baseDir, mcpServersRelativePath));
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            logger.LogWarning(ex,
+                "{Owner}: MCP config path '{RelativePath}' is invalid, skipping",
+                ownerDescription, mcpServersRelativePath);
+            return null;
+        }
+
         var normalizedBase = PathScope.Normalize(baseDir);
         if (!PathScope.IsSameOrUnderNormalized(PathScope.Normalize(mcpPath), normalizedBase))
         {
@@ -69,7 +85,14 @@ public static class McpManifestReader
         }
 
         if (doc.RootElement.TryGetProperty("mcpServers", out var serversElement))
-            return new McpServersBlock(doc, serversElement);
+        {
+            if (serversElement.ValueKind == JsonValueKind.Object)
+                return new McpServersBlock(doc, serversElement);
+
+            logger.LogWarning(
+                "{Owner}: 'mcpServers' in {Path} is a {Kind}, not a JSON object — skipping",
+                ownerDescription, mcpPath, serversElement.ValueKind);
+        }
 
         doc.Dispose();
         return null;

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpManifestReader.cs
@@ -70,7 +70,10 @@ public static class McpManifestReader
         }
 
         if (!File.Exists(mcpPath))
+        {
+            logger.LogWarning("{Owner}: MCP config not found at {Path}, skipping", ownerDescription, mcpPath);
             return null;
+        }
 
         JsonDocument doc;
         try

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using Domain.Common.Config.AI.MCP;
+
+namespace Infrastructure.AI.Plugins;
+
+/// <summary>
+/// Builds an <see cref="McpServerDefinition"/> from one entry of a <c>mcpServers</c> JSON block.
+/// Shared by <see cref="PluginLoader"/> (host-installed plugins) and bundle staging (an externally
+/// authored bundle's own <c>plugin.json</c>/<c>mcp.json</c>), so the two never independently decide
+/// how a server entry maps to a definition.
+/// </summary>
+public static class McpServerDefinitionBuilder
+{
+    /// <summary>
+    /// Builds a server definition from one <c>mcpServers</c> JSON entry. Branches on the declared
+    /// <c>type</c>: <c>"http"</c>/<c>"sse"</c> reads <c>url</c>; anything else (including an absent
+    /// <c>type</c>, matching every existing manifest that predates this branch) is treated as
+    /// <see cref="McpServerType.Stdio"/> and reads <c>command</c>/<c>args</c>/<c>env</c>.
+    /// </summary>
+    /// <param name="serverElement">The JSON value for this server's entry.</param>
+    /// <param name="declarationEnv">
+    /// Environment overrides from the owning plugin/bundle declaration, applied last so they take
+    /// precedence over manifest-declared env — mirrors the precedence <see cref="PluginLoader"/> already
+    /// enforced before this was extracted.
+    /// </param>
+    /// <param name="descriptionPrefix">A human-readable owner tag, e.g. <c>"[Plugin: azure]"</c>.</param>
+    /// <param name="serverName">The server's own name, appended to <paramref name="descriptionPrefix"/>.</param>
+    public static McpServerDefinition Build(
+        JsonElement serverElement,
+        IReadOnlyDictionary<string, string> declarationEnv,
+        string descriptionPrefix,
+        string serverName)
+    {
+        var type = ParseType(serverElement);
+
+        var definition = new McpServerDefinition
+        {
+            Enabled = true,
+            Type = type,
+            Description = $"{descriptionPrefix} {serverName}"
+        };
+
+        if (type is McpServerType.Http or McpServerType.Sse)
+        {
+            if (serverElement.TryGetProperty("url", out var url))
+                definition.Url = url.GetString();
+        }
+        else
+        {
+            if (serverElement.TryGetProperty("command", out var cmd))
+                definition.Command = cmd.GetString() ?? string.Empty;
+
+            if (serverElement.TryGetProperty("args", out var args))
+                definition.Args = args.EnumerateArray()
+                    .Select(a => a.GetString() ?? string.Empty)
+                    .ToList();
+        }
+
+        if (serverElement.TryGetProperty("env", out var env))
+        {
+            foreach (var envProp in env.EnumerateObject())
+                definition.Env[envProp.Name] = envProp.Value.GetString() ?? string.Empty;
+        }
+
+        // Declaration env overrides take precedence over manifest-declared env.
+        foreach (var (key, value) in declarationEnv)
+            definition.Env[key] = value;
+
+        return definition;
+    }
+
+    /// <summary>
+    /// Reads the optional <c>type</c> property, defaulting to <see cref="McpServerType.Stdio"/> — every
+    /// manifest written before this branch existed omits the property and means stdio.
+    /// </summary>
+    private static McpServerType ParseType(JsonElement serverElement)
+    {
+        if (!serverElement.TryGetProperty("type", out var typeElement))
+            return McpServerType.Stdio;
+
+        var raw = typeElement.GetString();
+        return raw?.ToLowerInvariant() switch
+        {
+            "http" => McpServerType.Http,
+            "sse" => McpServerType.Sse,
+            _ => McpServerType.Stdio
+        };
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
@@ -42,8 +42,12 @@ public static class McpServerDefinitionBuilder
 
         if (type is McpServerType.Http or McpServerType.Sse)
         {
-            if (serverElement.TryGetProperty("url", out var url))
-                definition.Url = url.GetString();
+            var url = serverElement.TryGetProperty("url", out var urlElement) ? urlElement.GetString() : null;
+            if (string.IsNullOrWhiteSpace(url))
+                throw new InvalidOperationException(
+                    $"'{serverName}' declares a {type} transport with no 'url' — a remote server must declare one.");
+
+            definition.Url = url;
         }
         else
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
@@ -146,6 +146,11 @@ public sealed class PluginLoader : IPluginLoader
             return false;
         }
 
+        // Last-writer-wins on a duplicate namespaced key — unlike BundleStagingService's TryAdd +
+        // keep-first-and-warn. Deliberately different, not an oversight: a host plugin's own manifest
+        // realistically never declares the same server name twice, so this path optimizes for the
+        // simpler write; a bundle's namespace is per-upload and a duplicate there is worth flagging to
+        // the (untrusted) bundle author rather than silently accepted.
         _mcpServersConfig.Servers[namespacedName] = definition;
         return true;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Application.AI.Common.Interfaces.Plugins;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.MCP;
@@ -105,55 +104,21 @@ public sealed class PluginLoader : IPluginLoader
 
     private List<string> LoadMcpServers(string pluginPath, PluginDeclaration declaration, string mcpRelativePath)
     {
-        var mcpPath = Path.GetFullPath(Path.Combine(pluginPath, mcpRelativePath));
-
-        if (!IsContainedWithin(mcpPath, pluginPath))
-        {
-            _logger.LogWarning(
-                "Plugin {Name}: MCP config path {Path} escapes plugin directory, skipping",
-                declaration.Name, mcpPath);
-            return [];
-        }
-
-        if (!File.Exists(mcpPath))
-        {
-            _logger.LogDebug(
-                "Plugin {Name}: MCP config not found at {Path}",
-                declaration.Name, mcpPath);
-            return [];
-        }
-
-        return ParseAndMergeMcpServers(mcpPath, declaration);
-    }
-
-    private List<string> ParseAndMergeMcpServers(string mcpPath, PluginDeclaration declaration)
-    {
         var names = new List<string>();
 
-        try
+        using var block = McpManifestReader.ReadMcpServersBlock(
+            pluginPath, mcpRelativePath, $"Plugin {declaration.Name}", _logger);
+        if (block is null)
+            return names;
+
+        foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
         {
-            var json = File.ReadAllText(mcpPath);
-            using var doc = JsonDocument.Parse(json, new JsonDocumentOptions
-            {
-                CommentHandling = JsonCommentHandling.Skip,
-                AllowTrailingCommas = true
-            });
+            var namespacedName = $"{declaration.Name}:{serverProp.Name}";
+            var definition = McpServerDefinitionBuilder.Build(
+                serverProp.Value, declaration.Env, $"[Plugin: {declaration.Name}]", serverProp.Name);
 
-            if (!doc.RootElement.TryGetProperty("mcpServers", out var serversElement))
-                return names;
-
-            foreach (var serverProp in serversElement.EnumerateObject())
-            {
-                var namespacedName = $"{declaration.Name}:{serverProp.Name}";
-                var definition = BuildServerDefinition(serverProp.Value, declaration, serverProp.Name);
-
-                _mcpServersConfig.Servers[namespacedName] = definition;
-                names.Add(namespacedName);
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to parse MCP config at {Path}", mcpPath);
+            _mcpServersConfig.Servers[namespacedName] = definition;
+            names.Add(namespacedName);
         }
 
         return names;
@@ -172,38 +137,5 @@ public sealed class PluginLoader : IPluginLoader
 
         return canonicalTarget.StartsWith(canonicalBase + Path.DirectorySeparatorChar, comparison)
             || string.Equals(canonicalTarget, canonicalBase, comparison);
-    }
-
-    private static McpServerDefinition BuildServerDefinition(
-        JsonElement serverElement,
-        PluginDeclaration declaration,
-        string serverName)
-    {
-        var definition = new McpServerDefinition
-        {
-            Enabled = true,
-            Type = McpServerType.Stdio,
-            Description = $"[Plugin: {declaration.Name}] {serverName}"
-        };
-
-        if (serverElement.TryGetProperty("command", out var cmd))
-            definition.Command = cmd.GetString() ?? string.Empty;
-
-        if (serverElement.TryGetProperty("args", out var args))
-            definition.Args = args.EnumerateArray()
-                .Select(a => a.GetString() ?? string.Empty)
-                .ToList();
-
-        if (serverElement.TryGetProperty("env", out var env))
-        {
-            foreach (var envProp in env.EnumerateObject())
-                definition.Env[envProp.Name] = envProp.Value.GetString() ?? string.Empty;
-        }
-
-        // Declaration env overrides take precedence over manifest-declared env
-        foreach (var (key, value) in declaration.Env)
-            definition.Env[key] = value;
-
-        return definition;
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Application.AI.Common.Interfaces.Plugins;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.MCP;
@@ -114,14 +115,39 @@ public sealed class PluginLoader : IPluginLoader
         foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
         {
             var namespacedName = $"{declaration.Name}:{serverProp.Name}";
-            var definition = McpServerDefinitionBuilder.Build(
-                serverProp.Value, declaration.Env, $"[Plugin: {declaration.Name}]", serverProp.Name);
-
-            _mcpServersConfig.Servers[namespacedName] = definition;
-            names.Add(namespacedName);
+            if (TryBuildAndRegisterOneServer(declaration, namespacedName, serverProp))
+                names.Add(namespacedName);
         }
 
         return names;
+    }
+
+    /// <summary>
+    /// Builds one manifest-declared server and registers it under <paramref name="namespacedName"/>.
+    /// A malformed entry (e.g. a non-string <c>args</c> element) is skipped and logged rather than
+    /// thrown — <see cref="Load"/>'s outer catch would otherwise mark the WHOLE plugin
+    /// <see cref="PluginLoadStatus.Failed"/> over one bad server, discarding the skill paths already
+    /// collected in the same call and leaving any server registered by an earlier entry in this same
+    /// loop orphaned (absent from the returned names, so nothing can deregister it later).
+    /// </summary>
+    private bool TryBuildAndRegisterOneServer(PluginDeclaration declaration, string namespacedName, JsonProperty serverProp)
+    {
+        McpServerDefinition definition;
+        try
+        {
+            definition = McpServerDefinitionBuilder.Build(
+                serverProp.Value, declaration.Env, $"[Plugin: {declaration.Name}]", serverProp.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Plugin {Name}: failed to build MCP server definition for '{ServerName}', skipping",
+                declaration.Name, serverProp.Name);
+            return false;
+        }
+
+        _mcpServersConfig.Servers[namespacedName] = definition;
+        return true;
     }
 
     private static bool IsContainedWithin(string resolvedPath, string basePath)

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/McpToolsExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/McpToolsExample.cs
@@ -67,7 +67,7 @@ public class McpToolsExample
         }
     }
 
-    private static void DisplayServerTable(Dictionary<string, Domain.Common.Config.AI.MCP.McpServerDefinition> servers)
+    private static void DisplayServerTable(IReadOnlyDictionary<string, Domain.Common.Config.AI.MCP.McpServerDefinition> servers)
     {
         var table = new Table().Border(TableBorder.Rounded);
         table.AddColumn("[bold]Name[/]");
@@ -133,7 +133,7 @@ public class McpToolsExample
     }
 
     private async Task TestServerConnectionAsync(
-        Dictionary<string, Domain.Common.Config.AI.MCP.McpServerDefinition> servers,
+        IReadOnlyDictionary<string, Domain.Common.Config.AI.MCP.McpServerDefinition> servers,
         CancellationToken cancellationToken)
     {
         var serverName = AnsiConsole.Prompt(

--- a/src/Content/Presentation/Presentation.ExecutionApi/appsettings.json
+++ b/src/Content/Presentation/Presentation.ExecutionApi/appsettings.json
@@ -67,6 +67,7 @@
       },
       "BundleExecution": {
         "Enabled": true,
+        "AllowBundleDeclaredMcpServers": false,
         "Auth": {
         }
       },

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -243,6 +243,9 @@ public sealed class RunBundleCommandHandlerTests
         result.IsSuccess.Should().BeTrue();
         created!.Envelope.AllowedMcpServers.Should().BeEquivalentTo(["host-server", "b1:echo"],
             "the bundle's own server must be additively granted, never replacing the caller's own grant");
+        created.Envelope.BundleOwnedMcpServers.Should().BeEquivalentTo(["b1:echo"],
+            "the authoritative bundle-ownership record must be stamped at the same point the grant is made, " +
+            "not left for a downstream caller to re-derive from the server name's shape");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -45,11 +45,12 @@ public sealed class RunBundleCommandHandlerTests
             NullLogger<RunBundleCommandHandler>.Instance);
     }
 
-    private static StagedBundle Staged() => new()
+    private static StagedBundle Staged(IReadOnlyList<string>? mcpServerNames = null) => new()
     {
         BundleId = "b1",
         StagedRootDirectory = "/tmp/b1",
-        Agent = new AgentDefinition { Id = "the-agent", Name = "The Agent" }
+        Agent = new AgentDefinition { Id = "the-agent", Name = "The Agent" },
+        McpServerNames = mcpServerNames ?? []
     };
 
     private static RunBundleCommand Command() => new()
@@ -223,6 +224,41 @@ public sealed class RunBundleCommandHandlerTests
         created!.Streaming.Should().BeTrue();
         created.Status.Should().Be(BundleRunStatus.Queued);
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // -- Bundle-owned MCP servers (issue #368) --
+
+    [Fact]
+    public async Task Handle_StagedBundleWithMcpServerNames_UnionsIntoEnvelopeAllowedMcpServers()
+    {
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged(mcpServerNames: ["b1:echo"]));
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        var callerEnvelope = new CapabilityEnvelope { AllowedMcpServers = ["host-server"] };
+        var result = await BuildSut(enabled: true)
+            .Handle(Command() with { Envelope = callerEnvelope }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        created!.Envelope.AllowedMcpServers.Should().BeEquivalentTo(["host-server", "b1:echo"],
+            "the bundle's own server must be additively granted, never replacing the caller's own grant");
+    }
+
+    [Fact]
+    public async Task Handle_StagedBundleWithNoMcpServerNames_LeavesEnvelopeUnchanged()
+    {
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        var callerEnvelope = new CapabilityEnvelope { AllowedMcpServers = ["host-server"] };
+        var result = await BuildSut(enabled: true)
+            .Handle(Command() with { Envelope = callerEnvelope }, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        created!.Envelope.Should().BeSameAs(callerEnvelope, "a bundle with no MCP servers must not allocate a new envelope");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
@@ -1,0 +1,53 @@
+using Application.AI.Common.Services.Tools;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Tools;
+
+/// <summary>
+/// Tests for <see cref="BundleOwnedMcpToolNaming"/> — the collision-proof naming scheme that closes a
+/// privilege-escalation path a code review found in the original #368 design: granting a bundle's
+/// self-reported MCP tool name verbatim let a malicious bundle advertise a tool named after a real,
+/// more privileged host tool and get it auto-granted by name coincidence.
+/// </summary>
+public sealed class BundleOwnedMcpToolNamingTests
+{
+    [Fact]
+    public void BuildToolName_SanitizesColonInServerKey()
+    {
+        var name = BundleOwnedMcpToolNaming.BuildToolName("bundle-abc123:echo", "search");
+
+        name.Should().Be("bundle-abc123_echo__search");
+    }
+
+    [Fact]
+    public void BuildToolName_PreservesRawToolNameUnsanitized()
+    {
+        // The tool's own name is left exactly as the (untrusted) server declared it — matching how any
+        // other MCP tool name is trusted today. Only the newly-injected server prefix is sanitized.
+        var name = BundleOwnedMcpToolNaming.BuildToolName("b1:echo", "weird name!");
+
+        name.Should().Be("b1_echo__weird name!");
+    }
+
+    [Fact]
+    public void BuildToolName_CannotProduceTheBareRealHostToolName()
+    {
+        // The core security property: no matter what a bundle's own server calls its tool, the
+        // namespaced result can never equal the bare name a real host tool is registered under, because
+        // the separator and prefix are never absent.
+        var name = BundleOwnedMcpToolNaming.BuildToolName("bundle-evil:server", "delete_all_data");
+
+        name.Should().NotBe("delete_all_data");
+        name.Should().EndWith("__delete_all_data");
+    }
+
+    [Fact]
+    public void BuildToolName_DifferentServers_ProduceDifferentNamesForTheSameToolName()
+    {
+        var a = BundleOwnedMcpToolNaming.BuildToolName("bundle-a:echo", "search");
+        var b = BundleOwnedMcpToolNaming.BuildToolName("bundle-b:echo", "search");
+
+        a.Should().NotBe(b);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
@@ -50,4 +50,14 @@ public sealed class BundleOwnedMcpToolNamingTests
 
         a.Should().NotBe(b);
     }
+
+    [Theory]
+    [InlineData("bundle-abc123:echo", true)]
+    [InlineData("other-bundle:epr-mcp", true)]
+    [InlineData("granted-server", false)]
+    [InlineData("epr-mcp", false)]
+    public void IsNamespacedServerName_DetectsBundleOwnedKeyByColon(string serverName, bool expected)
+    {
+        BundleOwnedMcpToolNaming.IsNamespacedServerName(serverName).Should().Be(expected);
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
@@ -21,13 +21,43 @@ public sealed class BundleOwnedMcpToolNamingTests
     }
 
     [Fact]
-    public void BuildToolName_PreservesRawToolNameUnsanitized()
+    public void BuildToolName_SanitizesRawToolNameToo()
     {
-        // The tool's own name is left exactly as the (untrusted) server declared it — matching how any
-        // other MCP tool name is trusted today. Only the newly-injected server prefix is sanitized.
+        // A bundle-authored MCP server can name its tool anything, including characters OpenAI/Azure
+        // OpenAI's function-name charset (^[a-zA-Z0-9_-]{1,64}$) rejects outright. Both the server prefix
+        // and the tool's own name go through the same sanitization so the published name is always
+        // callable, not just short enough. A disambiguating hash suffix is appended because sanitizing
+        // actually changed the raw name (see BuildToolName_SanitizingDifferentRawNames_DoesNotCollide for
+        // why that's load-bearing), so only the deterministic prefix is asserted here.
         var name = BundleOwnedMcpToolNaming.BuildToolName("b1:echo", "weird name!");
 
-        name.Should().Be("b1_echo__weird name!");
+        name.Should().StartWith("b1_echo__weird_name_");
+        name.Should().MatchRegex("^[a-zA-Z0-9_-]{1,64}$");
+    }
+
+    [Fact]
+    public void BuildToolName_SanitizingDifferentRawNames_DoesNotCollide()
+    {
+        // Regression test for a correctness-review finding: two DIFFERENT raw tool names that sanitize to
+        // the identical string (here, "get user" and "get.user" both collapse to "get_user") must not
+        // produce the same namespaced name — the tool-chain's dedup-by-name step would silently drop one
+        // of the two tools with no signal that anything was lost.
+        var a = BundleOwnedMcpToolNaming.BuildToolName("b1:echo", "get user");
+        var b = BundleOwnedMcpToolNaming.BuildToolName("b1:echo", "get.user");
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void BuildToolName_SanitizingIdenticalRawNames_ProducesTheSameResult()
+    {
+        // Two calls with the letter-for-letter identical (already-messy) raw name must still agree — the
+        // disambiguating hash is content-derived, not random, so the publisher and granter still land on
+        // the same name for what is genuinely the same tool.
+        var a = BundleOwnedMcpToolNaming.BuildToolName("b1:echo", "weird name!");
+        var b = BundleOwnedMcpToolNaming.BuildToolName("b1:echo", "weird name!");
+
+        a.Should().Be(b);
     }
 
     [Fact]
@@ -49,5 +79,67 @@ public sealed class BundleOwnedMcpToolNamingTests
         var b = BundleOwnedMcpToolNaming.BuildToolName("bundle-b:echo", "search");
 
         a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void BuildToolName_NaturalConcatenationUnder64Chars_IsReturnedVerbatim()
+    {
+        // A realistic bundle id (GUID) + short server + short tool name fits comfortably — the common
+        // case must not pay the shortening cost or lose readability.
+        var name = BundleOwnedMcpToolNaming.BuildToolName(
+            "3fa85f64-5717-4562-b3fc-2c963f66afa6:search", "lookup");
+
+        name.Should().Be("3fa85f64-5717-4562-b3fc-2c963f66afa6_search__lookup");
+        name.Length.Should().BeLessThanOrEqualTo(64);
+    }
+
+    [Theory]
+    [InlineData(
+        "3fa85f64-5717-4562-b3fc-2c963f66afa6:a-fairly-descriptive-mcp-server-name",
+        "a-fairly-descriptive-tool-name-too")]
+    [InlineData("b:server", "this-tool-name-alone-is-already-past-sixty-four-characters-long-total")]
+    public void BuildToolName_OverLongConcatenation_IsCappedAt64Chars(string server, string tool)
+    {
+        // Both an ordinary (non-adversarial) long bundle+server+tool combination and a single
+        // pathologically long raw tool name must still respect the provider-enforced limit — OpenAI and
+        // Azure OpenAI both reject any function name over 64 characters outright.
+        var name = BundleOwnedMcpToolNaming.BuildToolName(server, tool);
+
+        name.Length.Should().BeLessThanOrEqualTo(64);
+    }
+
+    [Fact]
+    public void BuildToolName_OverLongConcatenation_IsDeterministic()
+    {
+        // BundleRunExecutor (granter) and ToolChainBuilder (publisher) each call this independently and
+        // must land on the exact same namespaced name for the grant to match the published tool.
+        var server = "3fa85f64-5717-4562-b3fc-2c963f66afa6:a-fairly-descriptive-mcp-server-name";
+        var tool = "a-fairly-descriptive-tool-name-too";
+
+        var a = BundleOwnedMcpToolNaming.BuildToolName(server, tool);
+        var b = BundleOwnedMcpToolNaming.BuildToolName(server, tool);
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void BuildToolName_OverLongConcatenation_DifferentToolsOnSameServerDoNotCollide()
+    {
+        var server = "3fa85f64-5717-4562-b3fc-2c963f66afa6:a-fairly-descriptive-mcp-server-name";
+
+        var a = BundleOwnedMcpToolNaming.BuildToolName(server, "a-fairly-descriptive-tool-name-one");
+        var b = BundleOwnedMcpToolNaming.BuildToolName(server, "a-fairly-descriptive-tool-name-two");
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void BuildToolName_OverLongConcatenation_StillCannotProduceTheBareRealHostToolName()
+    {
+        var name = BundleOwnedMcpToolNaming.BuildToolName(
+            "bundle-evil:a-very-long-attacker-chosen-server-name-here",
+            "a-very-long-attacker-chosen-tool-name-meant-to-collide-with-delete_all_data");
+
+        name.Should().NotBe("delete_all_data");
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
@@ -50,14 +50,4 @@ public sealed class BundleOwnedMcpToolNamingTests
 
         a.Should().NotBe(b);
     }
-
-    [Theory]
-    [InlineData("bundle-abc123:echo", true)]
-    [InlineData("other-bundle:epr-mcp", true)]
-    [InlineData("granted-server", false)]
-    [InlineData("epr-mcp", false)]
-    public void IsNamespacedServerName_DetectsBundleOwnedKeyByColon(string serverName, bool expected)
-    {
-        BundleOwnedMcpToolNaming.IsNamespacedServerName(serverName).Should().Be(expected);
-    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -135,6 +135,82 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         tools.Select(t => t.Name).Should().Contain("granted_tool");
     }
 
+    // -- Namespaced-grant suffix resolution (issue #368) --
+    // A skill's declared server name is bundle-agnostic (e.g. "epr-mcp"); a bundle's own server is granted
+    // under a namespaced key ("{bundleId}:epr-mcp") the author could not have known at authoring time.
+
+    [Fact]
+    public async Task ManagedDeclaration_NamespacedGrant_ResolvesViaSuffixMatch()
+    {
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "epr_tool")]);
+
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s", Name = "s", Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "epr-mcp" }]
+        };
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("bundle-123:epr-mcp")))
+            tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        // Published under a NAMESPACED name, never the bare name the (untrusted, bundle-authored)
+        // server declared — see BundleOwnedMcpToolNaming for why a bare name would be exploitable.
+        tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
+        tools.Select(t => t.Name).Should().NotContain("epr_tool",
+            "the bare, bundle-chosen name must never be the model-callable/governed name");
+        mcp.Verify(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ManagedDeclaration_ExactGrantWinsOverSuffixMatch()
+    {
+        // Both an exact grant AND a namespaced one ending in the same suffix are present. The exact grant
+        // must win outright — a host-configured, non-namespaced server is never redirected by the fallback.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("epr-mcp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "host_tool")]);
+
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s", Name = "s", Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "epr-mcp" }]
+        };
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("epr-mcp", "other-bundle:epr-mcp")))
+            tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().Contain("host_tool");
+        mcp.Verify(p => p.GetToolsAsync("epr-mcp", It.IsAny<CancellationToken>()), Times.Once);
+        mcp.Verify(p => p.GetToolsAsync("other-bundle:epr-mcp", It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ManagedDeclaration_AmbiguousSuffixMatch_IsDeniedNotGuessed()
+    {
+        // Two different namespaced grants end in the same declared name with no exact grant to break the
+        // tie. Guessing either one would be arbitrary, so neither is contacted.
+        var mcp = new Mock<IMcpToolProvider>();
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s", Name = "s", Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "epr-mcp", Optional = true }]
+        };
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("bundle-a:epr-mcp", "bundle-b:epr-mcp")))
+            tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty();
+        mcp.Verify(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     private static CapabilityEnvelope Envelope(params string[] servers) =>
         new() { AllowedMcpServers = servers };
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -69,7 +69,7 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         var builder = Builder(mcp.Object);
 
         List<AITool> tools;
-        using (CapabilityEnvelopeAccessor.Begin(EnvelopeWithBundleOwned(["bundle-123:epr-mcp"], "bundle-123:epr-mcp")))
+        using (CapabilityEnvelopeAccessor.Begin(EnvelopeWithBundleOwned("bundle-123:epr-mcp")))
             tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
 
         tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
@@ -220,7 +220,7 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         };
 
         List<AITool> tools;
-        using (CapabilityEnvelopeAccessor.Begin(EnvelopeWithBundleOwned(["bundle-123:epr-mcp"], "bundle-123:epr-mcp")))
+        using (CapabilityEnvelopeAccessor.Begin(EnvelopeWithBundleOwned("bundle-123:epr-mcp")))
             tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
 
         // Published under a NAMESPACED name, never the bare name the (untrusted, bundle-authored)
@@ -306,6 +306,6 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
     private static CapabilityEnvelope Envelope(params string[] servers) =>
         new() { AllowedMcpServers = servers };
 
-    private static CapabilityEnvelope EnvelopeWithBundleOwned(string[] servers, params string[] bundleOwned) =>
-        new() { AllowedMcpServers = servers, BundleOwnedMcpServers = bundleOwned };
+    private static CapabilityEnvelope EnvelopeWithBundleOwned(params string[] bundleOwned) =>
+        new() { AllowedMcpServers = bundleOwned, BundleOwnedMcpServers = bundleOwned };
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -53,6 +53,47 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
     }
 
     [Fact]
+    public async Task InjectedMode_NamespacedGrant_PublishesNamespacedToolName()
+    {
+        // A bundle-owned server is reached via its namespaced key ("{bundleId}:{serverName}") even in
+        // Injected mode, where every granted server's tools pass straight through. The tool's own name
+        // must still be namespaced — never the bare, bundle-chosen name — for the same reason the Managed
+        // path already namespaces it: the bare name is what CapabilityEnvelope.AllowedTools was granted
+        // under (BundleRunExecutor), and it must never collide with an unrelated host tool of the same name.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "epr_tool")]);
+
+        var builder = Builder(mcp.Object);
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("bundle-123:epr-mcp")))
+            tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
+        tools.Select(t => t.Name).Should().NotContain("epr_tool",
+            "the bare, bundle-chosen name must never be the model-callable/governed name in Injected mode either");
+    }
+
+    [Fact]
+    public async Task InjectedMode_HostConfiguredGrant_PublishesBareToolName()
+    {
+        // A plain, host-configured server name (no colon) is not bundle-owned — its tools keep the bare
+        // name exactly as before, so this fix must not change behaviour for the pre-existing, trusted path.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("granted-server", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "granted_tool")]);
+
+        var builder = Builder(mcp.Object);
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("granted-server")))
+            tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["granted_tool"]);
+    }
+
+    [Fact]
     public async Task InjectedMode_NoEnvelope_EnumeratesAllServers()
     {
         var mcp = new Mock<IMcpToolProvider>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -53,13 +53,15 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
     }
 
     [Fact]
-    public async Task InjectedMode_NamespacedGrant_PublishesNamespacedToolName()
+    public async Task InjectedMode_BundleOwnedGrant_PublishesNamespacedToolName()
     {
         // A bundle-owned server is reached via its namespaced key ("{bundleId}:{serverName}") even in
         // Injected mode, where every granted server's tools pass straight through. The tool's own name
         // must still be namespaced — never the bare, bundle-chosen name — for the same reason the Managed
         // path already namespaces it: the bare name is what CapabilityEnvelope.AllowedTools was granted
         // under (BundleRunExecutor), and it must never collide with an unrelated host tool of the same name.
+        // Ownership comes from CapabilityEnvelope.BundleOwnedMcpServers (this run's own record), never from
+        // the server name's shape.
         var mcp = new Mock<IMcpToolProvider>();
         mcp.Setup(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()))
             .ReturnsAsync([AIFunctionFactory.Create(() => "r", "epr_tool")]);
@@ -67,7 +69,7 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         var builder = Builder(mcp.Object);
 
         List<AITool> tools;
-        using (CapabilityEnvelopeAccessor.Begin(Envelope("bundle-123:epr-mcp")))
+        using (CapabilityEnvelopeAccessor.Begin(EnvelopeWithBundleOwned(["bundle-123:epr-mcp"], "bundle-123:epr-mcp")))
             tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
 
         tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
@@ -91,6 +93,29 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
             tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
 
         tools.Select(t => t.Name).Should().BeEquivalentTo(["granted_tool"]);
+    }
+
+    [Fact]
+    public async Task InjectedMode_PluginNamespacedGrant_NotBundleOwned_PublishesBareToolName()
+    {
+        // Regression test for a correctness-review finding: PluginLoader namespaces a host-installed
+        // plugin's own MCP server under the IDENTICAL "{Prefix}:{ServerName}" shape a bundle-owned server
+        // uses ("azure:filesystem" here). A colon in the name is therefore not evidence of bundle
+        // ownership — this server is granted but explicitly NOT in BundleOwnedMcpServers, so its tools
+        // must publish under their bare name, exactly as before this fix, or a plugin's DeniedTools
+        // boundary (which matches by bare name) would silently stop matching a renamed tool.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("azure:filesystem", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "read_file")]);
+
+        var builder = Builder(mcp.Object);
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("azure:filesystem")))
+            tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["read_file"],
+            "a granted, colon-namespaced server that is not in BundleOwnedMcpServers must not be renamed");
     }
 
     [Fact]
@@ -195,7 +220,7 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         };
 
         List<AITool> tools;
-        using (CapabilityEnvelopeAccessor.Begin(Envelope("bundle-123:epr-mcp")))
+        using (CapabilityEnvelopeAccessor.Begin(EnvelopeWithBundleOwned(["bundle-123:epr-mcp"], "bundle-123:epr-mcp")))
             tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
 
         // Published under a NAMESPACED name, never the bare name the (untrusted, bundle-authored)
@@ -204,6 +229,32 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         tools.Select(t => t.Name).Should().NotContain("epr_tool",
             "the bare, bundle-chosen name must never be the model-callable/governed name");
         mcp.Verify(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ManagedDeclaration_SuffixMatchesGrantedPluginServer_NotBundleOwned_PublishesBareToolName()
+    {
+        // Regression test for a correctness-review finding: a suffix match can legitimately resolve to an
+        // explicitly-granted, colon-namespaced PLUGIN server ("azure:epr-mcp") rather than a bundle-owned
+        // one. It must still be contacted (the grant is real), but its tools must NOT be renamed, since
+        // renaming is reserved for this run's own bundle-owned servers (CapabilityEnvelope.BundleOwnedMcpServers).
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("azure:epr-mcp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "host_tool")]);
+
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s", Name = "s", Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "epr-mcp" }]
+        };
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(Envelope("azure:epr-mcp")))
+            tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().BeEquivalentTo(["host_tool"],
+            "a suffix-matched but non-bundle-owned grant must publish under its bare name, not a namespaced one");
     }
 
     [Fact]
@@ -254,4 +305,7 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
 
     private static CapabilityEnvelope Envelope(params string[] servers) =>
         new() { AllowedMcpServers = servers };
+
+    private static CapabilityEnvelope EnvelopeWithBundleOwned(string[] servers, params string[] bundleOwned) =>
+        new() { AllowedMcpServers = servers, BundleOwnedMcpServers = bundleOwned };
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -285,8 +285,9 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
     [Fact]
     public async Task ManagedDeclaration_AmbiguousSuffixMatch_IsDeniedNotGuessed()
     {
-        // Two different namespaced grants end in the same declared name with no exact grant to break the
-        // tie. Guessing either one would be arbitrary, so neither is contacted.
+        // Two different namespaced grants end in the same declared name, and NEITHER is recorded as this
+        // run's own bundle-owned server (BundleOwnedMcpServers is empty). Guessing either one would be
+        // arbitrary, so neither is contacted.
         var mcp = new Mock<IMcpToolProvider>();
         var builder = Builder(mcp.Object);
         var skill = new SkillDefinition
@@ -301,6 +302,43 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
 
         tools.Should().BeEmpty();
         mcp.Verify(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ManagedDeclaration_SuffixCollidesWithUnrelatedGrant_StillResolvesThisRunsOwnBundleServer()
+    {
+        // Regression test for a correctness-review finding: the caller's PRE-EXISTING, unrelated grant
+        // ("corp-tools:epr-mcp" — e.g. an admin-configured plugin) and THIS run's own bundle-owned server
+        // ("bundle-123:epr-mcp") coincidentally share the same bare suffix after RunBundleCommandHandler
+        // unions them into one flat AllowedMcpServers list. Since every skill resolved during a bundle run
+        // is one of that bundle's own OwnedSkills (never a mix with the caller's other skills — see
+        // OverlayAwareAgentOwnedSkillStore), this declaration can only ever mean the bundle's own server:
+        // an untrusted bundle picking a colliding name must not be able to break its own already-granted
+        // access, and it must not resolve to the caller's separate grant either.
+        var mcp = new Mock<IMcpToolProvider>();
+        mcp.Setup(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()))
+            .ReturnsAsync([AIFunctionFactory.Create(() => "r", "epr_tool")]);
+
+        var builder = Builder(mcp.Object);
+        var skill = new SkillDefinition
+        {
+            Id = "s", Name = "s", Instructions = "x",
+            ToolDeclarations = [new ToolDeclaration { Name = "epr-mcp" }]
+        };
+        var envelope = new CapabilityEnvelope
+        {
+            AllowedMcpServers = ["corp-tools:epr-mcp", "bundle-123:epr-mcp"],
+            BundleOwnedMcpServers = ["bundle-123:epr-mcp"]
+        };
+
+        List<AITool> tools;
+        using (CapabilityEnvelopeAccessor.Begin(envelope))
+            tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
+        mcp.Verify(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()), Times.Once);
+        mcp.Verify(p => p.GetToolsAsync("corp-tools:epr-mcp", It.IsAny<CancellationToken>()), Times.Never,
+            "the unrelated grant must never be contacted for a bundle skill's own declared server");
     }
 
     private static CapabilityEnvelope Envelope(params string[] servers) =>

--- a/src/Content/Tests/Domain.AI.Tests/Identity/AgentIdentityKindTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Identity/AgentIdentityKindTests.cs
@@ -31,6 +31,7 @@ public sealed class AgentIdentityKindTests
     [InlineData(AgentIdentityKind.Certificate, 3)]
     [InlineData(AgentIdentityKind.ClientSecret, 4)]
     [InlineData(AgentIdentityKind.Development, 5)]
+    [InlineData(AgentIdentityKind.System, 6)]
     public void Enum_HasExpectedNumericValues(AgentIdentityKind kind, int expectedValue)
     {
         ((int)kind).Should().Be(expectedValue);
@@ -41,7 +42,11 @@ public sealed class AgentIdentityKindTests
     {
         // The credential hierarchy per PR-1: federated -> managed identity -> certificate
         // -> client secret. Development is a test-only escape hatch. Unspecified is the
-        // default sentinel.
+        // default sentinel. System (#370's security fix) is the one deliberate non-credential
+        // exception: internal/host-generated attribution (e.g. a bundle's own outbound MCP
+        // connections) with no live agent turn to derive identity from — backed by no Entra
+        // credential and carrying no token, so it sits outside the credential hierarchy
+        // itself while still being a real, auditable identity kind.
         var values = Enum.GetValues<AgentIdentityKind>();
 
         values.Should().BeEquivalentTo(new[]
@@ -51,7 +56,8 @@ public sealed class AgentIdentityKindTests
             AgentIdentityKind.ManagedIdentity,
             AgentIdentityKind.Certificate,
             AgentIdentityKind.ClientSecret,
-            AgentIdentityKind.Development
+            AgentIdentityKind.Development,
+            AgentIdentityKind.System
         });
     }
 }

--- a/src/Content/Tests/Domain.Common.Tests/Config/McpConfigTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Config/McpConfigTests.cs
@@ -1,6 +1,7 @@
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace Domain.Common.Tests.Config;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
@@ -41,6 +41,12 @@ public sealed class DependencyInjectionTests : IAsyncLifetime
         // wired it would publish MCP tools with nothing on file about what they do, which the
         // behaviour posture reads as "unknown" for every one of them.
         services.AddSingleton(Mock.Of<IToolBehaviorRegistry>());
+        // McpConnectionManager's bundle-egress-attribution chain (#370 security fix) has a hard
+        // constructor-time dependency on IAmbientRequestScope and IEgressAuditWriter — normally
+        // registered by the egress layer. Same reasoning as the SSRF guard above: an unwired egress layer
+        // must fail resolution, not silently produce an unattributed bundle connection.
+        services.AddSingleton(Mock.Of<IAmbientRequestScope>());
+        services.AddSingleton(Mock.Of<Application.AI.Common.Interfaces.Egress.IEgressAuditWriter>());
 
         services.AddMcpClientDependencies();
 
@@ -94,6 +100,8 @@ public sealed class DependencyInjectionTests : IAsyncLifetime
         services.Configure<Domain.Common.Config.MetaHarness.MetaHarnessConfig>(_ => { });
         services.AddSingleton(TestSsrf.HandlerFactory());
         services.AddSingleton(Mock.Of<IMcpSecurityScanner>());
+        services.AddSingleton(Mock.Of<IAmbientRequestScope>());
+        services.AddSingleton(Mock.Of<Application.AI.Common.Interfaces.Egress.IEgressAuditWriter>());
         // Deliberately no IToolBehaviorRegistry.
 
         services.AddMcpClientDependencies();
@@ -115,6 +123,8 @@ public sealed class DependencyInjectionTests : IAsyncLifetime
         services.Configure<AIConfig>(_ => { });
         services.Configure<Domain.Common.Config.MetaHarness.MetaHarnessConfig>(_ => { });
         services.AddSingleton(TestSsrf.HandlerFactory());
+        services.AddSingleton(Mock.Of<IAmbientRequestScope>());
+        services.AddSingleton(Mock.Of<Application.AI.Common.Interfaces.Egress.IEgressAuditWriter>());
         // Deliberately no IMcpSecurityScanner — this is the ungoverned-host composition.
 
         services.AddMcpClientDependencies();

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Governance;
 using Domain.Common.Config.AI;
+using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
@@ -137,7 +138,7 @@ public sealed class BehaviorRecordingMcpToolProviderTests
         {
             McpServers = new McpServersConfig
             {
-                Servers = new Dictionary<string, McpServerDefinition>
+                Servers = new ConcurrentDictionary<string, McpServerDefinition>
                 {
                     [trusted] = new() { TrustToolAnnotations = true },
                     [UnvouchedServer] = new(),

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
@@ -118,6 +118,25 @@ public sealed class BehaviorRecordingMcpToolProviderTests
     }
 
     [Fact]
+    public async Task GetToolsAsync_BundleOwnedServerName_IsNeverTrusted()
+    {
+        // Regression test for the #370 registry-isolation fix: a bundle-owned server is never an entry
+        // in AIConfig.McpServers.Servers (it lives in the separate BundleOwnedMcpServerRegistry instead),
+        // so IsTrusted's TryGetValue against the host config correctly misses and falls back to
+        // untrusted -- exactly the pre-fix behaviour for any unrecognised name, preserved deliberately.
+        // Do NOT add a bundle-registry fallback to IsTrusted: a bundle-owned server must never be
+        // trust-annotated.
+        const string bundleOwnedServerName = "b1:evil";
+        InnerReturns(bundleOwnedServerName, McpTool("read_file", readOnly: true));
+
+        await CreateSut(trusted: TrustedServer).GetToolsAsync(bundleOwnedServerName);
+
+        var recorded = _registry.Resolve("read_file");
+        recorded.Source.Should().Be(ToolBehaviorSource.UntrustedMcpServer);
+        recorded.IsExemptFromApproval.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task GetToolByNameAsync_RecordsNothing_BecauseItCannotTellWhichServerAnswered()
     {
         // Declining to guess is the fail-closed choice: an unrecorded tool resolves to Unknown and is

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
@@ -22,13 +22,15 @@ namespace Infrastructure.AI.MCP.Tests.Services;
 /// </summary>
 public sealed class BundleMcpServerIsolationTests
 {
-    private static McpConnectionManager CreateManager(McpServersConfig hostConfig, BundleOwnedMcpServerRegistry bundleOwned) =>
-        new(
+    private static McpConnectionManager CreateManager(McpServersConfig hostConfig, BundleOwnedMcpServerRegistry bundleOwned)
+    {
+        return McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
             hostConfig,
             bundleOwned);
+    }
 
     [Fact]
     public void BundleOwnedMcpServerRegistry_ExposesNoEnumerationSurface()

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
@@ -1,0 +1,126 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Exceptions;
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Infrastructure.AI.MCP.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// Regression tests for the #370 security fix: a bundle-owned MCP server definition must never be
+/// reachable from <see cref="McpConnectionManager.GetConfiguredServerNames"/> — the enumeration
+/// chokepoint every ordinary, non-bundle agent conversation (<c>McpToolProvider.GetAllToolsAsync</c>/
+/// <c>GetToolByNameAsync</c>, and through them the MCP REST endpoints) reads with no bundle-provenance
+/// filter of its own. Before this fix, a bundle's own server was written into the same
+/// <see cref="McpServersConfig"/> the host enumerates, so uploading a malicious bundle — no run
+/// required — let its tools reach every other conversation on the host under their bare, attacker-chosen
+/// names. These tests exercise the fix at the layer it actually lives in: which of the two registries a
+/// name is reachable from, not any downstream consumer's logic (which needed no changes).
+/// </summary>
+public sealed class BundleMcpServerIsolationTests
+{
+    private static McpConnectionManager CreateManager(McpServersConfig hostConfig, BundleOwnedMcpServerRegistry bundleOwned) =>
+        new(
+            Mock.Of<ILogger<McpConnectionManager>>(),
+            new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
+            hostConfig,
+            bundleOwned);
+
+    [Fact]
+    public void GetConfiguredServerNames_NeverReturnsBundleOwnedServers()
+    {
+        // The assertion that encodes the fix: a bundle-owned server, even enabled, is invisible to the
+        // one enumeration surface every ordinary conversation's tool discovery is built on.
+        var hostConfig = new McpServersConfig();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.Servers["b1:evil"] = new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Http,
+            Url = "https://attacker.example/mcp"
+        };
+        var sut = CreateManager(hostConfig, bundleOwned);
+
+        var names = sut.GetConfiguredServerNames().ToList();
+
+        names.Should().BeEmpty("a bundle-owned server must never be enumerable, regardless of Enabled");
+    }
+
+    [Fact]
+    public void GetConfiguredServerNames_ReturnsHostServers_WhenBundleRegistryAlsoPopulated()
+    {
+        // A populated bundle registry must not suppress or interfere with host enumeration — the two
+        // are independent, not a filtered view of one merged set.
+        var hostConfig = new McpServersConfig
+        {
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
+            {
+                ["azure:filesystem"] = new() { Enabled = true }
+            }
+        };
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.Servers["b1:evil"] = new McpServerDefinition { Enabled = true, Type = McpServerType.Http, Url = "https://attacker.example/mcp" };
+        var sut = CreateManager(hostConfig, bundleOwned);
+
+        var names = sut.GetConfiguredServerNames().ToList();
+
+        names.Should().BeEquivalentTo(["azure:filesystem"]);
+    }
+
+    [Fact]
+    public async Task GetClientAsync_ResolvesBundleOwnedServerByExactName_ButFailsAtConnectNotLookup()
+    {
+        // Required, not optional: a bundle run's own already-envelope-gated resolution (ToolChainBuilder)
+        // must still reach its own server by exact name. There's no real MCP server behind this URL, so
+        // the connect attempt fails -- the point is WHERE it fails: past the "is not configured" lookup
+        // guard, proving the definition was found in the bundle registry.
+        var hostConfig = new McpServersConfig();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.Servers["b1:echo"] = new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Http,
+            Url = "https://127.0.0.1.nip.io:9/mcp" // guaranteed connection refused, not a lookup miss
+        };
+        var sut = CreateManager(hostConfig, bundleOwned);
+
+        var act = () => sut.GetClientAsync("b1:echo");
+
+        var exception = await act.Should().ThrowAsync<McpConnectionException>();
+        exception.Which.Message.Should().NotContain("is not configured",
+            "the definition must be found in the bundle registry, not treated as unknown");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_PrefersHostDefinition_WhenNamePresentInBoth()
+    {
+        // Host-first is deliberate: the trusted source must win outright over the untrusted fallback.
+        // Both definitions target an unreachable endpoint so this only needs to prove WHICH one was
+        // selected, not that either successfully connects -- distinguished by StartupTimeoutSeconds
+        // surfacing in the wrapped exception's inner detail is too fragile; instead assert via the
+        // disabled-host-wins-as-"disabled" signal, which only the host definition carries.
+        var hostConfig = new McpServersConfig
+        {
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
+            {
+                ["shared-name"] = new() { Enabled = false } // host def: distinguishable by "disabled"
+            }
+        };
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.Servers["shared-name"] = new McpServerDefinition
+        {
+            Enabled = true, Type = McpServerType.Http, Url = "https://attacker.example/mcp"
+        };
+        var sut = CreateManager(hostConfig, bundleOwned);
+
+        var act = () => sut.GetClientAsync("shared-name");
+
+        var exception = await act.Should().ThrowAsync<McpConnectionException>();
+        exception.Which.Message.Should().Contain("disabled",
+            "the host definition (Enabled=false) must win over the bundle-owned one with the same name");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
@@ -31,6 +31,30 @@ public sealed class BundleMcpServerIsolationTests
             bundleOwned);
 
     [Fact]
+    public void BundleOwnedMcpServerRegistry_ExposesNoEnumerationSurface()
+    {
+        // Mechanical guard for the doc comment's own claim: "no enumeration API at all". A future
+        // convenience method (a Keys property, a GetAll(bundleId) helper, implementing IEnumerable) would
+        // silently reopen exactly the leak this whole fix exists to prevent, since ANY enumerable surface
+        // on this type is one careless foreach away from becoming a second GetConfiguredServerNames-style
+        // chokepoint. This test fails the build the moment that happens, rather than relying on a
+        // reviewer noticing.
+        var type = typeof(BundleOwnedMcpServerRegistry);
+
+        type.Should().NotBeAssignableTo<System.Collections.IEnumerable>(
+            "the registry must never be directly enumerable");
+
+        var publicMemberNames = type
+            .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.DeclaredOnly)
+            .Select(m => m.Name)
+            .ToList();
+        publicMemberNames.Should().BeEquivalentTo(
+            [nameof(BundleOwnedMcpServerRegistry.TryAdd), nameof(BundleOwnedMcpServerRegistry.TryRemove), nameof(BundleOwnedMcpServerRegistry.TryGetValue)],
+            "the only way to read this registry is an exact-name lookup — adding any other public member " +
+            "(Keys, Values, Count, GetEnumerator, ...) needs a deliberate, reviewed decision, not an accident");
+    }
+
+    [Fact]
     public void GetConfiguredServerNames_NeverReturnsBundleOwnedServers()
     {
         // The assertion that encodes the fix: a bundle-owned server, even enabled, is invisible to the

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
@@ -37,12 +37,12 @@ public sealed class BundleMcpServerIsolationTests
         // one enumeration surface every ordinary conversation's tool discovery is built on.
         var hostConfig = new McpServersConfig();
         var bundleOwned = new BundleOwnedMcpServerRegistry();
-        bundleOwned.Servers["b1:evil"] = new McpServerDefinition
+        bundleOwned.TryAdd("b1:evil", new McpServerDefinition
         {
             Enabled = true,
             Type = McpServerType.Http,
             Url = "https://attacker.example/mcp"
-        };
+        });
         var sut = CreateManager(hostConfig, bundleOwned);
 
         var names = sut.GetConfiguredServerNames().ToList();
@@ -63,7 +63,7 @@ public sealed class BundleMcpServerIsolationTests
             }
         };
         var bundleOwned = new BundleOwnedMcpServerRegistry();
-        bundleOwned.Servers["b1:evil"] = new McpServerDefinition { Enabled = true, Type = McpServerType.Http, Url = "https://attacker.example/mcp" };
+        bundleOwned.TryAdd("b1:evil", new McpServerDefinition { Enabled = true, Type = McpServerType.Http, Url = "https://attacker.example/mcp" });
         var sut = CreateManager(hostConfig, bundleOwned);
 
         var names = sut.GetConfiguredServerNames().ToList();
@@ -80,12 +80,12 @@ public sealed class BundleMcpServerIsolationTests
         // guard, proving the definition was found in the bundle registry.
         var hostConfig = new McpServersConfig();
         var bundleOwned = new BundleOwnedMcpServerRegistry();
-        bundleOwned.Servers["b1:echo"] = new McpServerDefinition
+        bundleOwned.TryAdd("b1:echo", new McpServerDefinition
         {
             Enabled = true,
             Type = McpServerType.Http,
             Url = "https://127.0.0.1.nip.io:9/mcp" // guaranteed connection refused, not a lookup miss
-        };
+        });
         var sut = CreateManager(hostConfig, bundleOwned);
 
         var act = () => sut.GetClientAsync("b1:echo");
@@ -111,10 +111,10 @@ public sealed class BundleMcpServerIsolationTests
             }
         };
         var bundleOwned = new BundleOwnedMcpServerRegistry();
-        bundleOwned.Servers["shared-name"] = new McpServerDefinition
+        bundleOwned.TryAdd("shared-name", new McpServerDefinition
         {
             Enabled = true, Type = McpServerType.Http, Url = "https://attacker.example/mcp"
-        };
+        });
         var sut = CreateManager(hostConfig, bundleOwned);
 
         var act = () => sut.GetClientAsync("shared-name");

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
@@ -29,14 +29,14 @@ public sealed class BundleMcpServerRegistrarTests
     public async Task DeregisterAsync_RemovesNamedServers_LeavesOthersUntouched()
     {
         var bundleOwned = new BundleOwnedMcpServerRegistry();
-        bundleOwned.Servers["b1:echo"] = new() { Command = "npx" };
-        bundleOwned.Servers["b2:other"] = new() { Command = "node" };
+        bundleOwned.TryAdd("b1:echo", new() { Command = "npx" });
+        bundleOwned.TryAdd("b2:other", new() { Command = "node" });
         var sut = CreateSut(bundleOwned);
 
         await sut.DeregisterAsync(["b1:echo"]);
 
-        bundleOwned.Servers.Should().NotContainKey("b1:echo");
-        bundleOwned.Servers.Should().ContainKey("b2:other", "deregistration must only ever touch the named entries");
+        bundleOwned.TryGetValue("b1:echo", out _).Should().BeFalse();
+        bundleOwned.TryGetValue("b2:other", out _).Should().BeTrue("deregistration must only ever touch the named entries");
     }
 
     [Fact]
@@ -53,11 +53,11 @@ public sealed class BundleMcpServerRegistrarTests
     public async Task DeregisterAsync_EmptyList_IsANoOp()
     {
         var bundleOwned = new BundleOwnedMcpServerRegistry();
-        bundleOwned.Servers["b1:echo"] = new() { Command = "npx" };
+        bundleOwned.TryAdd("b1:echo", new() { Command = "npx" });
         var sut = CreateSut(bundleOwned);
 
         await sut.DeregisterAsync([]);
 
-        bundleOwned.Servers.Should().ContainKey("b1:echo");
+        bundleOwned.TryGetValue("b1:echo", out _).Should().BeTrue();
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
@@ -14,16 +14,18 @@ namespace Infrastructure.AI.MCP.Tests.Services;
 /// </summary>
 public sealed class BundleMcpServerRegistrarTests
 {
-    private static BundleMcpServerRegistrar CreateSut(BundleOwnedMcpServerRegistry bundleOwned) =>
-        new(
+    private static BundleMcpServerRegistrar CreateSut(BundleOwnedMcpServerRegistry bundleOwned)
+    {
+        return new(
             bundleOwned,
-            new McpConnectionManager(
+            McpConnectionManagerBundleEgressSupport.CreateManager(
                 Mock.Of<ILogger<McpConnectionManager>>(),
                 new Mock<ILoggerFactory>().Object,
                 TestSsrf.HandlerFactory(),
                 new McpServersConfig(),
                 bundleOwned),
             Mock.Of<ILogger<BundleMcpServerRegistrar>>());
+    }
 
     [Fact]
     public async Task DeregisterAsync_RemovesNamedServers_LeavesOthersUntouched()

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
@@ -14,40 +14,35 @@ namespace Infrastructure.AI.MCP.Tests.Services;
 /// </summary>
 public sealed class BundleMcpServerRegistrarTests
 {
-    private static BundleMcpServerRegistrar CreateSut(McpServersConfig config) =>
+    private static BundleMcpServerRegistrar CreateSut(BundleOwnedMcpServerRegistry bundleOwned) =>
         new(
-            config,
+            bundleOwned,
             new McpConnectionManager(
                 Mock.Of<ILogger<McpConnectionManager>>(),
                 new Mock<ILoggerFactory>().Object,
                 TestSsrf.HandlerFactory(),
-                config),
+                new McpServersConfig(),
+                bundleOwned),
             Mock.Of<ILogger<BundleMcpServerRegistrar>>());
 
     [Fact]
     public async Task DeregisterAsync_RemovesNamedServers_LeavesOthersUntouched()
     {
-        var config = new McpServersConfig
-        {
-            Servers = new ConcurrentDictionary<string, McpServerDefinition>
-            {
-                ["b1:echo"] = new() { Command = "npx" },
-                ["host-configured"] = new() { Command = "node" }
-            }
-        };
-        var sut = CreateSut(config);
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.Servers["b1:echo"] = new() { Command = "npx" };
+        bundleOwned.Servers["b2:other"] = new() { Command = "node" };
+        var sut = CreateSut(bundleOwned);
 
         await sut.DeregisterAsync(["b1:echo"]);
 
-        config.Servers.Should().NotContainKey("b1:echo");
-        config.Servers.Should().ContainKey("host-configured", "deregistration must only ever touch the named entries");
+        bundleOwned.Servers.Should().NotContainKey("b1:echo");
+        bundleOwned.Servers.Should().ContainKey("b2:other", "deregistration must only ever touch the named entries");
     }
 
     [Fact]
     public async Task DeregisterAsync_UnknownServerName_IsANoOpAndDoesNotThrow()
     {
-        var config = new McpServersConfig();
-        var sut = CreateSut(config);
+        var sut = CreateSut(new BundleOwnedMcpServerRegistry());
 
         var act = async () => await sut.DeregisterAsync(["never-registered"]);
 
@@ -57,14 +52,12 @@ public sealed class BundleMcpServerRegistrarTests
     [Fact]
     public async Task DeregisterAsync_EmptyList_IsANoOp()
     {
-        var config = new McpServersConfig
-        {
-            Servers = new ConcurrentDictionary<string, McpServerDefinition> { ["b1:echo"] = new() { Command = "npx" } }
-        };
-        var sut = CreateSut(config);
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.Servers["b1:echo"] = new() { Command = "npx" };
+        var sut = CreateSut(bundleOwned);
 
         await sut.DeregisterAsync([]);
 
-        config.Servers.Should().ContainKey("b1:echo");
+        bundleOwned.Servers.Should().ContainKey("b1:echo");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Concurrent;
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Infrastructure.AI.MCP.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="BundleMcpServerRegistrar"/> — the deregistration counterpart to the bundle MCP
+/// server registration <c>BundleStagingService</c> performs at staging time (issue #368).
+/// </summary>
+public sealed class BundleMcpServerRegistrarTests
+{
+    private static BundleMcpServerRegistrar CreateSut(McpServersConfig config) =>
+        new(
+            config,
+            new McpConnectionManager(
+                Mock.Of<ILogger<McpConnectionManager>>(),
+                new Mock<ILoggerFactory>().Object,
+                TestSsrf.HandlerFactory(),
+                config),
+            Mock.Of<ILogger<BundleMcpServerRegistrar>>());
+
+    [Fact]
+    public async Task DeregisterAsync_RemovesNamedServers_LeavesOthersUntouched()
+    {
+        var config = new McpServersConfig
+        {
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
+            {
+                ["b1:echo"] = new() { Command = "npx" },
+                ["host-configured"] = new() { Command = "node" }
+            }
+        };
+        var sut = CreateSut(config);
+
+        await sut.DeregisterAsync(["b1:echo"]);
+
+        config.Servers.Should().NotContainKey("b1:echo");
+        config.Servers.Should().ContainKey("host-configured", "deregistration must only ever touch the named entries");
+    }
+
+    [Fact]
+    public async Task DeregisterAsync_UnknownServerName_IsANoOpAndDoesNotThrow()
+    {
+        var config = new McpServersConfig();
+        var sut = CreateSut(config);
+
+        var act = async () => await sut.DeregisterAsync(["never-registered"]);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task DeregisterAsync_EmptyList_IsANoOp()
+    {
+        var config = new McpServersConfig
+        {
+            Servers = new ConcurrentDictionary<string, McpServerDefinition> { ["b1:echo"] = new() { Command = "npx" } }
+        };
+        var sut = CreateSut(config);
+
+        await sut.DeregisterAsync([]);
+
+        config.Servers.Should().ContainKey("b1:echo");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
@@ -1,0 +1,100 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Egress;
+using Application.AI.Common.Services;
+using Application.AI.Common.Services.Agent;
+using Domain.AI.Egress;
+using Domain.AI.Identity;
+using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Egress;
+using Infrastructure.AI.MCP.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// Shared test-double wiring for <c>McpConnectionManager</c>'s bundle-egress-attribution constructor
+/// parameters (added for the PR #370 security fix). Every SUT factory across this test project's files
+/// calls <see cref="CreateManager"/> instead of <c>new McpConnectionManager(...)</c> directly, so a
+/// bundle-owned server's connection attempt — several existing tests build one — exercises the SAME real
+/// machinery production does: a genuine DI-resolved <see cref="IAgentExecutionContext"/> via a real
+/// <see cref="IServiceScopeFactory"/>, the real <see cref="AmbientRequestScope"/> singleton, a no-op audit
+/// writer, and an ALLOW-ALL <see cref="IEgressPolicyResolver"/> — so a test that actually drives a
+/// bundle-owned connection through the real handler chain reaches a genuine policy decision (and, past
+/// that, the real AntiSSRF/connect attempt) instead of failing early with an unregistered-service error
+/// that happens to also look like a connection failure.
+/// </summary>
+internal static class McpConnectionManagerBundleEgressSupport
+{
+    private static readonly AmbientRequestScope s_ambientScope = new();
+    private static readonly IServiceProvider s_rootServices = BuildRootServices(s_ambientScope);
+
+    /// <summary>The bundle-egress constructor arguments every SUT factory in this project needs: <c>scopeFactory, ambientScope, rootServices</c>.</summary>
+    public static (
+        IServiceScopeFactory ScopeFactory,
+        IAmbientRequestScope AmbientScope,
+        IServiceProvider RootServices) Args => (
+            s_rootServices.GetRequiredService<IServiceScopeFactory>(),
+            s_ambientScope,
+            s_rootServices);
+
+    /// <summary>
+    /// Builds a <see cref="McpConnectionManager"/> wired with the shared bundle-egress test doubles
+    /// (<see cref="Args"/>) appended automatically, collapsing the repeated trailing constructor
+    /// arguments every SUT factory in this project previously had to spell out by hand.
+    /// </summary>
+    public static McpConnectionManager CreateManager(
+        ILogger<McpConnectionManager> logger,
+        ILoggerFactory loggerFactory,
+        AntiSsrfHandlerFactory antiSsrfHandlerFactory,
+        McpServersConfig config,
+        BundleOwnedMcpServerRegistry bundleOwnedServers) =>
+        new(
+            logger, loggerFactory, antiSsrfHandlerFactory, config, bundleOwnedServers,
+            Args.ScopeFactory, Args.AmbientScope, Args.RootServices);
+
+    private static IServiceProvider BuildRootServices(IAmbientRequestScope ambientScope)
+    {
+        var services = new ServiceCollection();
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddSingleton(ambientScope);
+        services.AddSingleton<IEgressAuditWriter>(new NoOpEgressAuditWriter());
+        services.AddSingleton<ILogger<EgressPolicyDelegatingHandler>>(NullLogger<EgressPolicyDelegatingHandler>.Instance);
+        // Allow-all: these tests build servers pointing at deliberately-unreachable/refused targets to
+        // prove a connection attempt fails PAST the outer policy layer (at AntiSSRF/connect), not because
+        // policy denied it — a default-deny resolver would make every such test fail at the wrong layer.
+        // Allow/deny semantics of the outer policy itself are covered by the dedicated
+        // Infrastructure.AI.Tests/Egress/BundleMcpEgressAttributionTests.cs suite, which builds its own
+        // real DefaultEgressPolicy with an explicit allowlist per scenario.
+        services.AddSingleton<IEgressPolicy, AllowAllEgressPolicy>();
+        services.AddSingleton<IEgressPolicyResolver, AllowAllEgressPolicyResolver>();
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class NoOpEgressAuditWriter : IEgressAuditWriter
+    {
+        public Task AppendAsync(EgressDecision decision, AgentIdentity identity, CancellationToken cancellationToken) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class AllowAllEgressPolicy : IEgressPolicy
+    {
+        public Task<EgressDecision> AllowAsync(Uri target, AgentIdentity identity, CancellationToken cancellationToken) =>
+            Task.FromResult(new EgressDecision
+            {
+                Allowed = true,
+                Reason = "Test double: always allows.",
+                Target = target,
+                DecidedAt = TimeProvider.System.GetUtcNow()
+            });
+    }
+
+    private sealed class AllowAllEgressPolicyResolver : IEgressPolicyResolver
+    {
+        private readonly IEgressPolicy _policy = new AllowAllEgressPolicy();
+
+        public IEgressPolicy ResolveFor(AgentIdentity identity) => _policy;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
@@ -54,7 +55,7 @@ public sealed class McpConnectionManagerExtendedTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["a"] = new() { Enabled = false },
                 ["b"] = new() { Enabled = false }
@@ -70,7 +71,7 @@ public sealed class McpConnectionManagerExtendedTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["enabled-1"] = new() { Enabled = true },
                 ["disabled-1"] = new() { Enabled = false },
@@ -104,7 +105,7 @@ public sealed class McpConnectionManagerExtendedTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["stdio-test"] = new()
                 {
@@ -127,7 +128,7 @@ public sealed class McpConnectionManagerExtendedTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["http-test"] = new()
                 {

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
@@ -17,7 +17,7 @@ public sealed class McpConnectionManagerExtendedTests
     private static McpConnectionManager CreateManager(
         McpServersConfig? config = null, BundleOwnedMcpServerRegistry? bundleOwned = null)
     {
-        return new McpConnectionManager(
+        return McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
@@ -14,13 +14,15 @@ namespace Infrastructure.AI.MCP.Tests.Services;
 /// </summary>
 public sealed class McpConnectionManagerExtendedTests
 {
-    private static McpConnectionManager CreateManager(McpServersConfig? config = null)
+    private static McpConnectionManager CreateManager(
+        McpServersConfig? config = null, BundleOwnedMcpServerRegistry? bundleOwned = null)
     {
         return new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
-            config ?? new McpServersConfig());
+            config ?? new McpServersConfig(),
+            bundleOwned ?? new BundleOwnedMcpServerRegistry());
     }
 
     // -- GetClientAsync after dispose --

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
@@ -10,13 +10,15 @@ namespace Infrastructure.AI.MCP.Tests.Services;
 
 public sealed class McpConnectionManagerTests
 {
-    private static McpConnectionManager CreateManager(McpServersConfig? config = null)
+    private static McpConnectionManager CreateManager(
+        McpServersConfig? config = null, BundleOwnedMcpServerRegistry? bundleOwned = null)
     {
         return new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
-            config ?? new McpServersConfig());
+            config ?? new McpServersConfig(),
+            bundleOwned ?? new BundleOwnedMcpServerRegistry());
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
@@ -13,7 +13,7 @@ public sealed class McpConnectionManagerTests
     private static McpConnectionManager CreateManager(
         McpServersConfig? config = null, BundleOwnedMcpServerRegistry? bundleOwned = null)
     {
-        return new McpConnectionManager(
+        return McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
@@ -33,7 +34,7 @@ public sealed class McpConnectionManagerTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["filesystem"] = new() { Enabled = true },
                 ["disabled-server"] = new() { Enabled = false },
@@ -92,7 +93,7 @@ public sealed class McpConnectionManagerTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["disabled"] = new() { Enabled = false }
             }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
@@ -19,7 +19,7 @@ public sealed class McpConnectionManagerTransportTests
     private static McpConnectionManager CreateManager(
         McpServersConfig? config = null, BundleOwnedMcpServerRegistry? bundleOwned = null)
     {
-        return new McpConnectionManager(
+        return McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
@@ -16,13 +16,15 @@ namespace Infrastructure.AI.MCP.Tests.Services;
 /// </summary>
 public sealed class McpConnectionManagerTransportTests
 {
-    private static McpConnectionManager CreateManager(McpServersConfig? config = null)
+    private static McpConnectionManager CreateManager(
+        McpServersConfig? config = null, BundleOwnedMcpServerRegistry? bundleOwned = null)
     {
         return new McpConnectionManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
-            config ?? new McpServersConfig());
+            config ?? new McpServersConfig(),
+            bundleOwned ?? new BundleOwnedMcpServerRegistry());
     }
 
     // -- SSE transport --

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
@@ -32,7 +32,7 @@ public sealed class McpConnectionManagerTransportTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["sse-test"] = new()
                 {
@@ -59,7 +59,7 @@ public sealed class McpConnectionManagerTransportTests
         // This tests that CreateHttpTransport doesn't throw during construction.
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["api-key-server"] = new()
                 {
@@ -89,7 +89,7 @@ public sealed class McpConnectionManagerTransportTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["bearer-server"] = new()
                 {
@@ -119,7 +119,7 @@ public sealed class McpConnectionManagerTransportTests
         // credential. It must now fail loudly at transport build before any send.
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["entra-no-scope"] = new()
                 {
@@ -149,7 +149,7 @@ public sealed class McpConnectionManagerTransportTests
         // connecting with no Authorization header.
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["bearer-empty"] = new()
                 {
@@ -183,7 +183,7 @@ public sealed class McpConnectionManagerTransportTests
         // lifecycle of the cached client, not a successful connect.
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["entra-server"] = new()
                 {
@@ -231,7 +231,7 @@ public sealed class McpConnectionManagerTransportTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["concurrent-test"] = new()
                 {
@@ -260,7 +260,7 @@ public sealed class McpConnectionManagerTransportTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["bad-type"] = new()
                 {
@@ -285,7 +285,7 @@ public sealed class McpConnectionManagerTransportTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["env-test"] = new()
                 {

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
@@ -21,7 +21,8 @@ public sealed class McpToolProviderExtendedTests
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
-            config ?? new McpServersConfig());
+            config ?? new McpServersConfig(),
+            new BundleOwnedMcpServerRegistry());
 
         var provider = new McpToolProvider(
             Mock.Of<ILogger<McpToolProvider>>(), manager);

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
@@ -76,7 +77,7 @@ public sealed class McpToolProviderExtendedTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["broken"] = new() { Enabled = true, Type = McpServerType.Stdio, Command = "" }
             }
@@ -93,7 +94,7 @@ public sealed class McpToolProviderExtendedTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["broken"] = new() { Enabled = true, Type = McpServerType.Stdio, Command = "" }
             }
@@ -125,7 +126,7 @@ public sealed class McpToolProviderExtendedTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["only-server"] = new() { Enabled = true, Type = McpServerType.Stdio, Command = "" }
             }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
@@ -17,7 +17,7 @@ public sealed class McpToolProviderExtendedTests
     private static (McpToolProvider Provider, McpConnectionManager Manager) CreateSut(
         McpServersConfig? config = null)
     {
-        var manager = new McpConnectionManager(
+        var manager = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
@@ -36,7 +37,7 @@ public sealed class McpToolProviderIntegrationTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["bad-server"] = new()
                 {
@@ -81,7 +82,7 @@ public sealed class McpToolProviderIntegrationTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["server-a"] = new()
                 {
@@ -123,7 +124,7 @@ public sealed class McpToolProviderIntegrationTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["broken"] = new()
                 {
@@ -158,7 +159,7 @@ public sealed class McpToolProviderIntegrationTests
     {
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["disabled"] = new() { Enabled = false }
             }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
@@ -21,7 +21,8 @@ public sealed class McpToolProviderIntegrationTests
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
-            config ?? new McpServersConfig());
+            config ?? new McpServersConfig(),
+            new BundleOwnedMcpServerRegistry());
 
         var provider = new McpToolProvider(
             Mock.Of<ILogger<McpToolProvider>>(),

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
@@ -17,7 +17,7 @@ public sealed class McpToolProviderIntegrationTests
     private static (McpToolProvider Provider, McpConnectionManager Manager) CreateProvider(
         McpServersConfig? config = null)
     {
-        var manager = new McpConnectionManager(
+        var manager = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
@@ -87,6 +87,7 @@ public sealed class McpToolProviderTests
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
-            new Domain.Common.Config.AI.MCP.McpServersConfig());
+            new Domain.Common.Config.AI.MCP.McpServersConfig(),
+            new Domain.Common.Config.AI.MCP.BundleOwnedMcpServerRegistry());
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
@@ -83,7 +83,7 @@ public sealed class McpToolProviderTests
 
     private static McpConnectionManager CreateConnectionManager()
     {
-        return new McpConnectionManager(
+        return McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(),
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.Core.CQRS.Agents.RunConversation;
 using Domain.AI.Agents;
@@ -6,6 +7,7 @@ using Domain.Common.Config;
 using FluentAssertions;
 using Infrastructure.AI.Bundles;
 using MediatR;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -43,7 +45,7 @@ public sealed class BundleRunExecutorTests : IDisposable
     }
 
     private (BundleRunExecutor Executor, InMemoryBundleRunJobStore JobStore, InMemoryBundleHandleStore HandleStore)
-        BuildSut(IMediator mediator)
+        BuildSut(IMediator mediator, IMcpToolProvider? mcpToolProvider = null)
     {
         var monitor = new StaticOptionsMonitor<AppConfig>(Config());
         var jobStore = new InMemoryBundleRunJobStore(monitor, _time);
@@ -54,11 +56,11 @@ public sealed class BundleRunExecutorTests : IDisposable
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
         var executor = new BundleRunExecutor(
-            jobStore, handleStore, scopeFactory, _time, NullLogger<BundleRunExecutor>.Instance);
+            jobStore, handleStore, scopeFactory, _time, NullLogger<BundleRunExecutor>.Instance, mcpToolProvider);
         return (executor, jobStore, handleStore);
     }
 
-    private StagedBundle StageOnDisk(string bundleId)
+    private StagedBundle StageOnDisk(string bundleId, IReadOnlyList<string>? mcpServerNames = null)
     {
         var dir = Path.Combine(Path.GetTempPath(), "bundle-executor-tests", bundleId);
         Directory.CreateDirectory(dir);
@@ -68,7 +70,8 @@ public sealed class BundleRunExecutorTests : IDisposable
         {
             BundleId = bundleId,
             StagedRootDirectory = dir,
-            Agent = new AgentDefinition { Id = "agent-" + bundleId, Name = "Agent " + bundleId }
+            Agent = new AgentDefinition { Id = "agent-" + bundleId, Name = "Agent " + bundleId },
+            McpServerNames = mcpServerNames ?? []
         };
     }
 
@@ -230,6 +233,79 @@ public sealed class BundleRunExecutorTests : IDisposable
         result.Record.StartedAt.Should().BeNull("a run that never started must not carry a start time");
         result.Record.Error.Should().Contain("expired");
         mediator.Verify(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // -- Bundle-owned MCP tool grants (issue #368) --
+
+    [Fact]
+    public async Task ExecuteAsync_BundleOwnsMcpServer_GrantsDiscoveredToolNamesIntoAmbientEnvelope()
+    {
+        Domain.AI.Bundles.CapabilityEnvelope? seenEnvelope = null;
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<object, CancellationToken>(
+                (_, _) => seenEnvelope = Application.AI.Common.Services.Governance.CapabilityEnvelopeAccessor.Current)
+            .ReturnsAsync(Ok());
+
+        var mcpToolProvider = new Mock<IMcpToolProvider>();
+        mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AITool> { AIFunctionFactory.Create(() => "r", "echo_tool") });
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = handleStore.Register(staged, "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id)
+            with
+        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } });
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        seenEnvelope.Should().NotBeNull();
+        // Namespaced, never the bare server-declared name — see BundleOwnedMcpToolNaming.
+        seenEnvelope!.AllowedTools.Should().Contain("b1_echo__echo_tool");
+        seenEnvelope.AllowedTools.Should().NotContain("echo_tool",
+            "the bare, bundle-chosen name must never be the granted/governed name");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BundleOwnedServerUnreachable_GrantsNoToolsButRunStillSucceeds()
+    {
+        var mediator = MediatorReturning(Ok());
+        var mcpToolProvider = new Mock<IMcpToolProvider>();
+        mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("server unreachable"));
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = handleStore.Register(staged, "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id));
+
+        var result = await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        result.Status.Should().Be(BundleRunExecutionStatus.Ran);
+        result.Record!.Status.Should().Be(BundleRunStatus.Succeeded,
+            "an unreachable bundle-owned server must contribute zero tools, not fail the run");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BundleOwnsMcpServer_DoesNotMutateStoredRecordEnvelope()
+    {
+        var mediator = MediatorReturning(Ok());
+        var mcpToolProvider = new Mock<IMcpToolProvider>();
+        mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AITool> { AIFunctionFactory.Create(() => "r", "echo_tool") });
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = handleStore.Register(staged, "owner-1");
+        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id)
+            with
+        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } });
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        jobStore.Get("j1")!.Envelope.AllowedTools.Should().BeEmpty(
+            "the stored record's envelope must not be mutated by run-scoped tool discovery");
     }
 
     public void Dispose()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -78,8 +78,11 @@ public sealed class BundleStagingServiceTests : IDisposable
     // --- Bundle-owned MCP servers (issue #368) -------------------------------------------------------
 
     [Fact]
-    public async Task StageAsync_BundleWithStdioMcpServer_RegistersNamespacedServerAndPopulatesMcpServerNames()
+    public async Task StageAsync_BundleWithStdioMcpServer_IsRejectedNotRegistered()
     {
+        // A bundle is untrusted, uploader-supplied content. Registering its self-declared `command` as a
+        // live stdio server would let any bundle author run an arbitrary process on the harness host —
+        // staging must reject it, not register it under a namespaced key.
         using var zip = ZipOf(
             ("AGENT.md", "---\nid: mcp-bundle\nname: MCP Bundle\n---\nx"),
             ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
@@ -92,10 +95,8 @@ public sealed class BundleStagingServiceTests : IDisposable
         var bundle = result.Value!;
         var namespacedName = $"{bundle.BundleId}:echo";
 
-        bundle.McpServerNames.Should().BeEquivalentTo([namespacedName]);
-        mcpServersConfig.Servers.Should().ContainKey(namespacedName);
-        mcpServersConfig.Servers[namespacedName].Type.Should().Be(McpServerType.Stdio);
-        mcpServersConfig.Servers[namespacedName].Command.Should().Be("npx");
+        bundle.McpServerNames.Should().BeEmpty("a stdio server must be rejected, not registered");
+        mcpServersConfig.Servers.Should().NotContainKey(namespacedName);
     }
 
     [Fact]
@@ -138,9 +139,9 @@ public sealed class BundleStagingServiceTests : IDisposable
         using var zip = ZipOf(
             ("AGENT.md", "---\nid: dup-mcp\nname: Dup MCP\n---\nx"),
             ("plugins/one/plugin.json", "{ \"name\": \"one\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
-            ("plugins/one/mcp.json", "{ \"mcpServers\": { \"shared\": { \"command\": \"npx\", \"args\": [\"one\"] } } }"),
+            ("plugins/one/mcp.json", "{ \"mcpServers\": { \"shared\": { \"type\": \"http\", \"url\": \"https://one.example.com/mcp\" } } }"),
             ("plugins/two/plugin.json", "{ \"name\": \"two\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
-            ("plugins/two/mcp.json", "{ \"mcpServers\": { \"shared\": { \"command\": \"npx\", \"args\": [\"two\"] } } }"));
+            ("plugins/two/mcp.json", "{ \"mcpServers\": { \"shared\": { \"type\": \"http\", \"url\": \"https://two.example.com/mcp\" } } }"));
 
         var mcpServersConfig = new McpServersConfig();
         var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -96,7 +96,7 @@ public sealed class BundleStagingServiceTests : IDisposable
         var namespacedName = $"{bundle.BundleId}:echo";
 
         bundle.McpServerNames.Should().BeEmpty("a stdio server must be rejected, not registered");
-        bundleOwnedMcpServers.Servers.Should().NotContainKey(namespacedName);
+        bundleOwnedMcpServers.TryGetValue(namespacedName, out _).Should().BeFalse();
     }
 
     [Fact]
@@ -113,8 +113,9 @@ public sealed class BundleStagingServiceTests : IDisposable
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         var namespacedName = $"{result.Value!.BundleId}:remote";
 
-        bundleOwnedMcpServers.Servers[namespacedName].Type.Should().Be(McpServerType.Http);
-        bundleOwnedMcpServers.Servers[namespacedName].Url.Should().Be("https://tools.example.com/mcp");
+        bundleOwnedMcpServers.TryGetValue(namespacedName, out var definition).Should().BeTrue();
+        definition!.Type.Should().Be(McpServerType.Http);
+        definition.Url.Should().Be("https://tools.example.com/mcp");
     }
 
     [Fact]
@@ -129,8 +130,9 @@ public sealed class BundleStagingServiceTests : IDisposable
         var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue("a malformed mcp.json must degrade, not fail the whole bundle");
-        result.Value!.McpServerNames.Should().BeEmpty();
-        bundleOwnedMcpServers.Servers.Should().BeEmpty();
+        result.Value!.McpServerNames.Should().BeEmpty(
+            "TryBuildAndRegisterOneServer only ever adds a name here on a successful registry TryAdd, " +
+            "so an empty list already proves nothing reached bundleOwnedMcpServers");
     }
 
     [Fact]
@@ -149,8 +151,9 @@ public sealed class BundleStagingServiceTests : IDisposable
         var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue("a non-object mcpServers value must degrade, not fail the whole bundle");
-        result.Value!.McpServerNames.Should().BeEmpty();
-        bundleOwnedMcpServers.Servers.Should().BeEmpty();
+        result.Value!.McpServerNames.Should().BeEmpty(
+            "TryBuildAndRegisterOneServer only ever adds a name here on a successful registry TryAdd, " +
+            "so an empty list already proves nothing reached bundleOwnedMcpServers");
     }
 
     [Fact]
@@ -167,8 +170,9 @@ public sealed class BundleStagingServiceTests : IDisposable
         var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
-        result.Value!.McpServerNames.Should().ContainSingle();
-        bundleOwnedMcpServers.Servers.Should().ContainSingle();
+        result.Value!.McpServerNames.Should().ContainSingle(
+            "TryBuildAndRegisterOneServer only ever adds a name here on a successful registry TryAdd, " +
+            "so a single returned name already proves exactly one entry reached bundleOwnedMcpServers");
     }
 
     // --- Hostile-archive guards ---------------------------------------------------------------------

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -89,7 +89,11 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"command\": \"npx\", \"args\": [\"echo-mcp\"] } } }"));
 
         var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
-        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
+        // AllowBundleDeclaredMcpServers must be ON here — otherwise the flag-off guard short-circuits
+        // RegisterBundleMcpServers before mcp.json is even parsed, and this test would pass for that
+        // reason instead of exercising the stdio-transport rejection it names and documents.
+        var appConfig = AllowlistedAppConfig();
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         var bundle = result.Value!;
@@ -108,7 +112,8 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("mcp.json", "{ \"mcpServers\": { \"remote\": { \"type\": \"http\", \"url\": \"https://tools.example.com/mcp\" } } }"));
 
         var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
-        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
+        var appConfig = AllowlistedAppConfig("tools.example.com");
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         var namespacedName = $"{result.Value!.BundleId}:remote";
@@ -116,6 +121,31 @@ public sealed class BundleStagingServiceTests : IDisposable
         bundleOwnedMcpServers.TryGetValue(namespacedName, out var definition).Should().BeTrue();
         definition!.Type.Should().Be(McpServerType.Http);
         definition.Url.Should().Be("https://tools.example.com/mcp");
+    }
+
+    [Fact]
+    public async Task StageAsync_BundleHttpMcpServerWithUnparsableUrl_IsRejectedNotSilentlyAllowlistedThrough()
+    {
+        // Regression test: an http/sse server whose declared "url" is not a valid absolute URI must be
+        // REJECTED by the registration-time allowlist gate, not fall through it unchecked. Uri.TryCreate
+        // failing used to skip the whole allowlist-check block (including the rejection), silently
+        // registering an unvalidated destination.
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: bad-url-bundle\nname: Bad URL Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"remote\": { \"type\": \"http\", \"url\": \"not-a-valid-absolute-uri\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        // Allowlist is irrelevant to this test's assertion — even a wide-open allowlist must not rescue
+        // a URL that never resolved to a checkable host in the first place.
+        var appConfig = AllowlistedAppConfig("not-a-valid-absolute-uri");
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().BeEmpty(
+            "an unparsable URL must be rejected at registration time, not silently registered");
+        var namespacedName = $"{result.Value.BundleId}:remote";
+        bundleOwnedMcpServers.TryGetValue(namespacedName, out _).Should().BeFalse();
     }
 
     [Fact]
@@ -167,7 +197,8 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("plugins/two/mcp.json", "{ \"mcpServers\": { \"shared\": { \"type\": \"http\", \"url\": \"https://two.example.com/mcp\" } } }"));
 
         var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
-        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
+        var appConfig = AllowlistedAppConfig("one.example.com", "two.example.com");
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         result.Value!.McpServerNames.Should().ContainSingle(
@@ -307,6 +338,35 @@ public sealed class BundleStagingServiceTests : IDisposable
         cfg.TempRoot = _stagingRoot;
         return CreateService(new AppConfig { AI = new AIConfig { BundleExecution = cfg } }, bundleOwnedMcpServers);
     }
+
+    /// <summary>
+    /// An <see cref="AppConfig"/> that opts into bundle-declared remote MCP servers
+    /// (<see cref="BundleExecutionConfig.AllowBundleDeclaredMcpServers"/>) and allowlists the given hosts on
+    /// <c>AI.Egress.DefaultAllowlist</c> — the registration-time destination check added for the PR #370
+    /// security fix rejects any bundle-declared server whose host isn't present here.
+    /// </summary>
+    private AppConfig AllowlistedAppConfig(params string[] hosts) => new()
+    {
+        AI = new AIConfig
+        {
+            BundleExecution = new BundleExecutionConfig
+            {
+                TempRoot = _stagingRoot,
+                AllowBundleDeclaredMcpServers = true,
+            },
+            Egress = new EgressConfig
+            {
+                DefaultAllowlist = hosts
+                    .Select(host => new EgressAllowlistConfigEntry
+                    {
+                        Host = host,
+                        Schemes = ["https"],
+                        Ports = [443],
+                    })
+                    .ToList(),
+            },
+        },
+    };
 
     private static BundleStagingService CreateService(
         AppConfig appConfig, BundleOwnedMcpServerRegistry? bundleOwnedMcpServers = null) =>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -134,6 +134,26 @@ public sealed class BundleStagingServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task StageAsync_McpServersPropertyIsNotAnObject_DegradesGracefullyWithoutFailingStaging()
+    {
+        // Regression test: mcp.json's "mcpServers" property parses as VALID json but the wrong shape (a
+        // string here, not an object) — EnumerateObject() on a non-object JsonElement throws, which used
+        // to propagate out of ReadMcpServersBlock uncaught and fail the whole bundle upload, contradicting
+        // this method's own documented "never fails staging" contract.
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: wrong-shape-mcp\nname: Wrong Shape MCP\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": \"not-an-object\" }"));
+
+        var mcpServersConfig = new McpServersConfig();
+        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue("a non-object mcpServers value must degrade, not fail the whole bundle");
+        result.Value!.McpServerNames.Should().BeEmpty();
+        mcpServersConfig.Servers.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task StageAsync_TwoNestedPluginsDeclareSameServerName_KeepsFirstAndDoesNotThrow()
     {
         using var zip = ZipOf(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.BundleExecution;
+using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
 using Infrastructure.AI.Agents;
 using Infrastructure.AI.Bundles;
@@ -49,6 +50,7 @@ public sealed class BundleStagingServiceTests : IDisposable
         bundle.Agent.Instructions.Should().Contain("Bundle instructions.");
         bundle.OwnedSkills.Select(s => s.Id).Should().ContainSingle(id => id == "greet");
         bundle.PluginManifests.Select(m => m.Name).Should().ContainSingle(n => n == "my-plugin");
+        bundle.McpServerNames.Should().BeEmpty("this bundle's plugin.json declares no mcpServers");
 
         // The staged files really live under the staging root, so disk-based skill disclosure can read them.
         Directory.Exists(bundle.StagedRootDirectory).Should().BeTrue();
@@ -71,6 +73,81 @@ public sealed class BundleStagingServiceTests : IDisposable
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         result.Value!.OwnedSkills.Select(s => s.Id).Should().BeEquivalentTo(["good"]);
+    }
+
+    // --- Bundle-owned MCP servers (issue #368) -------------------------------------------------------
+
+    [Fact]
+    public async Task StageAsync_BundleWithStdioMcpServer_RegistersNamespacedServerAndPopulatesMcpServerNames()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: mcp-bundle\nname: MCP Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"command\": \"npx\", \"args\": [\"echo-mcp\"] } } }"));
+
+        var mcpServersConfig = new McpServersConfig();
+        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        var bundle = result.Value!;
+        var namespacedName = $"{bundle.BundleId}:echo";
+
+        bundle.McpServerNames.Should().BeEquivalentTo([namespacedName]);
+        mcpServersConfig.Servers.Should().ContainKey(namespacedName);
+        mcpServersConfig.Servers[namespacedName].Type.Should().Be(McpServerType.Stdio);
+        mcpServersConfig.Servers[namespacedName].Command.Should().Be("npx");
+    }
+
+    [Fact]
+    public async Task StageAsync_BundleWithHttpMcpServer_RegistersHttpDefinitionWithUrl()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: http-bundle\nname: HTTP Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"remote\": { \"type\": \"http\", \"url\": \"https://tools.example.com/mcp\" } } }"));
+
+        var mcpServersConfig = new McpServersConfig();
+        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        var namespacedName = $"{result.Value!.BundleId}:remote";
+
+        mcpServersConfig.Servers[namespacedName].Type.Should().Be(McpServerType.Http);
+        mcpServersConfig.Servers[namespacedName].Url.Should().Be("https://tools.example.com/mcp");
+    }
+
+    [Fact]
+    public async Task StageAsync_MalformedMcpJson_DegradesGracefullyWithoutFailingStaging()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: bad-mcp\nname: Bad MCP\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ this is not valid json"));
+
+        var mcpServersConfig = new McpServersConfig();
+        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue("a malformed mcp.json must degrade, not fail the whole bundle");
+        result.Value!.McpServerNames.Should().BeEmpty();
+        mcpServersConfig.Servers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StageAsync_TwoNestedPluginsDeclareSameServerName_KeepsFirstAndDoesNotThrow()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: dup-mcp\nname: Dup MCP\n---\nx"),
+            ("plugins/one/plugin.json", "{ \"name\": \"one\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("plugins/one/mcp.json", "{ \"mcpServers\": { \"shared\": { \"command\": \"npx\", \"args\": [\"one\"] } } }"),
+            ("plugins/two/plugin.json", "{ \"name\": \"two\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("plugins/two/mcp.json", "{ \"mcpServers\": { \"shared\": { \"command\": \"npx\", \"args\": [\"two\"] } } }"));
+
+        var mcpServersConfig = new McpServersConfig();
+        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().ContainSingle();
+        mcpServersConfig.Servers.Should().ContainSingle();
     }
 
     // --- Hostile-archive guards ---------------------------------------------------------------------
@@ -198,20 +275,21 @@ public sealed class BundleStagingServiceTests : IDisposable
 
     // --- Helpers ------------------------------------------------------------------------------------
 
-    private BundleStagingService CreateService(BundleExecutionConfig? overrides = null)
+    private BundleStagingService CreateService(BundleExecutionConfig? overrides = null, McpServersConfig? mcpServersConfig = null)
     {
         var cfg = overrides ?? new BundleExecutionConfig();
         cfg.TempRoot = _stagingRoot;
-        return CreateService(new AppConfig { AI = new AIConfig { BundleExecution = cfg } });
+        return CreateService(new AppConfig { AI = new AIConfig { BundleExecution = cfg } }, mcpServersConfig);
     }
 
-    private static BundleStagingService CreateService(AppConfig appConfig) =>
+    private static BundleStagingService CreateService(AppConfig appConfig, McpServersConfig? mcpServersConfig = null) =>
         new(
             new OptionsMonitorStub(appConfig),
             new AgentMetadataParser(NullLogger<AgentMetadataParser>.Instance),
             new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader()),
             new UnsandboxedSkillFileReader(),
             new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
+            mcpServersConfig ?? new McpServersConfig(),
             NullLogger<BundleStagingService>.Instance);
 
     private void NoStagedDirectoriesRemain()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -88,15 +88,15 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
             ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"command\": \"npx\", \"args\": [\"echo-mcp\"] } } }"));
 
-        var mcpServersConfig = new McpServersConfig();
-        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         var bundle = result.Value!;
         var namespacedName = $"{bundle.BundleId}:echo";
 
         bundle.McpServerNames.Should().BeEmpty("a stdio server must be rejected, not registered");
-        mcpServersConfig.Servers.Should().NotContainKey(namespacedName);
+        bundleOwnedMcpServers.Servers.Should().NotContainKey(namespacedName);
     }
 
     [Fact]
@@ -107,14 +107,14 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
             ("mcp.json", "{ \"mcpServers\": { \"remote\": { \"type\": \"http\", \"url\": \"https://tools.example.com/mcp\" } } }"));
 
-        var mcpServersConfig = new McpServersConfig();
-        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         var namespacedName = $"{result.Value!.BundleId}:remote";
 
-        mcpServersConfig.Servers[namespacedName].Type.Should().Be(McpServerType.Http);
-        mcpServersConfig.Servers[namespacedName].Url.Should().Be("https://tools.example.com/mcp");
+        bundleOwnedMcpServers.Servers[namespacedName].Type.Should().Be(McpServerType.Http);
+        bundleOwnedMcpServers.Servers[namespacedName].Url.Should().Be("https://tools.example.com/mcp");
     }
 
     [Fact]
@@ -125,12 +125,12 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
             ("mcp.json", "{ this is not valid json"));
 
-        var mcpServersConfig = new McpServersConfig();
-        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue("a malformed mcp.json must degrade, not fail the whole bundle");
         result.Value!.McpServerNames.Should().BeEmpty();
-        mcpServersConfig.Servers.Should().BeEmpty();
+        bundleOwnedMcpServers.Servers.Should().BeEmpty();
     }
 
     [Fact]
@@ -145,12 +145,12 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
             ("mcp.json", "{ \"mcpServers\": \"not-an-object\" }"));
 
-        var mcpServersConfig = new McpServersConfig();
-        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue("a non-object mcpServers value must degrade, not fail the whole bundle");
         result.Value!.McpServerNames.Should().BeEmpty();
-        mcpServersConfig.Servers.Should().BeEmpty();
+        bundleOwnedMcpServers.Servers.Should().BeEmpty();
     }
 
     [Fact]
@@ -163,12 +163,12 @@ public sealed class BundleStagingServiceTests : IDisposable
             ("plugins/two/plugin.json", "{ \"name\": \"two\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
             ("plugins/two/mcp.json", "{ \"mcpServers\": { \"shared\": { \"type\": \"http\", \"url\": \"https://two.example.com/mcp\" } } }"));
 
-        var mcpServersConfig = new McpServersConfig();
-        var result = await CreateService(mcpServersConfig: mcpServersConfig).StageAsync(zip);
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var result = await CreateService(bundleOwnedMcpServers: bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         result.Value!.McpServerNames.Should().ContainSingle();
-        mcpServersConfig.Servers.Should().ContainSingle();
+        bundleOwnedMcpServers.Servers.Should().ContainSingle();
     }
 
     // --- Hostile-archive guards ---------------------------------------------------------------------
@@ -296,21 +296,23 @@ public sealed class BundleStagingServiceTests : IDisposable
 
     // --- Helpers ------------------------------------------------------------------------------------
 
-    private BundleStagingService CreateService(BundleExecutionConfig? overrides = null, McpServersConfig? mcpServersConfig = null)
+    private BundleStagingService CreateService(
+        BundleExecutionConfig? overrides = null, BundleOwnedMcpServerRegistry? bundleOwnedMcpServers = null)
     {
         var cfg = overrides ?? new BundleExecutionConfig();
         cfg.TempRoot = _stagingRoot;
-        return CreateService(new AppConfig { AI = new AIConfig { BundleExecution = cfg } }, mcpServersConfig);
+        return CreateService(new AppConfig { AI = new AIConfig { BundleExecution = cfg } }, bundleOwnedMcpServers);
     }
 
-    private static BundleStagingService CreateService(AppConfig appConfig, McpServersConfig? mcpServersConfig = null) =>
+    private static BundleStagingService CreateService(
+        AppConfig appConfig, BundleOwnedMcpServerRegistry? bundleOwnedMcpServers = null) =>
         new(
             new OptionsMonitorStub(appConfig),
             new AgentMetadataParser(NullLogger<AgentMetadataParser>.Instance),
             new SkillMetadataParser(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader()),
             new UnsandboxedSkillFileReader(),
             new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
-            mcpServersConfig ?? new McpServersConfig(),
+            bundleOwnedMcpServers ?? new BundleOwnedMcpServerRegistry(),
             NullLogger<BundleStagingService>.Instance);
 
     private void NoStagedDirectoriesRemain()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleHandleStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleHandleStoreTests.cs
@@ -7,6 +7,7 @@ using Infrastructure.AI.Bundles;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
+using Moq;
 using Xunit;
 
 namespace Infrastructure.AI.Tests.Bundles;
@@ -29,17 +30,18 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
         public IDisposable? OnChange(Action<T, string?> listener) => null;
     }
 
-    private InMemoryBundleHandleStore BuildSut()
+    private InMemoryBundleHandleStore BuildSut(IBundleMcpServerRegistrar? mcpServerRegistrar = null)
     {
         var cfg = new AppConfig();
         cfg.AI.BundleExecution.HandleTtl = Ttl;
         return new InMemoryBundleHandleStore(
             new StaticOptionsMonitor<AppConfig>(cfg),
             _time,
-            NullLogger<InMemoryBundleHandleStore>.Instance);
+            NullLogger<InMemoryBundleHandleStore>.Instance,
+            mcpServerRegistrar);
     }
 
-    private StagedBundle StageOnDisk(string bundleId)
+    private StagedBundle StageOnDisk(string bundleId, IReadOnlyList<string>? mcpServerNames = null)
     {
         var dir = Path.Combine(Path.GetTempPath(), "bundle-handle-tests", bundleId);
         Directory.CreateDirectory(dir);
@@ -50,7 +52,8 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
         {
             BundleId = bundleId,
             StagedRootDirectory = dir,
-            Agent = new AgentDefinition { Id = "agent-" + bundleId, Name = "Agent " + bundleId }
+            Agent = new AgentDefinition { Id = "agent-" + bundleId, Name = "Agent " + bundleId },
+            McpServerNames = mcpServerNames ?? []
         };
     }
 
@@ -201,6 +204,87 @@ public sealed class InMemoryBundleHandleStoreTests : IDisposable
 
         Directory.Exists(b1.StagedRootDirectory).Should().BeFalse();
         Directory.Exists(b2.StagedRootDirectory).Should().BeFalse();
+    }
+
+    // -- Bundle MCP server deregistration (issue #368) --
+
+    [Fact]
+    public void Remove_UnleasedWithMcpServers_DeregistersThem()
+    {
+        var registrar = new Mock<IBundleMcpServerRegistrar>();
+        registrar.Setup(r => r.DeregisterAsync(It.IsAny<IReadOnlyList<string>>())).Returns(Task.CompletedTask);
+        var sut = BuildSut(registrar.Object);
+        var bundle = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = sut.Register(bundle, "owner-1");
+
+        sut.Remove(handle).Should().BeTrue();
+
+        registrar.Verify(r => r.DeregisterAsync(
+            It.Is<IReadOnlyList<string>>(names => names.SequenceEqual(new[] { "b1:echo" }))), Times.Once);
+    }
+
+    [Fact]
+    public void SweepExpired_WithMcpServers_DeregistersThem()
+    {
+        var registrar = new Mock<IBundleMcpServerRegistrar>();
+        registrar.Setup(r => r.DeregisterAsync(It.IsAny<IReadOnlyList<string>>())).Returns(Task.CompletedTask);
+        var sut = BuildSut(registrar.Object);
+        var bundle = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        sut.Register(bundle, "owner-1");
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1));
+        sut.SweepExpired().Should().Be(1);
+
+        registrar.Verify(r => r.DeregisterAsync(
+            It.Is<IReadOnlyList<string>>(names => names.SequenceEqual(new[] { "b1:echo" }))), Times.Once);
+    }
+
+    [Fact]
+    public void Remove_WhileLeasedWithMcpServers_DeregistersOnlyAfterRelease()
+    {
+        var registrar = new Mock<IBundleMcpServerRegistrar>();
+        registrar.Setup(r => r.DeregisterAsync(It.IsAny<IReadOnlyList<string>>())).Returns(Task.CompletedTask);
+        var sut = BuildSut(registrar.Object);
+        var bundle = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = sut.Register(bundle, "owner-1");
+
+        var lease = sut.Acquire(handle)!;
+        sut.Remove(handle).Should().BeTrue();
+
+        registrar.Verify(r => r.DeregisterAsync(It.IsAny<IReadOnlyList<string>>()), Times.Never,
+            "deregistration must wait for the in-flight run to release its lease");
+
+        lease.Dispose();
+
+        registrar.Verify(r => r.DeregisterAsync(
+            It.Is<IReadOnlyList<string>>(names => names.SequenceEqual(new[] { "b1:echo" }))), Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_WithMcpServers_DeregistersThem()
+    {
+        var registrar = new Mock<IBundleMcpServerRegistrar>();
+        registrar.Setup(r => r.DeregisterAsync(It.IsAny<IReadOnlyList<string>>())).Returns(Task.CompletedTask);
+        var sut = BuildSut(registrar.Object);
+        var bundle = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        sut.Register(bundle, "owner-1");
+
+        sut.Dispose();
+
+        registrar.Verify(r => r.DeregisterAsync(
+            It.Is<IReadOnlyList<string>>(names => names.SequenceEqual(new[] { "b1:echo" }))), Times.Once);
+    }
+
+    [Fact]
+    public void Remove_WithNoMcpServers_NeverCallsRegistrar()
+    {
+        var registrar = new Mock<IBundleMcpServerRegistrar>();
+        var sut = BuildSut(registrar.Object);
+        var handle = sut.Register(StageOnDisk("b1"), "owner-1");
+
+        sut.Remove(handle).Should().BeTrue();
+
+        registrar.Verify(r => r.DeregisterAsync(It.IsAny<IReadOnlyList<string>>()), Times.Never);
     }
 
     public void Dispose()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/BundleMcpEgressAttributionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/BundleMcpEgressAttributionTests.cs
@@ -1,0 +1,159 @@
+using Application.AI.Common.Exceptions;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Egress;
+using Application.AI.Common.Services;
+using Application.AI.Common.Services.Agent;
+using Domain.AI.Egress;
+using Domain.AI.Identity;
+using Domain.Common.Config;
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Infrastructure.AI.Egress;
+using Infrastructure.AI.MCP.Services;
+using Infrastructure.AI.Tests.Egress.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Egress;
+
+/// <summary>
+/// Regression tests for the PR #370 security fix: a bundle-owned MCP server's outbound connections must be
+/// attributed to a real, auditable identity (<see cref="AgentIdentityKind.System"/>) and evaluated against the
+/// harness's egress allowlist on every request, closing the gap where a bundle could self-grant itself an
+/// unaudited exception to <c>CapabilityEnvelope</c>. A host-configured server's connection must remain
+/// completely unaffected — it never carried this attribution and must not start now.
+/// </summary>
+/// <remarks>
+/// Every scenario here targets a loopback URL (<c>127.0.0.1</c>), which the shared AntiSSRF terminal handler
+/// always blocks at connect time regardless of the outer egress-allowlist verdict. That makes the deny
+/// deterministic and network-free while still proving the thing under test: <see cref="EgressPolicyDelegatingHandler"/>
+/// writes its audit record and (when denying) throws <em>before</em> AntiSSRF is ever reached — see the ordering
+/// in <c>EgressPolicyDelegatingHandler.SendAsync</c> — so the audit assertions below are exercising the outer
+/// ring's real decision, not a downstream connect outcome.
+/// </remarks>
+public sealed class BundleMcpEgressAttributionTests
+{
+    private const string BundleOwnedUrl = "https://127.0.0.1:9443/mcp";
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedServerOnAllowlistedHost_AuditsAllowDecisionWithSystemIdentity()
+    {
+        var audit = new InMemoryEgressAuditWriter();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:remote", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Http,
+            Url = BundleOwnedUrl
+        });
+        var sut = BuildManager(
+            audit,
+            new McpServersConfig(),
+            bundleOwned,
+            allowlist:
+            [
+                new EgressAllowlistEntry { Host = "127.0.0.1", Schemes = ["https"], Ports = [9443] }
+            ]);
+
+        var act = () => sut.GetClientAsync("b1:remote");
+
+        // The outer policy allows the host, so the request reaches AntiSSRF next — which always blocks a
+        // loopback connect target. The point of this test is what happened BEFORE that block.
+        await act.Should().ThrowAsync<McpConnectionException>();
+
+        audit.Entries.Should().ContainSingle(
+            "a bundle-owned connection must go through the outer egress-policy handler on every request");
+        audit.Entries.TryPeek(out var entry).Should().BeTrue();
+        entry.Decision.Allowed.Should().BeTrue("the target host is on the configured allowlist");
+        entry.Identity.Kind.Should().Be(AgentIdentityKind.System,
+            "a bundle's own connection has no live agent turn to derive identity from and must be " +
+            "attributed to a real, auditable system identity instead");
+        entry.Identity.Id.Should().Be("b1:remote", "attribution is scoped to the exact bundle-owned server name");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedServerOnDisallowedHost_BlocksAndAuditsDenyDecision()
+    {
+        var audit = new InMemoryEgressAuditWriter();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:remote", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Http,
+            Url = BundleOwnedUrl
+        });
+        // Default-deny: no allowlist entries at all.
+        var sut = BuildManager(audit, new McpServersConfig(), bundleOwned, allowlist: []);
+
+        var act = () => sut.GetClientAsync("b1:remote");
+
+        await act.Should().ThrowAsync<McpConnectionException>();
+
+        audit.Entries.Should().ContainSingle();
+        audit.Entries.TryPeek(out var entry).Should().BeTrue();
+        entry.Decision.Allowed.Should().BeFalse("the target host is not on any configured allowlist");
+        entry.Identity.Kind.Should().Be(AgentIdentityKind.System);
+    }
+
+    [Fact]
+    public async Task GetClientAsync_HostConfiguredServer_NeverTouchesTheEgressAuditWriter()
+    {
+        // Regression guard for the unchanged path: a host-configured (admin-declared) server's connection
+        // must not gain the bundle-attribution/audit treatment just because the machinery now exists.
+        var audit = new InMemoryEgressAuditWriter();
+        var hostConfig = new McpServersConfig();
+        hostConfig.Servers["azure:filesystem"] = new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Http,
+            Url = BundleOwnedUrl
+        };
+        var sut = BuildManager(audit, hostConfig, new BundleOwnedMcpServerRegistry(), allowlist: []);
+
+        var act = () => sut.GetClientAsync("azure:filesystem");
+
+        // AntiSSRF still blocks the loopback target directly — the host path applies that ring unconditionally
+        // — but no outer policy handler sits in front of it for a host-configured server.
+        await act.Should().ThrowAsync<McpConnectionException>();
+
+        audit.Entries.Should().BeEmpty(
+            "a host-configured server's connection bypasses the egress-attribution path entirely");
+    }
+
+    private static McpConnectionManager BuildManager(
+        IEgressAuditWriter auditWriter,
+        McpServersConfig hostConfig,
+        BundleOwnedMcpServerRegistry bundleOwned,
+        IReadOnlyList<EgressAllowlistEntry> allowlist)
+    {
+        var policy = new DefaultEgressPolicy(allowlist, NullLogger<DefaultEgressPolicy>.Instance, TimeProvider.System);
+        var ambientScope = new AmbientRequestScope();
+        var rootServices = new ServiceCollection()
+            .AddScoped<IAgentExecutionContext, AgentExecutionContext>()
+            .AddSingleton<IEgressPolicy>(policy)
+            .AddSingleton<IEgressPolicyResolver>(new DefaultEgressPolicyResolver(policy))
+            .AddSingleton<IAmbientRequestScope>(ambientScope)
+            .AddSingleton(auditWriter)
+            // McpConnectionManager resolves both of these eagerly at construction (to build
+            // EgressPolicyDelegatingHandler by hand per bundle-owned server — see the "why not resolve the
+            // handler itself from DI" remarks on ResolveBundleEgressClient) — not from a registration of
+            // EgressPolicyDelegatingHandler itself, which would be resolved-but-never-invoked here.
+            .AddSingleton<ILogger<EgressPolicyDelegatingHandler>>(NullLogger<EgressPolicyDelegatingHandler>.Instance)
+            .BuildServiceProvider();
+
+        var antiSsrfFactory = new AntiSsrfHandlerFactory(new TestConfig.StaticOptionsMonitor<AppConfig>(new AppConfig()));
+
+        return new McpConnectionManager(
+            NullLogger<McpConnectionManager>.Instance,
+            NullLoggerFactory.Instance,
+            antiSsrfFactory,
+            hostConfig,
+            bundleOwned,
+            rootServices.GetRequiredService<IServiceScopeFactory>(),
+            ambientScope,
+            rootServices);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
@@ -1,10 +1,13 @@
 using Application.AI.Common.Exceptions;
-using Domain.Common.Config;
+using Application.AI.Common.Interfaces.Egress;
 using System.Collections.Concurrent;
+using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Services;
 using Infrastructure.AI.Tests.Egress.Support;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -55,11 +58,25 @@ public sealed class McpSsrfProtectionTests
             }
         };
 
+        // This test's server is host-configured (config.Servers), never bundle-owned, so the
+        // bundle-egress-attribution path added for the #370 security fix is never exercised here —
+        // FakeAmbientRequestScope's unsupported BeginScope is never invoked. IEgressAuditWriter and
+        // ILogger<EgressPolicyDelegatingHandler> are only present because McpConnectionManager resolves
+        // both eagerly at construction (regardless of transport kind), not because this test's host-only
+        // server path uses them.
+        var rootServices = new ServiceCollection()
+            .AddSingleton<IEgressAuditWriter>(new InMemoryEgressAuditWriter())
+            .AddSingleton<ILogger<EgressPolicyDelegatingHandler>>(NullLogger<EgressPolicyDelegatingHandler>.Instance)
+            .BuildServiceProvider();
+
         return new McpConnectionManager(
             NullLogger<McpConnectionManager>.Instance,
             NullLoggerFactory.Instance,
             antiSsrf,
             config,
-            new BundleOwnedMcpServerRegistry());
+            new BundleOwnedMcpServerRegistry(),
+            rootServices.GetRequiredService<IServiceScopeFactory>(),
+            new FakeAmbientRequestScope(identity: null),
+            rootServices);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
@@ -59,6 +59,7 @@ public sealed class McpSsrfProtectionTests
             NullLogger<McpConnectionManager>.Instance,
             NullLoggerFactory.Instance,
             antiSsrf,
-            config);
+            config,
+            new BundleOwnedMcpServerRegistry());
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Exceptions;
 using Domain.Common.Config;
+using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Services;
@@ -42,7 +43,7 @@ public sealed class McpSsrfProtectionTests
 
         var config = new McpServersConfig
         {
-            Servers = new Dictionary<string, McpServerDefinition>
+            Servers = new ConcurrentDictionary<string, McpServerDefinition>
             {
                 ["internal"] = new()
                 {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpManifestReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpManifestReaderTests.cs
@@ -1,0 +1,105 @@
+using FluentAssertions;
+using Infrastructure.AI.Plugins;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="McpManifestReader"/> — the shared locate/guard/parse helper used by both
+/// <see cref="PluginLoader"/> (host-installed plugins) and bundle staging, so a malformed manifest
+/// degrades identically (skip, log, never throw past this boundary) everywhere it's read.
+/// </summary>
+public sealed class McpManifestReaderTests : IDisposable
+{
+    private readonly string _baseDir = Path.Combine(Path.GetTempPath(), $"mcp-manifest-reader-tests-{Guid.NewGuid():N}");
+
+    public McpManifestReaderTests() => Directory.CreateDirectory(_baseDir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_baseDir))
+            Directory.Delete(_baseDir, recursive: true);
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_ValidObject_ReturnsBlock()
+    {
+        File.WriteAllText(Path.Combine(_baseDir, "mcp.json"), """{ "mcpServers": { "echo": { "command": "npx" } } }""");
+
+        using var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "./mcp.json", "Test", NullLogger.Instance);
+
+        block.Should().NotBeNull();
+        block!.Value.ServersElement.EnumerateObject().Should().ContainSingle(p => p.Name == "echo");
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_McpServersPropertyIsAString_ReturnsNullWithoutThrowing()
+    {
+        // Regression test: "mcpServers" parses as valid JSON but the wrong shape. Every caller enumerates
+        // ServersElement as an object's properties, which throws InvalidOperationException on any other
+        // JsonValueKind if this guard is missing — that exception must never escape this method.
+        File.WriteAllText(Path.Combine(_baseDir, "mcp.json"), """{ "mcpServers": "not-an-object" }""");
+
+        var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "./mcp.json", "Test", NullLogger.Instance);
+
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_McpServersPropertyIsAnArray_ReturnsNullWithoutThrowing()
+    {
+        File.WriteAllText(Path.Combine(_baseDir, "mcp.json"), """{ "mcpServers": [] }""");
+
+        var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "./mcp.json", "Test", NullLogger.Instance);
+
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_RelativePathContainsInvalidCharacter_ReturnsNullWithoutThrowing()
+    {
+        // Regression test: Path.Combine/Path.GetFullPath throws ArgumentException for an embedded NUL —
+        // this used to propagate straight out of ReadMcpServersBlock, uncaught, before the file-existence
+        // check ever ran.
+        var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "./mcp\0.json", "Test", NullLogger.Instance);
+
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_PathEscapesBaseDirectory_ReturnsNull()
+    {
+        var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "../../escape.json", "Test", NullLogger.Instance);
+
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_FileMissing_ReturnsNull()
+    {
+        var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "./missing.json", "Test", NullLogger.Instance);
+
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_MalformedJson_ReturnsNullWithoutThrowing()
+    {
+        File.WriteAllText(Path.Combine(_baseDir, "mcp.json"), "{ this is not valid json");
+
+        var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "./mcp.json", "Test", NullLogger.Instance);
+
+        block.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReadMcpServersBlock_NoMcpServersProperty_ReturnsNull()
+    {
+        File.WriteAllText(Path.Combine(_baseDir, "mcp.json"), """{ "somethingElse": true }""");
+
+        var block = McpManifestReader.ReadMcpServersBlock(_baseDir, "./mcp.json", "Test", NullLogger.Instance);
+
+        block.Should().BeNull();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Infrastructure.AI.Plugins;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Plugins;
+
+/// <summary>
+/// Tests for <see cref="McpServerDefinitionBuilder"/> — the shared, type-branching builder used by both
+/// <see cref="PluginLoader"/> (host-installed plugins) and bundle staging (issue #368) so the two never
+/// independently decide how an <c>mcpServers</c> JSON entry maps to an <see cref="McpServerDefinition"/>.
+/// </summary>
+public sealed class McpServerDefinitionBuilderTests
+{
+    private static readonly Dictionary<string, string> NoEnv = new();
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void Build_NoTypeField_DefaultsToStdioAndParsesCommandArgs()
+    {
+        var element = Parse("""{ "command": "npx", "args": ["-y", "server-name"] }""");
+
+        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Plugin: azure]", "azure-mcp");
+
+        definition.Type.Should().Be(McpServerType.Stdio);
+        definition.Command.Should().Be("npx");
+        definition.Args.Should().BeEquivalentTo(["-y", "server-name"]);
+        definition.Description.Should().Be("[Plugin: azure] azure-mcp");
+        definition.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Build_ExplicitStdioType_ParsesCommandArgs()
+    {
+        var element = Parse("""{ "type": "stdio", "command": "node", "args": ["server.js"] }""");
+
+        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "custom");
+
+        definition.Type.Should().Be(McpServerType.Stdio);
+        definition.Command.Should().Be("node");
+    }
+
+    [Fact]
+    public void Build_HttpType_ParsesUrlAndLeavesCommandEmpty()
+    {
+        var element = Parse("""{ "type": "http", "url": "https://tools.example.com/mcp" }""");
+
+        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+
+        definition.Type.Should().Be(McpServerType.Http);
+        definition.Url.Should().Be("https://tools.example.com/mcp");
+        definition.Command.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Build_SseType_ParsesUrl()
+    {
+        var element = Parse("""{ "type": "sse", "url": "https://tools.example.com/sse" }""");
+
+        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+
+        definition.Type.Should().Be(McpServerType.Sse);
+        definition.Url.Should().Be("https://tools.example.com/sse");
+    }
+
+    [Fact]
+    public void Build_HttpTypeWithNoUrl_LeavesUrlNull()
+    {
+        var element = Parse("""{ "type": "http" }""");
+
+        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+
+        definition.Url.Should().BeNull();
+    }
+
+    [Fact]
+    public void Build_EnvFromManifestAndDeclarationOverride_DeclarationWins()
+    {
+        var element = Parse("""{ "command": "npx", "env": { "A": "manifest", "B": "manifest-only" } }""");
+        var declarationEnv = new Dictionary<string, string> { ["A"] = "declaration" };
+
+        var definition = McpServerDefinitionBuilder.Build(element, declarationEnv, "[Plugin: p]", "s");
+
+        definition.Env["A"].Should().Be("declaration", "declaration env overrides take precedence over manifest env");
+        definition.Env["B"].Should().Be("manifest-only");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
@@ -65,14 +65,31 @@ public sealed class McpServerDefinitionBuilderTests
         definition.Url.Should().Be("https://tools.example.com/sse");
     }
 
-    [Fact]
-    public void Build_HttpTypeWithNoUrl_LeavesUrlNull()
+    [Theory]
+    [InlineData("""{ "type": "http" }""")]
+    [InlineData("""{ "type": "http", "url": null }""")]
+    [InlineData("""{ "type": "http", "url": "" }""")]
+    [InlineData("""{ "type": "http", "url": "   " }""")]
+    public void Build_HttpTypeWithNoUsableUrl_Throws(string json)
     {
-        var element = Parse("""{ "type": "http" }""");
+        // Regression test: a remote server with no usable url used to register with
+        // IsRemoteServer == true and Url == null, passing the bundle-path stdio-rejection
+        // gate and squatting a name that only fails much later, at connect time.
+        var element = Parse(json);
 
-        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+        var act = () => McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
 
-        definition.Url.Should().BeNull();
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Build_SseTypeWithNoUrl_Throws()
+    {
+        var element = Parse("""{ "type": "sse" }""");
+
+        var act = () => McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+
+        act.Should().Throw<InvalidOperationException>();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServersConfigBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServersConfigBindingTests.cs
@@ -1,0 +1,61 @@
+using System.Collections.Concurrent;
+using Domain.Common.Config.AI.MCP;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Plugins;
+
+/// <summary>
+/// Proves <see cref="McpServersConfig.Servers"/> binds correctly from real <c>IConfiguration</c>, the
+/// same way appsettings.json-declared MCP servers are bound in production
+/// (<c>services.Configure&lt;AIConfig&gt;(configuration.GetSection("AppConfig:AI"))</c> — see
+/// <c>Presentation.ConsoleUI/appsettings.json</c>'s <c>AI:McpServers:Servers:&lt;name&gt;</c> shape,
+/// which is the exact nesting this test's JSON mirrors).
+/// </summary>
+/// <remarks>
+/// A first version of this test used the wrong JSON shape (bound a section directly onto
+/// <see cref="McpServersConfig"/> without the intermediate <c>Servers</c> key) and appeared to prove
+/// that a <see cref="ConcurrentDictionary{TKey,TValue}"/>-typed property could not be populated by the
+/// standard binder — the test itself was wrong, not the binder. A corrected control proved
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> binds identically to a plain
+/// <see cref="Dictionary{TKey,TValue}"/>. Kept as a standing regression guard, and as a record of that
+/// correction, so nobody re-derives the same wrong conclusion from a bad control in the future.
+/// </remarks>
+public sealed class McpServersConfigBindingTests
+{
+    [Fact]
+    public void Bind_JsonConfiguredServers_PopulatesServersDictionary()
+    {
+        var json = """
+            {
+              "McpServers": {
+                "Servers": {
+                  "filesystem": {
+                    "Type": "Stdio",
+                    "Command": "npx",
+                    "Args": ["-y", "server-name"]
+                  },
+                  "remote": {
+                    "Type": "Http",
+                    "Url": "https://tools.example.com/mcp"
+                  }
+                }
+              }
+            }
+            """;
+
+        using var stream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json));
+        var configuration = new ConfigurationBuilder().AddJsonStream(stream).Build();
+
+        var target = new McpServersConfig();
+        configuration.GetSection("McpServers").Bind(target);
+
+        target.Servers.Should().HaveCount(2);
+        target.Servers.Should().ContainKey("filesystem");
+        target.Servers["filesystem"].Command.Should().Be("npx");
+        target.Servers["filesystem"].Args.Should().BeEquivalentTo(["-y", "server-name"]);
+        target.Servers["remote"].Type.Should().Be(McpServerType.Http);
+        target.Servers["remote"].Url.Should().Be("https://tools.example.com/mcp");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginLoaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginLoaderTests.cs
@@ -89,6 +89,36 @@ public sealed class PluginLoaderTests : IDisposable
     }
 
     [Fact]
+    public void Load_WithHttpMcpJson_MergesNamespacedHttpServerWithUrl()
+    {
+        // Root cause #1 of issue #368: PluginLoader hardcoded Stdio before McpServerDefinitionBuilder was
+        // extracted, so an Http-type entry was silently mis-built. Proves the shared builder fixed it here too.
+        var mcpConfig = new
+        {
+            mcpServers = new Dictionary<string, object>
+            {
+                ["remote"] = new { type = "http", url = "https://tools.example.com/mcp" }
+            }
+        };
+        File.WriteAllText(
+            Path.Combine(_tempDir, ".mcp.json"),
+            JsonSerializer.Serialize(mcpConfig));
+
+        var manifest = new PluginManifest
+        {
+            Name = "remote-plugin",
+            Version = "1.0.0",
+            McpServers = "./.mcp.json"
+        };
+
+        var result = _sut.Load(_tempDir, MakeDeclaration("remote-plugin"), manifest);
+
+        result.Should().NotBeNull();
+        _mcpServersConfig.Servers["remote-plugin:remote"].Type.Should().Be(McpServerType.Http);
+        _mcpServersConfig.Servers["remote-plugin:remote"].Url.Should().Be("https://tools.example.com/mcp");
+    }
+
+    [Fact]
     public void Load_EnvOverrides_MergedIntoMcpServers()
     {
         var mcpConfig = new

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginLoaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginLoaderTests.cs
@@ -186,6 +186,48 @@ public sealed class PluginLoaderTests : IDisposable
     }
 
     [Fact]
+    public void Load_OneMalformedMcpServerEntry_SkipsItButLoadsTheRest()
+    {
+        // Regression test: a per-entry build failure used to propagate out of LoadMcpServers
+        // uncaught, through Load's outer catch, marking the WHOLE plugin Failed with empty
+        // skill/server lists -- discarding a skill path already collected in the same call and
+        // orphaning any server registered by an earlier, good entry in the same mcpServers block.
+        var skillsDir = Path.Combine(_tempDir, "skills");
+        Directory.CreateDirectory(skillsDir);
+
+        var mcpConfig = new
+        {
+            mcpServers = new Dictionary<string, object>
+            {
+                ["good"] = new { command = "npx", args = new[] { "good-mcp" } },
+                ["bad"] = new { type = "http" } // no url -> McpServerDefinitionBuilder.Build throws
+            }
+        };
+        File.WriteAllText(
+            Path.Combine(_tempDir, ".mcp.json"),
+            JsonSerializer.Serialize(mcpConfig));
+
+        var manifest = new PluginManifest
+        {
+            Name = "mixed-plugin",
+            Version = "1.0.0",
+            Skills = "./skills/",
+            McpServers = "./.mcp.json"
+        };
+
+        var result = _sut.Load(_tempDir, MakeDeclaration("mixed-plugin"), manifest);
+
+        result.Should().NotBeNull();
+        result!.Status.Should().Be(PluginLoadStatus.Loaded,
+            "one malformed MCP server entry must not fail the whole plugin");
+        result.SkillPaths.Should().ContainSingle(skillsDir,
+            "skills already collected before the malformed entry must not be discarded");
+        result.McpServerNames.Should().ContainSingle("mixed-plugin:good");
+        _mcpServersConfig.Servers.Should().ContainKey("mixed-plugin:good");
+        _mcpServersConfig.Servers.Should().NotContainKey("mixed-plugin:bad");
+    }
+
+    [Fact]
     public void Load_McpJsonMissing_SkipsSilently()
     {
         var manifest = new PluginManifest


### PR DESCRIPTION
## Summary

Closes #368, filed by an outside contributor (splashthree). A bundle can ship its own `plugin.json` declaring an MCP server, but nothing ever registered it, resolved it against the run's capability envelope, or made its tools invocable — the server was parsed and silently discarded.

- Extract a shared, type-branching `McpServerDefinitionBuilder` (Stdio + Http/Sse) used by both `PluginLoader` and bundle staging, and a shared `McpManifestReader` for locating/parsing an `mcp.json` under the same path-escape guard both callers already relied on.
- `BundleStagingService` registers a bundle's own MCP servers under a bundle-scoped namespaced key at staging time; `RunBundleCommandHandler` additively unions those names into the run's envelope — the caller's own granted servers/tools are never narrowed.
- `ToolChainBuilder` resolves a skill's bundle-agnostic declared server name against a namespaced grant via suffix match, falling back only when no exact host-configured grant exists (so a host-configured, non-namespaced server is unaffected).
- `IBundleMcpServerRegistrar` deregisters a bundle's MCP servers (and disconnects any live client) when its handle is evicted — covers `Remove`, `SweepExpired`, the deferred `ReleaseLease` path, and host shutdown.

### Security fix mid-review

A code-review pass on the first version of this change found a real privilege-escalation: granting a bundle's self-reported tool names verbatim into the run's `AllowedTools` let a malicious bundle advertise a tool named after a real, more privileged host tool and get it auto-granted by name coincidence — the invocation-time governance gate authorizes by name alone, with no notion of which server a call actually resolves through. `BundleOwnedMcpToolNaming` + `NamespacedAIFunction` close this by construction: a tool resolved via a bundle-owned server is published to the model and governed under a namespaced name (`{server}__{tool}`) that can never collide with a host tool's bare name.

A second false alarm during that same pass (switching `McpServersConfig.Servers` to `ConcurrentDictionary` appeared to break config binding) turned out to be a bug in my own verification test, not the binder — corrected and kept as a regression-guard test.

## Test plan

- [x] Full solution build, 0 warnings
- [x] Full test suite green (22/22 assemblies, ~9,800 tests)
- [x] `gitnexus detect_changes` — affected-symbol set matches the design, no unintended changes
- [x] `/code-review` — 1 CRITICAL (fixed), 3 lower-severity (fixed or assessed as acceptable trade-offs)
- [x] `/simplify` — 2 genuine duplications extracted, 1 redundant test removed, 1 unnecessary field inlined

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HgyekFt9vVUfL75GP1HL7d