### PR TITLE
Streamline the ship pipeline: composite review, scoped tests, dedupe OWASP build

### DIFF
--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pre-push-review
+description: "Use before every git push or gh pr create that touches src/ — runs /code-review, then /simplify, then (when the diff is security-sensitive) the security-reviewer agent, and records both review-gate receipts in one pass. Triggers: \"pre-push review\", \"get this ready to push\", \"run the review gate\", or any time you're about to push/open a PR and haven't run both required reviews against the current diff yet."
+---
+
+# Pre-push review
+
+Runs everything the local push gate (`.claude/hooks/review-gate.ps1`) requires, in one
+pass, so no review step is left to memory across a long session.
+
+## Why this exists
+
+Before this skill, a session had to remember to invoke `/code-review` and `/simplify`
+as two (or three, counting `security-reviewer`) separate manual steps, potentially many
+messages apart. On 2026-08-13 a session ran `/code-review` and a security review twice
+each but never ran `/simplify` at all — caught only because the push gate itself
+refused the push. The gate already enforces that receipts *exist*; this skill makes it
+trivial to actually produce them, in the right order, without depending on memory
+across a long session.
+
+## Steps, in order
+
+1. **Check scope.** Diff the current branch against its base for `src/**` files with a
+   reviewable extension (`.cs .csproj .slnx .props .targets .razor .cshtml .ts .tsx .js
+   .jsx .html` — see `.claude/hooks/review-scope.ps1` for the authoritative list). If
+   nothing reviewable changed, say so and stop.
+
+2. **Run `/code-review`** (Skill tool, skill `code-review`) against the current diff.
+   Read its findings and fix anything HIGH or CRITICAL. If you changed code to fix a
+   finding, re-run `/code-review` against the corrected diff before moving on — never
+   record a receipt for a run whose findings you didn't act on.
+
+3. **Record the code-review receipt** as its own Bash call — never chained with
+   `git push` or with step 5's receipt call. The gate inspects the whole command string
+   before anything runs, so a receipt written earlier in the same chained command is
+   invisible to it:
+   ```
+   "<one-line summary of the code-review result>" | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind code-review
+   ```
+
+4. **Run `/simplify`** (Skill tool, skill `simplify`) against the same diff and apply
+   its fixes.
+
+5. **Record the simplify receipt**, same pattern, its own Bash call:
+   ```
+   "<one-line summary of the simplify result>" | pwsh -NoProfile -File .claude/hooks/save-review-receipt.ps1 -Kind simplify
+   ```
+
+6. **Decide on `security-reviewer`.** This has no receipt of its own — it's a judgment
+   call layered on top of the two mechanical gates, not something `review-gate.ps1`
+   checks. Run it (Agent tool, `security-reviewer`) whenever the diff touches auth,
+   identity, payments, secrets, or tool/agent governance — or when in doubt, ask
+   `.github/scripts/security-gate-scope.sh --base <base-branch>` and launch it if
+   `required=true`. Act on its findings before continuing.
+
+7. **Re-verify after any fix.** If step 2, 4, or 6 caused a code change, the fingerprint
+   the gate checks has changed. Repeat steps 2–5 (and 6, if still relevant) against the
+   new diff. Do not record a receipt and then keep editing — the gate blocks on a
+   fingerprint mismatch specifically to catch that.
+
+8. **Report.** State plainly that both receipts are recorded for the current diff and
+   the push is unblocked. Don't end by asking whether to run the reviews again or
+   whether it's ready — that's the decision this skill exists to make for you.
+
+## What this does not replace
+
+- The full local test suite still has to be green before push — this skill is about
+  the review gate, not the test gate.
+- CI's `correctness-review` and `security-review` still run again server-side after the
+  push. That's deliberate, not redundant with this skill: the local gate only fires for
+  pushes made through Claude Code, so CI is the backstop for every other path a change
+  can reach `main` — including a human pushing directly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,25 +55,6 @@ jobs:
       - name: Build
         run: dotnet build src/AgenticHarness.slnx --no-restore --configuration Release
 
-      # owasp-agentic-gate (below, needs: build-and-test) used to run its own dotnet restore +
-      # dotnet build --configuration Release from scratch before this step existed — a second
-      # full-solution build in sequence on every PR, purely to run one project's filtered test
-      # subset with a build it already has sitting in this job's workspace. Uploading the exact
-      # output lets that gate skip straight to `dotnet test --no-build`.
-      #
-      # Both bin/ and obj/ are included, not just bin/ — obj/ carries project.assets.json and
-      # the source-generator output some projects need even under --no-build, and a narrower
-      # glob risks silently missing one of them on a project that happens to use one.
-      - name: Upload build output for owasp-agentic-gate
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-build-output
-          path: |
-            src/**/bin/Release/**
-            src/**/obj/**
-          retention-days: 1
-          if-no-files-found: error
-
       # Output is tee'd to a file so the step below can explain a failure the summary lines hide.
       # `set -o pipefail` is what stops tee from swallowing dotnet's exit code — without it this
       # step reports success whenever the tests fail, which is the opposite of a gate.
@@ -195,15 +176,11 @@ jobs:
         with:
           dotnet-version: '10.x'
 
-      # Reuses build-and-test's own Release build instead of restoring and building the whole
-      # solution again — see the matching upload step's comment in that job. This job still needs
-      # its own checkout (for the source files dotnet test discovers tests from, and for
-      # explain-runner-crash.sh below) — only the restore/build work is skipped.
-      - name: Download build output from build-and-test
-        uses: actions/download-artifact@v7
-        with:
-          name: release-build-output
-          path: .
+      - name: Restore
+        run: dotnet restore src/AgenticHarness.slnx
+
+      - name: Build
+        run: dotnet build src/AgenticHarness.slnx --no-restore --configuration Release
 
       - name: Run OWASP Agentic eval fixtures (hard gate)
         id: owasp-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,25 @@ jobs:
       - name: Build
         run: dotnet build src/AgenticHarness.slnx --no-restore --configuration Release
 
+      # owasp-agentic-gate (below, needs: build-and-test) used to run its own dotnet restore +
+      # dotnet build --configuration Release from scratch before this step existed — a second
+      # full-solution build in sequence on every PR, purely to run one project's filtered test
+      # subset with a build it already has sitting in this job's workspace. Uploading the exact
+      # output lets that gate skip straight to `dotnet test --no-build`.
+      #
+      # Both bin/ and obj/ are included, not just bin/ — obj/ carries project.assets.json and
+      # the source-generator output some projects need even under --no-build, and a narrower
+      # glob risks silently missing one of them on a project that happens to use one.
+      - name: Upload build output for owasp-agentic-gate
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-build-output
+          path: |
+            src/**/bin/Release/**
+            src/**/obj/**
+          retention-days: 1
+          if-no-files-found: error
+
       # Output is tee'd to a file so the step below can explain a failure the summary lines hide.
       # `set -o pipefail` is what stops tee from swallowing dotnet's exit code — without it this
       # step reports success whenever the tests fail, which is the opposite of a gate.
@@ -176,11 +195,15 @@ jobs:
         with:
           dotnet-version: '10.x'
 
-      - name: Restore
-        run: dotnet restore src/AgenticHarness.slnx
-
-      - name: Build
-        run: dotnet build src/AgenticHarness.slnx --no-restore --configuration Release
+      # Reuses build-and-test's own Release build instead of restoring and building the whole
+      # solution again — see the matching upload step's comment in that job. This job still needs
+      # its own checkout (for the source files dotnet test discovers tests from, and for
+      # explain-runner-crash.sh below) — only the restore/build work is skipped.
+      - name: Download build output from build-and-test
+        uses: actions/download-artifact@v7
+        with:
+          name: release-build-output
+          path: .
 
       - name: Run OWASP Agentic eval fixtures (hard gate)
         id: owasp-tests

--- a/.github/workflows/security-gate-vocabulary-check.yml
+++ b/.github/workflows/security-gate-vocabulary-check.yml
@@ -1,0 +1,46 @@
+name: Security Gate Vocabulary Check
+
+# Non-blocking, scheduled replay of security-gate-scope.test.sh's historical-PR
+# regression suite. The content-based security-review trigger (security-review.yml,
+# via security-gate-scope.sh) has missed a category of risk five separate times since
+# it was built — filesystem paths, egress/SSRF, raw SQL, a rewritten security control
+# whose own type names weren't in the vocabulary, conversation ownership — and every
+# one was only caught after the fact, sometimes by a manual review the automated gate
+# itself had skipped.
+#
+# This adds no new detection. It catches the SAME test suite silently rotting between
+# those discoveries — a marker that stops matching, a replay case someone deletes, a
+# regex that becomes uncompilable — on a schedule, instead of waiting for the next
+# missed category to surface as a real near-incident.
+#
+# Deliberately NOT a required check and NOT triggered on pull_request: it replays
+# FIXED historical PRs by merge-base, so nothing about a new PR's own content changes
+# the outcome. A failure here means the vocabulary/harness itself needs attention, not
+# that any specific PR did something wrong — see .github/scripts/security-gate-scope.test.sh
+# for what each case proves.
+
+on:
+  schedule:
+    # 1st of every month, 06:00 UTC. A failure here shows up the same way any other
+    # failed scheduled workflow does — GitHub notifies the repo's watchers by default;
+    # no separate issue-filing step, to keep this addition small and dependency-free.
+    - cron: '0 6 1 * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  replay:
+    name: Replay security-gate-scope.sh against recent history
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The replay harness merge-bases against real historical commits without
+          # checking them out — it needs full history to do that, not the default
+          # shallow clone.
+          fetch-depth: 0
+
+      - name: Run the vocabulary regression suite
+        run: bash .github/scripts/security-gate-scope.test.sh

--- a/scripts/rails/test-touched.sh
+++ b/scripts/rails/test-touched.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# test-touched.sh — run only the test project(s) that own the code changed on this
+# branch, instead of the full 20+ project solution, for fast iteration.
+#
+# Why this exists: a session on 2026-08-13 ran the full-solution test suite three
+# times while iterating on a change that only ever touched four projects. Each full
+# run also drags in unrelated, environment-dependent failures (Docker not running
+# locally) that have nothing to do with the change and have to be manually triaged
+# away every time. This script scopes iteration runs to what could plausibly have
+# broken.
+#
+# THIS DOES NOT REPLACE THE FULL-SOLUTION RUN. A change can break a project it never
+# touches directly (a shared interface, a behavior contract). Run
+# `dotnet test src/AgenticHarness.slnx` once, for real, before every push — this
+# script is for the loop before that, not instead of it.
+#
+# Usage:
+#   scripts/rails/test-touched.sh [base-ref]
+#
+# base-ref defaults to origin/main. Any extra arguments after base-ref are passed
+# through verbatim to each `dotnet test` invocation (e.g. --filter, -v).
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+shift || true
+EXTRA_ARGS=("$@")
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Full (non-shallow) fetch of the base so the merge-base actually exists — mirrors
+# the same guard correctness-review.yml uses, for the same reason.
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "test-touched: base ref '$BASE_REF' not found locally. Try 'git fetch origin main' first." >&2
+  exit 1
+fi
+
+CHANGED_FILES="$(git diff --name-only --diff-filter=ACMR "$BASE_REF"...HEAD -- 'src/Content/**/*.cs' || true)"
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "test-touched: no changed .cs files under src/Content vs $BASE_REF — nothing to run."
+  exit 0
+fi
+
+# For each changed file, walk up to its nearest .csproj and record the project name.
+# A project whose name already ends in .Tests is its own target; otherwise resolve
+# the sibling <Name>.Tests project under src/Content/Tests/.
+declare -A TEST_PROJECT_PATHS=()
+declare -A SOURCE_PROJECTS_SEEN=()
+declare -a UNRESOLVED=()
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+  dir="$(dirname "$REPO_ROOT/$file")"
+  csproj=""
+  while [ "$dir" != "$REPO_ROOT" ] && [ "$dir" != "/" ]; do
+    match="$(find "$dir" -maxdepth 1 -name '*.csproj' 2>/dev/null | head -n1)"
+    if [ -n "$match" ]; then
+      csproj="$match"
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+
+  if [ -z "$csproj" ]; then
+    UNRESOLVED+=("$file")
+    continue
+  fi
+
+  project_name="$(basename "$csproj" .csproj)"
+  [ -n "${SOURCE_PROJECTS_SEEN[$project_name]:-}" ] && continue
+  SOURCE_PROJECTS_SEEN["$project_name"]=1
+
+  if [[ "$project_name" == *.Tests ]]; then
+    TEST_PROJECT_PATHS["$project_name"]="$csproj"
+    continue
+  fi
+
+  test_project_name="${project_name}.Tests"
+  test_project_dir="$REPO_ROOT/src/Content/Tests/$test_project_name"
+  test_csproj=""
+  # A plain `find` on a path that doesn't exist yet exits non-zero (unlike finding
+  # zero matches inside a real directory, which exits 0) — under `set -e`/pipefail
+  # that silently kills the whole script the first time a project has no test
+  # sibling (e.g. Presentation.ConsoleUI). Guard with -d first.
+  if [ -d "$test_project_dir" ]; then
+    test_csproj="$(find "$test_project_dir" -maxdepth 1 -name "$test_project_name.csproj" | head -n1)"
+  fi
+  if [ -n "$test_csproj" ]; then
+    TEST_PROJECT_PATHS["$test_project_name"]="$test_csproj"
+  else
+    echo "test-touched: no sibling test project found for '$project_name' (changed: $file) — not included in this run." >&2
+  fi
+done <<< "$CHANGED_FILES"
+
+if [ ${#UNRESOLVED[@]} -gt 0 ]; then
+  echo "test-touched: could not resolve a project for: ${UNRESOLVED[*]}" >&2
+fi
+
+if [ ${#TEST_PROJECT_PATHS[@]} -eq 0 ]; then
+  echo "test-touched: changed files resolved to zero test projects. Run the full solution instead."
+  exit 0
+fi
+
+echo "test-touched: running ${#TEST_PROJECT_PATHS[@]} test project(s) for the diff vs $BASE_REF:"
+for name in "${!TEST_PROJECT_PATHS[@]}"; do
+  echo "  - $name"
+done
+echo
+
+STATUS=0
+for name in "${!TEST_PROJECT_PATHS[@]}"; do
+  echo "=== $name ==="
+  if ! dotnet test "${TEST_PROJECT_PATHS[$name]}" "${EXTRA_ARGS[@]}"; then
+    STATUS=1
+  fi
+  echo
+done
+
+echo "test-touched: done. This is a SCOPED run — run 'dotnet test src/AgenticHarness.slnx' before push."
+exit "$STATUS"

--- a/scripts/rails/wait-for-checks.sh
+++ b/scripts/rails/wait-for-checks.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# wait-for-checks.sh — wait for a PR's CI runs to actually finish, correctly.
+#
+# `gh pr checks <pr>` only lists runs that currently report a conclusion or an
+# in-flight check. The moment a run is re-queued (`gh run rerun --failed`), its row
+# disappears from that table entirely rather than showing as pending — a waiter that
+# loops "until no row says pending" can therefore declare victory off a table that's
+# missing several still-queued gates. This happened for real once: it printed
+# "ALL GREEN" while two of six gates had not started.
+#
+# This polls `gh run list` instead, which does show re-queued runs, then prints the
+# checks table once everything has actually settled.
+#
+# Usage:
+#   scripts/rails/wait-for-checks.sh <branch> [pr-number] [poll-seconds]
+#
+# poll-seconds defaults to 15.
+
+set -euo pipefail
+
+BRANCH="${1:?usage: wait-for-checks.sh <branch> [pr-number] [poll-seconds]}"
+PR="${2:-}"
+POLL_SECONDS="${3:-15}"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "wait-for-checks: gh CLI not found." >&2
+  exit 1
+fi
+
+echo "wait-for-checks: polling runs for branch '$BRANCH' every ${POLL_SECONDS}s..."
+
+while true; do
+  PENDING="$(gh run list --branch "$BRANCH" --json status \
+    --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')"
+
+  if [ "$PENDING" -eq 0 ]; then
+    break
+  fi
+
+  echo "  $PENDING run(s) still queued/in_progress..."
+  sleep "$POLL_SECONDS"
+done
+
+echo "wait-for-checks: all runs settled."
+echo
+
+if [ -n "$PR" ]; then
+  gh pr checks "$PR"
+else
+  gh run list --branch "$BRANCH" --limit 20
+fi


### PR DESCRIPTION
## Summary

Three changes from an audit of the fix-to-merge pipeline, grounded in what actually
happened working a change through it this session:

- **Composite `pre-push-review` skill** — runs `/code-review`, `/simplify`, and
  (when warranted) `security-reviewer` in one pass. The push gate requires receipts
  for the first two; this session ran the reviews but skipped `/simplify`, caught
  only because the gate itself refused the push. Turns three separately-remembered
  steps into one.
- **`scripts/rails/test-touched.sh`** — scopes local test iteration to the projects
  a change actually touches, instead of the full 20+ project solution on every loop.
  Validated against the real #370 merge diff (correctly resolved and ran its 5 owning
  test projects, all green). Does not replace the full-solution run before push.
- **`scripts/rails/wait-for-checks.sh`** + a monthly **security-gate vocabulary
  replay** — `gh pr checks` silently drops re-queued runs, which has produced a
  false "all green" read before; the new script polls `gh run list` instead. The
  content-based security-review trigger has missed a category of risk five times
  since it was built, always caught after the fact — a new non-blocking scheduled
  workflow replays its own 53-case regression suite monthly so drift surfaces
  proactively instead.

## A fourth change was attempted and reverted — left in the history on purpose

The original version of this PR also tried to stop `owasp-agentic-gate` (a
**required** status check) from rebuilding the whole solution from scratch, by
reusing `build-and-test`'s Release build via an artifact upload/download instead.

**This PR's own required checks caught it broken**, exactly as the safety net was
supposed to work: `dotnet test --no-build` failed with "argument is invalid"
against the restored build, even though the identical `--no-build` pattern passed
cleanly against a build produced in the same job in `build-and-test` itself. Root
cause looks like a .NET 10 preview-SDK sensitivity to something that differs
between a build a job produces and immediately tests, versus one restored from an
artifact — not chased further, since further CI round-trips (~8 min each) cost
more than the ~1-2 min the change would have saved. Reverted in this PR; the finding
and next-step ideas are filed as #380 for anyone who wants to pick it up later.

## Test plan

- [x] `test-touched.sh` run against the real #370 merge diff — correct project
      resolution, all tests green
- [x] `security-gate-scope.test.sh` run locally — 53 passed, 0 failed (baseline
      the new scheduled workflow will replay monthly)
- [x] All checks green on this PR, including `OWASP Agentic Top-10 Gate` after the
      revert

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW