### PR TITLE
fix: add direct-endpoint Foundry Responses provider to bypass slow Project-scoped routing (#382)

### DIFF
--- a/src/Content/Domain/Domain.Common/Config/AI/AIAgentFrameworkClientType.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIAgentFrameworkClientType.cs
@@ -46,6 +46,7 @@ public enum AIAgentFrameworkClientType
 	/// and tools at runtime. No server-managed agent resource is created.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// Unlike the other client types, this provider yields an <c>AIAgent</c> rather than an
 	/// <c>IChatClient</c>, so it is constructed at the agent-factory level rather than via
 	/// <c>IChatClientFactory</c>. The harness middleware pipeline (OpenTelemetry, function
@@ -55,10 +56,34 @@ public enum AIAgentFrameworkClientType
 	/// an API key. Plain chat-completions inference against Foundry models is already available via
 	/// <see cref="AzureAIInference"/> / <see cref="AzureOpenAI"/>; this type adds the Foundry
 	/// Responses agent semantics.
-	/// </remarks>
-	/// <remarks>
+	/// </para>
+	/// <para>
 	/// Appended last to preserve the existing integer ordinals of the other members (enum values
 	/// may be persisted). New members must be added at the end for the same reason.
+	/// </para>
 	/// </remarks>
 	FoundryResponses,
+
+	/// <summary>
+	/// Azure AI Foundry Responses (direct inference) — same model and credential as
+	/// <see cref="FoundryResponses"/>, but calls the bare resource endpoint
+	/// (<c>AppConfig:AI:AIFoundry:ResourceEndpoint</c>) via a plain
+	/// <c>AzureOpenAIClient.GetResponsesClient().AsIChatClient(...)</c> instead of routing through
+	/// <c>AIProjectClient</c>'s Project-scoped endpoint.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Exists because Project-scoped Responses routing measured ~15x higher per-call latency than
+	/// the identical model/tenant/credential called directly against the resource endpoint — a
+	/// real service-side cost of the extra routing hop, not a client-framework artifact (issue
+	/// #382). Unlike <see cref="FoundryResponses"/>, this type yields a plain <c>IChatClient</c>
+	/// and is constructed via <c>IChatClientFactory</c> like the other <c>IChatClient</c>
+	/// providers — no <c>IFoundryAgentProvider</c> involved.
+	/// </para>
+	/// <para>
+	/// Appended last to preserve the existing integer ordinals of the other members (enum values
+	/// may be persisted). New members must be added at the end for the same reason.
+	/// </para>
+	/// </remarks>
+	FoundryDirectResponses,
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/AIFoundry/AIFoundryConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIFoundry/AIFoundryConfig.cs
@@ -1,3 +1,4 @@
+using Domain.Common.Config.AI;
 using Domain.Common.Config.Azure;
 
 namespace Domain.Common.Config.AI.AIFoundry;
@@ -21,11 +22,28 @@ public class AIFoundryConfig
     /// <summary>
     /// Gets or sets the AI Foundry project endpoint URL.
     /// </summary>
-    /// <example>https://my-project.services.ai.azure.com</example>
+    /// <example>https://my-project.services.ai.azure.com/api/projects/my-project</example>
     public string ProjectEndpoint { get; set; } = string.Empty;
 
     /// <summary>
+    /// Gets or sets the bare AI Foundry resource endpoint — the same resource
+    /// <see cref="ProjectEndpoint"/> targets, without the Project-scoped path segment.
+    /// </summary>
+    /// <remarks>
+    /// Used only by <see cref="AIAgentFrameworkClientType.FoundryDirectResponses"/> to bypass
+    /// Project-scoped routing, which measured ~15x higher per-call latency than calling the same
+    /// model directly through this endpoint (issue #382) — Project-scoped routing adds a real
+    /// orchestration hop, not a client-framework artifact. Independent of
+    /// <see cref="ProjectEndpoint"/>/<see cref="IsConfigured"/>: a consumer may configure this
+    /// without ever configuring the Project-scoped path, or both side by side.
+    /// </remarks>
+    /// <example>https://my-project.services.ai.azure.com</example>
+    public string ResourceEndpoint { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets the Entra ID credential configuration for authenticating with AI Foundry.
+    /// Shared by both <see cref="ProjectEndpoint"/> and <see cref="ResourceEndpoint"/> routing —
+    /// same resource, same tenant, same credential either way.
     /// </summary>
     public EntraCredentialConfig Entra { get; set; } = new();
 
@@ -33,4 +51,9 @@ public class AIFoundryConfig
     /// Whether AI Foundry is configured with a valid project endpoint.
     /// </summary>
     public bool IsConfigured => !string.IsNullOrWhiteSpace(ProjectEndpoint);
+
+    /// <summary>
+    /// Whether the bare resource endpoint is configured for direct (non-Project-scoped) routing.
+    /// </summary>
+    public bool IsDirectResponsesConfigured => !string.IsNullOrWhiteSpace(ResourceEndpoint);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -388,22 +388,58 @@ public static partial class DependencyInjection
     }
 
     /// <summary>
-    /// Registers Azure AI Foundry persistent agents administration client when configured.
+    /// Registers Azure AI Foundry persistent agents administration client when configured, and the
+    /// direct-endpoint Responses client independently (issue #382).
     /// </summary>
     private static void RegisterAIFoundryAgents(IServiceCollection services, AppConfig appConfig)
     {
-        if (appConfig.AI.AIFoundry.IsConfigured)
+        var foundry = appConfig.AI.AIFoundry;
+
+        if (!foundry.IsConfigured && !foundry.IsDirectResponsesConfigured)
+            return;
+
+        // Shared across both branches below: same resource, same tenant, same Entra credential
+        // either way (AIFoundryConfig.Entra's own doc), so a consumer configuring both
+        // ProjectEndpoint and ResourceEndpoint gets one credential chain, not two.
+        var credential = AzureCredentialFactory.CreateTokenCredential(foundry.Entra);
+
+        if (foundry.IsConfigured)
         {
-            var credential = AzureCredentialFactory.CreateTokenCredential(appConfig.AI.AIFoundry.Entra);
             services.AddSingleton(new PersistentAgentsAdministrationClient(
-                appConfig.AI.AIFoundry.ProjectEndpoint, credential));
+                foundry.ProjectEndpoint, credential));
 
             // Foundry Responses agent (direct inference) — AIProjectClient drives the project's
             // Responses API; FoundryAgentProvider builds the non-versioned ChatClientAgent for the
             // FoundryResponses client type. Both gated on the project endpoint being configured.
             services.AddSingleton(new AIProjectClient(
-                new Uri(appConfig.AI.AIFoundry.ProjectEndpoint), credential));
+                new Uri(foundry.ProjectEndpoint), credential));
             services.AddSingleton<IFoundryAgentProvider, FoundryAgentProvider>();
+        }
+
+        if (foundry.IsDirectResponsesConfigured)
+        {
+            // FoundryDirectResponses (issue #382): bypasses AIProjectClient's Project-scoped
+            // routing — measured ~15x slower than calling the same model/tenant/credential via the
+            // bare resource endpoint — using a plain AzureOpenAIClient against ResourceEndpoint.
+            // Gated independently of IsConfigured/ProjectEndpoint: a consumer may configure only
+            // this direct path, only the Project-scoped path, or both.
+            if (!Uri.TryCreate(foundry.ResourceEndpoint, UriKind.Absolute, out var resourceUri))
+            {
+                throw new InvalidOperationException(
+                    $"AppConfig:AI:AIFoundry:ResourceEndpoint '{foundry.ResourceEndpoint}' is not a " +
+                    "valid absolute URI.");
+            }
+
+            services.AddKeyedSingleton(
+                AgentFrameworkHelper.FoundryDirectResponsesClientKey,
+                (_, _) => new AzureOpenAIClient(
+                    resourceUri, credential, AgentFrameworkHelper.GetAzureOpenAIClientOptions()));
+
+            services.AddKeyedSingleton(
+                AgentFrameworkHelper.FoundryDirectResponsesNoRetryClientKey,
+                (_, _) => new AzureOpenAIClient(
+                    resourceUri, credential,
+                    AgentFrameworkHelper.GetAzureOpenAIClientOptions(disableProviderRetry: true)));
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.Providers.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.Providers.cs
@@ -121,6 +121,27 @@ public sealed partial class ChatClientFactory
         }
     }
 
+    /// <summary>
+    /// Creates an <see cref="IChatClient"/> for the Azure AI Foundry Responses API called directly
+    /// against the bare resource endpoint, bypassing <c>AIProjectClient</c>'s Project-scoped
+    /// routing (issue #382: Project-scoped routing measured ~15x higher per-call latency for the
+    /// identical model/tenant/credential).
+    /// </summary>
+    private Task<IChatClient> GetFoundryDirectResponsesChatClientAsync(
+        string deploymentName, bool disableProviderRetry, CancellationToken cancellationToken)
+    {
+        var key = disableProviderRetry
+            ? AgentFrameworkHelper.FoundryDirectResponsesNoRetryClientKey
+            : AgentFrameworkHelper.FoundryDirectResponsesClientKey;
+
+        var client = _serviceProvider.GetKeyedService<AzureOpenAIClient>(key)
+            ?? throw new AiProviderNotConfiguredException(
+                "FoundryDirectResponses is not configured. Set AppConfig:AI:AIFoundry:ResourceEndpoint " +
+                "and AppConfig:AI:AIFoundry:Entra.");
+
+        return Task.FromResult(client.GetResponsesClient().AsIChatClient(deploymentName));
+    }
+
     private Task<IChatClient> GetOpenAIChatClientAsync(
         string deploymentName, bool disableProviderRetry, CancellationToken cancellationToken)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Factories/ChatClientFactory.cs
@@ -5,6 +5,7 @@ using Azure.AI.OpenAI;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Infrastructure.AI.Clients;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -102,14 +103,20 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
     /// </summary>
     private IReadOnlyList<string> ComputeMissingSettings(AIAgentFrameworkClientType clientType)
     {
-        // FoundryResponses authenticates via the Foundry project endpoint + Entra (not an API key),
-        // so its only required setting lives under AppConfig:AI:AIFoundry.
-        if (clientType == AIAgentFrameworkClientType.FoundryResponses)
+        // Both Foundry types authenticate via Entra (not an API key), each against its own
+        // AppConfig:AI:AIFoundry setting — ProjectEndpoint for the Project-scoped agent path,
+        // ResourceEndpoint for the direct-inference path (issue #382).
+        var foundry = _appConfig.CurrentValue.AI.AIFoundry;
+        (bool IsConfigured, string RequiredSetting)? foundryRequirement = clientType switch
         {
-            return _appConfig.CurrentValue.AI.AIFoundry.IsConfigured
-                ? []
-                : ["AppConfig:AI:AIFoundry:ProjectEndpoint"];
-        }
+            AIAgentFrameworkClientType.FoundryResponses =>
+                (foundry.IsConfigured, "AppConfig:AI:AIFoundry:ProjectEndpoint"),
+            AIAgentFrameworkClientType.FoundryDirectResponses =>
+                (foundry.IsDirectResponsesConfigured, "AppConfig:AI:AIFoundry:ResourceEndpoint"),
+            _ => null
+        };
+        if (foundryRequirement is { } requirement)
+            return requirement.IsConfigured ? [] : [requirement.RequiredSetting];
 
         var framework = _appConfig.CurrentValue.AI.AgentFramework;
         var missing = new List<string>();
@@ -144,6 +151,10 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
             // not an IChatClient. Availability is reported here for consistency and health checks,
             // and is gated on the Foundry project endpoint being configured.
             AIAgentFrameworkClientType.FoundryResponses => _appConfig.CurrentValue.AI.AIFoundry.IsConfigured,
+            AIAgentFrameworkClientType.FoundryDirectResponses =>
+                _appConfig.CurrentValue.AI.AIFoundry.IsDirectResponsesConfigured
+                && _serviceProvider.GetKeyedService<AzureOpenAIClient>(
+                    AgentFrameworkHelper.FoundryDirectResponsesClientKey) != null,
             AIAgentFrameworkClientType.Echo => true,
             _ => false
         };
@@ -188,6 +199,7 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
             AIAgentFrameworkClientType.FoundryResponses => throw new InvalidOperationException(
                 "ClientType 'FoundryResponses' does not expose an IChatClient — it produces an AIAgent. " +
                 "Build it through AgentFactory (which uses IFoundryAgentProvider), not IChatClientFactory.GetChatClientAsync."),
+            AIAgentFrameworkClientType.FoundryDirectResponses => await GetFoundryDirectResponsesChatClientAsync(deploymentOrAgentId, disableProviderRetry, cancellationToken),
             AIAgentFrameworkClientType.Echo => new EchoChatClient(),
             _ => throw new ArgumentException($"Unsupported AI framework client type: {clientType}", nameof(clientType))
         };
@@ -204,6 +216,7 @@ public sealed partial class ChatClientFactory : IChatClientFactory, IDisposable
             { AIAgentFrameworkClientType.PersistentAgents, IsAvailable(AIAgentFrameworkClientType.PersistentAgents) },
             { AIAgentFrameworkClientType.Anthropic, IsAvailable(AIAgentFrameworkClientType.Anthropic) },
             { AIAgentFrameworkClientType.FoundryResponses, IsAvailable(AIAgentFrameworkClientType.FoundryResponses) },
+            { AIAgentFrameworkClientType.FoundryDirectResponses, IsAvailable(AIAgentFrameworkClientType.FoundryDirectResponses) },
             { AIAgentFrameworkClientType.Echo, IsAvailable(AIAgentFrameworkClientType.Echo) }
         };
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Helpers/AgentFrameworkHelper.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Helpers/AgentFrameworkHelper.cs
@@ -26,6 +26,23 @@ public static class AgentFrameworkHelper
     public const string NoProviderRetryClientKey = "no-provider-retry";
 
     /// <summary>
+    /// DI key for the <see cref="AzureOpenAIClient"/> targeting the bare AI Foundry resource
+    /// endpoint (<see cref="Domain.Common.Config.AI.AIAgentFrameworkClientType.FoundryDirectResponses"/>).
+    /// Keyed rather than resolved unkeyed because the harness's primary
+    /// <see cref="AzureOpenAIClient"/> registration (for <c>ClientType=AzureOpenAI</c>) uses a
+    /// different endpoint and credential (API key vs Entra) — the two must never share a slot.
+    /// </summary>
+    public const string FoundryDirectResponsesClientKey = "foundry-direct-responses";
+
+    /// <summary>
+    /// DI key for the retry-disabled variant of <see cref="FoundryDirectResponsesClientKey"/>,
+    /// resolved by the provider fallback chain — same reasoning as <see cref="NoProviderRetryClientKey"/>,
+    /// kept separate because it must combine with the Foundry-direct endpoint/credential, not
+    /// whichever provider <see cref="NoProviderRetryClientKey"/> would otherwise resolve.
+    /// </summary>
+    public const string FoundryDirectResponsesNoRetryClientKey = "foundry-direct-responses-no-retry";
+
+    /// <summary>
     /// Gets configured options for <see cref="AzureOpenAIClient"/>.
     /// </summary>
     /// <param name="networkTimeoutSeconds">Network timeout in seconds. Default: 300.</param>

--- a/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Config/AIConfigTests.cs
@@ -1,4 +1,5 @@
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.AIFoundry;
 using FluentAssertions;
 using Xunit;
 
@@ -83,6 +84,65 @@ public class AgentFrameworkConfigTests
 }
 
 /// <summary>
+/// Tests for <see cref="AIFoundryConfig"/>'s two independent configured-ness gates —
+/// <see cref="AIFoundryConfig.IsConfigured"/> (Project-scoped) and
+/// <see cref="AIFoundryConfig.IsDirectResponsesConfigured"/> (bare resource endpoint, issue #382)
+/// — proving neither depends on the other.
+/// </summary>
+public class AIFoundryConfigTests
+{
+    [Fact]
+    public void IsConfigured_WithNoProjectEndpoint_ReturnsFalse()
+    {
+        new AIFoundryConfig().IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsConfigured_WithProjectEndpoint_ReturnsTrue()
+    {
+        var config = new AIFoundryConfig { ProjectEndpoint = "https://my-project.services.ai.azure.com/api/projects/my-project" };
+
+        config.IsConfigured.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDirectResponsesConfigured_WithNoResourceEndpoint_ReturnsFalse()
+    {
+        new AIFoundryConfig().IsDirectResponsesConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDirectResponsesConfigured_WithResourceEndpoint_ReturnsTrue()
+    {
+        var config = new AIFoundryConfig { ResourceEndpoint = "https://my-resource.services.ai.azure.com" };
+
+        config.IsDirectResponsesConfigured.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDirectResponsesConfigured_WithWhitespaceResourceEndpoint_ReturnsFalse()
+    {
+        var config = new AIFoundryConfig { ResourceEndpoint = "   " };
+
+        config.IsDirectResponsesConfigured.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BothGates_AreIndependent_NeitherSettingSatisfiesTheOther()
+    {
+        // A consumer may configure only the direct path, only the Project-scoped path, or both —
+        // the two settings must never be conflated.
+        var directOnly = new AIFoundryConfig { ResourceEndpoint = "https://my-resource.services.ai.azure.com" };
+        directOnly.IsConfigured.Should().BeFalse();
+        directOnly.IsDirectResponsesConfigured.Should().BeTrue();
+
+        var projectOnly = new AIFoundryConfig { ProjectEndpoint = "https://my-project.services.ai.azure.com/api/projects/my-project" };
+        projectOnly.IsConfigured.Should().BeTrue();
+        projectOnly.IsDirectResponsesConfigured.Should().BeFalse();
+    }
+}
+
+/// <summary>
 /// Tests for <see cref="AIAgentFrameworkClientType"/> enum values.
 /// </summary>
 public class AIAgentFrameworkClientTypeTests
@@ -95,6 +155,7 @@ public class AIAgentFrameworkClientTypeTests
     [InlineData(AIAgentFrameworkClientType.Anthropic, 4)]
     [InlineData(AIAgentFrameworkClientType.Echo, 5)]
     [InlineData(AIAgentFrameworkClientType.FoundryResponses, 6)]
+    [InlineData(AIAgentFrameworkClientType.FoundryDirectResponses, 7)]
     public void Value_HasExpectedInteger(AIAgentFrameworkClientType type, int expected)
     {
         ((int)type).Should().Be(expected);
@@ -104,7 +165,7 @@ public class AIAgentFrameworkClientTypeTests
     public void AllValues_AreDistinct()
     {
         Enum.GetValues<AIAgentFrameworkClientType>().Should().OnlyHaveUniqueItems();
-        Enum.GetValues<AIAgentFrameworkClientType>().Should().HaveCount(7);
+        Enum.GetValues<AIAgentFrameworkClientType>().Should().HaveCount(8);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -81,6 +81,55 @@ public sealed class DependencyInjectionTests
         registry.Should().NotBeNull();
     }
 
+    /// <summary>
+    /// Proves FoundryDirectResponses (issue #382) is wired through the real composition root, not
+    /// just a hand-rolled test ServiceCollection — the standing lesson that a registration is
+    /// untested unless a test resolves it from the real composition root.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructureAIDependencies_FoundryDirectResponsesConfigured_IsAvailableThroughRealCompositionRoot()
+    {
+        var config = IsolatedAppConfig.Isolate(new Domain.Common.Config.AppConfig
+        {
+            AI = new Domain.Common.Config.AI.AIConfig
+            {
+                AIFoundry = new Domain.Common.Config.AI.AIFoundry.AIFoundryConfig
+                {
+                    ResourceEndpoint = "https://myresource.services.ai.azure.com"
+                }
+            }
+        });
+        var services = CreateBaseServices(config);
+        services.AddInfrastructureAIDependencies(config);
+        using var provider = services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<IChatClientFactory>();
+
+        factory.IsAvailable(Domain.Common.Config.AI.AIAgentFrameworkClientType.FoundryDirectResponses)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddInfrastructureAIDependencies_FoundryDirectResponsesMalformedResourceEndpoint_ThrowsAtRegistration()
+    {
+        var config = IsolatedAppConfig.Isolate(new Domain.Common.Config.AppConfig
+        {
+            AI = new Domain.Common.Config.AI.AIConfig
+            {
+                AIFoundry = new Domain.Common.Config.AI.AIFoundry.AIFoundryConfig
+                {
+                    ResourceEndpoint = "not-a-valid-uri"
+                }
+            }
+        });
+        var services = CreateBaseServices(config);
+
+        var act = () => services.AddInfrastructureAIDependencies(config);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*AppConfig:AI:AIFoundry:ResourceEndpoint*");
+    }
+
     [Fact]
     public void RegisterAIClients_UnconfiguredConfig_DoesNotRegisterAnyClients()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryAvailabilityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryAvailabilityTests.cs
@@ -1,7 +1,11 @@
+using Azure;
+using Azure.AI.OpenAI;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.AIFoundry;
 using FluentAssertions;
 using Infrastructure.AI.Factories;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -42,6 +46,22 @@ public sealed class ChatClientFactoryAvailabilityTests : IDisposable
 
         return new ChatClientFactory(options, sp);
     }
+
+    private const string FoundryDirectResponsesResourceEndpoint = "https://myresource.services.ai.azure.com";
+
+    private static AppConfig CreateFoundryDirectResponsesConfig() => new()
+    {
+        AI = new AIConfig
+        {
+            AgentFramework = new AgentFrameworkConfig(),
+            AIFoundry = new AIFoundryConfig { ResourceEndpoint = FoundryDirectResponsesResourceEndpoint }
+        }
+    };
+
+    private static void RegisterFakeFoundryDirectResponsesClient(ServiceCollection services) =>
+        services.AddKeyedSingleton(
+            AgentFrameworkHelper.FoundryDirectResponsesClientKey,
+            new AzureOpenAIClient(new Uri(FoundryDirectResponsesResourceEndpoint), new AzureKeyCredential("fake")));
 
     [Fact]
     public void IsAvailable_AzureOpenAI_NoClient_ReturnsFalse()
@@ -126,6 +146,80 @@ public sealed class ChatClientFactoryAvailabilityTests : IDisposable
     }
 
     [Fact]
+    public void IsAvailable_FoundryDirectResponses_NoConfig_ReturnsFalse()
+    {
+        using var factory = CreateFactory();
+
+        factory.IsAvailable(AIAgentFrameworkClientType.FoundryDirectResponses).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The config flag alone is not enough — <c>IsAvailable</c> must also confirm the keyed
+    /// <see cref="AzureOpenAIClient"/> DI registration actually exists, the same "config says yes,
+    /// but was it actually registered" split every other provider check makes.
+    /// </summary>
+    [Fact]
+    public void IsAvailable_FoundryDirectResponses_ConfiguredButClientNotRegistered_ReturnsFalse()
+    {
+        using var factory = CreateFactory(CreateFoundryDirectResponsesConfig());
+
+        factory.IsAvailable(AIAgentFrameworkClientType.FoundryDirectResponses).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAvailable_FoundryDirectResponses_ConfiguredWithClientRegistered_ReturnsTrue()
+    {
+        var services = new ServiceCollection();
+        RegisterFakeFoundryDirectResponsesClient(services);
+
+        using var factory = CreateFactory(CreateFoundryDirectResponsesConfig(), services);
+
+        factory.IsAvailable(AIAgentFrameworkClientType.FoundryDirectResponses).Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetProviderStatus_FoundryDirectResponses_Unconfigured_ReportsMissingResourceEndpoint()
+    {
+        var config = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig { ClientType = AIAgentFrameworkClientType.FoundryDirectResponses }
+            }
+        };
+
+        using var factory = CreateFactory(config);
+
+        var status = factory.GetProviderStatus();
+
+        status.IsConfigured.Should().BeFalse();
+        status.MissingSettings.Should().ContainSingle().Which.Should().Be("AppConfig:AI:AIFoundry:ResourceEndpoint");
+    }
+
+    [Fact]
+    public async Task GetChatClientAsync_FoundryDirectResponses_NotConfigured_ThrowsAiProviderNotConfiguredException()
+    {
+        using var factory = CreateFactory();
+
+        var act = () => factory.GetChatClientAsync(AIAgentFrameworkClientType.FoundryDirectResponses, "my-deployment");
+
+        await act.Should().ThrowAsync<Application.AI.Common.Exceptions.AiProviderNotConfiguredException>();
+    }
+
+    [Fact]
+    public async Task GetChatClientAsync_FoundryDirectResponses_Configured_ReturnsChatClient()
+    {
+        var services = new ServiceCollection();
+        RegisterFakeFoundryDirectResponsesClient(services);
+
+        using var factory = CreateFactory(CreateFoundryDirectResponsesConfig(), services);
+
+        var chatClient = await factory.GetChatClientAsync(AIAgentFrameworkClientType.FoundryDirectResponses, "my-deployment");
+
+        chatClient.Should().NotBeNull();
+    }
+
+    [Fact]
     public void IsAvailable_UnknownType_ReturnsFalse()
     {
         using var factory = CreateFactory();
@@ -134,19 +228,20 @@ public sealed class ChatClientFactoryAvailabilityTests : IDisposable
     }
 
     [Fact]
-    public void GetAvailableProviders_ReturnsAllSevenTypes()
+    public void GetAvailableProviders_ReturnsAllEightTypes()
     {
         using var factory = CreateFactory();
 
         var providers = factory.GetAvailableProviders();
 
-        providers.Should().HaveCount(7);
+        providers.Should().HaveCount(8);
         providers.Should().ContainKey(AIAgentFrameworkClientType.AzureOpenAI);
         providers.Should().ContainKey(AIAgentFrameworkClientType.OpenAI);
         providers.Should().ContainKey(AIAgentFrameworkClientType.AzureAIInference);
         providers.Should().ContainKey(AIAgentFrameworkClientType.PersistentAgents);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Anthropic);
         providers.Should().ContainKey(AIAgentFrameworkClientType.FoundryResponses);
+        providers.Should().ContainKey(AIAgentFrameworkClientType.FoundryDirectResponses);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Echo);
     }
 
@@ -167,6 +262,7 @@ public sealed class ChatClientFactoryAvailabilityTests : IDisposable
         providers[AIAgentFrameworkClientType.PersistentAgents].Should().BeFalse();
         providers[AIAgentFrameworkClientType.Anthropic].Should().BeFalse();
         providers[AIAgentFrameworkClientType.FoundryResponses].Should().BeFalse();
+        providers[AIAgentFrameworkClientType.FoundryDirectResponses].Should().BeFalse();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Factories/ChatClientFactoryTests.cs
@@ -80,8 +80,9 @@ public sealed class ChatClientFactoryTests : IDisposable
         providers.Should().ContainKey(AIAgentFrameworkClientType.PersistentAgents);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Anthropic);
         providers.Should().ContainKey(AIAgentFrameworkClientType.FoundryResponses);
+        providers.Should().ContainKey(AIAgentFrameworkClientType.FoundryDirectResponses);
         providers.Should().ContainKey(AIAgentFrameworkClientType.Echo);
-        providers.Should().HaveCount(7);
+        providers.Should().HaveCount(8);
     }
 
     [Fact]

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -65,7 +65,11 @@
     <PackageVersion Include="Polly.Core" Version="8.5.2" />
     <PackageVersion Include="Anthropic.SDK" Version="5.10.0" />
     <PackageVersion Include="Azure.AI.Inference" Version="1.0.0-beta.5" />
-    <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
+    <!-- 2.9.0-beta.1 restores compatibility with OpenAI 2.9.*; needed so the resolved OpenAI
+         package (2.10.0, pulled in by Microsoft.Agents.AI.OpenAI/Foundry) doesn't run against
+         an Azure.AI.OpenAI build compiled for OpenAI 2.8.0 — that combination throws
+         MissingMethodException on the Responses surface at runtime, not at build time. -->
+    <PackageVersion Include="Azure.AI.OpenAI" Version="2.9.0-beta.1" />
     <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.13.0" />
     <!-- Foundry stays on the 1.10 preview line while the rest of the Microsoft.Agents.AI
          family moves to 1.13.0: there is no 1.13 Foundry preview, and the 1.13 core does


### PR DESCRIPTION
## Summary

Closes #382. `AIProjectClient`'s Project-scoped Responses routing (the existing `FoundryResponses` client type) measured ~15x higher per-call latency than calling the identical model/tenant/credential directly against the bare resource endpoint — a real service-side cost of the extra routing hop (confirmed via an OpenTelemetry breakdown in the issue showing the entire discrepancy sits inside the single outbound HTTP wait, not auth/DNS/connection setup — see issue #382 and the code-review comment already posted there confirming nothing in this harness compounds it).

Adds `AIAgentFrameworkClientType.FoundryDirectResponses`: a plain `IChatClient` built via `AzureOpenAIClient.GetResponsesClient().AsIChatClient(deploymentName)` against a new `AppConfig:AI:AIFoundry:ResourceEndpoint` setting, reusing the same Entra credential as the existing (slow) `FoundryResponses` path. Unlike `FoundryResponses` — which yields an `AIAgent` via `IFoundryAgentProvider` and is excluded from the resilience/fallback chain — this is a normal `IChatClient` provider: constructed via `IChatClientFactory`, eligible for the provider fallback chain like `AzureOpenAI`/`OpenAI`.

Both Foundry paths stay independently configurable — `ResourceEndpoint` and `ProjectEndpoint` are separate, unrelated settings — so a consumer can adopt the fast path without touching the existing one, or run both side by side.

## Package bump

`Azure.AI.OpenAI` 2.8.0-beta.1 → 2.9.0-beta.1: the pinned version was built against `OpenAI` 2.8.0, but the transitively-resolved `OpenAI` package in this solution is 2.10.0 (pulled in by `Microsoft.Agents.AI.OpenAI`/`Microsoft.Agents.AI.Foundry`) — verified directly via `project.assets.json`. The Azure.AI.OpenAI changelog confirms 2.9.0-beta.1 "restores compatibility with the latest 2.9.* release of OpenAI" and is the version needed for the Responses surface to work correctly against that resolved version.

## Review

Both `/code-review` and `/simplify` ran against the full diff; receipts recorded per this repo's review-gate.

**code-review** found one real issue: `AzureCredentialFactory.CreateTokenCredential` was called twice in `RegisterAIFoundryAgents` when both `ProjectEndpoint` and `ResourceEndpoint` are configured, building two independent credential chains for the same Entra config. Fixed — build the credential once, guarded by an early return when neither Foundry path is configured, shared by both branches.

**simplify** (4 parallel agents) found and fixed three real issues: `ChatClientFactory.ComputeMissingSettings` had two near-identical if-blocks for the two Foundry types, collapsed into one switch-expression check; a stray duplicate `<remarks>` block on the new enum member (and on the pre-existing `FoundryResponses` member, same fix applied to both); and ~20 lines of duplicated test setup across 3 new tests, extracted into two small helpers matching the file's existing pattern. Two agents (reuse, altitude) separately suggested generalizing the `AzureOpenAIClient` + keyed-retry-pair registration machinery so a future Entra-authenticated provider could share it with the existing `AzureOpenAI` provider — deferred rather than applied, since both agents' own reasoning treats it as only justified once a second consumer actually needs it; noted here rather than forced into this fix's scope.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 errors
- [x] Full solution `dotnet test` — every suite green except the two pre-existing, unrelated Docker-dependent suites (`Infrastructure.AI.KnowledgeGraph.Tests`, `Presentation.AgentHub.Tests` — Docker not running locally)
- [x] New coverage: config gating (`AIFoundryConfig.IsDirectResponsesConfigured` independent of `IsConfigured`), `ChatClientFactory.IsAvailable`/`GetProviderStatus`/`GetChatClientAsync` for the new type, and a real-composition-root DI test proving the keyed client resolves through `AddInfrastructureAIDependencies` (not just a hand-rolled test `ServiceCollection`) plus a malformed-URI-throws-at-registration test
- [x] Both new mutation-sensitive checks (the DI-registration AND-condition, the malformed-URI guard) manually reverted and confirmed red before restoring
- [x] `/code-review` and `/simplify` receipts recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW