### PR TITLE
feat: stream tool-call activity on the bundle SSE feed

### DIFF
--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -1172,10 +1172,23 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                             <tr><td><code>TEXT_MESSAGE_START</code></td><td><code>messageId</code>, <code>role: "assistant"</code></td><td>Lazily, on the first real token. A run that emits no text emits no message frames at all.</td></tr>
                             <tr><td><code>TEXT_MESSAGE_CONTENT</code></td><td><code>messageId</code>, <code>delta</code></td><td>Per token batch. Append to your buffer.</td></tr>
                             <tr><td><code>TEXT_MESSAGE_END</code></td><td><code>messageId</code></td><td>Once, if the message was opened.</td></tr>
+                            <tr><td><code>TOOL_CALL_START</code></td><td><code>toolCallId</code>, <code>toolCallName</code></td><td>When the agent decides to call a tool. May arrive before the first <code>TEXT_MESSAGE_START</code>.</td></tr>
+                            <tr><td><code>TOOL_CALL_ARGS</code></td><td><code>toolCallId</code>, <code>delta</code></td><td>Immediately after <code>TOOL_CALL_START</code> — the complete arguments JSON in one frame, not an incremental delta.</td></tr>
+                            <tr><td><code>TOOL_CALL_END</code></td><td><code>toolCallId</code></td><td>Immediately after <code>TOOL_CALL_ARGS</code>.</td></tr>
+                            <tr><td><code>TOOL_CALL_RESULT</code></td><td><code>toolCallId</code>, <code>result</code></td><td>Once the tool has actually run.</td></tr>
                             <tr><td><code>RUN_FINISHED</code></td><td><code>threadId</code>, <code>runId</code></td><td>Terminal, on success.</td></tr>
                             <tr><td><code>RUN_ERROR</code></td><td><code>message</code> (caller-safe)</td><td>Terminal, on failure. Never both this and <code>RUN_FINISHED</code>.</td></tr>
                         </tbody>
                     </table>
+                    <p>
+                        Two things about the tool-call frames that are easy to assume wrong: the <code>delta</code>
+                        field on <code>TOOL_CALL_ARGS</code> is named to match the AG-UI wire vocabulary, but it is
+                        <strong>not incremental</strong> — the model-provider integration only ever exposes a tool
+                        call's arguments once fully assembled, so all three of <code>TOOL_CALL_START</code>,
+                        <code>TOOL_CALL_ARGS</code>, and <code>TOOL_CALL_END</code> arrive back-to-back in one burst.
+                        And tool-call frames freely interleave with text frames, including arriving before the
+                        assistant message ever opens — a client cannot assume text comes first.
+                    </p>
                     <div class="code-block">
                         <div class="code-block-header"><span class="code-block-lang">ts · consuming the stream</span></div>
                         <pre><code>async function runStreamed(API: string, handle: string, token: string): Promise&lt;string&gt; {
@@ -1205,6 +1218,7 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
       buffer = buffer.slice(cut + 2);
       const evt = JSON.parse(frame);
       if (evt.type === 'TEXT_MESSAGE_CONTENT') answer += evt.delta;
+      if (evt.type === 'TOOL_CALL_START') console.log(`calling ${evt.toolCallName}…`);
       if (evt.type === 'RUN_ERROR') throw new Error(evt.message);
       if (evt.type === 'RUN_FINISHED') return answer;
     }

--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -1163,7 +1163,10 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                     </p>
                     <p>
                         Frames are <code>data: {json}\n\n</code>, camelCase, with a <code>type</code> discriminator taken
-                        from the AG-UI wire vocabulary — so an AG-UI client library consumes this feed unchanged:
+                        from the AG-UI wire vocabulary — a hand-written client that switches on <code>type</code> works
+                        unchanged. A strict AG-UI client library is not guaranteed to: tool-call frames can arrive while
+                        a <code>TEXT_MESSAGE</code> is still open (see below, some AG-UI client libraries reject that),
+                        and <code>TOOL_CALL_RESULT</code>'s fields have no AG-UI precedent to match against.
                     </p>
                     <table>
                         <thead><tr><th>Frame <code>type</code></th><th>Payload</th><th>When</th></tr></thead>

--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -1175,7 +1175,7 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                             <tr><td><code>TOOL_CALL_START</code></td><td><code>toolCallId</code>, <code>toolCallName</code></td><td>When the agent decides to call a tool. May arrive before the first <code>TEXT_MESSAGE_START</code>.</td></tr>
                             <tr><td><code>TOOL_CALL_ARGS</code></td><td><code>toolCallId</code>, <code>delta</code></td><td>Immediately after <code>TOOL_CALL_START</code> — the complete arguments JSON in one frame, not an incremental delta.</td></tr>
                             <tr><td><code>TOOL_CALL_END</code></td><td><code>toolCallId</code></td><td>Immediately after <code>TOOL_CALL_ARGS</code>.</td></tr>
-                            <tr><td><code>TOOL_CALL_RESULT</code></td><td><code>toolCallId</code>, <code>result</code></td><td>Once the tool has actually run.</td></tr>
+                            <tr><td><code>TOOL_CALL_RESULT</code></td><td><code>toolCallId</code>, <code>result</code> (redacted preview)</td><td>Once the tool has actually run.</td></tr>
                             <tr><td><code>RUN_FINISHED</code></td><td><code>threadId</code>, <code>runId</code></td><td>Terminal, on success.</td></tr>
                             <tr><td><code>RUN_ERROR</code></td><td><code>message</code> (caller-safe)</td><td>Terminal, on failure. Never both this and <code>RUN_FINISHED</code>.</td></tr>
                         </tbody>
@@ -1188,6 +1188,13 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                         <code>TOOL_CALL_ARGS</code>, and <code>TOOL_CALL_END</code> arrive back-to-back in one burst.
                         And tool-call frames freely interleave with text frames, including arriving before the
                         assistant message ever opens — a client cannot assume text comes first.
+                    </p>
+                    <p>
+                        <code>TOOL_CALL_ARGS.delta</code> and <code>TOOL_CALL_RESULT.result</code> are never the raw
+                        payload — both pass through the same secret-redaction and length-truncation the harness
+                        applies before persisting tool activity to its observability store, since a live stream to
+                        a browser is just as much an exposure point as disk. If a tool call fails,
+                        <code>result</code> is a generic failure message, not the underlying exception text.
                     </p>
                     <div class="code-block">
                         <div class="code-block-header"><span class="code-block-lang">ts · consuming the stream</span></div>

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -349,8 +349,11 @@ paths:
         the run is recorded as `Failed` with reason `The run was cancelled.`
 
         Frames are `data: {json}\n\n` with camelCase properties and a `type` discriminator matching
-        the AG-UI wire vocabulary, so an AG-UI client library consumes the feed unchanged. Exactly
-        one terminal frame is emitted: `RUN_FINISHED` or `RUN_ERROR`.
+        the AG-UI wire vocabulary — a hand-written client that switches on `type` works unchanged.
+        A strict `@ag-ui/client`-style consumer is not guaranteed to: tool-call frames can arrive
+        while a `TEXT_MESSAGE` is still open (see below), which some AG-UI client libraries reject,
+        and `TOOL_CALL_RESULT`'s fields (`toolCallId`, `result`) have no AG-UI precedent to match
+        against. Exactly one terminal frame is emitted: `RUN_FINISHED` or `RUN_ERROR`.
 
         A tool call interleaves as `TOOL_CALL_START` → `TOOL_CALL_ARGS` → `TOOL_CALL_END`, then
         `TOOL_CALL_RESULT` once the tool has run — freely interleaved with `TEXT_MESSAGE_*` frames,

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -1342,7 +1342,10 @@ components:
         toolCallId: { type: string }
         result:
           type: string
-          description: The tool's output.
+          description: >-
+            A redacted, truncated preview of the tool's output — never the raw payload. Secret-shaped
+            values are replaced with "[REDACTED]" before truncation. If the tool call failed, this is a
+            generic failure message, not the underlying exception text.
 
     RunFinishedEvent:
       type: object

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -352,6 +352,11 @@ paths:
         the AG-UI wire vocabulary, so an AG-UI client library consumes the feed unchanged. Exactly
         one terminal frame is emitted: `RUN_FINISHED` or `RUN_ERROR`.
 
+        A tool call interleaves as `TOOL_CALL_START` → `TOOL_CALL_ARGS` → `TOOL_CALL_END`, then
+        `TOOL_CALL_RESULT` once the tool has run — freely interleaved with `TEXT_MESSAGE_*` frames,
+        and possibly *before* the first `TEXT_MESSAGE_START` if the agent calls a tool before
+        producing any text. A client must not assume the assistant message opens first.
+
         **Concurrency limit, not a rate limit.** Each open stream holds a permit for its lifetime;
         a caller may hold `MaxConcurrentStreamsPerCaller` (default 4) at once. Excess connections
         are rejected outright with `429`, never queued.
@@ -373,6 +378,14 @@ paths:
                   summary: A complete streamed run
                   value: |
                     data: {"type":"RUN_STARTED","threadId":"h-9f3c...","runId":"0b8f1c2d..."}
+
+                    data: {"type":"TOOL_CALL_START","toolCallId":"c-1a2b...","toolCallName":"query_knowledge_graph"}
+
+                    data: {"type":"TOOL_CALL_ARGS","toolCallId":"c-1a2b...","delta":"{\"query\":\"HPWH A004\"}"}
+
+                    data: {"type":"TOOL_CALL_END","toolCallId":"c-1a2b..."}
+
+                    data: {"type":"TOOL_CALL_RESULT","toolCallId":"c-1a2b...","result":"3 matching entries"}
 
                     data: {"type":"TEXT_MESSAGE_START","messageId":"7e2a...","role":"assistant"}
 
@@ -1235,6 +1248,10 @@ components:
         - $ref: "#/components/schemas/TextMessageStartEvent"
         - $ref: "#/components/schemas/TextMessageContentEvent"
         - $ref: "#/components/schemas/TextMessageEndEvent"
+        - $ref: "#/components/schemas/ToolCallStartEvent"
+        - $ref: "#/components/schemas/ToolCallArgsEvent"
+        - $ref: "#/components/schemas/ToolCallEndEvent"
+        - $ref: "#/components/schemas/ToolCallResultEvent"
         - $ref: "#/components/schemas/RunFinishedEvent"
         - $ref: "#/components/schemas/RunErrorEvent"
       discriminator:
@@ -1280,6 +1297,52 @@ components:
       properties:
         type: { type: string, const: TEXT_MESSAGE_END }
         messageId: { type: string }
+
+    ToolCallStartEvent:
+      type: object
+      description: Emitted when the agent decides to call a tool.
+      required: [type, toolCallId, toolCallName]
+      properties:
+        type: { type: string, const: TOOL_CALL_START }
+        toolCallId:
+          type: string
+          description: The provider-assigned id for this call, shared by every event for it.
+        toolCallName: { type: string }
+
+    ToolCallArgsEvent:
+      type: object
+      description: >-
+        Carries a tool call's arguments. Unlike `TextMessageContentEvent`, `delta` is NOT an
+        incremental delta — the underlying model-provider integration only ever exposes a tool
+        call's arguments once fully assembled, so this frame always carries the complete JSON
+        payload in one shot, immediately followed by `TOOL_CALL_END`. The field is still named
+        `delta` to match the AG-UI wire vocabulary exactly.
+      required: [type, toolCallId, delta]
+      properties:
+        type: { type: string, const: TOOL_CALL_ARGS }
+        toolCallId: { type: string }
+        delta:
+          type: string
+          description: The tool call's complete arguments, serialized as JSON.
+
+    ToolCallEndEvent:
+      type: object
+      description: Signals that a tool call's arguments are complete.
+      required: [type, toolCallId]
+      properties:
+        type: { type: string, const: TOOL_CALL_END }
+        toolCallId: { type: string }
+
+    ToolCallResultEvent:
+      type: object
+      description: Emitted once a tool call has actually run and produced a result.
+      required: [type, toolCallId, result]
+      properties:
+        type: { type: string, const: TOOL_CALL_RESULT }
+        toolCallId: { type: string }
+        result:
+          type: string
+          description: The tool's output.
 
     RunFinishedEvent:
       type: object

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
@@ -34,5 +34,20 @@ public static class ToolPayloadRedactor
     /// consumer needs it intact, e.g. tool-call arguments a client parses as JSON, where truncation
     /// would silently hand back invalid data instead of what was documented as the complete payload.
     /// </summary>
-    public static string Redact(string payload, ISecretRedactor? redactor) => redactor?.Redact(payload) ?? payload;
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="redactor"/> is non-null but returned <see langword="null"/>.
+    /// <see cref="ISecretRedactor.Redact"/> documents that as valid only for a null input, and
+    /// <paramref name="payload"/> here is non-nullable — so it can only mean the redactor is violating
+    /// its own contract. Falling back to the raw payload in that case (as a bare <c>??</c> would) is a
+    /// silent unredacted leak past a redaction boundary; fail loudly instead.
+    /// </exception>
+    public static string Redact(string payload, ISecretRedactor? redactor)
+    {
+        if (redactor is null)
+            return payload;
+
+        return redactor.Redact(payload) ?? throw new InvalidOperationException(
+            $"{redactor.GetType().Name}.Redact(string) returned null for non-null input, violating " +
+            $"{nameof(ISecretRedactor)}'s contract.");
+    }
 }

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
@@ -1,4 +1,6 @@
 using Application.AI.Common.Interfaces;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Helpers;
 
@@ -50,4 +52,49 @@ public static class ToolPayloadRedactor
             $"{redactor.GetType().Name}.Redact(string) returned null for non-null input, violating " +
             $"{nameof(ISecretRedactor)}'s contract.");
     }
+
+    /// <summary>
+    /// Guarded variant of <paramref name="produce"/> — typically a call to <see cref="Redact"/> or
+    /// <see cref="RedactAndTruncate"/>, optionally preceded by payload preparation such as JSON
+    /// serialization. Catches any exception (a redaction-contract violation from a misbehaving
+    /// <see cref="ISecretRedactor"/>, or a serialization failure), logs it as a warning via
+    /// <paramref name="logger"/>, and returns <paramref name="fallback"/> instead of propagating —
+    /// so a redaction failure degrades the one payload it affects rather than aborting the caller.
+    /// Centralizes the identical try/catch/log/fallback shape every exposure point around a
+    /// redaction call otherwise has to hand-roll — the same "one place" reasoning behind this class
+    /// applies to the failure path, not just the success path.
+    /// </summary>
+    /// <remarks>
+    /// Logs <paramref name="failureMessage"/> as a single plain string rather than a structured
+    /// template — this failure path is rare (a misbehaving redactor or an unserializable value) and
+    /// shared across call sites with different natural template arguments, so a caller-formatted
+    /// message is simpler than plumbing per-call structured fields through a generic helper.
+    /// </remarks>
+    public static string TryOrFallback(Func<string> produce, ILogger logger, string failureMessage, string fallback)
+    {
+        try
+        {
+            return produce();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "{FailureMessage}", failureMessage);
+            return fallback;
+        }
+    }
+
+    /// <summary>
+    /// Returns the text of a tool result, substituting <paramref name="genericFailureMessage"/> when
+    /// <see cref="FunctionResultContent.Exception"/> is set. On failure, <see cref="FunctionResultContent.Result"/>
+    /// already carries the raw exception message baked into a human-readable string —
+    /// <c>FunctionInvokingChatClient</c>'s <c>IncludeDetailedErrors</c> option (set unconditionally by
+    /// <c>AgentFactory</c>) appends <see cref="Exception.Message"/> verbatim, which can surface file
+    /// paths, connection details, or other internals. None of <see cref="Redact"/>'s patterns are
+    /// shaped to catch free-form exception prose, so redaction alone does not close this gap — every
+    /// consumer of a tool result's text (a live SSE stream, or the persisted trace store a dashboard
+    /// later renders) must call this before <see cref="Redact"/>/<see cref="RedactAndTruncate"/>, not
+    /// just the one exposure point that happened to be reviewed first.
+    /// </summary>
+    public static string SafeResultText(FunctionResultContent result, string genericFailureMessage = "Error: tool call failed.") =>
+        result.Exception is not null ? genericFailureMessage : result.Result?.ToString() ?? string.Empty;
 }

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
@@ -1,0 +1,38 @@
+using Application.AI.Common.Interfaces;
+
+namespace Application.AI.Common.Helpers;
+
+/// <summary>
+/// Applies the same redact-then-truncate treatment to a tool call's arguments or result before it
+/// leaves the trust boundary — whether that boundary is the persisted observability store
+/// (<c>ToolDiagnosticsMiddleware</c>) or a live SSE stream to a browser
+/// (<c>ExecuteAgentTurnCommandHandler</c>). Tool payloads routinely carry paths, connection strings,
+/// or tokens, so every exposure point needs the identical treatment — this is that one place.
+/// </summary>
+public static class ToolPayloadRedactor
+{
+    /// <summary>The length a redacted payload is capped to before it is stored or streamed.</summary>
+    public const int MaxPayloadSummaryLength = 500;
+
+    /// <summary>
+    /// Redacts <paramref name="payload"/> via <paramref name="redactor"/> (a no-op when
+    /// <paramref name="redactor"/> is <see langword="null"/>), then truncates the result to
+    /// <paramref name="maxLength"/> characters. Only safe for free-text previews (a log line, a
+    /// truncated result string a human reads) — never for a payload a consumer will parse as
+    /// structured data, since truncation can land mid-token and produce invalid output. Use
+    /// <see cref="Redact"/> for those.
+    /// </summary>
+    public static string RedactAndTruncate(string payload, ISecretRedactor? redactor, int maxLength = MaxPayloadSummaryLength)
+    {
+        var redacted = Redact(payload, redactor);
+        return redacted.Length > maxLength ? redacted[..maxLength] : redacted;
+    }
+
+    /// <summary>
+    /// Redacts <paramref name="payload"/> via <paramref name="redactor"/> (a no-op when
+    /// <paramref name="redactor"/> is <see langword="null"/>) with no length cap — for a payload whose
+    /// consumer needs it intact, e.g. tool-call arguments a client parses as JSON, where truncation
+    /// would silently hand back invalid data instead of what was documented as the complete payload.
+    /// </summary>
+    public static string Redact(string payload, ISecretRedactor? redactor) => redactor?.Redact(payload) ?? payload;
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
@@ -23,4 +23,33 @@ public interface IAgentTurnStreamSink
     /// <param name="delta">The newly generated assistant text fragment.</param>
     /// <param name="cancellationToken">Cancels emission when the consumer goes away.</param>
     Task EmitAsync(string delta, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Emits one complete tool call the model has decided to make — its id, name, and arguments — as a
+    /// single unit. Default no-op, so a sink that only cares about assistant text (or a transport that
+    /// predates tool-call streaming) needs no changes. Unlike <see cref="EmitAsync"/>, <paramref
+    /// name="argsJson"/> is never an incremental delta: the underlying chat-client abstraction only ever
+    /// exposes a tool call's arguments once fully assembled (the provider connector buffers raw
+    /// per-chunk argument JSON internally and never surfaces a partial parse), so every field here is
+    /// already complete and stable by the time this fires. A consumer that must publish start/args/end as
+    /// separate wire frames (e.g. an SSE feed following the AG-UI protocol) decomposes this single call
+    /// into that sequence itself — the three are always emitted together, in that order, with nothing a
+    /// caller could observe between them, so splitting them at this seam would only add API surface
+    /// without adding any real capability.
+    /// </summary>
+    /// <param name="toolCallId">The provider-assigned id for this call.</param>
+    /// <param name="toolCallName">The name of the tool being called.</param>
+    /// <param name="argsJson">The complete tool-call arguments, serialized as JSON.</param>
+    /// <param name="cancellationToken">Cancels emission when the consumer goes away.</param>
+    Task EmitToolCallAsync(string toolCallId, string toolCallName, string argsJson, CancellationToken cancellationToken) =>
+        Task.CompletedTask;
+
+    /// <summary>
+    /// Emits a tool call's result once the tool has actually run. Default no-op.
+    /// </summary>
+    /// <param name="toolCallId">The call this result belongs to.</param>
+    /// <param name="result">The tool's output.</param>
+    /// <param name="cancellationToken">Cancels emission when the consumer goes away.</param>
+    Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken) =>
+        Task.CompletedTask;
 }

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Traces;
 using Application.AI.Common.Services;
@@ -21,7 +22,6 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
 {
     private const int MaxToolsToLog = 5;
     private const int MaxPreviewLength = 200;
-    private const int MaxPayloadSummaryLength = 500;
 
     private readonly ILogger _logger;
     private readonly ITraceWriter? _traceWriter;
@@ -88,10 +88,7 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
         foreach (var result in functionResults)
         {
             var rawPayload = result.Result?.ToString() ?? string.Empty;
-            var redactedPayload = _redactor?.Redact(rawPayload) ?? rawPayload;
-            var trimmedPayload = redactedPayload.Length > MaxPayloadSummaryLength
-                ? redactedPayload[..MaxPayloadSummaryLength]
-                : redactedPayload;
+            var trimmedPayload = ToolPayloadRedactor.RedactAndTruncate(rawPayload, _redactor);
 
             // Always record the stdout against the matching call id so the
             // observability pipeline can render it on the per-invocation page
@@ -221,11 +218,7 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
             {
                 try
                 {
-                    argsJson = System.Text.Json.JsonSerializer.Serialize(args);
-                    if (_redactor is not null)
-                        argsJson = _redactor.Redact(argsJson);
-                    if (argsJson is not null && argsJson.Length > MaxPayloadSummaryLength)
-                        argsJson = argsJson[..MaxPayloadSummaryLength];
+                    argsJson = ToolPayloadRedactor.RedactAndTruncate(System.Text.Json.JsonSerializer.Serialize(args), _redactor);
                 }
                 catch (Exception ex)
                 {

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -117,7 +117,10 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
                     Type = TraceRecordTypes.ToolResult,
                     ExecutionRunId = _traceWriter.Scope.ExecutionRunId.ToString("D"),
                     TurnId = result.CallId ?? Guid.NewGuid().ToString("D"),
-                    ResultCategory = TraceResultCategories.Success,
+                    // SafeResultText strips the raw exception text from PayloadSummary on failure — that
+                    // text used to be the only signal a reader had that the call failed at all, so
+                    // ResultCategory must now carry that signal structurally instead.
+                    ResultCategory = result.Exception is not null ? TraceResultCategories.Error : TraceResultCategories.Success,
                     PayloadSummary = trimmedPayload
                 };
 

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -87,8 +87,19 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
 
         foreach (var result in functionResults)
         {
-            var rawPayload = result.Result?.ToString() ?? string.Empty;
-            var trimmedPayload = ToolPayloadRedactor.RedactAndTruncate(rawPayload, _redactor);
+            // A failed call's Result already carries the raw exception message baked in by
+            // IncludeDetailedErrors (see ExecuteAgentTurnCommandHandler.RedactedResultPreview) — this
+            // trace record feeds the dashboard's per-invocation page via ToolInvocationDetailDto,
+            // which is just as much an exposure point as the streamed SSE frame, so it gets the same
+            // generic-message substitution, not just redaction of the raw text.
+            var rawPayload = ToolPayloadRedactor.SafeResultText(result);
+            // A redaction-contract violation from _redactor must degrade this trace record, not
+            // abort the chat call this diagnostics middleware is only observing.
+            var trimmedPayload = ToolPayloadRedactor.TryOrFallback(
+                () => ToolPayloadRedactor.RedactAndTruncate(rawPayload, _redactor),
+                _logger,
+                $"[ToolDiag] Failed to redact tool result for CallId={result.CallId}",
+                fallback: "[unavailable]");
 
             // Always record the stdout against the matching call id so the
             // observability pipeline can render it on the per-invocation page

--- a/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
@@ -25,18 +25,40 @@ public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
     }
 
     private readonly Func<string, CancellationToken, Task> _onDelta;
+    private readonly Func<string, string, string, CancellationToken, Task>? _onToolCall;
+    private readonly Func<string, string, CancellationToken, Task>? _onToolCallResult;
 
     /// <summary>
-    /// Creates a sink that forwards each assistant text delta to <paramref name="onDelta"/>.
+    /// Creates a sink that forwards each assistant text delta to <paramref name="onDelta"/>, each
+    /// complete tool call to <paramref name="onToolCall"/>, and each tool result to
+    /// <paramref name="onToolCallResult"/>. A transport that only cares about text (e.g.
+    /// <c>ConversationOrchestrator</c>'s SignalR path) can omit the tool-call callbacks entirely; the
+    /// corresponding <see cref="IAgentTurnStreamSink"/> methods then no-op, identical to this type's
+    /// behaviour before tool-call streaming existed.
     /// </summary>
     /// <param name="onDelta">The transport callback invoked per text delta.</param>
-    public AgentTurnStreamSink(Func<string, CancellationToken, Task> onDelta)
+    /// <param name="onToolCall">Invoked with a complete tool call (id, name, arguments), or <see langword="null"/> to ignore it.</param>
+    /// <param name="onToolCallResult">Invoked with a tool call's result, or <see langword="null"/> to ignore it.</param>
+    public AgentTurnStreamSink(
+        Func<string, CancellationToken, Task> onDelta,
+        Func<string, string, string, CancellationToken, Task>? onToolCall = null,
+        Func<string, string, CancellationToken, Task>? onToolCallResult = null)
     {
         ArgumentNullException.ThrowIfNull(onDelta);
         _onDelta = onDelta;
+        _onToolCall = onToolCall;
+        _onToolCallResult = onToolCallResult;
     }
 
     /// <inheritdoc />
     public Task EmitAsync(string delta, CancellationToken cancellationToken) =>
         string.IsNullOrEmpty(delta) ? Task.CompletedTask : _onDelta(delta, cancellationToken);
+
+    /// <inheritdoc />
+    public Task EmitToolCallAsync(string toolCallId, string toolCallName, string argsJson, CancellationToken cancellationToken) =>
+        _onToolCall?.Invoke(toolCallId, toolCallName, argsJson, cancellationToken) ?? Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken) =>
+        _onToolCallResult?.Invoke(toolCallId, result, cancellationToken) ?? Task.CompletedTask;
 }

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -365,6 +365,12 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		CancellationToken cancellationToken)
 	{
 		var builder = new StringBuilder();
+		// Tracks which CallIds actually got a TOOL_CALL_START streamed, so a matching result can't
+		// stream on its own merits (a non-empty CallId) alone — the two guards below check different
+		// fields (Name vs nothing further), so a call skipped for missing Name but carrying a valid
+		// CallId would otherwise leave its result to stream unmatched: a TOOL_CALL_RESULT with no
+		// preceding TOOL_CALL_START a client could place.
+		var startedCallIds = new HashSet<string>();
 		await foreach (var update in agent.RunStreamingAsync(messages, cancellationToken: cancellationToken))
 		{
 			var delta = update.Text;
@@ -378,15 +384,19 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			{
 				switch (content)
 				{
-					case FunctionCallContent call when !string.IsNullOrEmpty(call.Name):
+					// Guards on both CallId and Name: a call with no id can't be matched to its later
+					// result (an empty toolCallId would violate the wire contract's required field), and
+					// a call with no name has nothing meaningful to announce.
+					case FunctionCallContent { CallId.Length: > 0 } call when !string.IsNullOrEmpty(call.Name):
+						startedCallIds.Add(call.CallId);
 						await sink.EmitToolCallAsync(
 							call.CallId, call.Name, RedactedArgsJson(call, redactor, logger), cancellationToken);
 						break;
 
-					// Guards on CallId, mirroring the FunctionCallContent case's guard on Name: a result
-					// with no id cannot be matched to the call it belongs to, so emitting it would only
-					// produce an orphaned frame a client cannot place.
-					case FunctionResultContent { CallId.Length: > 0 } result:
+					// Guards on CallId AND on having actually streamed a matching TOOL_CALL_START — a
+					// non-empty CallId alone isn't enough, since the call side can be skipped (e.g. empty
+					// Name) while still carrying a CallId this result shares.
+					case FunctionResultContent { CallId.Length: > 0 } result when startedCallIds.Contains(result.CallId):
 						var resultText = result.Result?.ToString() ?? string.Empty;
 						await sink.EmitToolCallResultAsync(
 							result.CallId, ToolPayloadRedactor.RedactAndTruncate(resultText, redactor), cancellationToken);

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -352,8 +352,11 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// <see cref="IAgentTurnStreamSink.EmitToolCallAsync"/> documents its JSON as always complete, and a
 	/// preview-length cap would silently hand a client invalid, unparseable JSON instead; the result
 	/// text has no such contract and gets the same redact-and-truncate preview treatment the middleware
-	/// uses. Usage and tool-call capture still flow through the chat-client middleware, so the caller's
-	/// post-turn accounting is unchanged. The same <paramref name="cancellationToken"/> flows to
+	/// uses — except when the tool failed, where a generic message is streamed instead of
+	/// <see cref="FunctionResultContent.Result"/>'s raw text, since <c>IncludeDetailedErrors</c> bakes
+	/// the exception message into that string (see <see cref="RedactedResultPreview"/>). Usage and
+	/// tool-call capture still flow through the chat-client middleware, so the caller's post-turn
+	/// accounting is unchanged. The same <paramref name="cancellationToken"/> flows to
 	/// <c>RunStreamingAsync</c>, so a disconnected consumer aborts the model call.
 	/// </summary>
 	private static async Task<string> RunStreamingTurnAsync(
@@ -369,7 +372,9 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		// stream on its own merits (a non-empty CallId) alone — the two guards below check different
 		// fields (Name vs nothing further), so a call skipped for missing Name but carrying a valid
 		// CallId would otherwise leave its result to stream unmatched: a TOOL_CALL_RESULT with no
-		// preceding TOOL_CALL_START a client could place.
+		// preceding TOOL_CALL_START a client could place. Deliberately scoped to this one call — the
+		// invariant it enforces (no orphaned RESULT) is local to a single turn's stream, not something
+		// a second IAgentTurnStreamSink elsewhere in the codebase needs to share.
 		var startedCallIds = new HashSet<string>();
 		await foreach (var update in agent.RunStreamingAsync(messages, cancellationToken: cancellationToken))
 		{
@@ -381,55 +386,85 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			}
 
 			foreach (var content in update.Contents)
-			{
-				switch (content)
-				{
-					// Guards on both CallId and Name: a call with no id can't be matched to its later
-					// result (an empty toolCallId would violate the wire contract's required field), and
-					// a call with no name has nothing meaningful to announce.
-					case FunctionCallContent { CallId.Length: > 0 } call when !string.IsNullOrEmpty(call.Name):
-						startedCallIds.Add(call.CallId);
-						await sink.EmitToolCallAsync(
-							call.CallId, call.Name, RedactedArgsJson(call, redactor, logger), cancellationToken);
-						break;
-
-					// Guards on CallId AND on having actually streamed a matching TOOL_CALL_START — a
-					// non-empty CallId alone isn't enough, since the call side can be skipped (e.g. empty
-					// Name) while still carrying a CallId this result shares.
-					case FunctionResultContent { CallId.Length: > 0 } result when startedCallIds.Contains(result.CallId):
-						var resultText = result.Result?.ToString() ?? string.Empty;
-						await sink.EmitToolCallResultAsync(
-							result.CallId, ToolPayloadRedactor.RedactAndTruncate(resultText, redactor), cancellationToken);
-						break;
-				}
-			}
+				await EmitToolCallActivityAsync(content, sink, startedCallIds, redactor, logger, cancellationToken);
 		}
 
 		return builder.ToString();
 	}
 
 	/// <summary>
-	/// Serializes and redacts a tool call's arguments for streaming. Mirrors
-	/// <c>ToolDiagnosticsMiddleware.LogToolCallsInResponse</c>'s own try/catch around the identical
-	/// serialize call: an unserializable argument value (an unsupported CLR type from a poorly-behaved
-	/// tool) must degrade to a logged warning, not abort the whole turn — text already streamed to the
-	/// client before this tool call must not be thrown away over a JSON-serialization failure.
+	/// Handles one item from a streaming update's <c>Contents</c> — a tool-call decision or a tool's
+	/// result — forwarding it to <paramref name="sink"/> when it's one of the two content types this
+	/// stream cares about. Extracted from <see cref="RunStreamingTurnAsync"/> to keep that method under
+	/// the 50-line convention.
+	/// </summary>
+	private static async Task EmitToolCallActivityAsync(
+		AIContent content,
+		IAgentTurnStreamSink sink,
+		HashSet<string> startedCallIds,
+		ISecretRedactor? redactor,
+		ILogger logger,
+		CancellationToken cancellationToken)
+	{
+		switch (content)
+		{
+			// Guards on both CallId and Name: a call with no id can't be matched to its later
+			// result (an empty toolCallId would violate the wire contract's required field), and
+			// a call with no name has nothing meaningful to announce.
+			case FunctionCallContent { CallId.Length: > 0 } call when !string.IsNullOrEmpty(call.Name):
+				startedCallIds.Add(call.CallId);
+				await sink.EmitToolCallAsync(
+					call.CallId, call.Name, RedactedArgsJson(call, redactor, logger), cancellationToken);
+				break;
+
+			// Guards on CallId AND on having actually streamed a matching TOOL_CALL_START — a
+			// non-empty CallId alone isn't enough, since the call side can be skipped (e.g. empty
+			// Name) while still carrying a CallId this result shares.
+			case FunctionResultContent { CallId.Length: > 0 } result when startedCallIds.Contains(result.CallId):
+				await sink.EmitToolCallResultAsync(
+					result.CallId, RedactedResultPreview(result, redactor, logger), cancellationToken);
+				break;
+		}
+	}
+
+	/// <summary>
+	/// Serializes and redacts a tool call's arguments for streaming. An unserializable argument value
+	/// (an unsupported CLR type from a poorly-behaved tool), or a redaction-contract violation from
+	/// <paramref name="redactor"/>, must degrade to a logged warning via
+	/// <see cref="ToolPayloadRedactor.TryOrFallback"/>, not abort the whole turn — text already
+	/// streamed to the client before this tool call must not be thrown away over either failure.
 	/// </summary>
 	private static string RedactedArgsJson(FunctionCallContent call, ISecretRedactor? redactor, ILogger logger)
 	{
 		if (call.Arguments is not { Count: > 0 } args)
 			return "{}";
 
-		try
-		{
-			return ToolPayloadRedactor.Redact(JsonSerializer.Serialize(args), redactor);
-		}
-		catch (Exception ex)
-		{
-			logger.LogWarning(ex,
-				"Failed to serialize streamed tool-call arguments for {Tool} CallId={CallId}", call.Name, call.CallId);
-			return "{}";
-		}
+		return ToolPayloadRedactor.TryOrFallback(
+			() => ToolPayloadRedactor.Redact(JsonSerializer.Serialize(args), redactor),
+			logger,
+			$"Failed to serialize or redact streamed tool-call arguments for {call.Name} CallId={call.CallId}",
+			fallback: "{}");
+	}
+
+	/// <summary>
+	/// Builds a safe, streamable preview of a tool's result. <see cref="ToolPayloadRedactor.SafeResultText"/>
+	/// substitutes a generic message when the call failed, since <c>FunctionInvokingChatClient</c>'s
+	/// <c>IncludeDetailedErrors</c> option (set unconditionally by <c>AgentFactory</c>) bakes the raw
+	/// exception message into <see cref="FunctionResultContent.Result"/> — the same substitution
+	/// <c>ToolDiagnosticsMiddleware</c> applies before persisting to the trace store a dashboard later
+	/// renders, since that is just as much an exposure point as this client-facing SSE frame. A
+	/// redaction-contract violation from <paramref name="redactor"/> degrades the same way, via
+	/// <see cref="ToolPayloadRedactor.TryOrFallback"/>.
+	/// </summary>
+	private static string RedactedResultPreview(FunctionResultContent result, ISecretRedactor? redactor, ILogger logger)
+	{
+		var resultText = ToolPayloadRedactor.SafeResultText(result);
+
+		return ToolPayloadRedactor.TryOrFallback(
+			() => ToolPayloadRedactor.RedactAndTruncate(resultText, redactor),
+			logger,
+			$"Failed to redact streamed tool-call result for CallId={result.CallId}",
+			fallback: "[unavailable]");
 	}
 
 	private static void RecordTurnError(string agentName)

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -368,13 +368,14 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		CancellationToken cancellationToken)
 	{
 		var builder = new StringBuilder();
-		// Tracks which CallIds actually got a TOOL_CALL_START streamed, so a matching result can't
-		// stream on its own merits (a non-empty CallId) alone — the two guards below check different
-		// fields (Name vs nothing further), so a call skipped for missing Name but carrying a valid
-		// CallId would otherwise leave its result to stream unmatched: a TOOL_CALL_RESULT with no
-		// preceding TOOL_CALL_START a client could place. Deliberately scoped to this one call — the
-		// invariant it enforces (no orphaned RESULT) is local to a single turn's stream, not something
-		// a second IAgentTurnStreamSink elsewhere in the codebase needs to share.
+		// Tracks which CallIds actually got a TOOL_CALL_START streamed — two jobs. (1) A matching
+		// result can't stream on its own merits (a non-empty CallId) alone: a call skipped for missing
+		// Name but carrying a valid CallId would otherwise leave its result to stream unmatched, a
+		// TOOL_CALL_RESULT with no preceding TOOL_CALL_START a client could place. (2) A provider
+		// connector that surfaces the same call twice must not double-emit a START/ARGS/END triple —
+		// HashSet.Add's bool return doubles as that guard. Deliberately scoped to this one call — the
+		// invariant it enforces is local to a single turn's stream, not something a second
+		// IAgentTurnStreamSink elsewhere in the codebase needs to share.
 		var startedCallIds = new HashSet<string>();
 		await foreach (var update in agent.RunStreamingAsync(messages, cancellationToken: cancellationToken))
 		{
@@ -411,8 +412,10 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			// Guards on both CallId and Name: a call with no id can't be matched to its later
 			// result (an empty toolCallId would violate the wire contract's required field), and
 			// a call with no name has nothing meaningful to announce.
-			case FunctionCallContent { CallId.Length: > 0 } call when !string.IsNullOrEmpty(call.Name):
-				startedCallIds.Add(call.CallId);
+			// startedCallIds.Add returning false means this CallId already started — a provider
+			// connector surfacing the same call twice must not double-emit a TOOL_CALL_START/ARGS/END
+			// triple to the client.
+			case FunctionCallContent { CallId.Length: > 0 } call when !string.IsNullOrEmpty(call.Name) && startedCallIds.Add(call.CallId):
 				await sink.EmitToolCallAsync(
 					call.CallId, call.Name, RedactedArgsJson(call, redactor, logger), cancellationToken);
 				break;

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -40,6 +40,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	private readonly IContextSnapshotNotifier _snapshotNotifier;
 	private readonly TimeProvider _timeProvider;
 	private readonly ILogger<ExecuteAgentTurnCommandHandler> _logger;
+	private readonly ISecretRedactor? _redactor;
 
 	public ExecuteAgentTurnCommandHandler(
 		IAgentConversationCache agentCache,
@@ -52,7 +53,8 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		IContextSnapshotComputer snapshotComputer,
 		IContextSnapshotNotifier snapshotNotifier,
 		TimeProvider timeProvider,
-		ILogger<ExecuteAgentTurnCommandHandler> logger)
+		ILogger<ExecuteAgentTurnCommandHandler> logger,
+		ISecretRedactor? redactor = null)
 	{
 		_agentCache = agentCache;
 		_admissionPipeline = admissionPipeline;
@@ -65,6 +67,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		_snapshotNotifier = snapshotNotifier;
 		_timeProvider = timeProvider;
 		_logger = logger;
+		_redactor = redactor;
 	}
 
 	public async Task<AgentTurnResult> Handle(ExecuteAgentTurnCommand request, CancellationToken cancellationToken)
@@ -143,7 +146,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 					// sink (tests, batch callers) fall back to a single blocking call.
 					var streamSink = AgentTurnStreamSink.Current;
 					response = streamSink is not null
-						? await RunStreamingTurnAsync(agent, messages, streamSink, cancellationToken)
+						? await RunStreamingTurnAsync(agent, messages, streamSink, _redactor, _logger, cancellationToken)
 						: await agent.RunAsync(messages, cancellationToken: cancellationToken);
 					turnSw.Stop();
 				}
@@ -339,29 +342,84 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// <summary>
 	/// Runs the turn in streaming mode, emitting each assistant text delta to
 	/// <paramref name="sink"/> as it arrives and returning the concatenated full text.
-	/// Tool invocation, usage, and tool-call capture happen transparently in the
-	/// chat-client middleware pipeline (which instruments the streaming path), so the
-	/// caller's post-turn accounting is unchanged. The same <paramref name="cancellationToken"/>
-	/// flows to <c>RunStreamingAsync</c>, so a disconnected consumer aborts the model call.
+	/// Also forwards tool-call activity — <see cref="FunctionCallContent"/> (the model's decision to
+	/// call a tool) and <see cref="FunctionResultContent"/> (the tool's output, once
+	/// <c>FunctionInvokingChatClient</c> has actually invoked it) both arrive as part of the same
+	/// <c>update.Contents</c> stream. Both are redacted via <see cref="ToolPayloadRedactor"/> before
+	/// reaching the sink — the same treatment <c>ToolDiagnosticsMiddleware</c> applies before the
+	/// identical data is persisted, since a live SSE stream is just as much an exposure point for
+	/// secrets as the observability store is. Arguments are redacted only, never truncated —
+	/// <see cref="IAgentTurnStreamSink.EmitToolCallAsync"/> documents its JSON as always complete, and a
+	/// preview-length cap would silently hand a client invalid, unparseable JSON instead; the result
+	/// text has no such contract and gets the same redact-and-truncate preview treatment the middleware
+	/// uses. Usage and tool-call capture still flow through the chat-client middleware, so the caller's
+	/// post-turn accounting is unchanged. The same <paramref name="cancellationToken"/> flows to
+	/// <c>RunStreamingAsync</c>, so a disconnected consumer aborts the model call.
 	/// </summary>
 	private static async Task<string> RunStreamingTurnAsync(
 		AIAgent agent,
 		IReadOnlyList<ChatMessage> messages,
 		IAgentTurnStreamSink sink,
+		ISecretRedactor? redactor,
+		ILogger logger,
 		CancellationToken cancellationToken)
 	{
 		var builder = new StringBuilder();
 		await foreach (var update in agent.RunStreamingAsync(messages, cancellationToken: cancellationToken))
 		{
 			var delta = update.Text;
-			if (string.IsNullOrEmpty(delta))
-				continue;
+			if (!string.IsNullOrEmpty(delta))
+			{
+				builder.Append(delta);
+				await sink.EmitAsync(delta, cancellationToken);
+			}
 
-			builder.Append(delta);
-			await sink.EmitAsync(delta, cancellationToken);
+			foreach (var content in update.Contents)
+			{
+				switch (content)
+				{
+					case FunctionCallContent call when !string.IsNullOrEmpty(call.Name):
+						await sink.EmitToolCallAsync(
+							call.CallId, call.Name, RedactedArgsJson(call, redactor, logger), cancellationToken);
+						break;
+
+					// Guards on CallId, mirroring the FunctionCallContent case's guard on Name: a result
+					// with no id cannot be matched to the call it belongs to, so emitting it would only
+					// produce an orphaned frame a client cannot place.
+					case FunctionResultContent { CallId.Length: > 0 } result:
+						var resultText = result.Result?.ToString() ?? string.Empty;
+						await sink.EmitToolCallResultAsync(
+							result.CallId, ToolPayloadRedactor.RedactAndTruncate(resultText, redactor), cancellationToken);
+						break;
+				}
+			}
 		}
 
 		return builder.ToString();
+	}
+
+	/// <summary>
+	/// Serializes and redacts a tool call's arguments for streaming. Mirrors
+	/// <c>ToolDiagnosticsMiddleware.LogToolCallsInResponse</c>'s own try/catch around the identical
+	/// serialize call: an unserializable argument value (an unsupported CLR type from a poorly-behaved
+	/// tool) must degrade to a logged warning, not abort the whole turn — text already streamed to the
+	/// client before this tool call must not be thrown away over a JSON-serialization failure.
+	/// </summary>
+	private static string RedactedArgsJson(FunctionCallContent call, ISecretRedactor? redactor, ILogger logger)
+	{
+		if (call.Arguments is not { Count: > 0 } args)
+			return "{}";
+
+		try
+		{
+			return ToolPayloadRedactor.Redact(JsonSerializer.Serialize(args), redactor);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex,
+				"Failed to serialize streamed tool-call arguments for {Tool} CallId={CallId}", call.Name, call.CallId);
+			return "{}";
+		}
 	}
 
 	private static void RecordTurnError(string agentName)

--- a/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
@@ -77,6 +77,20 @@ public sealed class PatternSecretRedactor : ISecretRedactor
         return false;
     }
 
+    // Every compiled pattern below gets a match timeout — this redactor now sits on a client-facing
+    // hot path (streamed tool-call arguments/results), fed by tool-controlled text, and the pattern
+    // set is expected to keep growing. None of today's patterns has a super-linear backtracking path,
+    // but a timeout is cheap insurance that a future addition can't turn a large tool result into a
+    // CPU stall on the request thread.
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+
+    // Keys covered by both the JSON-quoted pattern and the generic key=value/key:value pattern below —
+    // kept as one shared alternation so the two patterns can't drift out of sync (a key redacted in one
+    // shape but not the other was exactly the bug that motivated this constant).
+    private const string SecretKeyAlternation =
+        "api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd|" +
+        "account[_-]?key|shared[_-]?access[_-]?key|connection[_-]?string|sas[_-]?token";
+
     private static (Regex Pattern, string Replacement)[] BuildRedactionPatterns() =>
     [
         // Bearer tokens: case-insensitive; replaces entire match preserving the "Bearer" prefix.
@@ -84,7 +98,7 @@ public sealed class PatternSecretRedactor : ISecretRedactor
         (
             new Regex(
                 @"Bearer\s+[A-Za-z0-9\-._~+/]+=*",
-                RegexOptions.Compiled | RegexOptions.IgnoreCase),
+                RegexOptions.Compiled | RegexOptions.IgnoreCase, MatchTimeout),
             "Bearer [REDACTED]"
         ),
 
@@ -94,31 +108,45 @@ public sealed class PatternSecretRedactor : ISecretRedactor
         (
             new Regex(
                 @"(?i)(AccountKey|Password|pwd|SharedAccessKey)\s*=\s*(?!\[REDACTED\])[^;""'\s]+",
-                RegexOptions.Compiled),
+                RegexOptions.Compiled, MatchTimeout),
             "$1=[REDACTED]"
         ),
 
-        // Generic key=value / key:value secret pairs. Key alternation matches the JSON-quoted pattern
-        // below — client_secret/password/pwd only had "=" coverage via the connection-string pattern
-        // above, never ":", and client_secret had neither; keeping the two alternations in sync avoids
-        // a key being redacted in one shape (quoted JSON) but not another (bare key: value).
-        // Value matcher [^;"'\s]+ (matching the connection-string pattern above) stops at a quote,
-        // semicolon, or apostrophe — a plain \S+ is greedy across the whole rest of a whitespace-free
-        // string, so on compact JSON (no spaces) a key found inside a serialized string value (e.g.
-        // "...?api_key=abc123" embedded in a URL) would consume every remaining character in the
-        // document, including the closing quote, brace, and any keys after it, corrupting the JSON and
-        // silently dropping the rest of the payload's data.
+        // Generic key=value / key:value secret pairs, covering both quoted and unquoted values (a
+        // bare key with a quoted value — "api_key: \"value\"" in YAML, "api_key=\"value\"" in a log
+        // line — is a normal, common shape the JSON-quoted pattern below does NOT cover, since that
+        // pattern requires the KEY to be quoted too).
+        //
+        // The value alternation tries, in order: a double-quoted string, a single-quoted string, then
+        // a bounded unquoted run. Two mistakes this specifically avoids, both shipped and caught by
+        // review before merge:
+        //   1. A bare \S+ is greedy across the whole rest of a whitespace-free string, so on compact
+        //      JSON (no spaces) a key found inside a serialized string value (e.g. "...?api_key=abc123"
+        //      embedded in a URL) would consume every remaining character in the document — the
+        //      closing quote, every later key, the closing brace — corrupting the JSON and silently
+        //      dropping the rest of the payload.
+        //   2. Narrowing the value class to [^;"'\s]+ alone (excluding quotes) fixes (1) but makes the
+        //      pattern quote-hostile: a value that starts with a quote has nothing left to match at
+        //      that position, so the match fails outright and the secret passes through completely
+        //      unredacted — worse than the greedy-corruption bug it replaced, since (1) still exposed
+        //      the leaked leading string of the secret while (2) exposed the whole one. The quoted
+        //      alternatives above must be tried first so a quoted value is matched by its own bounded
+        //      class instead of falling through to the unquoted one.
+        //
+        // The separator is captured (not hardcoded) so the replacement preserves whichever of "=" or
+        // ":" the input actually used, rather than silently rewriting "api_key: value" into
+        // "api_key=value" and potentially invalidating the surrounding document.
         // Negative lookahead (?!\[REDACTED\]) ensures idempotency.
         (
             new Regex(
-                @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd)\s*[=:]\s*(?!\[REDACTED\])[^;""'\s]+",
-                RegexOptions.Compiled),
-            "$1=[REDACTED]"
+                $@"(?i)({SecretKeyAlternation})(\s*[=:]\s*)(?!\[REDACTED\])(?:""[^""]*""|'[^']*'|[^;""'\s]+)",
+                RegexOptions.Compiled, MatchTimeout),
+            "$1$2[REDACTED]"
         ),
 
         // JSON-quoted key/value secret pairs: "api_key":"value". The generic pattern above requires
-        // an unquoted \S+ value, so it never matches this shape — and tool payloads streamed to
-        // clients are routinely JSON (function-call arguments, tool results serialized as objects).
+        // an unquoted key, so it never matches this shape — and tool payloads streamed to clients are
+        // routinely JSON (function-call arguments, tool results serialized as objects).
         // The value matcher (?:\\.|[^"\\])* is escape-aware — it treats "\"" as part of the value
         // rather than ending the match there, unlike a plain [^"]* which stops at the first quote
         // character regardless of the preceding backslash and truncates the match mid-value, leaking
@@ -126,8 +154,8 @@ public sealed class PatternSecretRedactor : ISecretRedactor
         // Negative lookahead (?!\[REDACTED\]) ensures idempotency.
         (
             new Regex(
-                @"(?i)""(api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd)""\s*:\s*""(?!\[REDACTED\])(?:\\.|[^""\\])*""",
-                RegexOptions.Compiled),
+                $@"(?i)""({SecretKeyAlternation})""\s*:\s*""(?!\[REDACTED\])(?:\\.|[^""\\])*""",
+                RegexOptions.Compiled, MatchTimeout),
             @"""$1"":""[REDACTED]"""
         ),
     ];

--- a/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
@@ -102,10 +102,16 @@ public sealed class PatternSecretRedactor : ISecretRedactor
         // below — client_secret/password/pwd only had "=" coverage via the connection-string pattern
         // above, never ":", and client_secret had neither; keeping the two alternations in sync avoids
         // a key being redacted in one shape (quoted JSON) but not another (bare key: value).
+        // Value matcher [^;"'\s]+ (matching the connection-string pattern above) stops at a quote,
+        // semicolon, or apostrophe — a plain \S+ is greedy across the whole rest of a whitespace-free
+        // string, so on compact JSON (no spaces) a key found inside a serialized string value (e.g.
+        // "...?api_key=abc123" embedded in a URL) would consume every remaining character in the
+        // document, including the closing quote, brace, and any keys after it, corrupting the JSON and
+        // silently dropping the rest of the payload's data.
         // Negative lookahead (?!\[REDACTED\]) ensures idempotency.
         (
             new Regex(
-                @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd)\s*[=:]\s*(?!\[REDACTED\])\S+",
+                @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd)\s*[=:]\s*(?!\[REDACTED\])[^;""'\s]+",
                 RegexOptions.Compiled),
             "$1=[REDACTED]"
         ),

--- a/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
@@ -98,13 +98,31 @@ public sealed class PatternSecretRedactor : ISecretRedactor
             "$1=[REDACTED]"
         ),
 
-        // Generic key=value / key:value secret pairs.
+        // Generic key=value / key:value secret pairs. Key alternation matches the JSON-quoted pattern
+        // below — client_secret/password/pwd only had "=" coverage via the connection-string pattern
+        // above, never ":", and client_secret had neither; keeping the two alternations in sync avoids
+        // a key being redacted in one shape (quoted JSON) but not another (bare key: value).
         // Negative lookahead (?!\[REDACTED\]) ensures idempotency.
         (
             new Regex(
-                @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[=:]\s*(?!\[REDACTED\])\S+",
+                @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd)\s*[=:]\s*(?!\[REDACTED\])\S+",
                 RegexOptions.Compiled),
             "$1=[REDACTED]"
+        ),
+
+        // JSON-quoted key/value secret pairs: "api_key":"value". The generic pattern above requires
+        // an unquoted \S+ value, so it never matches this shape — and tool payloads streamed to
+        // clients are routinely JSON (function-call arguments, tool results serialized as objects).
+        // The value matcher (?:\\.|[^"\\])* is escape-aware — it treats "\"" as part of the value
+        // rather than ending the match there, unlike a plain [^"]* which stops at the first quote
+        // character regardless of the preceding backslash and truncates the match mid-value, leaking
+        // the remainder of an escaped secret and corrupting the surrounding JSON in the output.
+        // Negative lookahead (?!\[REDACTED\]) ensures idempotency.
+        (
+            new Regex(
+                @"(?i)""(api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd)""\s*:\s*""(?!\[REDACTED\])(?:\\.|[^""\\])*""",
+                RegexOptions.Compiled),
+            @"""$1"":""[REDACTED]"""
         ),
     ];
 }

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -104,7 +104,7 @@ The disjointness check exists because the global registries scan discovery roots
 
 ### Streaming transport
 
-`BundleRunStreamer` adds only the transport concern: it arms `AgentTurnStreamSink` so token deltas become `TEXT_MESSAGE_CONTENT` frames, and clears it in a `finally` so it can never leak onto a later request on the same thread. `BundleStreamEventWriter` serializes against the `BundleStreamEvent` *base type* so `[JsonPolymorphic]` emits the `type` discriminator -- serializing by runtime type silently drops it. The six event records deliberately duplicate a small subset of AG-UI rather than referencing the dashboard's 25-event vocabulary; if a third host needs them, extract a shared SSE primitive then.
+`BundleRunStreamer` adds only the transport concern: it arms `AgentTurnStreamSink` so token deltas become `TEXT_MESSAGE_CONTENT` frames, and clears it in a `finally` so it can never leak onto a later request on the same thread. `BundleStreamEventWriter` serializes against the `BundleStreamEvent` *base type* so `[JsonPolymorphic]` emits the `type` discriminator -- serializing by runtime type silently drops it. The ten event records deliberately duplicate a small subset of AG-UI rather than referencing the dashboard's 25-event vocabulary; if a third host needs them, extract a shared SSE primitive then.
 
 ### Fail-closed authentication, own audience
 
@@ -150,7 +150,7 @@ Presentation.ExecutionApi/
 ├── Streaming/
 │   ├── BundleRunStreamer.cs         Arms the text sink, calls IBundleRunExecutor, emits lifecycle frames
 │   ├── BundleStreamEventWriter.cs   `data: {json}\n\n`, flushed, write-serialized
-│   └── BundleStreamEvents.cs        The six AG-UI-shaped event records
+│   └── BundleStreamEvents.cs        The ten AG-UI-shaped event records
 ├── appsettings.json                 Enables BundleExecution; Auth intentionally empty
 └── appsettings.Development.json     Local opt-in (anonymous auth)
 ```

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleRunStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleRunStreamer.cs
@@ -59,16 +59,29 @@ public sealed class BundleRunStreamer
         // needs no synchronisation.
         var textStarted = false;
         var previousSink = AgentTurnStreamSink.Current;
-        AgentTurnStreamSink.Current = new AgentTurnStreamSink(async (delta, ct) =>
-        {
-            if (!textStarted)
+        AgentTurnStreamSink.Current = new AgentTurnStreamSink(
+            onDelta: async (delta, ct) =>
             {
-                textStarted = true;
-                await writer.WriteAsync(new BundleTextMessageStartEvent(messageId, "assistant"), ct).ConfigureAwait(false);
-            }
+                if (!textStarted)
+                {
+                    textStarted = true;
+                    await writer.WriteAsync(new BundleTextMessageStartEvent(messageId, "assistant"), ct).ConfigureAwait(false);
+                }
 
-            await writer.WriteAsync(new BundleTextMessageContentEvent(messageId, delta), ct).ConfigureAwait(false);
-        });
+                await writer.WriteAsync(new BundleTextMessageContentEvent(messageId, delta), ct).ConfigureAwait(false);
+            },
+            onToolCall: async (toolCallId, toolCallName, argsJson, ct) =>
+            {
+                // The AG-UI wire protocol wants three separate frames; the sink itself only ever
+                // reports one complete tool call, so this is where that single call fans out into
+                // start/args/end — see IAgentTurnStreamSink.EmitToolCallAsync's remarks for why the
+                // seam doesn't carry that split.
+                await writer.WriteAsync(new BundleToolCallStartEvent(toolCallId, toolCallName), ct).ConfigureAwait(false);
+                await writer.WriteAsync(new BundleToolCallArgsEvent(toolCallId, argsJson), ct).ConfigureAwait(false);
+                await writer.WriteAsync(new BundleToolCallEndEvent(toolCallId), ct).ConfigureAwait(false);
+            },
+            onToolCallResult: (toolCallId, result, ct) =>
+                writer.WriteAsync(new BundleToolCallResultEvent(toolCallId, result), ct));
 
         BundleRunExecution execution;
         try

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
@@ -25,6 +25,10 @@ namespace Presentation.ExecutionApi.Streaming;
 [JsonDerivedType(typeof(BundleTextMessageStartEvent), "TEXT_MESSAGE_START")]
 [JsonDerivedType(typeof(BundleTextMessageContentEvent), "TEXT_MESSAGE_CONTENT")]
 [JsonDerivedType(typeof(BundleTextMessageEndEvent), "TEXT_MESSAGE_END")]
+[JsonDerivedType(typeof(BundleToolCallStartEvent), "TOOL_CALL_START")]
+[JsonDerivedType(typeof(BundleToolCallArgsEvent), "TOOL_CALL_ARGS")]
+[JsonDerivedType(typeof(BundleToolCallEndEvent), "TOOL_CALL_END")]
+[JsonDerivedType(typeof(BundleToolCallResultEvent), "TOOL_CALL_RESULT")]
 [JsonDerivedType(typeof(BundleRunFinishedEvent), "RUN_FINISHED")]
 [JsonDerivedType(typeof(BundleRunErrorEvent), "RUN_ERROR")]
 public abstract record BundleStreamEvent;
@@ -54,6 +58,46 @@ public sealed record BundleTextMessageContentEvent(
 public sealed record BundleTextMessageEndEvent(
     /// <summary>The message that has finished streaming.</summary>
     [property: JsonPropertyName("messageId")] string MessageId) : BundleStreamEvent;
+
+/// <summary>
+/// Emitted when the agent decides to call a tool. Field names match the AgentHub's own AG-UI
+/// tool-call vocabulary (<c>Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs</c>) for consistency,
+/// even though this file deliberately does not reference those types directly — see this file's
+/// top-level remarks.
+/// </summary>
+public sealed record BundleToolCallStartEvent(
+    /// <summary>The provider-assigned id for this call, shared by every event for it.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId,
+    /// <summary>The name of the tool being called.</summary>
+    [property: JsonPropertyName("toolCallName")] string ToolCallName) : BundleStreamEvent;
+
+/// <summary>
+/// Carries a tool call's arguments. Unlike <see cref="BundleTextMessageContentEvent"/>, this is NOT an
+/// incremental delta — the underlying chat-client abstraction only ever exposes a tool call's
+/// arguments once fully assembled, so <see cref="Delta"/> always carries the complete JSON payload in
+/// one frame, immediately followed by <see cref="BundleToolCallEndEvent"/>.
+/// </summary>
+public sealed record BundleToolCallArgsEvent(
+    /// <summary>The call this payload belongs to.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId,
+    /// <summary>The tool call's complete arguments, serialized as JSON.</summary>
+    [property: JsonPropertyName("delta")] string Delta) : BundleStreamEvent;
+
+/// <summary>Signals that a tool call's arguments are complete.</summary>
+public sealed record BundleToolCallEndEvent(
+    /// <summary>The call that has finished emitting its arguments.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId) : BundleStreamEvent;
+
+/// <summary>
+/// Emitted once a tool call has actually run and produced a result. No precedent field-naming to
+/// match — <c>AgUiEventType.ToolCallResult</c> is a dead wire-vocabulary constant with no backing
+/// record anywhere in the repo.
+/// </summary>
+public sealed record BundleToolCallResultEvent(
+    /// <summary>The call this result belongs to.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId,
+    /// <summary>The tool's output.</summary>
+    [property: JsonPropertyName("result")] string Result) : BundleStreamEvent;
 
 /// <summary>Emitted once on successful completion of a streamed run. Terminal; no further frames follow.</summary>
 public sealed record BundleRunFinishedEvent(

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
@@ -96,7 +96,10 @@ public sealed record BundleToolCallEndEvent(
 public sealed record BundleToolCallResultEvent(
     /// <summary>The call this result belongs to.</summary>
     [property: JsonPropertyName("toolCallId")] string ToolCallId,
-    /// <summary>The tool's output.</summary>
+    /// <summary>
+    /// A redacted, truncated preview of the tool's output — never the raw payload. On failure this is a
+    /// generic message, not the underlying exception text.
+    /// </summary>
     [property: JsonPropertyName("result")] string Result) : BundleStreamEvent;
 
 /// <summary>Emitted once on successful completion of a streamed run. Terminal; no further frames follow.</summary>

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
@@ -7,12 +7,12 @@ namespace Presentation.ExecutionApi.Streaming;
 /// </summary>
 /// <remarks>
 /// <para>
-/// These records reproduce the subset of the AG-UI protocol a bundle run needs — run lifecycle plus assistant
-/// text streaming — so any AG-UI client library consumes the feed unchanged. The bundle API deliberately ships
-/// its <em>own</em> small copy rather than referencing the dashboard's full AG-UI vocabulary: this is a lean,
-/// isolated host for externally-authored agents, and coupling it to the dashboard's 25-event protocol (plan,
-/// drift, learning, escalation events it will never emit) would defeat that isolation. If a third host ever
-/// needs this, extract a shared Server-Sent-Events primitive then.
+/// These records reproduce the subset of the AG-UI protocol a bundle run needs — run lifecycle, assistant
+/// text streaming, and tool-call activity — so any AG-UI client library consumes the feed unchanged. The
+/// bundle API deliberately ships its <em>own</em> small copy rather than referencing the dashboard's full
+/// AG-UI vocabulary: this is a lean, isolated host for externally-authored agents, and coupling it to the
+/// dashboard's 25-event protocol (plan, drift, learning, escalation events it will never emit) would defeat
+/// that isolation. If a third host ever needs this, extract a shared Server-Sent-Events primitive then.
 /// </para>
 /// <para>
 /// The <c>type</c> property is the polymorphic discriminator on the wire. Frames MUST be serialized against

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
@@ -1,0 +1,80 @@
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Helpers;
+
+/// <summary>
+/// Unit tests for <see cref="ToolPayloadRedactor"/>. The load-bearing invariant here is fail-loud, not
+/// fail-open: a redactor that violates <see cref="ISecretRedactor.Redact"/>'s contract (returning
+/// <see langword="null"/> for non-null input) must never result in the raw, unredacted payload silently
+/// reaching a caller — see <see cref="Redact_ContractViolatingRedactor_ThrowsRatherThanLeakingRawPayload"/>.
+/// </summary>
+public sealed class ToolPayloadRedactorTests
+{
+    private sealed class NullReturningRedactor : ISecretRedactor
+    {
+        public string? Redact(string? input) => null;
+        public bool IsSecretKey(string configKey) => false;
+    }
+
+    private sealed class MarkerRedactor : ISecretRedactor
+    {
+        public const string Secret = "super-secret-value";
+        public const string Replacement = "[REDACTED]";
+
+        public string? Redact(string? input) => input?.Replace(Secret, Replacement);
+        public bool IsSecretKey(string configKey) => false;
+    }
+
+    [Fact]
+    public void Redact_NullRedactor_ReturnsPayloadUnchanged()
+    {
+        var result = ToolPayloadRedactor.Redact("api_key=super-secret", redactor: null);
+
+        result.Should().Be("api_key=super-secret");
+    }
+
+    [Fact]
+    public void Redact_ContractViolatingRedactor_ThrowsRatherThanLeakingRawPayload()
+    {
+        var redactor = new NullReturningRedactor();
+
+        var act = () => ToolPayloadRedactor.Redact("api_key=super-secret", redactor);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*violating*")
+            .Which.Message.Should().NotContain("super-secret");
+    }
+
+    [Fact]
+    public void RedactAndTruncate_RedactsBeforeTruncating()
+    {
+        var redactor = new MarkerRedactor();
+        var padding = new string('x', 20);
+        var payload = $"{padding}{MarkerRedactor.Secret}";
+        var redactedLength = padding.Length + MarkerRedactor.Replacement.Length;
+
+        // maxLength sits just above the fully-redacted length, but well below the raw payload length —
+        // long enough to keep the whole "[REDACTED]" replacement intact, too short to have kept an
+        // unredacted secret if truncation had run before redaction instead of after.
+        var maxLength = redactedLength + 2;
+        payload.Length.Should().BeGreaterThan(maxLength, "the test must force real truncation to be meaningful");
+
+        var result = ToolPayloadRedactor.RedactAndTruncate(payload, redactor, maxLength);
+
+        result.Should().Contain(MarkerRedactor.Replacement);
+        result.Should().NotContain("super-secret");
+    }
+
+    [Fact]
+    public void RedactAndTruncate_NullRedactor_StillTruncates()
+    {
+        var payload = new string('a', 50);
+
+        var result = ToolPayloadRedactor.RedactAndTruncate(payload, redactor: null, maxLength: 10);
+
+        result.Should().Be(new string('a', 10));
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
@@ -120,6 +120,47 @@ public sealed class ToolDiagnosticsMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeNext_FunctionResultHasException_TraceRecordCategoryIsError()
+    {
+        // SafeResultText strips the raw exception text (the only signal a reader previously had that
+        // the call failed) out of PayloadSummary — ResultCategory must carry that signal structurally
+        // instead of silently staying hard-coded Success for a call that actually failed.
+        var innerClient = MakeChatClient();
+        var (writerMock, middleware) = MakeMiddlewareWithWriter(innerClient);
+
+        var failure = new FunctionResultContent("call-1", "irrelevant")
+        {
+            Exception = new InvalidOperationException("boom")
+        };
+        var messages = new ChatMessage[] { new(ChatRole.Tool, [failure]) };
+
+        await middleware.GetResponseAsync(messages, null, CancellationToken.None);
+
+        writerMock.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.ResultCategory == TraceResultCategories.Error),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeNext_FunctionResultSucceeded_TraceRecordCategoryIsSuccess()
+    {
+        var innerClient = MakeChatClient();
+        var (writerMock, middleware) = MakeMiddlewareWithWriter(innerClient);
+
+        var messages = new ChatMessage[] { new(ChatRole.Tool, [new FunctionResultContent("call-1", "42 results")]) };
+
+        await middleware.GetResponseAsync(messages, null, CancellationToken.None);
+
+        writerMock.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.ResultCategory == TraceResultCategories.Success),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task InvokeNext_AppendTraceThrows_DoesNotRethrow()
     {
         var innerClient = MakeChatClient();

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
@@ -95,6 +95,31 @@ public sealed class ToolDiagnosticsMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeNext_FunctionResultHasException_TraceRecordDoesNotContainRawExceptionText()
+    {
+        // FunctionInvokingChatClient's IncludeDetailedErrors option (set unconditionally by
+        // AgentFactory) bakes Exception.Message verbatim into Result — this trace record feeds the
+        // dashboard's per-invocation page via ToolInvocationDetailDto, an exposure point just as real
+        // as the streamed SSE frame ExecuteAgentTurnCommandHandler.RedactedResultPreview sanitizes.
+        var innerClient = MakeChatClient();
+        var (writerMock, middleware) = MakeMiddlewareWithWriter(innerClient);
+
+        var failure = new FunctionResultContent("call-1", "Error: Function failed. Exception: /etc/shadow not found")
+        {
+            Exception = new InvalidOperationException("/etc/shadow not found")
+        };
+        var messages = new ChatMessage[] { new(ChatRole.Tool, [failure]) };
+
+        await middleware.GetResponseAsync(messages, null, CancellationToken.None);
+
+        writerMock.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.PayloadSummary != null && !r.PayloadSummary.Contains("/etc/shadow")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task InvokeNext_AppendTraceThrows_DoesNotRethrow()
     {
         var innerClient = MakeChatClient();

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
@@ -56,4 +56,50 @@ public class AgentTurnStreamSinkTests
             AgentTurnStreamSink.Current = null;
         }
     }
+
+    [Fact]
+    public async Task EmitToolCallAsync_ForwardsToTheCallback()
+    {
+        (string Id, string Name, string Args)? received = null;
+        var sink = new AgentTurnStreamSink(
+            (_, _) => Task.CompletedTask,
+            onToolCall: (id, name, args, _) => { received = (id, name, args); return Task.CompletedTask; });
+
+        await sink.EmitToolCallAsync("call-1", "search", "{\"q\":\"x\"}", CancellationToken.None);
+
+        received.Should().Be(("call-1", "search", "{\"q\":\"x\"}"));
+    }
+
+    [Fact]
+    public async Task EmitToolCallAsync_NoCallbackConfigured_NoOps()
+    {
+        var sink = new AgentTurnStreamSink((_, _) => Task.CompletedTask);
+
+        var act = () => sink.EmitToolCallAsync("call-1", "search", "{}", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task EmitToolCallResultAsync_ForwardsToTheCallback()
+    {
+        (string Id, string Result)? received = null;
+        var sink = new AgentTurnStreamSink(
+            (_, _) => Task.CompletedTask,
+            onToolCallResult: (id, result, _) => { received = (id, result); return Task.CompletedTask; });
+
+        await sink.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+
+        received.Should().Be(("call-1", "42"));
+    }
+
+    [Fact]
+    public async Task EmitToolCallResultAsync_NoCallbackConfigured_NoOps()
+    {
+        var sink = new AgentTurnStreamSink((_, _) => Task.CompletedTask);
+
+        var act = () => sink.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
 }

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -163,6 +163,42 @@ public class ExecuteAgentTurnCommandHandlerTests
         }
     }
 
+    [Fact]
+    public async Task Handle_ActiveStreamSink_DuplicateFunctionCallContentForSameCallId_EmitsToolCallStartOnce()
+    {
+        // A provider connector surfacing the same FunctionCallContent twice for one CallId (a
+        // duplicate update, a retry-shaped delta) must not double-emit a TOOL_CALL_START/ARGS triple
+        // to the client — startedCallIds.Add's bool return gates the second occurrence.
+        var duplicateCall = new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = "docs" });
+        var agent = TestableAIAgent.StreamingContent([duplicateCall], [duplicateCall]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var callStarts = 0;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (_, _, _, _) => { callStarts++; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            callStarts.Should().Be(1);
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
     /// <summary>A value that throws when JSON-serialized, to prove a bad tool argument degrades the
     /// streamed args to a warning rather than aborting the whole turn.</summary>
     private sealed class UnserializableArgValue

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -286,6 +286,82 @@ public class ExecuteAgentTurnCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ActiveStreamSink_ToolCallWithNoCallId_IsNotStreamed()
+    {
+        // A FunctionCallContent with a valid Name but no CallId used to stream anyway (the guard only
+        // checked Name), producing a frame with an empty toolCallId that violates the wire contract's
+        // required field. Guard on both now, mirroring the FunctionResultContent guard below it.
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent(string.Empty, "search", new Dictionary<string, object?> { ["q"] = "docs" })]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var callFired = false;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (_, _, _, _) => { callFired = true; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            callFired.Should().BeFalse();
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_CallWithEmptyNameButValidCallId_ResultIsAlsoNotStreamed()
+    {
+        // The asymmetry this guards against: a call skipped for having no Name (so no TOOL_CALL_START
+        // ever fires) must not let its later result — which shares the same, valid CallId — stream
+        // anyway. Before the fix, only the call side was skipped; the result side's independent
+        // CallId-only guard let it through, producing a TOOL_CALL_RESULT with no preceding START.
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent("call-1", string.Empty, new Dictionary<string, object?> { ["q"] = "docs" })],
+            [new FunctionResultContent("call-1", "should not stream either")]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var events = new List<string>();
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args}"); return Task.CompletedTask; },
+                onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result}"); return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert — the call is skipped (empty Name) and its result must be too, since streaming it
+            // alone would be an orphaned TOOL_CALL_RESULT with no preceding TOOL_CALL_START.
+            events.Should().BeEmpty();
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
     public async Task Handle_ActiveStreamSink_ToolCallArgsAndResult_AreRedactedBeforeStreaming()
     {
         // The same payloads ToolDiagnosticsMiddleware redacts before persisting must also be

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -420,6 +420,51 @@ public class ExecuteAgentTurnCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ActiveStreamSink_ToolCallFailed_StreamsGenericMessageNotRawException()
+    {
+        // FunctionInvokingChatClient's IncludeDetailedErrors option (set unconditionally by
+        // AgentFactory) bakes Exception.Message verbatim into FunctionResultContent.Result — e.g.
+        // "Error: Function failed. Exception: could not open '/etc/shadow'". That text can carry file
+        // paths, connection details, or other internals that must never reach a browser, so a failed
+        // call streams a generic message instead of the raw Result text.
+        var failure = new FunctionResultContent("call-1", "Error: Function failed. Exception: /etc/shadow not found")
+        {
+            Exception = new InvalidOperationException("/etc/shadow not found")
+        };
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent("call-1", "read_file", new Dictionary<string, object?> { ["path"] = "x" })],
+            [failure]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var toolResult = string.Empty;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (_, _, _, _) => Task.CompletedTask,
+                onToolCallResult: (_, r, _) => { toolResult = r; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            toolResult.Should().NotContain("/etc/shadow");
+            toolResult.Should().NotBeEmpty();
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
     public async Task Handle_CallerCancelled_ReturnsCancelledErrorKind()
     {
         // A cancellation via the caller's token (e.g. client disconnect) is routine — it must

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -412,6 +412,13 @@ public class ExecuteAgentTurnCommandHandlerTests
             // Assert
             args.Should().NotContain("secret-value").And.Contain("[REDACTED]");
             toolResult.Should().Be("[REDACTED]");
+            // TOOL_CALL_ARGS.delta is documented as always-complete, parseable JSON — a redactor that
+            // corrupts the surrounding structure (e.g. a greedy value matcher, see
+            // PatternSecretRedactorTests.Redact_SecretKeywordInsideJsonStringValue_DoesNotConsumeRestOfDocument
+            // in Infrastructure.AI.Tests for the concrete regex bug this guards against) would break
+            // this contract silently.
+            var act = () => System.Text.Json.JsonDocument.Parse(args);
+            act.Should().NotThrow();
         }
         finally
         {

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -120,6 +120,230 @@ public class ExecuteAgentTurnCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ActiveStreamSink_ToolCallActivity_EmitsInOrderAroundText()
+    {
+        // Arrange — text, then a tool call, then its result, then more text; the sink's tool-call
+        // methods must fire in order and interleaved correctly with the text deltas.
+        var agent = TestableAIAgent.StreamingContent(
+            [new TextContent("Looking that up")],
+            [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = "docs" })],
+            [new FunctionResultContent("call-1", "42 results")],
+            [new TextContent(" — found it.")]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var events = new List<string>();
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (delta, _) => { events.Add($"delta:{delta}"); return Task.CompletedTask; },
+                onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args}"); return Task.CompletedTask; },
+                onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result}"); return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            events.Should().Equal(
+                "delta:Looking that up",
+                "call:call-1:search:{\"q\":\"docs\"}",
+                "result:call-1:42 results",
+                "delta: — found it.");
+            result.Success.Should().BeTrue();
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    /// <summary>A value that throws when JSON-serialized, to prove a bad tool argument degrades the
+    /// streamed args to a warning rather than aborting the whole turn.</summary>
+    private sealed class UnserializableArgValue
+    {
+        public string Poison => throw new InvalidOperationException("cannot serialize this value");
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_UnserializableToolArgs_DoesNotAbortTheTurn()
+    {
+        // A tool call whose Arguments dictionary holds a value System.Text.Json can't serialize must
+        // degrade gracefully (like ToolDiagnosticsMiddleware's identical serialize call does), not
+        // throw out of the streaming loop and lose text already streamed to the client.
+        var agent = TestableAIAgent.StreamingContent(
+            [new TextContent("Looking that up")],
+            [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["bad"] = new UnserializableArgValue() })],
+            [new TextContent(" — done.")]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var toolCallArgs = string.Empty;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (_, _, args, _) => { toolCallArgs = args; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert — the turn still completes and streams the surrounding text; the tool call is
+            // reported with a safe fallback instead of the handler throwing.
+            result.Success.Should().BeTrue();
+            result.Response.Should().Be("Looking that up — done.");
+            toolCallArgs.Should().Be("{}");
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_LongToolCallArgs_AreNotTruncated()
+    {
+        // BundleToolCallArgsEvent.Delta is documented as always carrying the complete JSON payload.
+        // Truncating it at the same preview-length cap used for log strings would hand a client
+        // invalid, unparseable JSON — arguments must be redacted only, never truncated.
+        var longValue = new string('x', 600);
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = longValue })]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var toolCallArgs = string.Empty;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (_, _, args, _) => { toolCallArgs = args; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            toolCallArgs.Length.Should().BeGreaterThan(500);
+            var act = () => System.Text.Json.JsonDocument.Parse(toolCallArgs);
+            act.Should().NotThrow("the streamed args must remain valid, complete JSON");
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_ToolResultWithNoCallId_IsNotStreamed()
+    {
+        // A FunctionResultContent with no CallId can never be matched back to a TOOL_CALL_START, so
+        // streaming it would only produce an orphaned frame a client cannot place.
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionResultContent(string.Empty, "orphaned result")]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var resultFired = false;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCallResult: (_, _, _) => { resultFired = true; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            resultFired.Should().BeFalse();
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_ToolCallArgsAndResult_AreRedactedBeforeStreaming()
+    {
+        // The same payloads ToolDiagnosticsMiddleware redacts before persisting must also be
+        // redacted before they reach a live SSE client — this handler is a second exposure point
+        // for the identical sensitive data.
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["token"] = "secret-value" })],
+            [new FunctionResultContent("call-1", "secret-value")]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(It.Is<string>(s => s.Contains("secret-value"))))
+            .Returns<string>(s => s.Replace("secret-value", "[REDACTED]"));
+        var handlerWithRedactor = new ExecuteAgentTurnCommandHandler(
+            _agentCache.Object,
+            Mock.Of<Application.AI.Common.Interfaces.Governance.IToolCallAdmissionPipeline>(
+                p => p.GetTrace() == Domain.AI.Governance.GovernanceTrace.Empty),
+            _agentRegistry.Object,
+            new Mock<ISkillMetadataRegistry>().Object,
+            new Application.AI.Common.Services.Context.ConversationRegistrationTracker(),
+            new Mock<IObservabilityStore>().Object,
+            Mock.Of<ILlmUsageCapture>(c => c.TakeSnapshot() == new LlmUsageSnapshot(0, 0, 0, 0, null, 0m, 0m, Array.Empty<string>())),
+            new DefaultContextSnapshotComputer(),
+            new NullContextSnapshotNotifier(),
+            TimeProvider.System,
+            NullLogger<ExecuteAgentTurnCommandHandler>.Instance,
+            redactor.Object);
+
+        var args = string.Empty;
+        var toolResult = string.Empty;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (_, _, a, _) => { args = a; return Task.CompletedTask; },
+                onToolCallResult: (_, r, _) => { toolResult = r; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await handlerWithRedactor.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            args.Should().NotContain("secret-value").And.Contain("[REDACTED]");
+            toolResult.Should().Be("[REDACTED]");
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
     public async Task Handle_CallerCancelled_ReturnsCancelledErrorKind()
     {
         // A cancellation via the caller's token (e.g. client disconnect) is routine — it must

--- a/src/Content/Tests/Application.Core.Tests/Helpers/TestableAIAgent.cs
+++ b/src/Content/Tests/Application.Core.Tests/Helpers/TestableAIAgent.cs
@@ -12,7 +12,7 @@ namespace Application.Core.Tests.Helpers;
 public sealed class TestableAIAgent : AIAgent
 {
     private readonly Func<IEnumerable<ChatMessage>, CancellationToken, Task<AgentResponse>> _runHandler;
-    private readonly IReadOnlyList<string>? _streamingChunks;
+    private readonly IReadOnlyList<IReadOnlyList<AIContent>>? _streamingContentUpdates;
 
     public TestableAIAgent(string responseText)
         : this(_ => new AgentResponse(new ChatMessage(ChatRole.Assistant, responseText)))
@@ -25,29 +25,40 @@ public sealed class TestableAIAgent : AIAgent
     }
 
     public TestableAIAgent(Func<IEnumerable<ChatMessage>, CancellationToken, Task<AgentResponse>> handler)
-        : this(handler, streamingChunks: null)
+        : this(handler, streamingContentUpdates: null)
     {
     }
 
     private TestableAIAgent(
         Func<IEnumerable<ChatMessage>, CancellationToken, Task<AgentResponse>> handler,
-        IReadOnlyList<string>? streamingChunks)
+        IReadOnlyList<IReadOnlyList<AIContent>>? streamingContentUpdates)
     {
         _runHandler = handler;
-        _streamingChunks = streamingChunks;
+        _streamingContentUpdates = streamingContentUpdates;
     }
 
     /// <summary>
     /// Creates a TestableAIAgent that emits the given <paramref name="chunks"/> as distinct
     /// streaming updates (and their concatenation for the blocking path), so streaming
-    /// callers can assert per-delta emission.
+    /// callers can assert per-delta emission. A thin wrapper over <see cref="StreamingContent"/>:
+    /// each chunk becomes a single-item <see cref="TextContent"/> update.
     /// </summary>
-    public static TestableAIAgent Streaming(params string[] chunks)
+    public static TestableAIAgent Streaming(params string[] chunks) =>
+        StreamingContent([.. chunks.Select(c => (IReadOnlyList<AIContent>)[new TextContent(c)])]);
+
+    /// <summary>
+    /// Creates a TestableAIAgent whose streaming path yields exactly the given content-bearing
+    /// updates, in order — e.g. a text delta, then a <see cref="FunctionCallContent"/>, then a
+    /// <see cref="FunctionResultContent"/> — so tests can simulate tool-call activity interleaved
+    /// with text mid-stream. The blocking path concatenates every <see cref="TextContent"/> across
+    /// all updates.
+    /// </summary>
+    public static TestableAIAgent StreamingContent(params IReadOnlyList<AIContent>[] updates)
     {
-        var full = string.Concat(chunks);
+        var full = string.Concat(updates.SelectMany(u => u).OfType<TextContent>().Select(t => t.Text));
         return new TestableAIAgent(
             (_, _) => Task.FromResult(new AgentResponse(new ChatMessage(ChatRole.Assistant, full))),
-            chunks);
+            streamingContentUpdates: updates);
     }
 
     /// <summary>
@@ -73,12 +84,12 @@ public sealed class TestableAIAgent : AIAgent
         AgentRunOptions? options,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        if (_streamingChunks is not null)
+        if (_streamingContentUpdates is not null)
         {
             // Surface configured failures (e.g. Throwing) on the streaming path too.
             await _runHandler(messages, cancellationToken);
-            foreach (var chunk in _streamingChunks)
-                yield return new AgentResponseUpdate(ChatRole.Assistant, chunk);
+            foreach (var contents in _streamingContentUpdates)
+                yield return new AgentResponseUpdate(ChatRole.Assistant, contents.ToList());
             yield break;
         }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
@@ -245,4 +245,28 @@ public class PatternSecretRedactorTests
         result.Should().Contain("[REDACTED]");
         result.Should().NotContain("superSecret123");
     }
+
+    /// <summary>
+    /// A secret keyword found inside a JSON string value (a query string embedded in a "url" field, on
+    /// whitespace-free serialized JSON) is redacted without corrupting the surrounding document. A
+    /// plain <c>\S+</c> value matcher is greedy across the entire rest of a whitespace-free string,
+    /// consuming every remaining character — the closing quote, every later key, and the closing brace
+    /// — and replacing it all with a single "[REDACTED]", destroying the rest of the payload's data.
+    /// </summary>
+    [Fact]
+    public void Redact_SecretKeywordInsideJsonStringValue_DoesNotConsumeRestOfDocument()
+    {
+        var sut = CreateRedactor();
+        var input = """{"url":"https://api.example.com/v1?api_key=abc123","method":"GET"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("[REDACTED]");
+        result.Should().NotContain("abc123");
+        // The rest of the JSON document must survive the redaction pass intact and remain valid JSON.
+        var act = () => System.Text.Json.JsonDocument.Parse(result);
+        act.Should().NotThrow();
+        using var doc = System.Text.Json.JsonDocument.Parse(result);
+        doc.RootElement.GetProperty("method").GetString().Should().Be("GET");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
@@ -269,4 +269,64 @@ public class PatternSecretRedactorTests
         using var doc = System.Text.Json.JsonDocument.Parse(result);
         doc.RootElement.GetProperty("method").GetString().Should().Be("GET");
     }
+
+    /// <summary>
+    /// A bare (unquoted) key with a double-quoted value — e.g. a log line or shell env-var display —
+    /// is redacted. Bounding the generic pattern's value class to [^;"'\s]+ alone (excluding quotes,
+    /// to fix the JSON-corruption case above) makes the pattern quote-hostile: a value starting with a
+    /// quote has nothing left to match at that position, so the whole match fails and the secret passes
+    /// through completely unredacted. The value alternation must try a quoted form first.
+    /// </summary>
+    [Theory]
+    [InlineData("api_key=\"sk-live-ABCDEF\"", "sk-live-ABCDEF")]
+    [InlineData("api_key='sk-live-ABCDEF'", "sk-live-ABCDEF")]
+    [InlineData("access_token=\"ghp_SECRETVALUE\"", "ghp_SECRETVALUE")]
+    public void Redact_UnquotedKeyWithQuotedValue_RedactsValue(string input, string secret)
+    {
+        var sut = CreateRedactor();
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("[REDACTED]");
+        result.Should().NotContain(secret);
+    }
+
+    /// <summary>
+    /// A YAML-style "key: value" pair with a quoted value is redacted, and the original ":" separator
+    /// survives in the output — the pre-existing replacement hardcoded "=" regardless of which
+    /// separator the input actually used, which would rewrite "api_key: value" into the different,
+    /// potentially document-invalidating "api_key=value".
+    /// </summary>
+    [Fact]
+    public void Redact_ColonSeparatedKeyWithQuotedValue_PreservesColonSeparator()
+    {
+        var sut = CreateRedactor();
+        var input = "api_key: \"sk-live-ABCDEF\"";
+
+        var result = sut.Redact(input);
+
+        result.Should().Be("api_key: [REDACTED]");
+    }
+
+    /// <summary>
+    /// Storage/connection-string-shaped keys (AccountKey, SharedAccessKey, connection string, SAS
+    /// token) are covered by the JSON-quoted pattern too, not just the semicolon-delimited
+    /// connection-string pattern — which cannot match the JSON shape "AccountKey":"..." since the
+    /// character after the key is a quote, not "=".
+    /// </summary>
+    [Theory]
+    [InlineData("AccountKey")]
+    [InlineData("SharedAccessKey")]
+    [InlineData("connection_string")]
+    [InlineData("sas_token")]
+    public void Redact_JsonQuotedStorageKey_RedactsValue(string key)
+    {
+        var sut = CreateRedactor();
+        var input = $$"""{"{{key}}":"b64-super-secret-value"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("[REDACTED]");
+        result.Should().NotContain("b64-super-secret-value");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
@@ -161,4 +161,88 @@ public class PatternSecretRedactorTests
         sut.IsSecretKey("DbPassword").Should().BeTrue();
         sut.IsSecretKey("MaxIterations").Should().BeFalse();
     }
+
+    /// <summary>
+    /// A JSON-quoted secret key/value pair — the shape tool call arguments and results are routinely
+    /// serialized as — is redacted. The pre-existing generic key=value/key:value pattern requires an
+    /// unquoted value and never matches this shape, so a distinct pattern is required.
+    /// </summary>
+    [Fact]
+    public void Redact_JsonQuotedApiKey_RedactsValue()
+    {
+        var sut = CreateRedactor();
+        var input = """{"toolName":"http_call","api_key":"sk-superSecret123","timeout":30}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("""api_key":"[REDACTED]""");
+        result.Should().NotContain("sk-superSecret123");
+    }
+
+    /// <summary>
+    /// Calling Redact twice on a JSON-quoted secret is idempotent — the "[REDACTED]" placeholder
+    /// must not itself match the JSON-shaped pattern on a second pass.
+    /// </summary>
+    [Fact]
+    public void Redact_AlreadyRedactedJsonQuotedSecret_ReturnsUnchanged()
+    {
+        var sut = CreateRedactor();
+        var input = """{"password":"[REDACTED]"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().Be(input);
+    }
+
+    /// <summary>
+    /// A JSON-quoted secret value containing an escaped quote (e.g. the actual value is <c>ab"cd</c>,
+    /// serialized as <c>"ab\"cd"</c>) is redacted in full. A plain <c>[^"]*</c> value matcher stops at
+    /// the escaped quote character regardless of the preceding backslash, truncating the match mid-value
+    /// and leaking the remainder of the secret in plaintext while corrupting the surrounding JSON.
+    /// </summary>
+    [Fact]
+    public void Redact_JsonQuotedSecretWithEscapedQuote_RedactsEntireValue()
+    {
+        var sut = CreateRedactor();
+        var input = """{"password":"ab\"cd"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().Be("""{"password":"[REDACTED]"}""");
+        result.Should().NotContain("ab");
+        result.Should().NotContain("cd");
+    }
+
+    /// <summary>
+    /// An unquoted "client_secret=" pair — not covered by any pattern before this fix, since the
+    /// connection-string pattern's alternation omits client_secret and the generic key=value pattern's
+    /// alternation only covered api_key/access_token/secret_key.
+    /// </summary>
+    [Fact]
+    public void Redact_UnquotedClientSecret_RedactsValue()
+    {
+        var sut = CreateRedactor();
+        var input = "client_secret=superSecret123";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("[REDACTED]");
+        result.Should().NotContain("superSecret123");
+    }
+
+    /// <summary>
+    /// An unquoted "password:" pair (colon form) — the pre-existing connection-string pattern only
+    /// matched "Password=" (equals form), leaving the colon form of the same key unredacted.
+    /// </summary>
+    [Fact]
+    public void Redact_UnquotedPasswordWithColon_RedactsValue()
+    {
+        var sut = CreateRedactor();
+        var input = "password: superSecret123";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("[REDACTED]");
+        result.Should().NotContain("superSecret123");
+    }
 }

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleRunStreamerTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleRunStreamerTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Services;
 using Domain.AI.Bundles;
@@ -16,20 +17,38 @@ namespace Presentation.ExecutionApi.Tests;
 /// </summary>
 public sealed class BundleRunStreamerTests
 {
-    /// <summary>A fake executor that records whether the ambient sink was armed, optionally emits deltas through
-    /// it, then returns a configured outcome.</summary>
-    private sealed class FakeExecutor(BundleRunExecution result, params string[] deltas) : IBundleRunExecutor
+    /// <summary>A fake executor that records whether the ambient sink was armed, optionally drives it through
+    /// a caller-supplied script (deltas and/or tool-call events, in any order), then returns a configured
+    /// outcome.</summary>
+    private sealed class FakeExecutor : IBundleRunExecutor
     {
+        private readonly BundleRunExecution _result;
+        private readonly Func<IAgentTurnStreamSink, CancellationToken, Task> _script;
+
         public bool SinkArmedDuringRun { get; private set; }
+
+        public FakeExecutor(BundleRunExecution result, params string[] deltas)
+            : this(result, async (sink, ct) =>
+            {
+                foreach (var delta in deltas)
+                    await sink.EmitAsync(delta, ct);
+            })
+        {
+        }
+
+        public FakeExecutor(BundleRunExecution result, Func<IAgentTurnStreamSink, CancellationToken, Task> script)
+        {
+            _result = result;
+            _script = script;
+        }
 
         public async Task<BundleRunExecution> ExecuteAsync(string jobId, CancellationToken cancellationToken)
         {
             var sink = AgentTurnStreamSink.Current;
             SinkArmedDuringRun = sink is not null;
             if (sink is not null)
-                foreach (var delta in deltas)
-                    await sink.EmitAsync(delta, cancellationToken);
-            return result;
+                await _script(sink, cancellationToken);
+            return _result;
         }
     }
 
@@ -111,6 +130,50 @@ public sealed class BundleRunStreamerTests
         var frames = await RunAndParseAsync(executor, Record());
 
         frames.Select(Type).Should().Equal("RUN_STARTED", "RUN_FINISHED");
+    }
+
+    [Fact]
+    public async Task StreamAsync_ToolCallActivity_EmitsInterleavedWithText()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), async (sink, ct) =>
+        {
+            await sink.EmitAsync("Looking that up", ct);
+            await sink.EmitToolCallAsync("call-1", "search", "{\"q\":\"docs\"}", ct);
+            await sink.EmitToolCallResultAsync("call-1", "42 results", ct);
+            await sink.EmitAsync(" — found it.", ct);
+        });
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        frames.Select(Type).Should().Equal(
+            "RUN_STARTED", "TEXT_MESSAGE_START", "TEXT_MESSAGE_CONTENT",
+            "TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "TOOL_CALL_RESULT",
+            "TEXT_MESSAGE_CONTENT", "TEXT_MESSAGE_END", "RUN_FINISHED");
+
+        var start = frames.Single(f => Type(f) == "TOOL_CALL_START");
+        start.GetProperty("toolCallId").GetString().Should().Be("call-1");
+        start.GetProperty("toolCallName").GetString().Should().Be("search");
+
+        frames.Single(f => Type(f) == "TOOL_CALL_ARGS").GetProperty("delta").GetString()
+            .Should().Be("{\"q\":\"docs\"}");
+        frames.Single(f => Type(f) == "TOOL_CALL_END").GetProperty("toolCallId").GetString()
+            .Should().Be("call-1");
+        frames.Single(f => Type(f) == "TOOL_CALL_RESULT").GetProperty("result").GetString()
+            .Should().Be("42 results");
+    }
+
+    [Fact]
+    public async Task StreamAsync_ToolCallBeforeAnyText_DoesNotOpenAStrayTextMessage()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), async (sink, ct) =>
+        {
+            await sink.EmitToolCallAsync("call-1", "search", "{}", ct);
+        });
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        frames.Select(Type).Should().Equal(
+            "RUN_STARTED", "TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "RUN_FINISHED");
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleStreamEventsSerializationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleStreamEventsSerializationTests.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FluentAssertions;
+using Presentation.ExecutionApi.Streaming;
+using Xunit;
+
+namespace Presentation.ExecutionApi.Tests;
+
+/// <summary>
+/// Serialization tests for the four tool-call <see cref="BundleStreamEvent"/> records — written through the
+/// real <see cref="BundleStreamEventWriter"/> (matching <c>BundleRunStreamerTests</c>'s real-wire-JSON
+/// approach) so a regression in the writer's serializer options is caught here too, not just the discriminator
+/// wiring on <see cref="BundleStreamEvent"/> itself.
+/// </summary>
+public sealed class BundleStreamEventsSerializationTests
+{
+    /// <summary>Same shape as <c>BundleStreamEventWriter</c>'s private options, needed for the round-trip
+    /// deserialize assertions (the writer only exposes serialization, not the options themselves).</summary>
+    private static readonly JsonSerializerOptions DeserializeOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static async Task<JsonElement> WriteAndParseAsync(BundleStreamEvent evt)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BundleStreamEventWriter(stream))
+            await writer.WriteAsync(evt, CancellationToken.None);
+
+        var body = Encoding.UTF8.GetString(stream.ToArray());
+        var json = body["data: ".Length..].TrimEnd('\n', '\r');
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    [Fact]
+    public async Task ToolCallStartEvent_SerializesWithDiscriminatorAndFields()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallStartEvent("call-1", "search"));
+
+        element.GetProperty("type").GetString().Should().Be("TOOL_CALL_START");
+        element.GetProperty("toolCallId").GetString().Should().Be("call-1");
+        element.GetProperty("toolCallName").GetString().Should().Be("search");
+    }
+
+    [Fact]
+    public async Task ToolCallArgsEvent_SerializesWithDiscriminatorAndFields()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallArgsEvent("call-1", "{\"q\":\"docs\"}"));
+
+        element.GetProperty("type").GetString().Should().Be("TOOL_CALL_ARGS");
+        element.GetProperty("toolCallId").GetString().Should().Be("call-1");
+        element.GetProperty("delta").GetString().Should().Be("{\"q\":\"docs\"}");
+    }
+
+    [Fact]
+    public async Task ToolCallEndEvent_SerializesWithDiscriminatorAndFields()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallEndEvent("call-1"));
+
+        element.GetProperty("type").GetString().Should().Be("TOOL_CALL_END");
+        element.GetProperty("toolCallId").GetString().Should().Be("call-1");
+    }
+
+    [Fact]
+    public async Task ToolCallResultEvent_SerializesWithDiscriminatorAndFields()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallResultEvent("call-1", "42 results"));
+
+        element.GetProperty("type").GetString().Should().Be("TOOL_CALL_RESULT");
+        element.GetProperty("toolCallId").GetString().Should().Be("call-1");
+        element.GetProperty("result").GetString().Should().Be("42 results");
+    }
+
+    [Theory]
+    [InlineData(typeof(BundleToolCallStartEvent))]
+    [InlineData(typeof(BundleToolCallArgsEvent))]
+    [InlineData(typeof(BundleToolCallEndEvent))]
+    [InlineData(typeof(BundleToolCallResultEvent))]
+    public void EachToolCallEventType_RoundTripsThroughThePolymorphicBase(Type derivedType)
+    {
+        BundleStreamEvent original = derivedType == typeof(BundleToolCallStartEvent)
+            ? new BundleToolCallStartEvent("call-1", "search")
+            : derivedType == typeof(BundleToolCallArgsEvent)
+                ? new BundleToolCallArgsEvent("call-1", "{}")
+                : derivedType == typeof(BundleToolCallEndEvent)
+                    ? new BundleToolCallEndEvent("call-1")
+                    : new BundleToolCallResultEvent("call-1", "ok");
+
+        var json = JsonSerializer.Serialize(original, typeof(BundleStreamEvent), DeserializeOptions);
+        var roundTripped = JsonSerializer.Deserialize<BundleStreamEvent>(json, DeserializeOptions);
+
+        roundTripped.Should().BeOfType(derivedType);
+        roundTripped.Should().Be(original);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #367. The bundle run SSE stream (`GET /api/bundles/{handle}/runs/{jobId}/stream`) went silent the moment the agent started calling tools — a client sees `RUN_STARTED`, then nothing, then eventually the first `TEXT_MESSAGE_CONTENT` once the model resumes talking. For a multi-step tool-using run that gap can be 30+ seconds of dead air.

**Verified against the actual Microsoft.Extensions.AI source before designing this** (dotnet/extensions on GitHub): a tool call's arguments are never streamed incrementally — the OpenAI connector buffers raw per-chunk argument JSON internally and only exposes a complete `FunctionCallContent` once fully assembled. So `TOOL_CALL_ARGS` carries the whole payload in one frame, not a token-by-token delta, immediately followed by `TOOL_CALL_END` — still a large improvement over total silence, just not the literal incremental delta the issue's phrasing evokes.

- `IAgentTurnStreamSink` gains `EmitToolCallAsync` (one atomic call: id, name, complete args) and `EmitToolCallResultAsync`, both additive default-no-op interface methods so the existing SignalR path (`ConversationOrchestrator`) needs zero changes.
- `ExecuteAgentTurnCommandHandler` forwards `FunctionCallContent`/`FunctionResultContent` through that seam, redacting both via a new shared `ToolPayloadRedactor` helper before they reach the sink — the same treatment `ToolDiagnosticsMiddleware` already applies before persisting the identical data, since a live SSE stream is just as much an exposure point for secrets. Arguments are redacted only (never truncated — a client parses them as JSON and truncation would corrupt it); results get the redact-and-truncate preview treatment.
- `BundleStreamEvents` gains four new wire event records (`TOOL_CALL_START`/`ARGS`/`END`/`RESULT`); `BundleRunStreamer` decomposes the sink's one `EmitToolCallAsync` call into the three separate SSE frames the AG-UI wire protocol expects.

### Fixed during review, before this shipped

- The streaming path's JSON serialization of tool arguments was unguarded, unlike the identical call in `ToolDiagnosticsMiddleware` — an unserializable argument would have aborted the whole turn (losing text already streamed to the client) instead of degrading gracefully.
- A `FunctionResultContent` with no `CallId` could have reached the client as an orphaned `TOOL_CALL_RESULT` frame with no preceding `START`.
- `ToolDiagnosticsMiddleware`'s own redact-then-truncate logic, previously duplicated verbatim in two places, is now one shared helper — this PR's new streaming code would have been a third copy.
- `IAgentTurnStreamSink` originally split one atomic "tool call decided" event into three separate methods (Start/Args/End); collapsed to one, since the framework guarantees they always fire together with nothing a caller could observe between them.

## Test plan

- [x] Full solution build, 0 errors
- [x] Full test runs after every change: `Application.AI.Common.Tests` (1986/1986), `Application.Core.Tests` (1098/1098), `Presentation.ExecutionApi.Tests` (132/132) — all green
- [x] New regression tests: unserializable tool args don't abort the turn, long tool-call args are never truncated (stay valid JSON), a result with no CallId is never streamed, tool-call activity redacted before streaming, full interleaving with text deltas
- [x] `/code-review` — 5 findings (2 HIGH, 1 MEDIUM, 2 LOW accepted as documented residuals), all real ones fixed
- [x] `/simplify` — 4 review angles; 3 real findings applied (shared redaction helper, collapsed sink interface, deduped test helper)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>