### PR TITLE
fix: honor policy YAML's default_action instead of silently denying (#384)

### DIFF
--- a/.claude/rules/rag-knowledge-graph.md
+++ b/.claude/rules/rag-knowledge-graph.md
@@ -1,0 +1,34 @@
+---
+paths: src/Content/**/Infrastructure.AI.RAG/**/*.cs, src/Content/**/Infrastructure.AI.KnowledgeGraph/**/*.cs, src/Content/**/Governance/**/*.cs, src/Content/**/SkillTraining/**/*.cs
+---
+# RAG & Knowledge Architecture
+
+The harness includes a full RAG pipeline (`Infrastructure.AI.RAG`) and a production knowledge graph layer (`Infrastructure.AI.KnowledgeGraph`) inspired by [Cognee](https://github.com/topoteretes/cognee).
+
+## RAG Capabilities
+- **Ingestion**: 3 chunking strategies (structure-aware, fixed-size, semantic), contextual enrichment (Anthropic pattern), RAPTOR hierarchical summarization
+- **Retrieval**: Hybrid dense+sparse via Reciprocal Rank Fusion, query transformation (RAG Fusion, HyDE), query classification/routing
+- **Quality**: CRAG evaluation with refinement loops, configurable accept/refine/reject thresholds
+- **Assembly**: Token budget enforcement, pointer expansion (sibling/parent), citation tracking
+- **Reranking**: Azure Semantic, Cross-Encoder, NoOp (strategy-keyed DI)
+- **Stores**: Azure AI Search + FAISS (vector), Azure AI Search + SQLite FTS5 (BM25)
+- **Complexity Routing** (Phase A): LLM-based query complexity classification, tiered pipeline selection, 30-50% cost reduction on mixed workloads
+- **Multi-Hop** (Phase B): Query decomposition, iterative retrieval with sufficiency evaluation, answer faithfulness evaluation for hallucination detection
+- **Full Autonomy** (Phase D): Multi-source parallel orchestration (vector + BM25 + graph), retrieval cost tracking, quality gates at each pipeline stage
+
+## Knowledge Graph (Implemented — from Cognee analysis)
+1. **Production Graph Backend** — Neo4j, Kuzu, and PostgreSQL backends behind `IGraphDatabaseBackend`. Entity extraction, Leiden community detection (`LeidenCommunityDetector`), in-memory store for development
+2. **Feedback-Weighted Search** — `GraphFeedbackStore` + `LlmFeedbackDetector` track retrieval quality on graph nodes/edges. Future retrievals blend semantic relevance with historical feedback weights
+3. **Cross-Session Knowledge Persistence** — `Remember()`/`Recall()`/`Forget()`/`Improve()` via `IKnowledgeMemory`. `InMemorySessionCache` for fast reads with background sync to `ICrossSessionMemoryStore`. `MemoryDecayService` handles configurable decay tiers (CRITICAL/STANDARD/EPHEMERAL)
+4. **Entity-Level Provenance** — `DefaultProvenanceStamper` stamps every node/edge with source pipeline, task, and timestamp. `ComplianceAwareGraphStore` enforces retention policies. `DefaultErasureOrchestrator` handles right-to-erasure with `ErasureReceipt` records
+5. **Multi-Tenant Knowledge Isolation** — `TenantIsolatedGraphStore` enforces per-record boundaries by **tenant AND owner** via `IKnowledgeScopeValidator`: a record is visible only when its tenant matches (or is global/null) and its owner matches (or is shared-in-tenant/null). Identity is captured at the entry point (`KnowledgeScopeMiddleware`/`KnowledgeScopeHubFilter`) and flows ambiently (`AsyncLocal`) into child scopes + post-turn background writes; `ComplianceAwareGraphStore` stamps `TenantId` on write (owner stays writer-authoritative). Memory is scope-namespaced (`memory:{tenant}:{user}:{key}`). Enforced across **all three backends** — in-memory, Neo4j, and PostgreSQL all persist and filter `OwnerId`/`TenantId` (Postgres self-initializes its schema)
+
+## Governance Subsystems
+- **Drift Detection**: EWMA-based quality monitoring against baselines, three severity levels, DriftEscalationBridge
+- **Learnings**: CQRS-based knowledge capture with exponential decay, scheduled pruning, drift integration
+- **Escalation**: Multi-approval workflows (AllOf/AnyOf/Quorum), JSONL audit, AG-UI notifications
+- **Autonomy Tiers**: Manual/Supervised/Autonomous enforcement via MediatR pipeline behavior, response sanitizers
+- **Resilience**: Polly circuit breakers, provider fallback chains, health state tracking
+
+## Skill Training (SkillOpt port)
+Single-skill-document optimizer modeled on [microsoft/SkillOpt](https://github.com/microsoft/SkillOpt). 6-stage loop (rollout → reflect → aggregate → select → apply → gate) in `Application.AI.Common/CQRS/SkillTraining/TrainSkill/`. Bounded `Edit{Op,Target,Content}` operations (Append/InsertAfter/Replace/Delete) against the SKILL.md, validated by a gate that uses Hard/Soft/Mixed metric projection and strict-greater accept semantics. Epoch boundary runs SlowUpdate (paired longitudinal forgetting detection) and MetaSkillUpdate (cross-epoch strategy memory via `IKnowledgeMemory`). Pure components (`PatchApplier`, `GateEvaluator`, `PatchAggregator`, `TopKEditSelector`, 3 LR schedulers) are stateless. `IPatchProposer` + `IRolloutRunner` ship with `NotConfigured*` fail-fast defaults — consumers replace with agent-backed Infrastructure impls.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,37 +3,6 @@
 ## Purpose
 Production-grade template for a Microsoft Agent Framework agent with a full agentic harness — multi-skill agents, local plugins, MCP, tools, RAG, and knowledge graph systems — modeled after Claude Code's architecture. Built on the ApplicationTemplate Clean Architecture pattern. Designed for enterprise consumers to clone and extend.
 
-## RAG & Knowledge Architecture
-The harness includes a full RAG pipeline (`Infrastructure.AI.RAG`) and a production knowledge graph layer (`Infrastructure.AI.KnowledgeGraph`) inspired by [Cognee](https://github.com/topoteretes/cognee).
-
-### RAG Capabilities
-- **Ingestion**: 3 chunking strategies (structure-aware, fixed-size, semantic), contextual enrichment (Anthropic pattern), RAPTOR hierarchical summarization
-- **Retrieval**: Hybrid dense+sparse via Reciprocal Rank Fusion, query transformation (RAG Fusion, HyDE), query classification/routing
-- **Quality**: CRAG evaluation with refinement loops, configurable accept/refine/reject thresholds
-- **Assembly**: Token budget enforcement, pointer expansion (sibling/parent), citation tracking
-- **Reranking**: Azure Semantic, Cross-Encoder, NoOp (strategy-keyed DI)
-- **Stores**: Azure AI Search + FAISS (vector), Azure AI Search + SQLite FTS5 (BM25)
-- **Complexity Routing** (Phase A): LLM-based query complexity classification, tiered pipeline selection, 30-50% cost reduction on mixed workloads
-- **Multi-Hop** (Phase B): Query decomposition, iterative retrieval with sufficiency evaluation, answer faithfulness evaluation for hallucination detection
-- **Full Autonomy** (Phase D): Multi-source parallel orchestration (vector + BM25 + graph), retrieval cost tracking, quality gates at each pipeline stage
-
-### Knowledge Graph (Implemented — from Cognee analysis)
-1. **Production Graph Backend** — Neo4j, Kuzu, and PostgreSQL backends behind `IGraphDatabaseBackend`. Entity extraction, Leiden community detection (`LeidenCommunityDetector`), in-memory store for development
-2. **Feedback-Weighted Search** — `GraphFeedbackStore` + `LlmFeedbackDetector` track retrieval quality on graph nodes/edges. Future retrievals blend semantic relevance with historical feedback weights
-3. **Cross-Session Knowledge Persistence** — `Remember()`/`Recall()`/`Forget()`/`Improve()` via `IKnowledgeMemory`. `InMemorySessionCache` for fast reads with background sync to `ICrossSessionMemoryStore`. `MemoryDecayService` handles configurable decay tiers (CRITICAL/STANDARD/EPHEMERAL)
-4. **Entity-Level Provenance** — `DefaultProvenanceStamper` stamps every node/edge with source pipeline, task, and timestamp. `ComplianceAwareGraphStore` enforces retention policies. `DefaultErasureOrchestrator` handles right-to-erasure with `ErasureReceipt` records
-5. **Multi-Tenant Knowledge Isolation** — `TenantIsolatedGraphStore` enforces per-record boundaries by **tenant AND owner** via `IKnowledgeScopeValidator`: a record is visible only when its tenant matches (or is global/null) and its owner matches (or is shared-in-tenant/null). Identity is captured at the entry point (`KnowledgeScopeMiddleware`/`KnowledgeScopeHubFilter`) and flows ambiently (`AsyncLocal`) into child scopes + post-turn background writes; `ComplianceAwareGraphStore` stamps `TenantId` on write (owner stays writer-authoritative). Memory is scope-namespaced (`memory:{tenant}:{user}:{key}`). Enforced across **all three backends** — in-memory, Neo4j, and PostgreSQL all persist and filter `OwnerId`/`TenantId` (Postgres self-initializes its schema)
-
-### Governance Subsystems
-- **Drift Detection**: EWMA-based quality monitoring against baselines, three severity levels, DriftEscalationBridge
-- **Learnings**: CQRS-based knowledge capture with exponential decay, scheduled pruning, drift integration
-- **Escalation**: Multi-approval workflows (AllOf/AnyOf/Quorum), JSONL audit, AG-UI notifications
-- **Autonomy Tiers**: Manual/Supervised/Autonomous enforcement via MediatR pipeline behavior, response sanitizers
-- **Resilience**: Polly circuit breakers, provider fallback chains, health state tracking
-
-### Skill Training (SkillOpt port)
-Single-skill-document optimizer modeled on [microsoft/SkillOpt](https://github.com/microsoft/SkillOpt). 6-stage loop (rollout → reflect → aggregate → select → apply → gate) in `Application.AI.Common/CQRS/SkillTraining/TrainSkill/`. Bounded `Edit{Op,Target,Content}` operations (Append/InsertAfter/Replace/Delete) against the SKILL.md, validated by a gate that uses Hard/Soft/Mixed metric projection and strict-greater accept semantics. Epoch boundary runs SlowUpdate (paired longitudinal forgetting detection) and MetaSkillUpdate (cross-epoch strategy memory via `IKnowledgeMemory`). Pure components (`PatchApplier`, `GateEvaluator`, `PatchAggregator`, `TopKEditSelector`, 3 LR schedulers) are stateless. `IPatchProposer` + `IRolloutRunner` ship with `NotConfigured*` fail-fast defaults — consumers replace with agent-backed Infrastructure impls.
-
 ## Stack
 - C# .NET 10, Clean Architecture, CQRS/MediatR, FluentValidation, AutoMapper
 - Microsoft.Agents.AI, Microsoft.Extensions.AI, Azure.AI.OpenAI

--- a/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
@@ -48,13 +48,17 @@ public sealed class GovernanceConfigValidator : AbstractValidator<GovernanceConf
             .IsInEnum()
             .WithMessage("McpToolBlockThreshold must be a defined ThreatLevel value.");
 
-        // A blank policy path can never resolve to a file — the DI registration filters it out via
-        // File.Exists, so it never loads. Surface it as a typo rather than silently dropping it.
+        // A blank policy path can never resolve to a file. AddGovernanceDependencies now throws on any
+        // configured path (blank or not) that doesn't resolve to a real file (#384) — but that call runs
+        // eagerly during service registration (BuildGlobalSolutionServices), before ValidateOnStart()'s
+        // deferred check ever runs at IHost.StartAsync(), so in practice the construction-time exception
+        // fires first for this exact case. This rule still adds value for any caller that validates
+        // GovernanceConfig without going through AddGovernanceDependencies at all.
         RuleForEach(x => x.PolicyPaths)
             .Must(path => !string.IsNullOrWhiteSpace(path))
             .WithMessage(
-                "PolicyPaths contains a blank entry. A blank path resolves to no file and is silently " +
-                "dropped — remove it or supply the policy file path.");
+                "PolicyPaths contains a blank entry. A blank path never resolves to a file — remove it " +
+                "or supply the policy file path.");
 
         // Landmine guard: these sub-features only run through the AGT kernel path, which the composition
         // root wires exclusively when Enabled=true. Turning one on while governance is disabled is a

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Adapters/AgtPolicyEngineAdapter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Adapters/AgtPolicyEngineAdapter.cs
@@ -71,7 +71,12 @@ internal sealed class AgtPolicyEngineAdapter : IGovernancePolicyEngine
         return GovernanceDecision.Allowed(ms);
     }
 
-    public void LoadPolicyFile(string yamlPath) => _engine.LoadYamlFile(yamlPath);
+    // Reads once via PolicyYamlGuard (which also validates) and hands the same content to LoadYaml,
+    // rather than reading the file a second time through LoadYamlFile — see PolicyYamlGuard's remarks
+    // for why this specific mistake needs a guard at all, and why this is only one of two required
+    // call sites (the other is DependencyInjection.AddGovernanceDependencies, for the startup path).
+    public void LoadPolicyFile(string yamlPath) =>
+        _engine.LoadYaml(PolicyYamlGuard.ReadAndValidate(yamlPath));
 
     private static GovernancePolicyAction ParseAction(string? action) => action?.ToLowerInvariant() switch
     {

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Adapters/PolicyYamlGuard.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Adapters/PolicyYamlGuard.cs
@@ -1,0 +1,118 @@
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace Infrastructure.AI.Governance.Adapters;
+
+/// <summary>
+/// Guards against a policy YAML's <c>default_action</c> field being silently ignored because it was
+/// written in a different casing.
+/// </summary>
+/// <remarks>
+/// Microsoft.AgentGovernance's <c>Policy.FromYaml</c> deserializes with YamlDotNet's
+/// <c>UnderscoredNamingConvention</c> and no per-field override for <c>DefaultAction</c> — unlike
+/// <c>ApiVersion</c>, which carries an explicit <c>[YamlMember(Alias = "apiVersion")]</c>. Combined with
+/// <c>IgnoreUnmatchedProperties()</c>, a policy author who writes the natural-looking camelCase
+/// <c>defaultAction</c> gets it silently dropped: no error, no warning, and a policy that looks correct
+/// but falls back to denying every tool that doesn't match an explicit rule. This shipped in the
+/// harness's own <c>default-policy.yaml</c> once (#384).
+/// <para>
+/// <b>Two call sites, both required, both through <see cref="ReadAndValidate"/>.</b> A policy file
+/// reaches the AGT engine two ways: dynamically via <see cref="AgtPolicyEngineAdapter.LoadPolicyFile"/>,
+/// and at startup via <c>DependencyInjection.ReadAndValidatePolicyFiles</c>, whose content then feeds
+/// <c>GovernanceKernel.LoadPolicyFromYaml</c> rather than the kernel's own constructor, which would
+/// otherwise load every configured <c>PolicyPaths</c> entry itself (<c>PolicyEngine.LoadYamlFile</c> in
+/// a loop) and bypass this guard entirely. The startup path is the one that loaded the actual miscased
+/// file in #384, so this guard must run there too, not only on the adapter's method.
+/// </para>
+/// <para>
+/// The check is structural (parses the document's real top-level keys) rather than a text/regex scan,
+/// so it isn't fooled by indentation, quoting, casing variants beyond the one exact mistake, or a
+/// coincidental substring inside an unrelated string value.
+/// </para>
+/// <para>
+/// <b>Considered and declined: a fully general strict deserializer.</b>
+/// <c>PolicyEngine.LoadPolicy(Policy)</c> is public, and nothing stops the harness building its own
+/// <c>Policy</c>/<c>PolicyRule</c> graph via a deserializer with <c>IgnoreUnmatchedProperties()</c> off,
+/// catching any unrecognized key generically instead of hand-checking one. Declined for now: that means
+/// re-implementing AGT's own YAML-to-<c>Policy</c> mapping ourselves, with real risk of silently
+/// diverging from AGT's actual parsing semantics as it evolves, to generalize a fix for a vulnerability
+/// surface that is currently exactly one field wide (see <c>ApiVersion</c>'s alias and every
+/// <c>PolicyRule</c> property being single-word, noted above) — worth revisiting if that stops being true.
+/// </para>
+/// </remarks>
+internal static class PolicyYamlGuard
+{
+    private const string CorrectKey = "default_action";
+
+    /// <summary>
+    /// Reads <paramref name="yamlPath"/> once and validates it, so a caller that also needs the content
+    /// (to hand to <c>PolicyEngine.LoadYaml</c> instead of re-reading the same file) gets both from one
+    /// I/O call.
+    /// </summary>
+    /// <exception cref="FileNotFoundException">
+    /// The file does not exist. Matches the message shape <c>Policy.FromYamlFile</c> itself throws, so
+    /// this check does not change the caller-visible contract for a missing file.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">The document uses a mis-cased default-action key.</exception>
+    public static string ReadAndValidate(string yamlPath)
+    {
+        if (!File.Exists(yamlPath))
+            throw new FileNotFoundException($"Policy file not found: '{yamlPath}'", yamlPath);
+
+        var content = File.ReadAllText(yamlPath);
+        Validate(yamlPath, content);
+        return content;
+    }
+
+    // Not exposed publicly: every real load path goes through ReadAndValidate above, which reads the
+    // file itself before calling this. Kept as a separate method for readability, not as a second
+    // supported entry point.
+    // No naming convention applied — this deliberately reads keys exactly as the author wrote them,
+    // which is the whole point: checking what they wrote, not what AGT's own (different) convention
+    // would normalize it to. WithMaximumRecursion matches the bound YamlEvalDatasetLoader already
+    // applies to YAML read off disk elsewhere in this repo — defense-in-depth against a pathologically
+    // deep document, not something this guard's own logic needs.
+    private static readonly IDeserializer StructuralDeserializer =
+        new DeserializerBuilder().WithMaximumRecursion(64).Build();
+
+    private static void Validate(string yamlPath, string content)
+    {
+        Dictionary<object, object>? topLevel;
+        try
+        {
+            topLevel = StructuralDeserializer.Deserialize<Dictionary<object, object>>(content);
+        }
+        catch (YamlException)
+        {
+            // Malformed YAML is the underlying engine's error to raise, in its own shape — this guard
+            // exists to catch one specific otherwise-silent mistake, not to be a general YAML validator.
+            // Safe only because Dictionary<object, object> accepts a strict superset of what AGT's own
+            // YamlPolicyDocument shape accepts (same parser, looser target) — anything that fails to
+            // deserialize here would fail in AGT's own parse too, so skipping the check here doesn't let
+            // a genuinely malformed document slip through unnoticed.
+            return;
+        }
+
+        if (topLevel is null)
+            return;
+
+        var keys = topLevel.Keys.Select(k => k?.ToString() ?? string.Empty).ToList();
+        if (keys.Contains(CorrectKey))
+            return;
+
+        var misCased = keys.FirstOrDefault(k => Normalize(k).Equals("defaultaction", StringComparison.OrdinalIgnoreCase));
+
+        if (misCased is not null)
+            throw new InvalidOperationException(
+                $"Policy YAML '{yamlPath}' declares '{misCased}', but the governance engine's YAML " +
+                $"parser only recognizes the exact key '{CorrectKey}' (snake_case) — any other casing " +
+                "is silently ignored, and the policy falls back to denying every tool that doesn't " +
+                $"match an explicit rule. Rename '{misCased}' to '{CorrectKey}'.");
+    }
+
+    // Strips every separator style a policy author might reach for instead of an underscore
+    // (defaultaction, default-action, "default action") so all of them normalize to the same
+    // comparison target, not just the underscore case.
+    private static string Normalize(string key) =>
+        new(key.Where(c => c is not ('_' or '-' or ' ')).ToArray());
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/DependencyInjection.cs
@@ -29,10 +29,7 @@ public static class DependencyInjection
         this IServiceCollection services,
         GovernanceConfig config)
     {
-        var resolvedPaths = config.PolicyPaths
-            .Select(p => Path.IsPathRooted(p) ? p : Path.Combine(AppContext.BaseDirectory, p))
-            .Where(File.Exists)
-            .ToList();
+        var policyContents = ReadAndValidatePolicyFiles(config.PolicyPaths);
 
         var options = new GovernanceOptions
         {
@@ -42,16 +39,21 @@ public static class DependencyInjection
             ConflictStrategy = (AgentGovernance.Policy.ConflictResolutionStrategy)(int)config.ConflictStrategy
         };
 
-        foreach (var path in resolvedPaths)
-            options.PolicyPaths.Add(path);
-
+        // PolicyPaths deliberately left empty: GovernanceKernel's constructor would otherwise re-read
+        // and re-parse every path itself via PolicyEngine.LoadYamlFile, duplicating the read
+        // ReadAndValidatePolicyFiles already did. LoadPolicyFromYaml below reuses that same content.
         var kernel = new GovernanceKernel(options);
+        foreach (var content in policyContents)
+            kernel.LoadPolicyFromYaml(content);
 
         services.AddSingleton(kernel);
-        services.AddSingleton(kernel.PolicyEngine);
         services.AddSingleton<AuditLogger>();
 
-        services.AddSingleton<IGovernancePolicyEngine, AgtPolicyEngineAdapter>();
+        // Deliberately not registering the raw PolicyEngine as its own resolvable service (unlike
+        // AuditLogger above): PolicyEngine.LoadYamlFile/LoadYaml/LoadPolicy all bypass PolicyYamlGuard,
+        // so a consumer that could resolve PolicyEngine directly and load its own YAML through it would
+        // reintroduce #384. Only the adapter needs it, so it's captured in this factory instead.
+        services.AddSingleton<IGovernancePolicyEngine>(_ => new AgtPolicyEngineAdapter(kernel.PolicyEngine));
 
         // Prompt-injection detection is optional. The AGT kernel only builds an InjectionDetector when
         // GovernanceConfig.EnablePromptInjectionDetection is true, so registering kernel.InjectionDetector
@@ -94,6 +96,38 @@ public static class DependencyInjection
         AddDataClassificationProvider(services, config.DataClassification);
 
         return services;
+    }
+
+    /// <summary>
+    /// Resolves every configured policy path, then reads and validates each one via
+    /// <see cref="PolicyYamlGuard"/> — the guard-covered replacement for the read
+    /// <see cref="GovernanceKernel"/>'s constructor would otherwise perform itself.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// A configured path doesn't resolve to a real file. A missing entry used to be silently dropped
+    /// (<c>.Where(File.Exists)</c>), which could leave the whole declarative policy layer un-loaded —
+    /// <c>HasPolicies</c> false, every tool call skipping this layer entirely — with no signal beyond a
+    /// quieter-than-expected policy set. Fail loudly instead: the same silent-degradation class this
+    /// method's other guard (mis-cased <c>default_action</c>, #384) exists to kill.
+    /// </exception>
+    private static List<string> ReadAndValidatePolicyFiles(IReadOnlyList<string> configuredPaths)
+    {
+        var resolvedPaths = configuredPaths
+            .Select(p => Path.IsPathRooted(p) ? p : Path.Combine(AppContext.BaseDirectory, p))
+            .ToList();
+
+        // ReadAndValidate below re-checks File.Exists per path, so a fully-present config pays one
+        // redundant stat call per file — accepted deliberately, since this check's value isn't the
+        // stat itself, it's reporting every missing path in one message instead of failing on the
+        // first one ReadAndValidate happens to hit.
+        var missing = resolvedPaths.Where(p => !File.Exists(p)).ToList();
+        if (missing.Count > 0)
+            throw new InvalidOperationException(
+                "GovernanceConfig.PolicyPaths references files that do not exist: " +
+                $"{string.Join(", ", missing)}. Refusing to start with a configured policy layer that " +
+                "would silently load nothing.");
+
+        return resolvedPaths.Select(PolicyYamlGuard.ReadAndValidate).ToList();
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Infrastructure.AI.Governance.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Infrastructure.AI.Governance.csproj
@@ -14,6 +14,9 @@
          (Microsoft.AgentGovernance.Extensions.Microsoft.Agents / .ModelContextProtocol) do not yet
          exist on NuGet; adapter wiring for those surfaces will be hand-rolled until packages publish. -->
     <PackageReference Include="Microsoft.AgentGovernance" />
+    <!-- Direct reference (not just AgentGovernance's transitive one) so PolicyYamlGuard can parse a
+         policy document's raw top-level keys structurally instead of text-scanning for a known mistake. -->
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/Policies/default-policy.yaml
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/Policies/default-policy.yaml
@@ -1,28 +1,44 @@
+# Default governance policy for the agentic harness template.
+#
+# These rules are an illustrative starting point, not a complete security posture — they name this
+# harness's actual built-in tools (see Infrastructure.AI/Tools/**/ToolName) so the policy is functional
+# out of the box, but consumers should extend or replace them to match their own tools and risk
+# tolerance. Sandbox capability enforcement, the ChangeProposal approval gate, and the other checks in
+# ToolInvocationGovernor all run independently of this file; it is one layer, not the only one.
+#
+# A `warn` action currently only tags the governance.action=warn metric (AgtPolicyEngineAdapter maps
+# Warn to Allowed=true and the caller-visible decision discards the matched rule) — there is no log
+# line or audit entry beyond that metric today. Don't read "warn" below as producing a visible signal
+# by itself.
 name: default-policy
 description: Default governance policy for the agentic harness template
 scope: global
-defaultAction: allow
+default_action: allow
 rules:
-  - name: block-system-exec
-    condition: "tool == 'execute_command' || tool == 'shell_exec' || tool == 'run_process'"
-    action: deny
+  # All four shell out to a real CLI inside the sandbox (WorkspaceCommandRunner for run_tests/run_lint,
+  # IacSandboxRunner for iac_plan/iac_scan) -- despite their own tool-level docs describing the iac_*
+  # pair as "read-only" (true of their observable effect on the repo/cluster, not of what they're
+  # capable of while running). Their actual granted capabilities differ, verified against each
+  # runner's own RequiredCapabilities, not assumed: run_tests/run_lint get FileRead|FileWrite|Subprocess
+  # ONLY -- WorkspaceCommandRunner's own doc comment states NetworkAccess is deliberately NOT granted
+  # (the workspace skill's egress allowlist is empty by design) -- while iac_plan/iac_scan additionally
+  # get NetworkAccess (IacSandboxRunner). iac_generate is NOT included here: IIacGenerator.GenerateAsync
+  # is documented as deterministic templating with no sandbox invocation at all, so it genuinely belongs
+  # with the read-only tools below.
+  - name: warn-sandboxed-execution
+    condition: "tool == 'run_tests' || tool == 'run_lint' || tool == 'iac_plan' || tool == 'iac_scan'"
+    action: warn
     priority: 100
-    description: Block direct system execution tools by default
+    description: Warn on tools that shell out to a CLI inside the sandbox (subprocess capability; iac_plan/iac_scan additionally get network access, run_tests/run_lint do not)
 
-  - name: block-network-raw
-    condition: "tool == 'raw_http' || tool == 'tcp_connect'"
-    action: deny
-    priority: 90
-    description: Block raw network access tools
-
-  - name: warn-file-write
-    condition: "tool == 'file_write' || tool == 'file_delete'"
+  - name: warn-file-mutation
+    condition: "tool == 'write_file' || tool == 'file_system'"
     action: warn
     priority: 50
-    description: Warn on file mutation operations
+    description: Warn on tools that can write to the local workspace
 
-  - name: allow-read-tools
-    condition: "tool == 'file_read' || tool == 'web_search' || tool == 'web_fetch'"
+  - name: allow-read-only-tools
+    condition: "tool == 'read_file' || tool == 'list_files' || tool == 'document_search' || tool == 'iac_generate'"
     action: allow
     priority: 10
-    description: Explicitly allow read-only tools
+    description: Explicitly allow tools with no sandbox/subprocess/network capability

--- a/src/Content/Infrastructure/Infrastructure.AI.Governance/README.md
+++ b/src/Content/Infrastructure/Infrastructure.AI.Governance/README.md
@@ -227,8 +227,21 @@ Policy YAML files are configured as `<None Include="Policies/**/*.yaml" CopyToOu
 
 1. Create a YAML file in the `Policies/` folder following AGT's policy schema.
 2. Add the filename to `GovernanceConfig.PolicyPaths` in appsettings.
-3. The policy is loaded at startup by `GovernanceKernel` via resolved paths.
+3. The policy is loaded at startup: `DependencyInjection.ReadAndValidatePolicyFiles` resolves and reads
+   each configured path, then hands the content to `GovernanceKernel.LoadPolicyFromYaml`.
 4. Or load dynamically at runtime: `_policyEngine.LoadPolicyFile(path)`.
+
+**`default_action` must be snake_case, not camelCase.** AGT's YAML parser deserializes with a
+snake_case naming convention and no override for this field (unlike `apiVersion`, which does have
+one) — a policy written as `defaultAction: allow` is silently ignored rather than rejected, and the
+engine falls back to denying every tool that doesn't match an explicit rule (#384). `PolicyYamlGuard`
+now checks for this on **both** load paths — the startup path (step 3, from `PolicyPaths`) and the
+dynamic path (step 4, `LoadPolicyFile`) — so either one now fails loudly instead of silently on load.
+The harness still doesn't own the deserializer, so getting the key right in the source YAML is on you.
+This is caught on both harness-owned load paths, not guaranteed everywhere: code that resolves the AGT
+`PolicyEngine` from the container directly and calls its own `LoadYamlFile`/`LoadYaml` bypasses
+`PolicyYamlGuard` entirely — go through `IGovernancePolicyEngine`/`AddGovernanceDependencies`, not the
+raw engine type.
 
 ### How to Debug Policy Evaluation
 

--- a/src/Content/Presentation/Presentation.Dashboard/CLAUDE.md
+++ b/src/Content/Presentation/Presentation.Dashboard/CLAUDE.md
@@ -1,0 +1,30 @@
+# Presentation.Dashboard
+
+Operator-facing metrics/observability dashboard. React SPA, separate stack from the rest of the .NET solution — treat as its own project, not a Presentation-layer C# concern.
+
+## Stack
+- React 19, TypeScript, Vite 8, Tailwind 4
+- TanStack Query (server state), Zustand (client state), React Router 8
+- Radix UI + shadcn components, Recharts for charts
+- MSAL (`@azure/msal-browser`/`msal-react`) for auth, `@microsoft/signalr` for realtime, `@ag-ui/client` for agent-run streaming
+- Vitest + Testing Library (unit), Playwright (e2e)
+
+## Commands (run from this directory)
+- `npm run dev` — dev server on port 5174
+- `npm run dev:all` — dev server + `Presentation.AgentHub` API concurrently
+- `npm run build` — `tsc -b && vite build`
+- `npm run typecheck` — `tsc -b` only
+- `npm run lint` — eslint
+- `npm test` / `npm run test:watch` / `npm run test:coverage` — Vitest
+- `npm run test:e2e` — Playwright
+
+## Layout
+- `src/routes/` — one folder per dashboard page (Overview, Cost, Spend, Budget, Tokens, Quality, Safety, Governance, Rag, Evals, Sessions, Tools, Catalog, Pulse, DesignSystem)
+- `src/components/` — grouped by domain: `agent/`, `charts/`, `context/`, `layout/`, `metrics/`, `panels/`, `primitives/`, `theme/`
+- `src/api/` — API client code; `src/realtime/` — SignalR wiring; `src/auth/` — MSAL setup
+- `src/stores/` — Zustand stores; `src/hooks/`, `src/lib/`, `src/config/`
+- `src/test/` — shared test helpers (`helpers/`) and mocks (`mocks/`)
+
+## Notes
+- Backing API is `Presentation.AgentHub` — `npm run dev:all` runs both together.
+- `dist/`, `coverage/`, `test-results/`, `node_modules/` are build/test output — never hand-edit, never treat as source when exploring.

--- a/src/Content/Presentation/Presentation.WebUI/CLAUDE.md
+++ b/src/Content/Presentation/Presentation.WebUI/CLAUDE.md
@@ -1,0 +1,30 @@
+# Presentation.WebUI
+
+End-user chat/agent UI. React SPA, separate stack from the rest of the .NET solution — treat as its own project, not a Presentation-layer C# concern.
+
+## Stack
+- React 19, TypeScript, Vite 8, Tailwind 4
+- TanStack Query (server state), Zustand (client state), React Router 8, React Hook Form + Zod
+- Radix UI / Base UI + shadcn components
+- MSAL (`@azure/msal-browser`/`msal-react`) for auth, `@microsoft/signalr` for realtime, `@ag-ui/client` for agent-run streaming
+- `react-markdown` + `rehype-highlight`/`rehype-sanitize`/`remark-gfm` for rendering agent output
+- Vitest + Testing Library (unit), Playwright (e2e)
+
+## Commands (run from this directory)
+- `npm run dev` — dev server
+- `npm run dev:all` — dev server + `Presentation.AgentHub` API concurrently
+- `npm run build` — `tsc -b && vite build`
+- `npm run typecheck` — `tsc -b` only
+- `npm run lint` — eslint
+- `npm test` / `npm run test:watch` / `npm run test:coverage` — Vitest
+- `npm run test:e2e` — Playwright
+
+## Layout
+- `src/features/` — feature folders: `agents/`, `chat/` (+ `widgets/`), `commands/`, `config/`, `conversations/`, `mcp/`
+- `src/components/` — `ui/` (shadcn-generated primitives), `layout/`, `theme/`
+- `src/views/`, `src/stores/`, `src/hooks/`, `src/lib/`, `src/types/`
+- Tests are co-located in `__tests__/` subfolders next to the code they cover (`features/chat/__tests__/`, `hooks/__tests__/`, `lib/__tests__/`, etc.), plus a shared `src/test/` for setup/helpers
+
+## Notes
+- Backing API is `Presentation.AgentHub` — `npm run dev:all` runs both together.
+- `dist/`, `coverage/`, `test-results/`, `node_modules/` are build/test output — never hand-edit, never treat as source when exploring.

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Adapters/AgtPolicyEngineAdapterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Adapters/AgtPolicyEngineAdapterTests.cs
@@ -1,18 +1,26 @@
 using AgentGovernance.Policy;
 using Domain.AI.Governance;
 using Infrastructure.AI.Governance.Adapters;
+using Tests.Common;
 using Xunit;
 
 namespace Infrastructure.AI.Governance.Tests.Adapters;
 
-public sealed class AgtPolicyEngineAdapterTests
+public sealed class AgtPolicyEngineAdapterTests : IDisposable
 {
     private readonly PolicyEngine _engine = new();
     private readonly AgtPolicyEngineAdapter _adapter;
+    private readonly List<string> _tempPaths = [];
 
     public AgtPolicyEngineAdapterTests()
     {
         _adapter = new AgtPolicyEngineAdapter(_engine);
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in _tempPaths)
+            File.Delete(path);
     }
 
     [Fact]
@@ -66,21 +74,6 @@ public sealed class AgtPolicyEngineAdapterTests
     }
 
     [Fact]
-    public void LoadPolicyFile_DelegatesToEngine()
-    {
-        var yaml = """
-            name: loaded-policy
-            rules:
-              - name: test-rule
-                condition: "true"
-                action: allow
-            """;
-        _engine.LoadYaml(yaml);
-
-        Assert.True(_adapter.HasPolicies);
-    }
-
-    [Fact]
     public void EvaluateToolCall_WithArguments_PassesThemAsContext()
     {
         var args = new Dictionary<string, object?> { ["path"] = "/etc/passwd" };
@@ -88,5 +81,137 @@ public sealed class AgtPolicyEngineAdapterTests
         var decision = _adapter.EvaluateToolCall("agent-1", "read_file", args);
 
         Assert.True(decision.IsAllowed);
+    }
+
+    // #384: the shipped default-policy.yaml declares `default_action: allow` (snake_case, as
+    // Microsoft.AgentGovernance's YAML deserializer requires) so a tool that matches none of its
+    // rules must be allowed, not denied.
+    [Fact]
+    public void LoadPolicyFile_ShippedDefaultPolicy_UnmatchedToolIsAllowed()
+    {
+        var path = RepoRoot.Combine(
+            "src", "Content", "Infrastructure", "Infrastructure.AI.Governance", "Policies", "default-policy.yaml");
+
+        _adapter.LoadPolicyFile(path);
+        var decision = _adapter.EvaluateToolCall("agent-1", "some_tool_no_rule_names");
+
+        Assert.True(decision.IsAllowed);
+        Assert.Equal(GovernancePolicyAction.Allow, decision.Action);
+    }
+
+    // AgentGovernance's Policy.FromYaml deserializes with UnderscoredNamingConvention and no
+    // per-field override for DefaultAction (unlike ApiVersion, which has an explicit alias), and
+    // IgnoreUnmatchedProperties() means a camelCase `defaultAction` key is silently dropped rather
+    // than erroring — Policy.DefaultAction then silently falls back to Deny regardless of the
+    // author's intent. LoadPolicyFile must fail loudly instead of accepting a policy document that
+    // would misbehave silently.
+    [Theory]
+    [InlineData("defaultAction")]
+    [InlineData("DefaultAction")]
+    [InlineData("Default_Action")]
+    [InlineData("default-action")]
+    [InlineData("default action")]
+    public void LoadPolicyFile_MisCasedDefaultAction_ThrowsActionableException(string misCasedKey)
+    {
+        var path = WriteTempPolicy($"""
+            name: casing-mistake
+            {misCasedKey}: allow
+            rules:
+              - name: block-exec
+                condition: "tool == 'execute_command'"
+                action: deny
+            """);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => _adapter.LoadPolicyFile(path));
+
+        Assert.Contains(misCasedKey, ex.Message);
+        Assert.Contains("default_action", ex.Message);
+    }
+
+    // Premise control: the guard's whole justification is that AGT itself silently drops a mis-cased
+    // key rather than erroring. This proves that premise directly against the real engine, bypassing
+    // the guard entirely (LoadYaml, not LoadPolicyFile) — if a future AGT/YamlDotNet upgrade turns on
+    // case-insensitive property matching, this is the test that should fail, not a puzzled read of why
+    // the guard started rejecting valid policies.
+    [Fact]
+    public void EngineDirectly_MisCasedDefaultAction_IsSilentlyDroppedAndDeniesUnmatchedTool()
+    {
+        _engine.LoadYaml("""
+            name: premise-control
+            DefaultAction: allow
+            rules:
+              - name: block-exec
+                condition: "tool == 'execute_command'"
+                action: deny
+            """);
+
+        var decision = _adapter.EvaluateToolCall("agent-1", "read_file");
+
+        Assert.False(decision.IsAllowed);
+    }
+
+    // The guard parses real YAML structure (the document's actual key set) rather than text-scanning
+    // for a substring, so a correctly-keyed policy whose description happens to mention the mistaken
+    // key by name (e.g. documenting the migration from #384) must not be rejected.
+    [Fact]
+    public void LoadPolicyFile_CorrectKeyWithMisCasedNameMentionedInDescription_DoesNotThrow()
+    {
+        var path = WriteTempPolicy("""
+            name: describes-the-old-mistake
+            default_action: allow
+            description: "the old, wrong key was defaultAction — see #384"
+            rules:
+              - name: block-exec
+                condition: "tool == 'execute_command'"
+                action: deny
+            """);
+
+        var ex = Record.Exception(() => _adapter.LoadPolicyFile(path));
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void LoadPolicyFile_SnakeCaseDefaultActionAllow_UnmatchedToolIsAllowed()
+    {
+        var path = WriteTempPolicy("""
+            name: correctly-cased
+            default_action: allow
+            rules:
+              - name: block-exec
+                condition: "tool == 'execute_command'"
+                action: deny
+            """);
+
+        _adapter.LoadPolicyFile(path);
+        var decision = _adapter.EvaluateToolCall("agent-1", "read_file");
+
+        Assert.True(decision.IsAllowed);
+        Assert.Equal(GovernancePolicyAction.Allow, decision.Action);
+    }
+
+    [Fact]
+    public void LoadPolicyFile_NoDefaultActionSpecified_DeniesUnmatchedToolByDefault()
+    {
+        var path = WriteTempPolicy("""
+            name: no-default-specified
+            rules:
+              - name: block-exec
+                condition: "tool == 'execute_command'"
+                action: deny
+            """);
+
+        _adapter.LoadPolicyFile(path);
+        var decision = _adapter.EvaluateToolCall("agent-1", "read_file");
+
+        Assert.False(decision.IsAllowed);
+    }
+
+    private string WriteTempPolicy(string yaml)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.yaml");
+        File.WriteAllText(path, yaml);
+        _tempPaths.Add(path);
+        return path;
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Composition/GovernanceDependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Composition/GovernanceDependencyInjectionTests.cs
@@ -52,4 +52,56 @@ public sealed class GovernanceDependencyInjectionTests
             .Should().BeOfType<AgtPromptInjectionAdapter>(
                 "with detection on the scanner must wrap the AGT PromptInjectionDetector");
     }
+
+    // #384: GovernanceKernel's constructor loads every configured PolicyPaths entry itself
+    // (PolicyEngine.LoadYamlFile in its own loop) — this is the actual path that loaded the harness's
+    // own miscased default-policy.yaml, entirely bypassing AgtPolicyEngineAdapter.LoadPolicyFile. A
+    // guard that only lives on the adapter's method never runs here, so this proves the guard fires on
+    // the real startup path, not only on the separate runtime-load API a production host never calls.
+    [Fact]
+    public void AddGovernanceDependencies_ConfiguredPolicyPathUsesMisCasedDefaultAction_ThrowsBeforeKernelConstruction()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.yaml");
+        File.WriteAllText(path, """
+            name: casing-mistake
+            defaultAction: allow
+            rules:
+              - name: block-exec
+                condition: "tool == 'execute_command'"
+                action: deny
+            """);
+
+        try
+        {
+            var config = new GovernanceConfig { Enabled = true, PolicyPaths = [path] };
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            var act = () => services.AddGovernanceDependencies(config);
+
+            act.Should().Throw<InvalidOperationException>()
+                .WithMessage("*defaultAction*default_action*");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // A configured-but-missing path used to be silently dropped via .Where(File.Exists) — the whole
+    // declarative policy layer could end up unloaded with no signal beyond a quieter-than-expected
+    // policy set. Fail loudly instead, before GovernanceKernel is even constructed.
+    [Fact]
+    public void AddGovernanceDependencies_ConfiguredPolicyPathDoesNotExist_ThrowsBeforeKernelConstruction()
+    {
+        var missingPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.yaml");
+        var config = new GovernanceConfig { Enabled = true, PolicyPaths = [missingPath] };
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var act = () => services.AddGovernanceDependencies(config);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{missingPath}*");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Infrastructure.AI.Governance.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Infrastructure.AI.Governance.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.Governance/Infrastructure.AI.Governance.csproj" />
+    <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Closes #384. `Microsoft.AgentGovernance`'s `Policy.FromYaml` deserializes with a snake_case naming convention and no per-field override for `DefaultAction` (unlike `ApiVersion`, which has an explicit alias). Combined with `IgnoreUnmatchedProperties()`, the harness's own `default-policy.yaml` writing camelCase `defaultAction: allow` was silently dropped, so every tool call that didn't match an explicit rule was denied regardless of the YAML's stated intent — confirmed by decompiling the pinned `Microsoft.AgentGovernance` 3.0.2 assembly, not guessed.

- Renamed the shipped policy's key to `default_action`.
- Added a shared `PolicyYamlGuard` that structurally parses a policy document's real top-level keys (not a text/regex scan) and catches any mis-cased variant of the key — camelCase, PascalCase, kebab-case, space-separated.
- **The first version of this fix only guarded `AgtPolicyEngineAdapter.LoadPolicyFile`, which turned out to be dead code for the actual incident** — decompiling `GovernanceKernel`'s constructor showed it loads every configured `PolicyPaths` entry itself (`PolicyEngine.LoadYamlFile` in a loop), bypassing the adapter entirely. That's the real startup path that loaded the original miscased file. The guard now runs at both seams: the DI composition root (`DependencyInjection.ReadAndValidatePolicyFiles`, feeding `GovernanceKernel.LoadPolicyFromYaml` so the kernel's own constructor never re-reads the same files) and the adapter's dynamic `LoadPolicyFile`.
- The raw AGT `PolicyEngine` is no longer separately registered in DI — only the guarded adapter is — closing a path where a future consumer could resolve the raw engine and reload YAML unguarded.
- The shipped policy's rules referenced generic placeholder tool names (`execute_command`, `raw_http`, `file_write`, ...) that don't exist anywhere in this harness — masked by the original bug's accidental deny-all. Retargeted to this harness's real `ToolName` constants, with `iac_plan`/`iac_scan` correctly classified as sandboxed-execution (they shell out to terraform/checkov via `IacSandboxRunner`) rather than read-only, and their actual granted capabilities (including network access) stated accurately against each tool's own permission profile.

Two follow-ups filed for changes judged out of scope for this fix:
- #386 — decouple `Governance.Enabled` from prompt-injection detection and MCP security scanning (the original issue's second, independent ask).
- #387 — derive policy risk classification from `ToolCapability` declarations instead of hand-transcribing it into YAML (a factual error in this PR's own first-draft retargeting — caught by review — is the concrete evidence for why).

## Review history

This PR went through two full `/code-review` passes and two full security-reviewer passes, each catching real issues in the prior version:
- Pass 1 caught the dead-code guard placement (HIGH).
- Pass 2 caught the tool-name mismatch in the retargeted policy, a missing-path silent-drop gap, and several test/doc hygiene issues.
- Final `/simplify` pass caught a dead public API, a missing recursion guard (matching an existing sibling convention in this repo), and the network-capability factual error described above.

## Test plan

- [x] Full solution build, 0 errors
- [x] `Infrastructure.AI.Governance.Tests`: 254/254 passing
- [x] `Application.AI.Common.Tests` (governance subset): 300/300 passing
- [x] `Presentation.Common.Tests` (governance binding subset): 9/9 passing
- [x] New regression tests: mis-cased `default_action` throws (5 casing variants, including kebab-case and space-separated), a correctly-cased policy whose description merely *mentions* the mistaken key doesn't false-positive, a premise-control test proving AGT itself silently drops the mis-cased key (not just that the new guard throws), the DI/startup path throws before `GovernanceKernel` construction, a missing configured policy path throws
- [x] `/code-review` — two passes, all real findings fixed
- [x] `/simplify` — four angles, all real findings fixed
- [x] Two independent `security-reviewer` passes — both APPROVE-WITH-CHANGES, all required/recommended changes applied

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>