### PR TITLE
feat: govern tool combinations, not just individual tools (#332)

### DIFF
--- a/documentation/security/tool-behavior-gating.md
+++ b/documentation/security/tool-behavior-gating.md
@@ -110,4 +110,4 @@ An exemption is honoured even for a tool that declares itself destructive, provi
 | Applying the posture | `ToolInvocationGovernor.RequiresApprovalForDeclaredBehavior` |
 | Refusing an inert configuration at boot | `GovernanceConfigValidator` |
 
-Related: [`mcp-tool-definition-scanning.md`](./mcp-tool-definition-scanning.md) governs what an MCP server is allowed to put in the model's context. This document governs what it is allowed to do once it is there.
+Related: [`mcp-tool-definition-scanning.md`](./mcp-tool-definition-scanning.md) governs what an MCP server is allowed to put in the model's context. This document governs what a single tool is allowed to do once it is there. [`tool-composition-analysis.md`](./tool-composition-analysis.md) governs what an agent's *combination* of tools may do together — a risk no per-tool control, this one included, can represent.

--- a/documentation/security/tool-composition-analysis.md
+++ b/documentation/security/tool-composition-analysis.md
@@ -1,0 +1,148 @@
+# Governing Tool Combinations
+
+> Date: 2026-08-14. Target: .NET 10 (Microsoft Agentic Harness). Audience: harness engineers and template consumers who run agents with tools they did not all write themselves.
+
+## 1. Executive summary
+
+Every existing tool-governance control in the harness — allow/deny lists, per-agent authorization, [behaviour gating](./tool-behavior-gating.md) — asks whether a single tool may run. None of them asks the question that actually matters for indirect prompt injection: **what can this agent do with these tools together?**
+
+A tool that fetches a web page is not dangerous. A tool that sends email is not dangerous. An agent holding both is an exfiltration primitive: an attacker who controls the page controls what it says, the agent reads what it says, and the agent can act on it — including sending data back out. Every individual permission check passes. The composition is the vulnerability.
+
+With a pairing configured under **`AI:Governance:ToolCompositionGating`**, the harness now flags this at agent build time — naming both tools and the capability pairing that implicates them — and, when the pairing's posture is `RequireApproval`, gates the sink tool at call time exactly as [behaviour gating](./tool-behavior-gating.md) does.
+
+The posture is **off by default**, and inert by construction rather than by a switch: every pairing defaults to `Allow`, so a host that configures nothing here reports and enforces nothing.
+
+## 2. The deliberate fail-open, and why it is not negotiable
+
+Every capability classification in the harness that answers "unknown" normally treats that as unsafe — an unknown knowledge scope means global, not private; an unrecorded tool behaviour means gated, not exempt. **This feature inverts that rule, on purpose.**
+
+A tool nothing can classify contributes **no** capability bits — neither source nor sink. The alternative (unknown means "could be either") would flag every agent holding two or more unclassified tools, which is the *universal taint destroys signal* failure this whole design exists to avoid: if everything is tainted, nothing is.
+
+The mitigation is not silence. Every build reports how many tools it could not classify (`agent.governance.tool_composition_unclassified`), so the blind spot is visible rather than hidden. See §7 for what that number tends to look like on a real host.
+
+## 3. The capability vocabulary
+
+Five bits, two source and three sink, on `Domain.Common.Config.AI.Governance.ToolCompositionCapability`:
+
+| Bit | What it means |
+| --- | --- |
+| `IngestsUntrustedInput` | Brings content into the conversation the agent did not author — a fetched page, an inbound email, a search result, an indexed document. |
+| `ReadsCredentials` | Reads secrets, credentials, or access tokens. |
+| `WritesFiles` | Writes, modifies, or deletes files or persistent state. |
+| `ExecutesCode` | Runs code, shell commands, or scripts. |
+| `SendsOutbound` | Sends data outside the process — email, webhooks, chat, HTTP POST. |
+
+A tool can carry more than one bit (`[Flags]`) — a browser-automation tool that reads a page and can also submit a form is genuinely both. The composition check excludes **self-pairs**: a single tool that is both a source and a sink is [behaviour gating](./tool-behavior-gating.md)'s job, not a composition risk, because gating one tool for what it alone can do is exactly what that feature already covers.
+
+**Named `ToolCompositionCapability`, not `ToolCapability`** — a `Domain.AI.Sandbox.ToolCapability` already exists (the sandbox's execution-grant vocabulary: file/network/process access). The two are unrelated concepts that happened to want the same short name; only one of them could keep it.
+
+## 4. Where classification comes from
+
+Four sources, strict precedence, each described in `IToolCapabilityResolver`'s remarks:
+
+1. **A per-tool operator override** (`ToolCompositionGatingConfig.ToolCapabilities`) — authoritative in both directions, and the only way to *clear* a bit another source found. Clearing requires naming the tool's server, for the identical reason `ToolBehaviorExemption.Server` does: a tool name belongs to nobody, and a name-only override would hand back the exact bypass that rule prevents.
+2. **A first-party tool's own declaration** (`ITool.Capabilities`) — authoritative in both directions once the tool is registered, *including* an explicit "declares nothing" default. A registered first-party tool never falls through to the keyword heuristic below it, so a tool a maintainer chose to leave undeclared shows up as unclassified rather than being silently guessed at.
+3. **An MCP `openWorldHint: true` annotation** — adds `IngestsUntrustedInput`, believed from any server regardless of trust, because it only ever adds friction to this check; a hostile server gains nothing by asserting it. (Contrast [behaviour gating](./tool-behavior-gating.md)'s `readOnlyHint`, which *removes* friction and is trusted only from a vouched-for source.)
+4. **The narrow built-in keyword heuristic** — only for a name with no first-party registration at all (a third-party MCP tool with none of the above).
+
+A **per-server operator override** (`ServerCapabilities`) layers on top of all four, **additive only** — it can add bits every tool from that server inherits, never clear one.
+
+## 5. The keyword heuristic, and what it deliberately excludes
+
+Token-based, matching whole tokens (or a small number of adjacent-token pairs) against the tool's published name — never a substring:
+
+| Capability | Tokens / pairs |
+| --- | --- |
+| `IngestsUntrustedInput` | `fetch`, `browse`, `crawl`, `scrape`; `(web\|http)+search`; `read+(email\|inbox\|mail)` |
+| `SendsOutbound` | `send`, `email`, `webhook`, `publish`, `upload`, `notify`; `http+post` |
+| `ExecutesCode` | `exec`, `execute`, `shell`, `bash`, `terminal`, `eval`, `spawn`; `run+(command\|script\|code)` |
+| `WritesFiles` | `(write\|edit\|save\|delete)+(file\|directory\|path\|fs)` |
+| `ReadsCredentials` | `secret`, `credential`, `keyvault`, `vault`, `password` |
+
+**Deliberately excluded — this is the whole design**: `read, get, list, search, query, load, open, write, create, update, sync, call, request, submit, run, key, auth, token`. Each of these tags a large fraction of any real tool set. `read` alone would mark every file, database, and memory lookup as an untrusted source; bare `run` would catch `run_skill_script`. *Universal taint destroys signal, and it arrives one plausible-looking token at a time.* A keyword added here without an equally deliberate argument for why it will not flag ordinary tools is a regression, not an improvement.
+
+The token split handles bundle-owned MCP tools' namespaced names (`{bundleId}:{server}__{tool}`) correctly: splitting on `_`, `-`, `.`, and the `__` separator recovers the original tool's tokens from the tail.
+
+## 6. Where the check runs, and why nowhere else
+
+**Analysis runs at agent build time**, inside `ToolChainBuilder`, at its two whole-agent-set exits: `BuildMergedToolsWithSourcesAsync` (the main agent build) and `BuildToolsByName` (delegated subagents). These are the only two points where the *complete* cross-skill tool set is known — a per-skill check would only ever see one skill's tools and could not confirm or rule out a pairing that spans two, which is exactly the realistic shape (a web-fetch skill plus an email skill on the same agent).
+
+**Not inside `AgentExecutionContextFactory`**, despite that being the more obvious-looking place. A merged test in this repo, `NoFactoryDecidesAPerRunFactAtConstructionTime`, forbids any file under a `Factories/` directory from reading live per-run governance state — because a factory runs once and its output is cached, so anything it decided is frozen before the run that needs it (the exact #347 defect, where a bundle's disclosure tools reached the model ungoverned). `ToolChainBuilder` sits outside that directory, but the same principle governs the design regardless: **the build stamps only the co-residency fact, never the posture verdict.**
+
+**The posture is resolved live, every time it is asked**, by `ToolCompositionPostureResolver` — once at build time (to decide what `ToolCompositionReporter` reports) and independently again at call time (to decide whether `ToolInvocationGovernor` gates). An operator's config change takes effect on an already-built agent's next call without a rebuild, for the same reason behaviour gating's posture does: the *structural* fact (which tools are co-resident) is fixed once discovered, the *policy* response to it is not.
+
+## 7. Enforcement — the carry, and why it lives where it does
+
+Applied **inside** `ToolInvocationGovernor`, alongside behaviour gating's posture — not as a sixth admission gate. A gate of its own would need its own route to a human, and two independent approval questions about one call is exactly the failure the governor's single-question design prevents: an approver clears "write tools need sign-off" and thereby silently clears "this tool is a live exfiltration sink," a question they were never shown.
+
+**The carrier is the `GovernedAIFunction` wrapper**, not the agent execution context. There are two different types named "agent execution context" in this codebase, and neither works: the one holding the tool list is not registered in dependency injection at all, and the one that is (reachable from the governor on every path) carries agent identity but no tools. `GovernedAIFunction` is built fresh per agent by `ToolChainBuilder` — a singleton, but its *output* is per-instance — so per-instance state on the wrapper is exactly the right shape: it survives to call time on every path that reaches a governed tool, including plan steps and delegated subagents, which each open a fresh scope that would otherwise start blank.
+
+## 8. Config
+
+```jsonc
+{
+  "AppConfig": {
+    "AI": {
+      "Governance": {
+        "EnforceToolInvocation": true,
+        "ToolCompositionGating": {
+          "DefaultPosture": "Allow",
+          "Pairings": [
+            { "Source": "IngestsUntrustedInput", "Sink": "SendsOutbound", "Posture": "RequireApproval" }
+          ],
+          "ToolCapabilities": [
+            {
+              "Tool": "notion_search",
+              "Server": "notion",
+              "Capabilities": ["IngestsUntrustedInput"],
+              "Reason": "returns page bodies authored by third parties"
+            }
+          ],
+          "ServerCapabilities": [
+            {
+              "Server": "web",
+              "Capabilities": ["IngestsUntrustedInput"],
+              "Reason": "every tool on this server returns fetched page content"
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+No `Enabled` flag — `DefaultPosture: Allow` with an empty `Pairings` list *is* the off state. A `RequireApproval` pairing needs `EnforceToolInvocation: true` for the identical reason [behaviour gating](./tool-behavior-gating.md) does: the governor arms on invocation enforcement *or* a bundle run's capability envelope, so leaving enforcement off would apply the posture to bundle runs alone while every agent turn and plan step goes ungated. `GovernanceConfigValidator` refuses that combination at startup.
+
+Every override (`ToolCapabilities`, `ServerCapabilities`) requires a `Reason` — the first thing a reviewer reads when asking why a tool was, or was not, flagged.
+
+## 9. Known limits
+
+- **The `AIContext` channel is a structural blind spot, and its unclassified count is NOT yet incremented.** Tools arriving at turn time through an `AIContextProvider` (`GoverningToolContextProvider`) never pass through `ToolChainBuilder`, so build-time analysis cannot see them — and, as shipped, that provider does not call the composition analyzer or increment `agent.governance.tool_composition_unclassified` either, so this specific gap is currently silent rather than visible. Wiring that provider into the analyzer is a follow-up, not part of this change.
+- **The Execution API's direct-invocation path (`DirectToolInvoker`) is out of scope entirely, structurally.** That surface has no concept of an agent's assembled tool set at all — a caller names one tool and it runs, with no sibling tools in view — so there is no set for composition analysis to reason over. A `RequireApproval` pairing is silently inert for any tool called this way.
+- **`ConnectorToolAdapter`-provisioned tools are unclassified by default.** External connectors (email, webhook, Notion, Slack, GitHub, …) registered via the generic connector adapter share one `ITool` implementation across every connector instance, so a per-class `Capabilities` override would give every connector — present and future — the identical declaration, which is wrong for most of them. Classify these via `ToolCapabilities`/`ServerCapabilities` operator overrides per deployment; a per-connector first-party declaration is a follow-up.
+- **Self-pairs are excluded**, by design — see §3. A future issue may extend enforcement to cover a single tool that is both.
+- **Name-keyed**, like behaviour gating: two servers advertising the same tool name share one resolution.
+- **No argument awareness.** The posture asks about a tool pairing, not about a call's arguments — an operator wanting `write_file` gated only for production paths needs the declarative policy engine.
+- **Bundle-owned MCP tools are invisible to the MCP-annotation source (§4.3) only.** The tool-behaviour registry that carries the `openWorldHint` signal is keyed on the bare tool name, while bundle-owned tools are published under a namespaced name. First-party declarations and the keyword heuristic are unaffected, since both operate on the published name directly. Tracked as a follow-up against the shared registry, not fixed here — fixing the registry's key changes behaviour gating's treatment of those tools too, and needs its own review.
+- **Coverage of a real third-party MCP estate is unmeasured.** The keyword vocabulary is deliberately narrow; measure the unclassified fraction on a real host after adopting this, and treat a high fraction as a signal to add first-party declarations or operator overrides, not to widen the keywords.
+- **`Origin` describes the profile, not the bit.** A profile carrying two capability bits from two different sources (a keyword-matched bit and an MCP-annotation-added bit, say) reports only the single strongest source's name. A finding's `SourceOrigin`/`SinkOrigin` is therefore "the strongest source that vouches for this tool," not necessarily "the source of the exact bit that made this pairing fire." Precise per-bit provenance would need a richer data model and is a follow-up.
+
+## 10. Where it lives
+
+| Concern | Type |
+| --- | --- |
+| The capability vocabulary | `Domain.Common.Config.AI.Governance.ToolCompositionCapability` |
+| What a tool was classified as, and by what | `Domain.AI.Governance.ToolCapabilityProfile` / `ToolCapabilityOrigin` |
+| A co-resident source/sink fact | `Domain.AI.Governance.ToolCompositionFinding` |
+| The fact carried from build to call time | `Domain.AI.Governance.ToolCompositionTaint` |
+| Resolving a tool's capabilities | `IToolCapabilityResolver` / `ToolCapabilityResolver` |
+| The narrow keyword vocabulary | `ToolCapabilityKeywordRules` |
+| Analyzing a whole tool set | `IToolCompositionAnalyzer` / `ToolCompositionAnalyzer` |
+| Resolving a pairing's live posture | `ToolCompositionPostureResolver` |
+| Reporting (audit, metrics, log) | `ToolCompositionReporter` |
+| Stamping the enforcement carrier | `ToolChainBuilder.ApplyCompositionTaint` |
+| Applying the posture at call time | `ToolInvocationGovernor.RequiresApprovalForToolComposition` |
+| Refusing an inert configuration at boot | `GovernanceConfigValidator` |
+
+Related: [`tool-behavior-gating.md`](./tool-behavior-gating.md) governs what a single tool may do. This document governs what an agent's *combination* of tools may do together — the class of risk individual-tool governance cannot represent at all.

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -26,6 +26,7 @@ using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace Application.AI.Common;
 
@@ -157,6 +158,35 @@ public static class DependencyInjection
         // unconditionally: recording costs nothing, and only the posture in
         // GovernanceConfig.ToolBehaviorGating turns the recordings into a decision.
         services.AddSingleton<Interfaces.Tools.IToolBehaviorRegistry, Services.Tools.ToolBehaviorRegistry>();
+
+        // Tool capability resolver — what a tool can do with the data that flows through it (source of
+        // untrusted/sensitive content, or a costly sink), for the tool-composition check. A sibling to
+        // the behaviour registry above, answering a different question. Registered unconditionally, like
+        // it: resolving costs nothing, and only ToolCompositionGatingConfig's pairings turn a resolved
+        // profile into a reported or enforced posture.
+        //
+        // The bounded registered-key set is supplied explicitly (the same KeyedToolRegistrationKeys(services)
+        // call IToolCatalog's registration below already makes) rather than left to a DI-resolved
+        // IReadOnlySet<string>, which nothing else registers. The resolver is called with every tool
+        // name in an agent's set, including MCP and bundle-owned names that are never registration
+        // keys — probing IServiceProvider.GetKeyedService with a name outside this bounded set would
+        // teach the root container's key-accessor cache a new, permanently-retained entry per distinct
+        // unregistered name, which is unbounded growth for a bundle-owned name space. See
+        // ToolCapabilityResolver's remarks.
+        services.AddSingleton<Interfaces.Tools.IToolCapabilityResolver>(sp => new Services.Tools.ToolCapabilityResolver(
+            sp,
+            sp.GetRequiredService<Interfaces.Tools.IToolBehaviorRegistry>(),
+            sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.GovernanceConfig>>(),
+            new HashSet<string>(KeyedToolRegistrationKeys(services), StringComparer.Ordinal)));
+
+        // Tool composition analyzer + reporter — flags an agent's assembled tool set for an
+        // untrusted-input/credential-reading tool co-resident with a file-write/code-exec/outbound-send
+        // tool. Registered unconditionally and passively, like the capability resolver above; the
+        // reporter is a concrete class rather than an interface because it has exactly one production
+        // consumer (ToolChainBuilder) and exists only to keep that consumer's three call sites reporting
+        // through the same channels identically — see its own remarks.
+        services.AddSingleton<Interfaces.Governance.IToolCompositionAnalyzer, Services.Governance.ToolCompositionAnalyzer>();
+        services.AddSingleton<Services.Governance.ToolCompositionReporter>();
 
         // Tool catalog — enumerates the host's keyed ITool registrations for callers that need to
         // discover what they may invoke. Singleton because the registrations cannot change once the

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -370,7 +370,7 @@ public partial class AgentExecutionContextFactory
             : requested;
 
         if (toolNames.Count > 0)
-            context.Tools = _toolChainBuilder.BuildToolsByName(toolNames);
+            context.Tools = _toolChainBuilder.BuildToolsByName(toolNames, context.Name);
 
         return context;
     }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Escalation;
 using Domain.AI.Escalation;
+using Domain.AI.Governance;
 
 namespace Application.AI.Common.Interfaces.Governance;
 
@@ -188,10 +189,19 @@ public interface IToolCallAdmissionPipeline
 /// work. A single Execution API invocation has no sequence to evaluate, and a plan DAG has its own
 /// retry and recovery — counting either would be machinery that could not fire, or could only misfire.
 /// </param>
+/// <param name="CompositionTaint">
+/// The tool-composition findings that implicate <see cref="ToolName"/> as a sink, stamped at agent
+/// build time by <c>ToolChainBuilder</c> and carried here by <c>GovernedAIFunction</c> — the only
+/// carrier that reaches every execution path, since neither <c>AgentExecutionContext</c> type is both
+/// populated with the tool set and reachable from a freshly-scoped plan step. Null for every call this
+/// wrapper did not stamp, which the governor reads identically to "no findings". See
+/// <c>ToolInvocationGovernor.RequiresApprovalForToolComposition</c>.
+/// </param>
 public sealed record ToolCallAdmissionRequest(
     string ToolName,
     IReadOnlyDictionary<string, object?>? Arguments = null,
-    bool CountsTowardLoopDetection = false);
+    bool CountsTowardLoopDetection = false,
+    ToolCompositionTaint? CompositionTaint = null);
 
 /// <summary>
 /// The admission chain's verdict for one tool call.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCompositionAnalyzer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCompositionAnalyzer.cs
@@ -1,0 +1,71 @@
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// Analyzes an agent's assembled tool set for a dangerous <em>combination</em> — an untrusted-input or
+/// credential-reading tool co-resident with a tool that writes files, executes code, or sends data
+/// outbound. Every individual tool-governance control (allow/deny lists, per-agent authorization,
+/// behaviour gating) asks whether a single tool may run; this asks what the whole set can do together,
+/// which is the shape an indirect-prompt-injection exfiltration primitive actually takes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Runs at build time, over the whole assembled set, not per call.</strong> A single tool
+/// carries no information about whether a dangerous pairing exists — only the set does. Called from
+/// <c>ToolChainBuilder</c>'s three whole-agent-set exits, never from a per-tool or per-skill resolution
+/// step, which would only ever see a fragment of the eventual set and could neither confirm nor rule
+/// out a cross-skill pairing.
+/// </para>
+/// <para>
+/// <strong>The control case is true by construction.</strong> An agent holding only a source-capable
+/// tool, or only a sink-capable tool, produces an empty opposite-side set, so the cross product that
+/// produces findings is empty — there is no code path by which a one-sided tool set can produce a
+/// finding. This is the mandated control in the issue's acceptance criteria, and it is a property of
+/// the algorithm's shape rather than a filter applied after the fact.
+/// </para>
+/// </remarks>
+public interface IToolCompositionAnalyzer
+{
+    /// <summary>
+    /// Analyzes <paramref name="tools"/> for every co-resident source/sink pairing — a structural fact
+    /// about the set, computed independently of the currently-configured posture. See
+    /// <see cref="ToolCompositionAssessment.Findings"/>'s remarks for why filtering by posture happens
+    /// later, live, rather than here.
+    /// </summary>
+    /// <param name="tools">The agent's fully assembled tool set.</param>
+    /// <returns>Every co-residency fact, and the names of tools nothing could classify.</returns>
+    ToolCompositionAssessment Analyze(IReadOnlyList<AITool> tools);
+}
+
+/// <summary>
+/// The result of analyzing one agent's tool set for composition risk.
+/// </summary>
+/// <param name="Findings">
+/// Every co-resident source/sink pairing found, <strong>regardless of current posture</strong> — a
+/// pairing under <see cref="CompositionPosture.Allow"/> is included here just like any other. Posture
+/// filtering happens live, separately, at the two places that actually need a verdict:
+/// <c>ToolCompositionReporter</c> (what to report at build time) and
+/// <c>ToolInvocationGovernor.RequiresApprovalForToolComposition</c> (whether to gate at call time). See
+/// <c>ToolCompositionFinding</c>'s remarks for why baking the posture in here would silently break a
+/// live config change on an already-built agent.
+/// Capped at 50 with <see cref="Truncated"/> set when the true count exceeds the cap — a set with
+/// enough distinct source and sink tools to exceed it is already a configuration worth a human's
+/// attention regardless of the exact count.
+/// </param>
+/// <param name="UnclassifiedTools">
+/// Tools nothing could classify — the blind spot this check's deliberate fail-open produces. Reported
+/// rather than silently absorbed, so an operator can see how much of the tool set this analysis
+/// actually covers.
+/// </param>
+/// <param name="Truncated">Whether <see cref="Findings"/> was capped before every real finding was emitted.</param>
+public sealed record ToolCompositionAssessment(
+    IReadOnlyList<ToolCompositionFinding> Findings,
+    IReadOnlyList<string> UnclassifiedTools,
+    bool Truncated = false)
+{
+    /// <summary>No findings, no unclassified tools — the assessment of an empty or fully-benign set.</summary>
+    public static ToolCompositionAssessment Empty { get; } = new([], []);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
@@ -37,6 +37,12 @@ public interface IToolInvocationGovernor
     /// risk, capability, envelope, and policy checks all key off the tool name alone, so passing
     /// arguments cannot change whether a call is allowed.
     /// </param>
+    /// <param name="composition">
+    /// The tool-composition findings that implicate this tool as a sink, when the caller has them —
+    /// see <see cref="ToolCallAdmissionRequest.CompositionTaint"/>. Null when the caller did not stamp
+    /// one (a plan step, the Execution API, or a turn where composition analysis found nothing), which
+    /// the governor reads identically to an empty finding list.
+    /// </param>
     /// <returns>
     /// An allow decision, or a deny decision carrying a model-facing message to return in place of
     /// the tool result. When enforcement is disabled the governor records the would-be decision but
@@ -49,7 +55,8 @@ public interface IToolInvocationGovernor
     ValueTask<ToolInvocationDecision> AuthorizeAsync(
         string toolName,
         CancellationToken cancellationToken,
-        IReadOnlyDictionary<string, object?>? arguments = null);
+        IReadOnlyDictionary<string, object?>? arguments = null,
+        ToolCompositionTaint? composition = null);
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
@@ -1,5 +1,6 @@
 using Domain.AI.Changes;
 using Domain.AI.Models;
+using Domain.Common.Config.AI.Governance;
 
 namespace Application.AI.Common.Interfaces.Tools;
 
@@ -129,6 +130,25 @@ public interface ITool
     /// to <c>ToolOutputCompressionConfig.DefaultTokenThreshold</c>.
     /// </summary>
     int? CompressionTokenThreshold => null;
+
+    /// <summary>
+    /// What this tool can do with the data that flows through it — bringing untrusted or sensitive
+    /// content into the conversation, or acting on that content in a costly way. Feeds the tool
+    /// composition check (<c>IToolCompositionAnalyzer</c>), which flags an agent holding both a source
+    /// and a sink capability across its assembled tool set as an indirect-prompt-injection exfiltration
+    /// primitive — see <see cref="ToolCompositionCapability"/>.
+    /// </summary>
+    /// <remarks>
+    /// Default is <see cref="ToolCompositionCapability.None"/> — unlike
+    /// <see cref="IsReadOnly"/> and <see cref="IsConcurrencySafe"/>, this default is NOT fail-closed.
+    /// An unclassified tool contributes no capability bits at all, deliberately, because the
+    /// composition check treats "unknown" as neither a source nor a sink: a fail-closed default here
+    /// (unknown means both) would flag every agent holding two or more undeclared tools, which is the
+    /// "universal taint destroys signal" failure the check exists to avoid. Declare this only where the
+    /// answer is unambiguous; an ambiguous tool is better left undeclared than guessed at, and the
+    /// composition analyzer's unclassified-tool count makes that gap visible rather than silent.
+    /// </remarks>
+    ToolCompositionCapability Capabilities => ToolCompositionCapability.None;
 
     /// <summary>
     /// Executes a tool operation with the given parameters.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolCapabilityResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolCapabilityResolver.cs
@@ -1,0 +1,43 @@
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+
+namespace Application.AI.Common.Interfaces.Tools;
+
+/// <summary>
+/// Resolves what a tool can do with the data that flows through it — the classification the tool
+/// composition check reasons over. A sibling to <see cref="IToolBehaviorRegistry"/>, answering a
+/// different question: that registry describes a single tool's mutability, this describes the
+/// direction data flows through it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Precedence, strict and in this order:</strong> a per-tool operator override
+/// (authoritative, both directions) beats the base classification — a first-party tool's own
+/// declaration, or, when that says nothing, the narrow built-in keyword heuristic against the
+/// tool's published name — which is then augmented (never replaced) by an MCP open-world annotation
+/// and a per-server operator override, both of which may only <em>add</em> capability bits, never
+/// clear one another source already found. See <see cref="ToolCompositionGatingConfig"/>'s remarks for
+/// why clearing is restricted to a named, per-tool override.
+/// </para>
+/// <para>
+/// <strong>Unclassified is not a fail-closed default.</strong> A tool nothing can classify resolves to
+/// <see cref="ToolCompositionCapability.None"/> — deliberately the opposite of how the rest of this harness treats
+/// "unknown". See <see cref="ToolCapabilityProfile"/>'s remarks and <c>ToolCompositionAnalyzer</c> for
+/// why: an unknown-means-both default would flag every agent holding two or more unclassified tools,
+/// which is the failure this check exists to avoid.
+/// </para>
+/// </remarks>
+public interface IToolCapabilityResolver
+{
+    /// <summary>
+    /// Resolves the effective capability profile for a tool's published name — the name as it appears
+    /// in an agent's assembled tool set, which for a bundle-owned MCP tool is the namespaced name, not
+    /// the server's bare raw name.
+    /// </summary>
+    /// <param name="publishedToolName">The tool's published name.</param>
+    /// <returns>
+    /// The resolved profile. Never null; a tool nothing could classify returns
+    /// <see cref="ToolCapabilityProfile.Unclassified"/> rather than throwing.
+    /// </returns>
+    ToolCapabilityProfile Resolve(string publishedToolName);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IToolChainBuilder.cs
@@ -32,8 +32,14 @@ public interface IToolChainBuilder
     /// rather than sourced from a skill. Names that resolve to no registered tool are skipped.
     /// </summary>
     /// <param name="toolNames">The keyed-DI tool names to resolve.</param>
+    /// <param name="agentName">
+    /// The resolved agent's name, for tool-composition reporting only — see
+    /// <c>ToolCompositionReporter</c>. Optional because not every caller has assigned a name yet;
+    /// falls back to a generic label rather than throwing when omitted, since the composition analysis
+    /// itself still runs and stamps enforcement regardless of what the report is labelled with.
+    /// </param>
     /// <returns>The resolved, converted, governance-wrapped tools (empty when none resolve).</returns>
-    List<AITool> BuildToolsByName(IReadOnlyList<string> toolNames);
+    List<AITool> BuildToolsByName(IReadOnlyList<string> toolNames, string? agentName = null);
 
     /// <summary>
     /// Merges and deduplicates tools from multiple skills, applying an optional whitelist.

--- a/src/Content/Application/Application.AI.Common/OpenTelemetry/Metrics/GovernanceMetrics.cs
+++ b/src/Content/Application/Application.AI.Common/OpenTelemetry/Metrics/GovernanceMetrics.cs
@@ -108,4 +108,21 @@ public static class GovernanceMetrics
     /// </summary>
     public static Counter<long> SpinInterventions { get; } =
         AppInstrument.Meter.CreateCounter<long>(GovernanceConventions.SpinInterventions, "{intervention}", "Spin / no-progress guard interventions");
+
+    /// <summary>
+    /// Tool-composition findings — an untrusted-input or credential-reading tool co-resident with a
+    /// file-write, code-execution, or outbound-send tool, under a posture that is not Allow. Tags:
+    /// agent.governance.composition.source_capability, agent.governance.composition.sink_capability,
+    /// agent.governance.composition.posture. No tool-name tag — see <see cref="McpToolCollisions"/>'s
+    /// remarks for the same cardinality rule.
+    /// </summary>
+    public static Counter<long> ToolCompositionFindings { get; } =
+        AppInstrument.Meter.CreateCounter<long>(GovernanceConventions.ToolCompositionFindings, "{finding}", "Tool composition findings");
+
+    /// <summary>
+    /// Tools a composition analysis could not classify as either a source or a sink — the coverage gap
+    /// this check's deliberate fail-open produces, made visible rather than silent. Untagged.
+    /// </summary>
+    public static Counter<long> ToolCompositionUnclassified { get; } =
+        AppInstrument.Meter.CreateCounter<long>(GovernanceConventions.ToolCompositionUnclassified, "{tool}", "Tools unclassified by composition analysis");
 }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -142,7 +142,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // null included: the governor distinguishes "no arguments were available" from "the call had
         // none", and narrows its argument-conditioned rules accordingly.
         var decision = await _governor
-            .AuthorizeAsync(toolName, cancellationToken, request.Arguments)
+            .AuthorizeAsync(toolName, cancellationToken, request.Arguments, request.CompositionTaint)
             .ConfigureAwait(false);
         if (!decision.IsAllowed)
             return Refuse(decision.DeniedMessage, toolName);

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionAnalyzer.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionAnalyzer.cs
@@ -1,0 +1,118 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Default <see cref="IToolCompositionAnalyzer"/>. Resolves every tool's capability profile, partitions
+/// into source-capable and sink-capable tools, and emits one finding per co-resident (source tool,
+/// sink tool, source bit, sink bit) fact.
+/// </summary>
+/// <remarks>
+/// <strong>Findings are not filtered by posture.</strong> A finding here is a structural fact about
+/// the tool set — which sources and sinks are co-resident — not a policy verdict. Whether a given
+/// pairing is currently worth reporting or enforcing is decided separately and live, by
+/// <see cref="ToolCompositionPostureResolver"/>, at the moment each of those questions is actually
+/// asked. See <c>ToolCompositionFinding</c>'s remarks for why filtering here would silently break a
+/// config change on an already-built agent.
+/// </remarks>
+public sealed class ToolCompositionAnalyzer : IToolCompositionAnalyzer
+{
+    /// <summary>
+    /// Hard cap on emitted findings. A tool set producing more than this many distinct source/sink
+    /// pairings is already a configuration worth a human's attention regardless of the exact count —
+    /// see <see cref="ToolCompositionAssessment.Truncated"/>.
+    /// </summary>
+    private const int MaxFindings = 50;
+
+    private readonly IToolCapabilityResolver _capabilityResolver;
+
+    /// <summary>Initializes a new instance of the <see cref="ToolCompositionAnalyzer"/> class.</summary>
+    public ToolCompositionAnalyzer(IToolCapabilityResolver capabilityResolver)
+    {
+        ArgumentNullException.ThrowIfNull(capabilityResolver);
+        _capabilityResolver = capabilityResolver;
+    }
+
+    /// <inheritdoc />
+    public ToolCompositionAssessment Analyze(IReadOnlyList<AITool> tools)
+    {
+        ArgumentNullException.ThrowIfNull(tools);
+
+        if (tools.Count == 0)
+            return ToolCompositionAssessment.Empty;
+
+        var profiles = new List<ToolCapabilityProfile>(tools.Count);
+        var seenNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var tool in tools)
+        {
+            // A tool set can legitimately contain the same name only once by construction upstream
+            // (ToolChainBuilder dedups before this runs), but resolving defensively rather than
+            // trusting that invariant costs nothing and avoids a duplicate profile if it ever does not.
+            if (!seenNames.Add(tool.Name))
+                continue;
+
+            profiles.Add(_capabilityResolver.Resolve(tool.Name));
+        }
+
+        var unclassified = profiles
+            .Where(p => p.Origin == ToolCapabilityOrigin.Unclassified)
+            .Select(p => p.ToolName)
+            .ToList();
+
+        // Each entry names exactly one bit, so a source or sink tool carrying multiple bits appears
+        // once per bit — the cross product below then evaluates each bit-pair independently against
+        // its own configured posture.
+        var sourceEntries = ExpandBySide(profiles, ToolCompositionCapabilities.SourceBits);
+        var sinkEntries = ExpandBySide(profiles, ToolCompositionCapabilities.SinkBits);
+
+        if (sourceEntries.Count == 0 || sinkEntries.Count == 0)
+            return new ToolCompositionAssessment([], unclassified);
+
+        // Materialized in full before capping — never short-circuited mid cross-product. A break at
+        // exactly MaxFindings cannot tell "the cap coincided with the last real pairing" apart from
+        // "more were dropped", and mislabeling the former as truncated is itself a false report on a
+        // feature whose whole design goal is not reporting things that are not there. Tool sets are
+        // small (a handful to a few dozen tools), so the full cross product is cheap regardless.
+        var allFindings = new List<ToolCompositionFinding>();
+        foreach (var source in sourceEntries)
+        {
+            foreach (var sink in sinkEntries)
+            {
+                // Self-pairs excluded: a tool that is both the source and the sink is one tool doing
+                // one thing, which is #324's behaviour-gating job, not a composition risk. See
+                // ToolCompositionCapability's remarks.
+                if (string.Equals(source.Profile.ToolName, sink.Profile.ToolName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                allFindings.Add(new ToolCompositionFinding(
+                    source.Profile.ToolName, source.Bit,
+                    sink.Profile.ToolName, sink.Bit,
+                    source.Profile.Origin, sink.Profile.Origin));
+            }
+        }
+
+        var truncated = allFindings.Count > MaxFindings;
+        var findings = truncated ? allFindings.GetRange(0, MaxFindings) : allFindings;
+
+        return new ToolCompositionAssessment(findings, unclassified, truncated);
+    }
+
+    private static List<(ToolCapabilityProfile Profile, ToolCompositionCapability Bit)> ExpandBySide(
+        List<ToolCapabilityProfile> profiles, IReadOnlyList<ToolCompositionCapability> bits)
+    {
+        var expanded = new List<(ToolCapabilityProfile, ToolCompositionCapability)>();
+        foreach (var profile in profiles)
+        {
+            foreach (var bit in bits)
+            {
+                if ((profile.Capabilities & bit) == bit)
+                    expanded.Add((profile, bit));
+            }
+        }
+        return expanded;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionPostureResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionPostureResolver.cs
@@ -1,0 +1,36 @@
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// The single place that maps a (source capability, sink capability) pairing to its configured
+/// posture. Used identically by <see cref="ToolCompositionReporter"/> (to decide what to report at
+/// build time) and by <c>ToolInvocationGovernor.RequiresApprovalForToolComposition</c> (to decide
+/// whether to gate at call time) — both against their own live config snapshot, at their own moment.
+/// </summary>
+/// <remarks>
+/// A second copy of this lookup is exactly how the two callers would drift: one reading a stale
+/// snapshot the other doesn't, or one applying a default the other doesn't. There is deliberately one
+/// implementation.
+/// </remarks>
+public static class ToolCompositionPostureResolver
+{
+    /// <summary>
+    /// Resolves the posture for one (source, sink) capability pairing: the first matching entry in
+    /// <see cref="ToolCompositionGatingConfig.Pairings"/>, or <see cref="ToolCompositionGatingConfig.DefaultPosture"/>
+    /// when nothing matches.
+    /// </summary>
+    public static CompositionPosture Resolve(ToolCompositionGatingConfig gating, ToolCompositionCapability source, ToolCompositionCapability sink)
+    {
+        ArgumentNullException.ThrowIfNull(gating);
+
+        foreach (var pairing in gating.Pairings)
+        {
+            if (pairing.Source == source && pairing.Sink == sink)
+                return pairing.Posture;
+        }
+
+        return gating.DefaultPosture;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionReporter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionReporter.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.OpenTelemetry.Metrics;
+using Domain.AI.Governance;
+using Domain.AI.Telemetry.Conventions;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// Reports a <see cref="ToolCompositionAssessment"/> through the three existing governance telemetry
+/// channels — audit, metrics, structured log — so the three build-time call sites that stamp
+/// composition findings (<c>ToolChainBuilder.BuildToolsAsync</c>,
+/// <c>BuildMergedToolsWithSourcesAsync</c>, and <c>BuildToolsByName</c>) cannot report differently.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>No new side channel.</strong> The acceptance criteria for this feature require findings to
+/// be "visible through existing governance metrics/telemetry rather than a new side channel". This type
+/// exists only to make sure both call sites use those existing channels identically — it is not itself
+/// a fourth channel.
+/// </para>
+/// <para>
+/// <strong>Why not the turn-scoped <see cref="IGovernanceTraceRecorder"/>.</strong> That recorder is
+/// scoped to one agent turn and reset by the admission chain at the start of each turn — see its own
+/// XML doc. A finding computed at agent <em>build</em> time, before any turn exists, would be recorded
+/// into whichever turn's scope happens to be active, or wiped by the first turn's own reset. Audit and
+/// metrics are both process-scoped and carry no such lifetime mismatch.
+/// </para>
+/// </remarks>
+public sealed class ToolCompositionReporter
+{
+    private readonly IGovernanceAuditService _auditService;
+    private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
+    private readonly ILogger<ToolCompositionReporter> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="ToolCompositionReporter"/> class.</summary>
+    public ToolCompositionReporter(
+        IGovernanceAuditService auditService,
+        IOptionsMonitor<GovernanceConfig> governanceConfig,
+        ILogger<ToolCompositionReporter> logger)
+    {
+        ArgumentNullException.ThrowIfNull(auditService);
+        ArgumentNullException.ThrowIfNull(governanceConfig);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _auditService = auditService;
+        _governanceConfig = governanceConfig;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Reports every finding and the unclassified-tool count in <paramref name="assessment"/>.
+    /// A no-op assessment (no findings, no unclassified tools) reports nothing at all — the common case
+    /// for a host that has not configured any pairing above <see cref="CompositionPosture.Allow"/>.
+    /// </summary>
+    /// <param name="agentName">
+    /// The agent whose tool set produced this assessment. Named parameter deliberately called
+    /// <c>agentName</c> rather than <c>agentId</c>: <see cref="IGovernanceAuditService.Log"/>'s
+    /// parameter is named <c>agentId</c>, but the caller — <c>ToolChainBuilder</c>, running inside
+    /// <c>AgentExecutionContextFactory.MapToAgentContextAsync</c> — resolves its own tool set before the
+    /// agent's id is assigned, so the agent's name is the only stable identifier in scope. Documented
+    /// here rather than silently substituted.
+    /// </param>
+    public void Report(string agentName, ToolCompositionAssessment assessment)
+    {
+        ArgumentNullException.ThrowIfNull(assessment);
+
+        if (assessment.Findings.Count == 0 && assessment.UnclassifiedTools.Count == 0)
+            return;
+
+        var governance = _governanceConfig.CurrentValue;
+        var gating = governance.ToolCompositionGating;
+
+        foreach (var finding in assessment.Findings)
+        {
+            // Posture is resolved live, here, against the current config — never trusted from the
+            // finding, which carries none. See ToolCompositionFinding's remarks: a finding is a
+            // structural fact, and under the default configuration (every pairing Allow) this loop
+            // reports nothing at all, which is what keeps the feature inert by default even though
+            // Findings itself is populated with every co-resident pairing regardless of posture.
+            var posture = ToolCompositionPostureResolver.Resolve(gating, finding.SourceCapability, finding.SinkCapability);
+            if (posture == CompositionPosture.Allow)
+                continue;
+
+            var path = finding.Path;
+
+            var tags = new TagList
+            {
+                { GovernanceConventions.CompositionSourceCapabilityTag, finding.SourceCapability.ToString() },
+                { GovernanceConventions.CompositionSinkCapabilityTag, finding.SinkCapability.ToString() },
+                { GovernanceConventions.CompositionPostureTag, posture.ToString() },
+            };
+            GovernanceMetrics.ToolCompositionFindings.Add(1, tags);
+
+            _logger.LogWarning(
+                "Tool composition finding for agent {AgentName}: {Path} (posture: {Posture})",
+                agentName, path, posture);
+
+            if (governance.EnableAudit)
+                _auditService.Log(agentName, $"tool_composition:{path}", posture.ToString());
+        }
+
+        if (assessment.UnclassifiedTools.Count > 0)
+        {
+            GovernanceMetrics.ToolCompositionUnclassified.Add(assessment.UnclassifiedTools.Count);
+
+            // Unclassified is the expected common case (ToolCapabilityKeywordRules' own remarks: the
+            // vocabulary is deliberately narrow, so most third-party tools go unclassified) — this
+            // guard is what keeps the join from running, and being thrown away, on almost every build.
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Tool composition analysis for agent {AgentName}: {Count} tool(s) unclassified — {Tools}",
+                    agentName, assessment.UnclassifiedTools.Count, string.Join(", ", assessment.UnclassifiedTools));
+            }
+        }
+
+        if (assessment.Truncated)
+        {
+            _logger.LogWarning(
+                "Tool composition analysis for agent {AgentName}: finding count truncated at the cap — " +
+                "the tool set has more source/sink pairings than were reported",
+                agentName);
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -154,7 +154,8 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     public async ValueTask<ToolInvocationDecision> AuthorizeAsync(
         string toolName,
         CancellationToken cancellationToken,
-        IReadOnlyDictionary<string, object?>? arguments = null)
+        IReadOnlyDictionary<string, object?>? arguments = null,
+        ToolCompositionTaint? composition = null)
     {
         // Opt-in: when enforcement is off the governor never engages — pure pass-through, no record,
         // no behaviour change for existing deployments. Read live rather than from the trace's sticky
@@ -203,7 +204,8 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
 
         // Every gate that can decide on its own runs first; the human is asked last, once.
         // See AuthorizeInOrderAsync for why that ordering is the design and not an accident.
-        return await AuthorizeInOrderAsync(agentId, toolName, permission, profile, arguments, cancellationToken)
+        return await AuthorizeInOrderAsync(
+                agentId, toolName, permission, profile, arguments, composition, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -238,7 +240,8 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     /// </remarks>
     private async ValueTask<ToolInvocationDecision> AuthorizeInOrderAsync(
         string agentId, string toolName, PermissionDecision permission, ToolRiskProfile profile,
-        IReadOnlyDictionary<string, object?>? arguments, CancellationToken cancellationToken)
+        IReadOnlyDictionary<string, object?>? arguments, ToolCompositionTaint? composition,
+        CancellationToken cancellationToken)
     {
         // One snapshot for the whole decision. Two stages read this config, and reading the monitor
         // twice would let a reload land between them — deciding half the call under one policy and
@@ -277,6 +280,12 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         // one call is exactly the shape this method exists to prevent.
         if (RequiresApprovalForDeclaredBehavior(toolName, governance.ToolBehaviorGating, out var behaviorReason))
             (approvalReasons ??= []).Add(behaviorReason);
+
+        // Composition posture: is this call the sink half of a dangerous tool combination stamped at
+        // build time. A fourth source of approval reasons, folded into the same accumulator as the
+        // three above for the identical reason — see AuthorizeInOrderAsync's remarks.
+        if (RequiresApprovalForToolComposition(composition, governance.ToolCompositionGating, out var compositionReason))
+            (approvalReasons ??= []).Add(compositionReason);
 
         // Independent envelope confirmation. Defence in depth against a resolver arbitration bug —
         // see EnvelopeGrantsToolWhenArmed's remarks for the two occasions that arbitration was wrong.
@@ -471,6 +480,58 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         => behavior.IsVouchedFor
            || (!string.IsNullOrWhiteSpace(exemption.Server)
                && string.Equals(exemption.Server, behavior.ServerName, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Whether this call is the sink half of a tool combination flagged at agent build time, under a
+    /// pairing posture that requires human approval.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Reads a fact stamped at build time, decides against config read live.</strong>
+    /// <paramref name="composition"/> carries only which source tools are co-resident with this sink —
+    /// a fact about the tool set, fixed once the agent is assembled. Whether that fact currently
+    /// requires approval is read fresh from <paramref name="gating"/> every call, so a config reload
+    /// changes enforcement immediately without rebuilding any agent, and no factory ever decides a
+    /// per-run posture at construction time — see <c>NoFactoryDecidesAPerRunFactAtConstructionTime</c>.
+    /// </para>
+    /// <para>
+    /// <strong>Null composition is not "unclassified", it is "nothing to say".</strong> A caller that
+    /// did not stamp a taint (a plan step, the Execution API, or a build whose analysis found nothing
+    /// for this tool) is read identically to an empty finding list — there is no separate "unknown"
+    /// outcome here, unlike <see cref="RequiresApprovalForDeclaredBehavior"/>'s treatment of an
+    /// unrecorded tool behaviour. The composition check's own fail-open (an unclassified tool is
+    /// neither a source nor a sink) already happened when the taint was computed.
+    /// </para>
+    /// </remarks>
+    /// <param name="composition">The taint stamped on this call's <c>GovernedAIFunction</c> wrapper, or
+    /// null when nothing was stamped.</param>
+    /// <param name="gating">The posture config, from the same snapshot the rest of the decision uses.</param>
+    /// <param name="reason">The approver-facing reason, when one is needed.</param>
+    /// <returns>True when a human must rule on this call because of a tool combination it completes.</returns>
+    private static bool RequiresApprovalForToolComposition(
+        ToolCompositionTaint? composition, ToolCompositionGatingConfig gating, out string reason)
+    {
+        reason = string.Empty;
+
+        if (composition is not { Findings.Count: > 0 })
+            return false;
+
+        // Posture resolved live, per finding, against this call's own config snapshot — never trusted
+        // from the finding, which carries none. See ToolCompositionFinding's remarks: this is what
+        // lets an operator's config change take effect on an already-built agent without a rebuild.
+        var requiring = composition.Findings
+            .Where(f => ToolCompositionPostureResolver.Resolve(gating, f.SourceCapability, f.SinkCapability)
+                        == CompositionPosture.RequireApproval)
+            .ToList();
+        if (requiring.Count == 0)
+            return false;
+
+        // Every implicated pairing goes into one reason string, for the same "show the approver
+        // everything actually being decided" argument AuthorizeInOrderAsync's remarks make about
+        // accumulating reasons across gates — here it is one gate accumulating across findings.
+        reason = "tool composition: " + string.Join("; ", requiring.Select(f => f.Path));
+        return true;
+    }
 
     /// <summary>
     /// Applies the graded-autonomy risk gate to an Allow decision. Tightens Allow → Ask/Deny when the

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Escalation;
+using Domain.AI.Governance;
 using Microsoft.Extensions.AI;
 
 namespace Application.AI.Common.Services.Tools;
@@ -29,15 +30,39 @@ namespace Application.AI.Common.Services.Tools;
 /// This is the invocation-time chokepoint for the agent's autonomous tool calls, applied to every
 /// converted tool regardless of source (keyed-DI, MCP, or skill-provided).
 /// </para>
+/// <para>
+/// <strong>Also the carrier for tool-composition findings.</strong> <c>ToolChainBuilder</c> stamps a
+/// <see cref="ToolCompositionTaint"/> onto a sink tool's wrapper at agent build time, when its
+/// composition analysis found a co-resident source tool in the same tool set — see
+/// <see cref="ToolChainBuilder.ApplyCompositionTaint"/>. This instance carries that fact from build
+/// time to call time; the wrapper's per-agent lifetime (a fresh instance per build, even though
+/// <c>ToolChainBuilder</c> itself is a singleton) is what makes per-instance state here safe, unlike
+/// the ambient ownership on <see cref="ToolAdmissionAccessor"/> or scoped state on
+/// <c>AgentExecutionContext</c>, neither of which is populated in every execution path that can reach
+/// a governed call — see the type's own remarks for why those two carriers were rejected.
+/// </para>
 /// </remarks>
 internal sealed class GovernedAIFunction : DelegatingAIFunction
 {
     private const string ReportedBy = "agent-turn";
 
-    public GovernedAIFunction(AIFunction innerFunction)
+    private readonly ToolCompositionTaint? _compositionTaint;
+
+    public GovernedAIFunction(AIFunction innerFunction, ToolCompositionTaint? compositionTaint = null)
         : base(innerFunction)
     {
+        _compositionTaint = compositionTaint;
     }
+
+    /// <summary>
+    /// The wrapped function, for <c>ToolChainBuilder.ApplyCompositionTaint</c> to unwrap and re-wrap
+    /// with a later-discovered taint. <see cref="DelegatingAIFunction.InnerFunction"/> is
+    /// <see langword="protected"/>, inaccessible from the builder even though both types share this
+    /// assembly — <see langword="protected"/> restricts to the declaring type and its subclasses, not
+    /// to the assembly, so this internal accessor is what makes re-wrapping possible without widening
+    /// the base member itself.
+    /// </summary>
+    internal AIFunction Inner => InnerFunction;
 
     protected override async ValueTask<object?> InvokeCoreAsync(
         AIFunctionArguments arguments,
@@ -49,7 +74,8 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
 
         var admission = await admissionPipeline
             .AdmitAsync(
-                new ToolCallAdmissionRequest(Name, arguments, CountsTowardLoopDetection: true),
+                new ToolCallAdmissionRequest(
+                    Name, arguments, CountsTowardLoopDetection: true, CompositionTaint: _compositionTaint),
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityKeywordRules.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityKeywordRules.cs
@@ -1,0 +1,137 @@
+using System.Text.RegularExpressions;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// The narrow, built-in keyword vocabulary that classifies a third-party tool's capabilities from its
+/// published name, when no first-party declaration, MCP annotation, or operator override answers first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Token-based, never substring.</strong> The published name is split on <c>_ - .</c> and camel
+/// boundaries — including the <c>__</c> bundle-namespace separator, which splits into an empty token and
+/// is filtered out, so <c>bundleid_srv__web_fetch</c> still yields the <c>fetch</c> token from the
+/// original tool name. Each rule matches whole tokens or an adjacent-token pair, never a fragment inside
+/// a longer word — matching a fragment is exactly how a rule silently widens over time.
+/// </para>
+/// <para>
+/// <strong>The exclusion list is the design, not an oversight.</strong> <c>read, get, list, search,
+/// query, load, open, write, create, update, sync, call, request, submit, run, key, auth, token</c> are
+/// deliberately absent from every rule below. Each tags a large fraction of any real tool set:
+/// <c>read</c> alone would mark every file, database, and memory lookup as an untrusted source;
+/// bare <c>run</c> would catch <c>run_skill_script</c>. This is the AgentHound design note this feature
+/// is built on, carried over verbatim: "keyword sets are kept deliberately narrow — universal taint
+/// destroys signal." A keyword added here without an equally deliberate argument for why it will not
+/// flag ordinary tools is a regression, not an improvement.
+/// </para>
+/// <para>
+/// <strong>What this buys, and what it does not.</strong> This heuristic is expected to classify a
+/// minority of any real third-party MCP tool estate — the design accepts that trade explicitly, because
+/// the alternative (a wide vocabulary) fails the acceptance criteria's control case: an agent holding
+/// only a source tool, or only a sink tool, must never produce a finding. A narrow vocabulary that
+/// classifies less is preferable to a wide one that classifies wrong.
+/// </para>
+/// </remarks>
+public static class ToolCapabilityKeywordRules
+{
+    // Splits on the standard tool-name separators plus a camelCase boundary. `__` (the bundle-namespace
+    // separator) produces an empty entry between the two underscores, filtered out below rather than
+    // guarded against here — RegexOptions.Compiled because this runs once per tool per resolution.
+    private static readonly Regex Tokenizer = new(
+        @"[_\-.]+|(?<=[a-z0-9])(?=[A-Z])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly string[] IngestsUntrustedInputTokens =
+        ["fetch", "browse", "crawl", "scrape"];
+
+    private static readonly string[] SendsOutboundTokens =
+        ["send", "email", "webhook", "publish", "upload", "notify"];
+
+    private static readonly string[] ExecutesCodeTokens =
+        ["exec", "execute", "shell", "bash", "terminal", "eval", "spawn"];
+
+    private static readonly string[] ReadsCredentialsTokens =
+        ["secret", "credential", "keyvault", "vault", "password"];
+
+    /// <summary>
+    /// Classifies <paramref name="publishedToolName"/> by matching whole tokens (and a small number of
+    /// adjacent-token pairs) against the narrow keyword vocabulary. Returns
+    /// <see cref="ToolCompositionCapability.None"/> when nothing matches — the common case, and the deliberate one.
+    /// </summary>
+    public static ToolCompositionCapability Classify(string publishedToolName)
+    {
+        if (string.IsNullOrWhiteSpace(publishedToolName))
+            return ToolCompositionCapability.None;
+
+        var tokens = Tokenizer.Split(publishedToolName)
+            .Where(t => t.Length > 0)
+            .Select(t => t.ToLowerInvariant())
+            .ToArray();
+
+        if (tokens.Length == 0)
+            return ToolCompositionCapability.None;
+
+        var tokenSet = new HashSet<string>(tokens, StringComparer.Ordinal);
+        var capability = ToolCompositionCapability.None;
+
+        if (ContainsAny(tokenSet, IngestsUntrustedInputTokens)
+            || HasAdjacentPair(tokens, IsWebOrHttp, t => t is "search")
+            || HasAdjacentPair(tokens, t => t is "read", IsEmailLike))
+        {
+            capability |= ToolCompositionCapability.IngestsUntrustedInput;
+        }
+
+        if (ContainsAny(tokenSet, SendsOutboundTokens)
+            || HasAdjacentPair(tokens, t => t is "http", t => t is "post"))
+        {
+            capability |= ToolCompositionCapability.SendsOutbound;
+        }
+
+        if (ContainsAny(tokenSet, ExecutesCodeTokens)
+            || HasAdjacentPair(tokens, t => t is "run", IsCommandLike))
+        {
+            capability |= ToolCompositionCapability.ExecutesCode;
+        }
+
+        if (HasAdjacentPair(tokens, IsWriteLike, IsFileLike))
+            capability |= ToolCompositionCapability.WritesFiles;
+
+        if (ContainsAny(tokenSet, ReadsCredentialsTokens))
+            capability |= ToolCompositionCapability.ReadsCredentials;
+
+        return capability;
+    }
+
+    private static bool ContainsAny(HashSet<string> tokens, string[] candidates)
+    {
+        foreach (var candidate in candidates)
+            if (tokens.Contains(candidate))
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// Whether two adjacent tokens in <paramref name="tokens"/> satisfy <paramref name="first"/>
+    /// followed immediately by <paramref name="second"/>, in either order. Order-insensitive because a
+    /// tool name reasonably reads either <c>web_search</c> or <c>search_web</c> for the same capability,
+    /// and the token pair — not the word order — is the signal.
+    /// </summary>
+    private static bool HasAdjacentPair(
+        IReadOnlyList<string> tokens, Func<string, bool> first, Func<string, bool> second)
+    {
+        for (var i = 0; i < tokens.Count - 1; i++)
+        {
+            if ((first(tokens[i]) && second(tokens[i + 1])) || (second(tokens[i]) && first(tokens[i + 1])))
+                return true;
+        }
+        return false;
+    }
+
+    private static bool IsWebOrHttp(string token) => token is "web" or "http";
+    private static bool IsEmailLike(string token) => token is "email" or "inbox" or "mail";
+    private static bool IsCommandLike(string token) => token is "command" or "script" or "code";
+    private static bool IsWriteLike(string token) => token is "write" or "edit" or "save" or "delete";
+    private static bool IsFileLike(string token) => token is "file" or "directory" or "path" or "fs";
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityResolver.cs
@@ -1,0 +1,210 @@
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Default <see cref="IToolCapabilityResolver"/>. Reads a first-party tool's declaration straight off
+/// its keyed-DI registration, falls back to the narrow keyword heuristic, and augments with the MCP
+/// open-world hint and operator overrides — see the interface's remarks for the exact precedence.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered as a singleton, like <see cref="ToolBehaviorRegistry"/>: it holds no per-call state and
+/// every input it needs (the config snapshot, the behaviour registry, keyed DI) is already safe to read
+/// from any scope.
+/// </para>
+/// <para>
+/// <strong>Never probes keyed DI with a name outside the bounded registered-key set supplied to the
+/// constructor.</strong> This resolver is called for every tool in an agent's set, including
+/// MCP and bundle-owned tools whose published names are not registration keys — a bundle-owned name
+/// embeds a per-run bundle id, so that key space is unbounded across a process lifetime.
+/// <c>IServiceProvider.GetKeyedService</c> caches an accessor per distinct key it is asked about, even
+/// for a key nothing is registered under, in the ROOT container this singleton holds — so probing an
+/// unbounded name space there is unbounded, process-lifetime memory growth, not a per-call cost. The
+/// bounded key set (built once, at the same place <see cref="ToolCatalog"/>'s is) is what keeps the
+/// probe itself bounded.
+/// </para>
+/// </remarks>
+public sealed class ToolCapabilityResolver : IToolCapabilityResolver
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IToolBehaviorRegistry _behaviorRegistry;
+    private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
+    private readonly IReadOnlySet<string> _registeredFirstPartyToolKeys;
+
+    /// <summary>Initializes a new instance of the <see cref="ToolCapabilityResolver"/> class.</summary>
+    /// <param name="registeredFirstPartyToolKeys">
+    /// The bounded set of keys <see cref="ITool"/> is actually registered under — see this type's
+    /// remarks for why probing keyed DI outside this set is unsafe.
+    /// </param>
+    public ToolCapabilityResolver(
+        IServiceProvider serviceProvider,
+        IToolBehaviorRegistry behaviorRegistry,
+        IOptionsMonitor<GovernanceConfig> governanceConfig,
+        IReadOnlySet<string> registeredFirstPartyToolKeys)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(behaviorRegistry);
+        ArgumentNullException.ThrowIfNull(governanceConfig);
+        ArgumentNullException.ThrowIfNull(registeredFirstPartyToolKeys);
+
+        _serviceProvider = serviceProvider;
+        _behaviorRegistry = behaviorRegistry;
+        _governanceConfig = governanceConfig;
+        _registeredFirstPartyToolKeys = registeredFirstPartyToolKeys;
+    }
+
+    /// <inheritdoc />
+    public ToolCapabilityProfile Resolve(string publishedToolName)
+    {
+        if (string.IsNullOrWhiteSpace(publishedToolName))
+            return ToolCapabilityProfile.Unclassified(publishedToolName ?? string.Empty);
+
+        var config = _governanceConfig.CurrentValue.ToolCompositionGating;
+
+        // The behaviour registry is keyed on the same published name this method receives (see
+        // BehaviorRecordingMcpToolProvider.Record), so it doubles as the source of two facts this
+        // resolver needs: which MCP server (if any) advertised the tool, and its open-world hint.
+        var behavior = _behaviorRegistry.Resolve(publishedToolName);
+        var serverName = behavior.ServerName;
+
+        // 1. Per-tool operator override wins outright, in both directions, when it applies to this
+        // tool's actual source. A blank Server on the override applies to any source by that name —
+        // safe only because the validator requires Server whenever Capabilities is empty (a clearing
+        // override), so a name-only override reaching here can only ever add bits, never remove them.
+        var toolOverride = FindApplicableToolOverride(config.ToolCapabilities, publishedToolName, serverName);
+        if (toolOverride is not null)
+        {
+            return new ToolCapabilityProfile(
+                publishedToolName, ToOneFlags(toolOverride.Capabilities),
+                ToolCapabilityOrigin.OperatorOverride, serverName);
+        }
+
+        var (capabilities, origin) = ResolveBase(publishedToolName);
+
+        // 2. MCP open-world annotation adds IngestsUntrustedInput — believed from any source, unlike a
+        // loosening readOnlyHint claim, because it only ever adds friction to this check. A hostile
+        // server gains nothing by asserting it.
+        //
+        // Origin is upgraded whenever a STRONGER source contributes, not only when the profile was
+        // previously None. A profile is a single record describing possibly-several bits from
+        // possibly-several sources, and Origin can only ever report one of them — reporting the
+        // strongest source that vouches for the profile, rather than whichever source happened to run
+        // first, is what keeps an approver from being shown "keyword guess" for a bit a real server
+        // annotation actually backs.
+        if (behavior.OpenWorld == true && (capabilities & ToolCompositionCapability.IngestsUntrustedInput) == ToolCompositionCapability.None)
+        {
+            capabilities |= ToolCompositionCapability.IngestsUntrustedInput;
+            origin = StrongerOf(origin, ToolCapabilityOrigin.McpAnnotation);
+        }
+
+        // 3. Per-server operator override — additive only. Never applied ahead of the per-tool override
+        // above: a per-tool override that clears bits must win over a server-wide addition, or the
+        // clearing override would be immediately re-tainted by the server it was written to override.
+        // OperatorOverride is the strongest source by construction, so a non-empty server override
+        // always wins the Origin label — an operator's explicit, reviewed statement about a server
+        // outranks any guess, whether or not it happens to overlap bits a weaker source already found.
+        if (serverName is { Length: > 0 })
+        {
+            var serverOverride = config.ServerCapabilities.FirstOrDefault(
+                s => string.Equals(s.Server, serverName, StringComparison.OrdinalIgnoreCase));
+
+            if (serverOverride is { Capabilities.Count: > 0 })
+            {
+                capabilities |= ToOneFlags(serverOverride.Capabilities);
+                origin = ToolCapabilityOrigin.OperatorOverride;
+            }
+        }
+
+        return capabilities == ToolCompositionCapability.None
+            ? ToolCapabilityProfile.Unclassified(publishedToolName)
+            : new ToolCapabilityProfile(publishedToolName, capabilities, origin, serverName);
+    }
+
+    /// <summary>
+    /// The base classification before any annotation or override augments it: a first-party tool's own
+    /// declaration, authoritative in both directions, or — only when no first-party registration exists
+    /// at all — the narrow keyword heuristic against the published name.
+    /// </summary>
+    /// <remarks>
+    /// <strong>A registered first-party tool's declaration is never overridden by the keyword
+    /// heuristic, even when it is the DIM default <see cref="ToolCompositionCapability.None"/>.</strong>
+    /// <see cref="ITool.Capabilities"/>'s own remarks document why: leaving a tool undeclared is meant
+    /// to surface as a visible unclassified count, not to be silently patched over by a name-based
+    /// guess. The keyword heuristic exists for the case a first-party declaration cannot cover at
+    /// all — a third-party MCP tool, which has no <see cref="ITool"/> registration to consult.
+    /// </remarks>
+    private (ToolCompositionCapability Capabilities, ToolCapabilityOrigin Origin) ResolveBase(string publishedToolName)
+    {
+        // Gated on the bounded registered-key set before ever reaching the container — see this
+        // type's remarks. An MCP or bundle-owned name that is not a registration key skips straight to
+        // the keyword heuristic below, exactly as it would if GetKeyedService had been called and
+        // returned null, but without teaching the root provider a new permanent, never-reused key.
+        var firstParty = _registeredFirstPartyToolKeys.Contains(publishedToolName)
+            ? _serviceProvider.GetKeyedService<ITool>(publishedToolName)
+            : null;
+        if (firstParty is not null)
+        {
+            return firstParty.Capabilities != ToolCompositionCapability.None
+                ? (firstParty.Capabilities, ToolCapabilityOrigin.FirstParty)
+                : (ToolCompositionCapability.None, ToolCapabilityOrigin.Unclassified);
+        }
+
+        var keyword = ToolCapabilityKeywordRules.Classify(publishedToolName);
+        return keyword != ToolCompositionCapability.None
+            ? (keyword, ToolCapabilityOrigin.KeywordHeuristic)
+            : (ToolCompositionCapability.None, ToolCapabilityOrigin.Unclassified);
+    }
+
+    /// <summary>
+    /// The per-tool override matching rule: the name matches, and either the override names no server
+    /// (applies to any source) or names the server this declaration actually came from.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Deliberately not the same rule as <c>ToolInvocationGovernor.ExemptionCoversSource</c>,</strong>
+    /// though both exist to stop a tool name — which belongs to nobody — from letting a server-scoped
+    /// config entry silently cover a different server's tool of the same name. That rule additionally
+    /// requires <c>behavior.IsVouchedFor</c> before honouring a bare-name entry, because a behaviour
+    /// exemption can <em>loosen</em> a gate (skip approval for a tool that would otherwise need it).
+    /// A bare-name entry here can only ever <em>add</em> capability bits: the validator requires
+    /// <c>Server</c> whenever <c>Capabilities</c> is empty, so a clearing override without a named
+    /// server never reaches this method at all. Adding bits only makes the composition check more
+    /// cautious, so there is no loosening direction here that needs a provenance guard.
+    /// </remarks>
+    private static ToolCapabilityOverride? FindApplicableToolOverride(
+        List<ToolCapabilityOverride> overrides, string toolName, string? serverName) =>
+        overrides.FirstOrDefault(entry =>
+            string.Equals(entry.Tool, toolName, StringComparison.OrdinalIgnoreCase)
+            && (string.IsNullOrWhiteSpace(entry.Server)
+                || string.Equals(entry.Server, serverName, StringComparison.OrdinalIgnoreCase)));
+
+    /// <summary>
+    /// Trust ranking used to decide which source's name is reported when more than one has vouched for
+    /// a profile. Distinct from declaration order in <see cref="ToolCapabilityOrigin"/> itself, which is
+    /// definition order, not strength order.
+    /// </summary>
+    private static readonly Dictionary<ToolCapabilityOrigin, int> OriginStrength = new()
+    {
+        [ToolCapabilityOrigin.Unclassified] = 0,
+        [ToolCapabilityOrigin.KeywordHeuristic] = 1,
+        [ToolCapabilityOrigin.McpAnnotation] = 2,
+        [ToolCapabilityOrigin.FirstParty] = 3,
+        [ToolCapabilityOrigin.OperatorOverride] = 4,
+    };
+
+    private static ToolCapabilityOrigin StrongerOf(ToolCapabilityOrigin a, ToolCapabilityOrigin b) =>
+        OriginStrength[b] > OriginStrength[a] ? b : a;
+
+    private static ToolCompositionCapability ToOneFlags(List<ToolCompositionCapability> flags)
+    {
+        var combined = ToolCompositionCapability.None;
+        foreach (var flag in flags)
+            combined |= flag;
+        return combined;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Governance;
 using Domain.AI.Skills;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Plugins;
@@ -27,6 +28,8 @@ public partial class ToolChainBuilder : IToolChainBuilder
     private readonly IMcpToolProvider? _mcpToolProvider;
     private readonly IMcpToolSurfaceScanner? _surfaceScanner;
     private readonly IOptionsMonitor<AIConfig>? _aiConfig;
+    private readonly IToolCompositionAnalyzer? _compositionAnalyzer;
+    private readonly ToolCompositionReporter? _compositionReporter;
 
     public ToolChainBuilder(
         ILogger<ToolChainBuilder> logger,
@@ -34,7 +37,9 @@ public partial class ToolChainBuilder : IToolChainBuilder
         IToolConverter? toolConverter = null,
         IMcpToolProvider? mcpToolProvider = null,
         IMcpToolSurfaceScanner? surfaceScanner = null,
-        IOptionsMonitor<AIConfig>? aiConfig = null)
+        IOptionsMonitor<AIConfig>? aiConfig = null,
+        IToolCompositionAnalyzer? compositionAnalyzer = null,
+        ToolCompositionReporter? compositionReporter = null)
     {
         _logger = logger;
         _serviceProvider = serviceProvider;
@@ -42,6 +47,8 @@ public partial class ToolChainBuilder : IToolChainBuilder
         _mcpToolProvider = mcpToolProvider;
         _surfaceScanner = surfaceScanner;
         _aiConfig = aiConfig;
+        _compositionAnalyzer = compositionAnalyzer;
+        _compositionReporter = compositionReporter;
     }
 
     /// <summary>
@@ -75,7 +82,13 @@ public partial class ToolChainBuilder : IToolChainBuilder
     {
         var provisioned = await BuildProvisionedToolsAsync(skill, options, cancellationToken);
         var (tools, _) = ResolveSurvivingTools(provisioned);
-        return tools;
+
+        // The third whole-agent-set exit — see ApplyCompositionTaint's remarks. Unlike the per-skill
+        // BuildInjectedModeToolsAsync/BuildManagedModeToolsAsync it is built from, this method's return
+        // value IS the complete agent tool set whenever a caller resolves an agent from a single skill,
+        // so it gets the same treatment as the two multi-skill exits rather than being left uncovered.
+        var agentName = options.AgentNameOverride ?? skill.Name;
+        return ApplyCompositionTaint(tools, agentName);
     }
 
     private Task<List<ProvisionedTool>> BuildProvisionedToolsAsync(
@@ -271,7 +284,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
             .ToList();
 
     /// <inheritdoc />
-    public List<AITool> BuildToolsByName(IReadOnlyList<string> toolNames)
+    public List<AITool> BuildToolsByName(IReadOnlyList<string> toolNames, string? agentName = null)
     {
         var tools = new List<AITool>();
         foreach (var name in toolNames)
@@ -283,7 +296,12 @@ public partial class ToolChainBuilder : IToolChainBuilder
 
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var provisioned = tools.Where(t => seen.Add(t.Name)).Select(t => new ProvisionedTool(t, null)).ToList();
-        return FinalizeChain(provisioned, "keyed-DI resolution by name").ConvertAll(p => p.Tool);
+        var finalized = FinalizeChain(provisioned, "keyed-DI resolution by name").ConvertAll(p => p.Tool);
+
+        // One of the three whole-agent-set exits — see ApplyCompositionTaint's remarks: a delegated
+        // subagent's tool set is fully known only here, exactly like the merged path's is only known
+        // after ResolveSurvivingTools.
+        return ApplyCompositionTaint(finalized, agentName ?? "unknown-agent");
     }
 
     /// <inheritdoc />
@@ -325,7 +343,79 @@ public partial class ToolChainBuilder : IToolChainBuilder
             attributedMcp.IntersectWith(deduplicated.Select(t => t.Name));
         }
 
-        return new MergedToolChain(deduplicated, attributedMcp);
+        // One of the three whole-agent-set exits — see ApplyCompositionTaint's remarks. This is the
+        // real, cross-skill tool set an agent runs with; a per-skill check earlier in this method's own
+        // call chain (BuildProvisionedToolsAsync → BuildInjectedModeToolsAsync/BuildManagedModeToolsAsync
+        // → FinalizeChain) would only ever see one skill's tools and could never confirm or rule out a
+        // pairing that spans two skills — exactly the shape of the realistic exfiltration case (a
+        // web-fetch skill plus an email skill on the same agent).
+        var agentName = options.AgentNameOverride ?? skills.FirstOrDefault()?.Name ?? "unknown-agent";
+        var taintedTools = ApplyCompositionTaint(deduplicated, agentName);
+
+        return new MergedToolChain(taintedTools, attributedMcp);
+    }
+
+    /// <summary>
+    /// Runs tool-composition analysis over a whole agent's assembled tool set and re-wraps each
+    /// implicated sink's <see cref="GovernedAIFunction"/> with the findings that name it, so
+    /// <c>ToolInvocationGovernor</c> can enforce a RequireApproval posture at call time without needing
+    /// to see the rest of the agent's tool set. Also reports the assessment through
+    /// <see cref="ToolCompositionReporter"/> — build-time reporting and call-time enforcement are stamped
+    /// from the exact same analysis run, so they can never describe two different tool sets.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Runs at exactly three places: here, <see cref="BuildToolsAsync"/>, and
+    /// <see cref="BuildToolsByName"/>.</strong> All three are genuine whole-agent-set exits — the point
+    /// past which no more tools are added for that agent build. The per-skill
+    /// <c>BuildInjectedModeToolsAsync</c>/<c>BuildManagedModeToolsAsync</c> that feed into
+    /// <see cref="BuildToolsAsync"/> and this method are not: each only ever sees a fragment of the
+    /// eventual set and is not a valid vantage point for a cross-skill composition check.
+    /// </para>
+    /// <para>
+    /// <strong>Degrades to a no-op when analysis is unavailable</strong> (a null <c>_compositionAnalyzer</c>,
+    /// the same optional-collaborator pattern this class already applies to <c>_surfaceScanner</c> and
+    /// <c>_aiConfig</c>) — every production host registers the analyzer unconditionally, so this only
+    /// matters for a test fixture that constructs <see cref="ToolChainBuilder"/> directly without it.
+    /// </para>
+    /// </remarks>
+    private List<AITool> ApplyCompositionTaint(List<AITool> tools, string agentName)
+    {
+        if (_compositionAnalyzer is null)
+            return tools;
+
+        var assessment = _compositionAnalyzer.Analyze(tools);
+        _compositionReporter?.Report(agentName, assessment);
+
+        if (assessment.Findings.Count == 0)
+            return tools;
+
+        // Grouped so a sink implicated by more than one finding is re-wrapped exactly once, carrying
+        // every finding that names it — never overwritten by a second, later finding for the same sink.
+        var findingsBySink = new Dictionary<string, List<ToolCompositionFinding>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var finding in assessment.Findings)
+        {
+            if (!findingsBySink.TryGetValue(finding.SinkTool, out var forSink))
+                findingsBySink[finding.SinkTool] = forSink = [];
+            forSink.Add(finding);
+        }
+
+        return tools.Select(t =>
+        {
+            // Every tool reaching this point that can carry a taint is already a GovernedAIFunction —
+            // WrapGoverned (via FinalizeChain, upstream of all three call sites) wraps every AIFunction
+            // tool unconditionally. A tool that is not one (a rare non-AIFunction AITool) cannot carry a
+            // taint and passes through unchanged; it is also, by construction, never a sink an operator
+            // could have classified, since first-party capability declarations live on ITool, resolved
+            // only for keyed-DI tools that ARE AIFunctions once converted.
+            if (t is not GovernedAIFunction governed || !findingsBySink.TryGetValue(t.Name, out var findings))
+                return t;
+
+            // Re-wrap rather than mutate: the taint is set once, in the constructor, so carrying a
+            // finding discovered by THIS analysis means unwrapping to the same inner function and
+            // rewrapping — never double-governing, since InnerFunction always points at the real tool.
+            return (AITool)new GovernedAIFunction(governed.Inner, new ToolCompositionTaint(findings));
+        }).ToList();
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/GovernanceConfigValidator.cs
@@ -1,4 +1,5 @@
 using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
 using FluentValidation;
 
 namespace Application.Core.Validation;
@@ -140,5 +141,91 @@ public sealed class GovernanceConfigValidator : AbstractValidator<GovernanceConf
                 "say why the tool is safe despite not declaring itself read-only: this list is the " +
                 "first thing a reviewer reads when asking why a tool was never gated, and an entry " +
                 "with no justification is indistinguishable from one added to silence a prompt.");
+
+        // Same landmine as ToolBehaviorGating above, for the tool-composition posture: it is applied by
+        // the same tool governor, so it needs the same company. See that rule's message for why leaving
+        // enforcement off is not "posture off" but "posture applies to bundle runs alone".
+        When(x => x.ToolCompositionGating.DefaultPosture == CompositionPosture.RequireApproval
+                  || x.ToolCompositionGating.Pairings.Any(p => p.Posture == CompositionPosture.RequireApproval), () =>
+        {
+            RuleFor(x => x.EnforceToolInvocation)
+                .Equal(true)
+                .WithMessage(
+                    "ToolCompositionGating has a pairing (or DefaultPosture) set to RequireApproval, " +
+                    "which requires Governance.EnforceToolInvocation=true. The posture is applied by " +
+                    "the same tool governor ToolBehaviorGating uses, which engages either when " +
+                    "invocation enforcement is on or when a bundle run publishes a capability envelope " +
+                    "— so leaving enforcement off does not switch the posture off, it applies it to " +
+                    "bundle runs alone while every agent turn and plan step goes ungated.");
+        });
+
+        RuleForEach(x => x.ToolCompositionGating.Pairings)
+            .Must(p => ToolCompositionCapabilities.SourceBits.Contains(p.Source))
+            .WithMessage(
+                "ToolCompositionGating.Pairings contains an entry whose Source is not a source " +
+                "capability (IngestsUntrustedInput or ReadsCredentials). A pairing names one source " +
+                "bit and one sink bit — remove the entry or correct the capability.");
+
+        RuleForEach(x => x.ToolCompositionGating.Pairings)
+            .Must(p => ToolCompositionCapabilities.SinkBits.Contains(p.Sink))
+            .WithMessage(
+                "ToolCompositionGating.Pairings contains an entry whose Sink is not a sink capability " +
+                "(WritesFiles, ExecutesCode, or SendsOutbound). A pairing names one source bit and one " +
+                "sink bit — remove the entry or correct the capability.");
+
+        RuleFor(x => x.ToolCompositionGating.Pairings)
+            .Must(pairings => pairings.Select(p => (p.Source, p.Sink)).Distinct().Count() == pairings.Count)
+            .WithMessage(
+                "ToolCompositionGating.Pairings contains two entries for the same (Source, Sink) pair. " +
+                "Only the first is ever consulted — remove the duplicate or the operator's later " +
+                "posture change will silently do nothing.");
+
+        // Per-tool overrides: name and reason are the same "first thing a reviewer reads" requirement
+        // as ToolBehaviorGating.Exemptions above, for the identical reason.
+        RuleForEach(x => x.ToolCompositionGating.ToolCapabilities)
+            .Must(entry => !string.IsNullOrWhiteSpace(entry.Tool))
+            .WithMessage(
+                "ToolCompositionGating.ToolCapabilities contains an entry with no tool name. A blank " +
+                "name matches nothing and overrides nothing — remove the entry or name the tool.");
+
+        RuleForEach(x => x.ToolCompositionGating.ToolCapabilities)
+            .Must(entry => !string.IsNullOrWhiteSpace(entry.Reason))
+            .WithMessage(
+                "ToolCompositionGating.ToolCapabilities contains an entry with no reason. Every " +
+                "override must say why — this list is the first thing a reviewer reads when asking why " +
+                "a tool was, or was not, flagged.");
+
+        // The loosening-direction rule ToolBehaviorExemption.Server already enforces, restated here for
+        // the same reason: clearing a name-keyed tool's capabilities without naming its server hands
+        // back the exact bypass that rule exists to prevent.
+        RuleForEach(x => x.ToolCompositionGating.ToolCapabilities)
+            .Must(entry => entry.Capabilities.Count > 0 || !string.IsNullOrWhiteSpace(entry.Server))
+            .WithMessage(
+                "ToolCompositionGating.ToolCapabilities contains an entry with an empty Capabilities " +
+                "list and no Server. Clearing a tool's capabilities by name alone would apply to any " +
+                "server that ever advertises a tool by that name — name the server this override is " +
+                "actually for.");
+
+        RuleForEach(x => x.ToolCompositionGating.ServerCapabilities)
+            .Must(entry => !string.IsNullOrWhiteSpace(entry.Server))
+            .WithMessage(
+                "ToolCompositionGating.ServerCapabilities contains an entry with no server name. A " +
+                "blank name matches nothing and overrides nothing — remove the entry or name the server.");
+
+        RuleForEach(x => x.ToolCompositionGating.ServerCapabilities)
+            .Must(entry => !string.IsNullOrWhiteSpace(entry.Reason))
+            .WithMessage(
+                "ToolCompositionGating.ServerCapabilities contains an entry with no reason. Every " +
+                "override must say why every tool on that server carries these capabilities.");
+
+        // A server override may only ADD capability bits — see ToolCompositionGatingConfig's remarks
+        // for why clearing is restricted to a named, per-tool override. An empty list here is either a
+        // typo or an attempt to de-taint a whole server by omission, and neither is honoured silently.
+        RuleForEach(x => x.ToolCompositionGating.ServerCapabilities)
+            .Must(entry => entry.Capabilities.Count > 0)
+            .WithMessage(
+                "ToolCompositionGating.ServerCapabilities contains an entry with an empty Capabilities " +
+                "list. A server override may only ADD capability bits to every tool it advertises — an " +
+                "empty list adds nothing and the entry does nothing; remove it or list the capabilities.");
     }
 }

--- a/src/Content/Domain/Domain.AI/Governance/ToolCapabilityProfile.cs
+++ b/src/Content/Domain/Domain.AI/Governance/ToolCapabilityProfile.cs
@@ -1,0 +1,72 @@
+using Domain.Common.Config.AI.Governance;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// Where a tool's capability declaration came from, in the precedence order it is resolved.
+/// </summary>
+/// <remarks>
+/// Kept separate from the capability bits themselves — the same reason <see cref="ToolBehaviorSource"/>
+/// is separate from <see cref="ToolBehavior.ReadOnly"/> — because a finding must be able to say
+/// <em>how sure</em> the classification is ("this tool declared itself" vs. "this tool's name matched a
+/// keyword"), and because <see cref="Unclassified"/> is itself a reportable fact: it is the metric that
+/// shows how much of the tool estate this check cannot see at all.
+/// </remarks>
+public enum ToolCapabilityOrigin
+{
+    /// <summary>
+    /// Nothing classified the tool. Resolves to <see cref="ToolCompositionCapability.None"/> — a deliberate
+    /// fail-open, not a fail-closed, unlike almost everything else this harness classifies as unknown.
+    /// See <c>ToolCapabilityResolver</c>'s remarks for why: a fail-closed "unknown means both a source
+    /// and a sink" would flag every agent holding two or more unclassified tools, which is exactly the
+    /// "universal taint destroys signal" failure this feature exists to avoid.
+    /// </summary>
+    Unclassified = 0,
+
+    /// <summary>The tool is registered in this process and declared its capabilities directly via
+    /// <c>ITool.Capabilities</c>.</summary>
+    FirstParty = 1,
+
+    /// <summary>
+    /// Inferred from the tool's MCP behaviour annotation (<c>openWorldHint: true</c> contributes
+    /// <see cref="ToolCompositionCapability.IngestsUntrustedInput"/>). Believed from any source, unlike a
+    /// loosening <c>readOnlyHint</c> claim — an open-world claim only ever adds friction to this
+    /// check, so a hostile server gains nothing by asserting it.
+    /// </summary>
+    McpAnnotation = 2,
+
+    /// <summary>
+    /// Matched by the narrow, built-in keyword vocabulary against the tool's published name. The
+    /// weakest signal, and the one most likely to be wrong in either direction — see
+    /// <c>ToolCapabilityKeywordRules</c>.
+    /// </summary>
+    KeywordHeuristic = 3,
+
+    /// <summary>
+    /// Set explicitly by the operator, per tool or per server, in configuration. Authoritative — an
+    /// operator override always wins over every other source. See <c>ToolCompositionGatingConfig</c>.
+    /// </summary>
+    OperatorOverride = 4,
+}
+
+/// <summary>
+/// What a tool has been classified as capable of, and where that classification came from.
+/// </summary>
+/// <param name="ToolName">The tool's published name, as it appears in the assembled tool set.</param>
+/// <param name="Capabilities">The resolved capability flags. <see cref="ToolCompositionCapability.None"/> when
+/// unclassified.</param>
+/// <param name="Origin">Which source produced this classification.</param>
+/// <param name="ServerName">The MCP server that advertised this tool, or <see langword="null"/> for a
+/// first-party tool. Carried for the same reason <see cref="ToolBehavior.ServerName"/> is: a per-server
+/// operator override needs to know which server a tool actually came from.</param>
+public sealed record ToolCapabilityProfile(
+    string ToolName,
+    ToolCompositionCapability Capabilities,
+    ToolCapabilityOrigin Origin,
+    string? ServerName = null)
+{
+    /// <summary>The profile of a tool nothing could classify: no capability bits, origin
+    /// <see cref="ToolCapabilityOrigin.Unclassified"/>.</summary>
+    public static ToolCapabilityProfile Unclassified(string toolName) =>
+        new(toolName, ToolCompositionCapability.None, ToolCapabilityOrigin.Unclassified);
+}

--- a/src/Content/Domain/Domain.AI/Governance/ToolCompositionFinding.cs
+++ b/src/Content/Domain/Domain.AI/Governance/ToolCompositionFinding.cs
@@ -1,0 +1,78 @@
+using Domain.Common.Config.AI.Governance;
+
+namespace Domain.AI.Governance;
+
+/// <summary>
+/// One co-resident source/sink pairing found in an agent's assembled tool set: a tool carrying a
+/// source capability alongside a different tool carrying a sink capability.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>This is a fact, not a verdict — deliberately, and it is the whole reason the build-time
+/// analysis is safe.</strong> It carries no <c>Posture</c>. Which posture applies to
+/// (<see cref="SourceCapability"/>, <see cref="SinkCapability"/>) is looked up fresh, every time it
+/// matters, against the live <c>ToolCompositionGatingConfig</c> — once by
+/// <c>ToolCompositionReporter</c> at build time (to decide what is worth reporting) and independently
+/// again by <c>ToolInvocationGovernor.RequiresApprovalForToolComposition</c> at call time (to decide
+/// whether to gate). Both read <c>ToolCompositionPostureResolver.Resolve</c>, the one place that
+/// mapping is decided, so an operator's config change takes effect for an already-built agent the next
+/// time its sink tool is called — without a rebuild — for exactly the same reason #324's behaviour
+/// posture does: the STRUCTURAL fact (what a tool declares, or here, which tools are co-resident) is
+/// fixed once discovered; the POLICY response to that fact is read live.
+/// </para>
+/// <para>
+/// The corollary limit, worth stating plainly: a config change that alters WHICH tools count as a
+/// source or a sink (a new keyword rule, a new <c>ToolCapabilities</c>/<c>ServerCapabilities</c>
+/// override) changes the fact itself, not just the policy response to it, and does need an agent
+/// rebuild to take effect — the same limit #324's tool-behaviour registry already accepts for a
+/// tool's declared annotations.
+/// </para>
+/// </remarks>
+/// <param name="SourceTool">The tool that can bring untrusted or sensitive content into the agent's
+/// context.</param>
+/// <param name="SourceCapability">Which source bit triggered this finding. Exactly one bit, even when
+/// <paramref name="SourceTool"/>'s full profile carries more than one — a finding names one bit-pair so
+/// an operator overriding one pairing's posture does not silently affect another.</param>
+/// <param name="SinkTool">The tool that can act on that content in a way that costs something.
+/// Always a different tool from <paramref name="SourceTool"/> — see <c>ToolCompositionAnalyzer</c>'s
+/// remarks on why self-pairs (one tool that is both) are excluded from this check.</param>
+/// <param name="SinkCapability">Which sink bit triggered this finding. Exactly one bit, for the same
+/// reason as <paramref name="SourceCapability"/>.</param>
+/// <param name="SourceOrigin">Where <paramref name="SourceTool"/>'s classification came from.</param>
+/// <param name="SinkOrigin">Where <paramref name="SinkTool"/>'s classification came from.</param>
+public sealed record ToolCompositionFinding(
+    string SourceTool,
+    ToolCompositionCapability SourceCapability,
+    string SinkTool,
+    ToolCompositionCapability SinkCapability,
+    ToolCapabilityOrigin SourceOrigin,
+    ToolCapabilityOrigin SinkOrigin)
+{
+    /// <summary>
+    /// A stable, human-readable description of the finding: both tools and the capability pairing that
+    /// implicated them. This is the string an approver reads, the string that goes into the audit log,
+    /// and the acceptance-criteria requirement that a finding "name both tools and the path".
+    /// </summary>
+    public string Path => $"{SourceTool} ({SourceCapability}) → {SinkTool} ({SinkCapability})";
+}
+
+/// <summary>
+/// The immutable result of analyzing one agent's assembled tool set for composition risk, carried from
+/// build time — where the tool set is known — to call time, where the posture is enforced live. See
+/// <c>ToolChainBuilder</c>'s stamping of this onto <c>GovernedAIFunction</c> and
+/// <c>ToolInvocationGovernor.RequiresApprovalForToolComposition</c>'s consumption of it.
+/// </summary>
+/// <param name="Findings">
+/// Every co-residency fact for the tool set this taint was computed over, <strong>regardless of
+/// current posture</strong> — see <see cref="ToolCompositionFinding"/>'s remarks for why filtering by
+/// posture here would silently break a live config change. A sink tool's <c>GovernedAIFunction</c>
+/// wrapper carries only the findings that name it as the sink — see
+/// <c>ToolChainBuilder.ApplyCompositionTaint</c> — so the governor never has to search the whole list
+/// per call.
+/// </param>
+public sealed record ToolCompositionTaint(IReadOnlyList<ToolCompositionFinding> Findings)
+{
+    /// <summary>No findings implicate this tool. The common case — every non-sink tool, and every sink
+    /// tool with no co-resident source anywhere in the same tool set.</summary>
+    public static ToolCompositionTaint None { get; } = new([]);
+}

--- a/src/Content/Domain/Domain.AI/Telemetry/Conventions/GovernanceConventions.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Conventions/GovernanceConventions.cs
@@ -48,6 +48,26 @@ public static class GovernanceConventions
     public const string ClassificationModeTag = "agent.governance.classification.mode";
     public const string EnforcedTag = "agent.governance.enforced";
 
+    /// <summary>
+    /// Tool-composition findings emitted at agent build time — a source-capable tool co-resident with a
+    /// sink-capable tool under a posture that is not Allow. Tags: <see cref="CompositionSourceCapabilityTag"/>,
+    /// <see cref="CompositionSinkCapabilityTag"/>, <see cref="CompositionPostureTag"/>. Deliberately
+    /// carries no tool-name or agent-name tag — both are attacker-influenced strings of unbounded
+    /// cardinality, the same rule <see cref="McpToolCollisions"/> already applies.
+    /// </summary>
+    public const string ToolCompositionFindings = "agent.governance.tool_composition_findings";
+
+    /// <summary>
+    /// Tools an agent's composition analysis could not classify as either a source or a sink. Untagged —
+    /// this is a coverage metric, not a per-tool one. A rising count relative to tool-set size is the
+    /// signal that the check's blind spot (see <c>ToolCapabilityProfile.Unclassified</c>) is growing.
+    /// </summary>
+    public const string ToolCompositionUnclassified = "agent.governance.tool_composition_unclassified";
+
+    public const string CompositionSourceCapabilityTag = "agent.governance.composition.source_capability";
+    public const string CompositionSinkCapabilityTag = "agent.governance.composition.sink_capability";
+    public const string CompositionPostureTag = "agent.governance.composition.posture";
+
     /// <summary>Tag values for <see cref="SpinReasonTag"/> — why the spin guard broke the loop.</summary>
     public static class SpinReasonValues
     {

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/ToolCompositionCapability.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/ToolCompositionCapability.cs
@@ -1,0 +1,126 @@
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// What a tool can do with the data that flows through it, for the purpose of detecting a dangerous
+/// <em>combination</em> of tools rather than judging any one tool alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lives in <c>Domain.Common</c> rather than <c>Domain.AI</c>, alongside <see cref="ThreatLevel"/>,
+/// because <see cref="Domain.Common.Config.AI.Governance.ToolCompositionGatingConfig"/> — a
+/// <c>Domain.Common</c> config type — must be able to reference it, and <c>Domain.Common</c> cannot
+/// depend on <c>Domain.AI</c> (the dependency runs the other way). The richer domain types that use
+/// this enum — <c>Domain.AI.Governance.ToolCapabilityProfile</c>, <c>ToolCompositionFinding</c>,
+/// <c>ToolCompositionTaint</c> — live in <c>Domain.AI</c> and reference this from there, exactly as
+/// <c>GovernanceConfig</c>'s other enum-typed fields already do.
+/// </para>
+/// <para>
+/// <strong>This is a direction-of-data-flow vocabulary, not a mutability vocabulary.</strong>
+/// <c>ToolBehavior</c> (the four MCP hints — read-only, destructive, idempotent, open-world) answers
+/// "how much can this one tool change?". This answers a different question: "can this tool bring
+/// attacker-controlled content into the conversation, or can it act on that content in a way that
+/// costs something?" A tool that only reads can still be the source half of an exfiltration pair — a
+/// web-search tool is read-only and is exactly the shape of tool this vocabulary must flag as a
+/// source.
+/// </para>
+/// <para>
+/// Two source bits, three sink bits. <see cref="IngestsUntrustedInput"/> and
+/// <see cref="ReadsCredentials"/> bring content into the agent's context that the agent did not
+/// author and, in the first case, that an attacker may have authored on purpose.
+/// <see cref="WritesFiles"/>, <see cref="ExecutesCode"/>, and <see cref="SendsOutbound"/> are where
+/// that content can do damage once it has been read. The composition check
+/// (<c>IToolCompositionAnalyzer</c>) looks for an agent holding at least one bit from each group.
+/// </para>
+/// <para>
+/// <strong>Flags, because a tool can genuinely be both.</strong> A browser-automation tool that reads
+/// a page and can also submit a form is a source and a sink in the same tool. The composition check
+/// deliberately excludes self-pairs (see <c>ToolCompositionAnalyzer</c>'s remarks) — that case is
+/// #324's job, since gating a single tool for what it alone can do is exactly what behaviour gating
+/// already covers.
+/// </para>
+/// <para>
+/// <strong>The vocabulary is deliberately small.</strong> A wider one — anything that touches
+/// "read" or "write" in general — destroys the signal this check exists to produce: nearly every
+/// real tool reads or writes something, so a wide vocabulary flags nearly every agent and the finding
+/// stops meaning anything. See <c>ToolCapabilityKeywordRules</c> for the exact, narrow rule set and
+/// the much larger list of tokens deliberately left out of it.
+/// </para>
+/// </remarks>
+[Flags]
+public enum ToolCompositionCapability
+{
+    /// <summary>No known capability. Not the same as "known to have no capability" — see
+    /// <c>ToolCapabilityOrigin.Unclassified</c>, which this value is paired with when nothing could
+    /// classify the tool at all.</summary>
+    None = 0,
+
+    /// <summary>
+    /// The tool can bring content into the conversation that the agent did not author and does not
+    /// control — a fetched web page, an inbound email, a search result, a downloaded file. The
+    /// canonical injection carrier: an attacker who controls the source controls what the agent reads.
+    /// </summary>
+    IngestsUntrustedInput = 1,
+
+    /// <summary>
+    /// The tool can read secrets, credentials, or access tokens. Distinct from
+    /// <see cref="IngestsUntrustedInput"/> because the risk here is not that the content is
+    /// attacker-authored, but that it is sensitive — the composition risk is exfiltrating it, not
+    /// being instructed by it.
+    /// </summary>
+    ReadsCredentials = 2,
+
+    /// <summary>The tool can write, modify, or delete files or other persistent state.</summary>
+    WritesFiles = 4,
+
+    /// <summary>The tool can execute arbitrary code, shell commands, or scripts.</summary>
+    ExecutesCode = 8,
+
+    /// <summary>
+    /// The tool can send data outside the current process or trust boundary — email, webhooks, chat
+    /// messages, HTTP POSTs to an arbitrary or attacker-influenced destination. The canonical
+    /// exfiltration sink.
+    /// </summary>
+    SendsOutbound = 16,
+}
+
+/// <summary>
+/// The membership split of <see cref="ToolCompositionCapability"/> into source and sink bits — the one
+/// place that grouping is written. Referenced by <c>ToolCompositionAnalyzer</c> (which bits to look for
+/// on each side of a pairing) and <c>GovernanceConfigValidator</c> (which bits a
+/// <see cref="ToolCompositionPairing.Source"/>/<see cref="ToolCompositionPairing.Sink"/> may legally
+/// name). Adding a sixth capability bit means deciding its side once, here.
+/// </summary>
+public static class ToolCompositionCapabilities
+{
+    /// <summary>Bits that bring untrusted or sensitive content into the agent's context.</summary>
+    public static readonly IReadOnlyList<ToolCompositionCapability> SourceBits =
+        [ToolCompositionCapability.IngestsUntrustedInput, ToolCompositionCapability.ReadsCredentials];
+
+    /// <summary>Bits that can act on that content in a way that costs something.</summary>
+    public static readonly IReadOnlyList<ToolCompositionCapability> SinkBits =
+        [ToolCompositionCapability.WritesFiles, ToolCompositionCapability.ExecutesCode, ToolCompositionCapability.SendsOutbound];
+}
+
+/// <summary>
+/// The posture applied to one (source capability, sink capability) pairing. Bound per pairing from
+/// <see cref="ToolCompositionGatingConfig.Pairings"/>, always resolved <strong>live</strong> against
+/// the current config — never frozen into a <c>Domain.AI.Governance.ToolCompositionFinding</c>. See
+/// that type's remarks for why: a posture baked in at agent build time cannot honour a config change
+/// without an agent rebuild.
+/// </summary>
+public enum CompositionPosture
+{
+    /// <summary>The pairing is permitted. No report is emitted, and enforcement never engages.
+    /// Zero by construction, so an unconfigured pairing — the default for every pairing on a host that
+    /// has set nothing — is inert.</summary>
+    Allow = 0,
+
+    /// <summary>The pairing is reported (audit, metrics, structured log) but the sink tool is not
+    /// additionally gated at call time.</summary>
+    Warn = 1,
+
+    /// <summary>The pairing is reported, and the sink tool additionally requires human approval at
+    /// call time — folded into the same single approval question #324's behaviour posture already
+    /// asks, never a second one. See <c>ToolInvocationGovernor.RequiresApprovalForToolComposition</c>.</summary>
+    RequireApproval = 2,
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/Governance/ToolCompositionGatingConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Governance/ToolCompositionGatingConfig.cs
@@ -1,0 +1,127 @@
+namespace Domain.Common.Config.AI.Governance;
+
+/// <summary>
+/// Governs tool <em>combinations</em> rather than individual tools: an agent holding both a tool that
+/// can ingest untrusted or sensitive content and a tool that can act on it in a costly way is an
+/// indirect-prompt-injection exfiltration primitive, even though every per-tool permission check
+/// passes. Bound from <c>AppConfig:AI:Governance:ToolCompositionGating</c> in appsettings.json.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>What this adds that #324 (behaviour gating) does not.</strong> Every existing tool
+/// governance control — allow/deny lists, per-agent authorization, behaviour gating — asks "may this
+/// agent call this tool?" one tool at a time. None asks what this does: "what can this agent do with
+/// these tools <em>together</em>?" A tool that fetches a web page is not dangerous. A tool that sends
+/// email is not dangerous. An agent holding both is an exfiltration primitive.
+/// </para>
+/// <para>
+/// <strong>Off by default, and inert by construction rather than by a switch.</strong> Unlike
+/// <see cref="ToolBehaviorGatingConfig"/>, this config carries no boolean "enabled" flag. Its
+/// <see cref="DefaultPosture"/> is <see cref="CompositionPosture.Allow"/> and <see cref="Pairings"/>
+/// starts empty, so a host that sets nothing here has every pairing resolve to Allow — no findings, no
+/// enforcement. That is deliberate: the acceptance test for this feature is that the default
+/// configuration is inert, and a config shape with nothing to "turn off" cannot regress into looking
+/// off while quietly being on.
+/// </para>
+/// <para>
+/// <strong>Enforcement needs company, exactly like #324.</strong> A pairing configured as
+/// <see cref="CompositionPosture.RequireApproval"/> is applied inside the same tool governor #324's
+/// posture lives in, so it needs <see cref="GovernanceConfig.EnforceToolInvocation"/> for the same
+/// reason: the governor arms on enforcement or on a bundle run's capability envelope, and leaving
+/// enforcement off would apply the posture to bundle runs alone. <c>GovernanceConfigValidator</c>
+/// rejects that combination at startup.
+/// </para>
+/// </remarks>
+public sealed class ToolCompositionGatingConfig
+{
+    /// <summary>
+    /// The posture applied to a (source capability, sink capability) pairing that has no explicit entry
+    /// in <see cref="Pairings"/>. <see cref="CompositionPosture.Allow"/> by default, so an unconfigured
+    /// host reports and enforces nothing.
+    /// </summary>
+    public CompositionPosture DefaultPosture { get; init; } = CompositionPosture.Allow;
+
+    /// <summary>
+    /// The posture for specific (source capability, sink capability) pairings, overriding
+    /// <see cref="DefaultPosture"/> for that pairing only.
+    /// </summary>
+    public List<ToolCompositionPairing> Pairings { get; init; } = [];
+
+    /// <summary>
+    /// Per-tool capability overrides, authoritative over both the first-party declaration and the
+    /// keyword heuristic. The only way to classify a third-party MCP tool the built-in keyword
+    /// vocabulary does not recognise, and the only way to correct a keyword false positive.
+    /// </summary>
+    public List<ToolCapabilityOverride> ToolCapabilities { get; init; } = [];
+
+    /// <summary>
+    /// Per-server capability overrides, applied to every tool advertised by that server.
+    /// <strong>Additive only</strong> — a server override can add capability bits a tool would not
+    /// otherwise have, but can never remove a bit the tool's own declaration, the MCP annotation, or the
+    /// keyword heuristic already found. Removing a bit is a loosening decision and must be made per
+    /// tool, in writing, with a stated reason — the same rule <see cref="ToolBehaviorExemption.Server"/>
+    /// enforces for behaviour gating, for the same reason: a server-wide "this server never sends
+    /// outbound" claim is exactly the kind of blanket exemption that quietly re-opens the hole this
+    /// feature exists to close.
+    /// </summary>
+    public List<ToolCapabilityServerOverride> ServerCapabilities { get; init; } = [];
+}
+
+/// <summary>The posture for one (source capability, sink capability) pairing.</summary>
+public sealed class ToolCompositionPairing
+{
+    /// <summary>The source-side capability. Must be <see cref="ToolCompositionCapability.IngestsUntrustedInput"/>
+    /// or <see cref="ToolCompositionCapability.ReadsCredentials"/> — validated at startup.</summary>
+    public ToolCompositionCapability Source { get; init; }
+
+    /// <summary>The sink-side capability. Must be <see cref="ToolCompositionCapability.WritesFiles"/>,
+    /// <see cref="ToolCompositionCapability.ExecutesCode"/>, or <see cref="ToolCompositionCapability.SendsOutbound"/> —
+    /// validated at startup.</summary>
+    public ToolCompositionCapability Sink { get; init; }
+
+    /// <summary>The posture for this pairing.</summary>
+    public CompositionPosture Posture { get; init; }
+}
+
+/// <summary>One tool's capability override, and why.</summary>
+public sealed class ToolCapabilityOverride
+{
+    /// <summary>The tool name, matched case-insensitively against the tool's published name.</summary>
+    public string Tool { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The MCP server this override is for. Required when <see cref="Capabilities"/> is empty — i.e.
+    /// this override clears bits another source found — because clearing a name-keyed tool's
+    /// capabilities without naming its server hands back the exact bypass
+    /// <c>ToolBehaviorExemption.Server</c> exists to prevent: a tool name belongs to nobody, and any
+    /// other configured server can advertise a genuinely dangerous tool under the same name tomorrow.
+    /// </summary>
+    public string? Server { get; init; }
+
+    /// <summary>The capability bits this tool actually has, replacing whatever the first-party
+    /// declaration or keyword heuristic found. An empty list clears every bit — see
+    /// <see cref="Server"/>'s remarks for why that requires naming the server.</summary>
+    public List<ToolCompositionCapability> Capabilities { get; init; } = [];
+
+    /// <summary>Why this override is correct. Required — a blank reason fails startup validation, for
+    /// the same reason it does on <see cref="ToolBehaviorExemption.Reason"/>: this list is the first
+    /// place a reviewer looks when asking why a tool was never flagged.</summary>
+    public string Reason { get; init; } = string.Empty;
+}
+
+/// <summary>One MCP server's additive capability override, and why.</summary>
+public sealed class ToolCapabilityServerOverride
+{
+    /// <summary>The MCP server name every advertised tool inherits these capabilities from.</summary>
+    public string Server { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The capability bits added to every tool this server advertises, on top of whatever the
+    /// per-tool sources found. Must be non-empty — see <see cref="ToolCompositionGatingConfig.ServerCapabilities"/>'s
+    /// remarks for why a server override may only add.
+    /// </summary>
+    public List<ToolCompositionCapability> Capabilities { get; init; } = [];
+
+    /// <summary>Why every tool on this server carries these capabilities. Required.</summary>
+    public string Reason { get; init; } = string.Empty;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/GovernanceConfig.cs
@@ -151,6 +151,15 @@ public sealed class GovernanceConfig
     public ToolBehaviorGatingConfig ToolBehaviorGating { get; init; } = new();
 
     /// <summary>
+    /// Governs tool <em>combinations</em> — an untrusted-input tool co-resident with a high-impact sink
+    /// — rather than individual tools. Every pairing defaults to
+    /// <see cref="CompositionPosture.Allow"/>, so a host that configures nothing here reports
+    /// and enforces nothing; a pairing set to <see cref="CompositionPosture.RequireApproval"/>
+    /// is, like <see cref="ToolBehaviorGating"/>, inert without <see cref="EnforceToolInvocation"/>.
+    /// </summary>
+    public ToolCompositionGatingConfig ToolCompositionGating { get; init; } = new();
+
+    /// <summary>
     /// Posture for the MCP tool surface scan — collision, shadowing, and definition drift — layered
     /// on top of the per-tool content rules. Gated by <see cref="EnableMcpSecurity"/>, the same flag
     /// that gates the per-tool scanner, rather than a second switch: a control an operator believes is

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Tools;
 using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 using Microsoft.Extensions.Logging;
 
@@ -78,6 +79,15 @@ public sealed class DelegateToSubagentTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.High;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Delegation is the closest fit among the three sink bits: it initiates further autonomous
+    /// behaviour with the subagent's own tool access, which is what a supplied task description built
+    /// from untrusted content would actually exploit — not a literal code-execution call, but the same
+    /// shape of "content this agent read now drives further action."
+    /// </remarks>
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.ExecutesCode;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => false;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
 using Application.Core.CQRS.RAG.IngestDocument;
 using Domain.AI.Changes;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -71,6 +72,15 @@ public sealed class DocumentIngestTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.Medium;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The document being ingested is, by definition, content this agent did not author — the
+    /// canonical untrusted-input shape, whether or not the document's own contents are later flagged
+    /// by anything else. Not also declared <c>WritesFiles</c>: it mutates vector/BM25 index state, not
+    /// the file system, and the narrow vocabulary does not have an "index write" bit of its own.
+    /// </remarks>
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.IngestsUntrustedInput;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => false;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Changes;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 using Domain.AI.RAG.Enums;
 
@@ -75,6 +76,14 @@ public sealed class DocumentSearchTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.Low;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The index this searches can contain documents nobody on this agent's side authored — the RAG
+    /// poisoning shape: an attacker who can get a document indexed controls what a later search
+    /// returns, exactly like a web-fetch tool controls what a page returns.
+    /// </remarks>
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.IngestsUntrustedInput;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Changes;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools;
@@ -47,6 +48,16 @@ public sealed class FileSystemTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.High;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Both a source and a sink: <c>read</c>/<c>search</c> can surface content this agent did not
+    /// author (a file another actor wrote into the sandbox), and <c>write</c> mutates it. Declared as
+    /// both rather than left ambiguous — the composition analyzer excludes self-pairs, so this alone
+    /// never produces a finding, but genuinely combines with a different tool on either side.
+    /// </remarks>
+    public ToolCompositionCapability Capabilities =>
+        ToolCompositionCapability.IngestsUntrustedInput | ToolCompositionCapability.WritesFiles;
 
     /// <inheritdoc />
     public string Description => "Reads, writes, lists, and searches files within the project sandbox.";

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsProposeRemediationTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/GitOpsProposeRemediationTool.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.GitOps;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Changes;
 using Domain.AI.Models;
+using Domain.Common.Config.AI.Governance;
 
 namespace Infrastructure.AI.Tools.GitOps;
 
@@ -66,6 +67,15 @@ public sealed class GitOpsProposeRemediationTool : ITool
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => false;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Routes through change-proposal governance rather than writing directly — the same shape as
+    /// <c>WorkspaceWriteFileTool</c>, and classified identically for the same reason: the approval gate
+    /// on the proposal is a separate control, not a substitute for this tool being a sink for
+    /// composition purposes.
+    /// </remarks>
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.WritesFiles;
 
     /// <inheritdoc />
     public async Task<ToolResult> ExecuteAsync(

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceReadFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceReadFileTool.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
 using Domain.AI.Changes;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 
 namespace Infrastructure.AI.Tools.Workspace;
@@ -55,6 +56,14 @@ public sealed class WorkspaceReadFileTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.Low;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// A file in the working copy is content this agent did not necessarily author — cloned
+    /// repository content, a downloaded dependency, or a file another tool wrote in the same turn —
+    /// so reading it is the classic untrusted-input shape even though the tool itself is read-only.
+    /// </remarks>
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.IngestsUntrustedInput;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => true;

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
 using Domain.AI.Changes;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 using Domain.AI.Sandbox;
 using Microsoft.Extensions.DependencyInjection;
@@ -63,6 +64,9 @@ public sealed class WorkspaceRunLintTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.Low;
+
+    /// <inheritdoc />
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.ExecutesCode;
 
     /// <inheritdoc />
     public string Description =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
 using Domain.AI.Changes;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 using Domain.AI.Sandbox;
 using Microsoft.Extensions.DependencyInjection;
@@ -63,6 +64,9 @@ public sealed class WorkspaceRunTestsTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.Medium;
+
+    /// <inheritdoc />
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.ExecutesCode;
 
     /// <inheritdoc />
     public string Description =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
 using Domain.Common.Helpers;
 using Domain.AI.Changes;
+using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 using Domain.AI.SkillTraining;
 using MediatR;
@@ -73,6 +74,15 @@ public sealed class WorkspaceWriteFileTool : ITool
 
     /// <inheritdoc />
     public BlastRadius RiskTier => BlastRadius.High;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Routes through change-proposal governance rather than writing directly, but its effect — file
+    /// content leaving the agent's control and landing in the workspace — is exactly the sink shape
+    /// this capability names. The approval gate on the proposal is a separate control, not a
+    /// substitute for this tool being classified as a sink for composition purposes.
+    /// </remarks>
+    public ToolCompositionCapability Capabilities => ToolCompositionCapability.WritesFiles;
 
     /// <inheritdoc />
     public bool IsConcurrencySafe => false;

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
@@ -1,0 +1,232 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
+using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// The tool-composition RequireApproval posture, exercised through the real admission chain — the same
+/// pattern <see cref="ToolBehaviorPostureTests"/> uses for #324, applied to #332.
+/// </summary>
+public sealed class ToolCompositionPostureTests
+{
+    private const string Agent = "test-agent";
+    private const string SinkTool = "send_email";
+
+    private readonly Mock<IAgentExecutionContext> _context = new();
+    private readonly Mock<IToolPermissionService> _permissions = new();
+    private readonly Mock<IGovernancePolicyEngine> _policyEngine = new();
+    private readonly Mock<ICapabilityEnforcer> _capabilities = new();
+    private readonly Mock<IToolApprovalRouter> _approvalRouter = new();
+    private readonly ToolBehaviorRegistry _behavior = new(new ServiceCollection().BuildServiceProvider());
+
+    private readonly IToolRiskClassifier _riskClassifier =
+        Mock.Of<IToolRiskClassifier>(c =>
+            c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true));
+
+    public ToolCompositionPostureTests()
+    {
+        _context.Setup(x => x.AgentId).Returns(Agent);
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("allowed by default"));
+        _capabilities
+            .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Domain.Common.Result.Success());
+        _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
+        _approvalRouter
+            .Setup(x => x.RequestApprovalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolApprovalResult.NotRouted("tool approval routing is disabled"));
+    }
+
+    [Fact]
+    public async Task RequireApprovalPairing_TaintedSink_IsGatedNamingThePath()
+    {
+        var taint = new ToolCompositionTaint([Finding("web_fetch", ToolCompositionCapability.IngestsUntrustedInput)]);
+
+        var admission = await Admit(RequireApprovalGating, taint);
+
+        Assert.False(admission.IsAllowed);
+        AssertApprovalWasSought("web_fetch");
+        AssertApprovalWasSought(SinkTool);
+    }
+
+    [Fact]
+    public async Task AllowPairing_TaintedSink_RunsWithoutApproval()
+    {
+        // The control for the test above: the SAME taint under a posture that has not opted this
+        // pairing into RequireApproval must not gate anything. Config with nothing set is off.
+        var taint = new ToolCompositionTaint([Finding("web_fetch", ToolCompositionCapability.IngestsUntrustedInput)]);
+
+        var admission = await Admit(new GovernanceConfig { EnforceToolInvocation = true }, taint);
+
+        Assert.True(admission.IsAllowed);
+        AssertNoApprovalWasSought();
+    }
+
+    [Fact]
+    public async Task WarnPairing_TaintedSink_RunsWithoutApproval()
+    {
+        // Warn reports (elsewhere, via ToolCompositionReporter) but does not gate at call time.
+        var gating = new ToolCompositionGatingConfig
+        {
+            Pairings =
+            [
+                new ToolCompositionPairing
+                {
+                    Source = ToolCompositionCapability.IngestsUntrustedInput,
+                    Sink = ToolCompositionCapability.SendsOutbound,
+                    Posture = CompositionPosture.Warn,
+                },
+            ],
+        };
+        var taint = new ToolCompositionTaint([Finding("web_fetch", ToolCompositionCapability.IngestsUntrustedInput)]);
+
+        var admission = await Admit(Enforcing(gating), taint);
+
+        Assert.True(admission.IsAllowed);
+        AssertNoApprovalWasSought();
+    }
+
+    [Fact]
+    public async Task NoTaint_RequireApprovalConfigured_RunsWithoutApproval()
+    {
+        // No finding was stamped for this call — a plan step, or a build whose analysis found nothing
+        // for this tool. Null composition reads identically to "no findings", never as "unknown".
+        var admission = await Admit(RequireApprovalGating, composition: null);
+
+        Assert.True(admission.IsAllowed);
+        AssertNoApprovalWasSought();
+    }
+
+    [Fact]
+    public async Task RequireApprovalPairing_LiveConfigChange_TakesEffectWithoutRebuildingTheTaint()
+    {
+        // The whole point of NOT freezing a posture into the finding: the identical ToolCompositionTaint
+        // instance (the "build") enforces differently as the config (read live) changes underneath it.
+        var taint = new ToolCompositionTaint([Finding("web_fetch", ToolCompositionCapability.IngestsUntrustedInput)]);
+
+        var beforeChange = await Admit(new GovernanceConfig { EnforceToolInvocation = true }, taint);
+        Assert.True(beforeChange.IsAllowed);
+
+        var afterChange = await Admit(RequireApprovalGating, taint);
+        Assert.False(afterChange.IsAllowed);
+    }
+
+    [Fact]
+    public async Task BehaviorGatingAndCompositionBothObject_RaiseExactlyOneApprovalRequest()
+    {
+        // The property #324's doc calls out explicitly: two independent reasons to ask a human must
+        // still produce ONE question, or an approver clears a question they were never shown.
+        _behavior.RecordAdvertised(SinkTool, new ToolBehavior(ToolBehaviorSource.UntrustedMcpServer, Destructive: true, ServerName: "email"));
+
+        var gating = new GovernanceConfig
+        {
+            EnforceToolInvocation = true,
+            EnableAudit = true,
+            ToolCompositionGating = RequireApprovalGating.ToolCompositionGating,
+            ToolBehaviorGating = new ToolBehaviorGatingConfig { RequireApprovalForNonReadOnlyTools = true },
+        };
+        var taint = new ToolCompositionTaint([Finding("web_fetch", ToolCompositionCapability.IngestsUntrustedInput)]);
+
+        var admission = await Admit(gating, taint);
+
+        Assert.False(admission.IsAllowed);
+        _approvalRouter.Verify(
+            x => x.RequestApprovalAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static ToolCompositionFinding Finding(string sourceTool, ToolCompositionCapability sourceCapability) =>
+        new(sourceTool, sourceCapability, SinkTool, ToolCompositionCapability.SendsOutbound,
+            ToolCapabilityOrigin.KeywordHeuristic, ToolCapabilityOrigin.KeywordHeuristic);
+
+    private static GovernanceConfig Enforcing(ToolCompositionGatingConfig gating) => new()
+    {
+        EnforceToolInvocation = true,
+        EnableAudit = true,
+        ToolCompositionGating = gating,
+    };
+
+    private static GovernanceConfig RequireApprovalGating => Enforcing(new ToolCompositionGatingConfig
+    {
+        Pairings =
+        [
+            new ToolCompositionPairing
+            {
+                Source = ToolCompositionCapability.IngestsUntrustedInput,
+                Sink = ToolCompositionCapability.SendsOutbound,
+                Posture = CompositionPosture.RequireApproval,
+            },
+        ],
+    });
+
+    private async Task<ToolCallAdmission> Admit(GovernanceConfig governance, ToolCompositionTaint? composition)
+    {
+        var monitor = Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == governance);
+        var trace = new GovernanceTraceRecorder(monitor, _riskClassifier);
+
+        var governor = new ToolInvocationGovernor(
+            _context.Object,
+            _permissions.Object,
+            _riskClassifier,
+            _behavior,
+            Mock.Of<IAutonomyDecisionEvaluator>(),
+            _policyEngine.Object,
+            Mock.Of<IGovernanceAuditService>(),
+            Mock.Of<IDenialTracker>(),
+            _capabilities.Object,
+            _approvalRouter.Object,
+            trace,
+            monitor,
+            Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == new PermissionsConfig()),
+            Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == new SandboxConfig()),
+            NullLogger<ToolInvocationGovernor>.Instance);
+
+        var pipeline = AdmissionHarness.Pipeline(governor: governor, trace: trace);
+
+        return await pipeline.AdmitAsync(
+            new ToolCallAdmissionRequest(SinkTool, CompositionTaint: composition), CancellationToken.None);
+    }
+
+    private void AssertApprovalWasSought(string expectedReasonFragment) =>
+        _approvalRouter.Verify(
+            x => x.RequestApprovalAsync(
+                Agent,
+                It.IsAny<string>(),
+                It.Is<string>(reason => reason.Contains(expectedReasonFragment, StringComparison.Ordinal)),
+                It.IsAny<BlastRadius>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
+
+    private void AssertNoApprovalWasSought() =>
+        _approvalRouter.Verify(
+            x => x.RequestApprovalAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/ToolCompositionAnalyzerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/ToolCompositionAnalyzerTests.cs
@@ -1,0 +1,177 @@
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Moq;
+using Xunit;
+using ToolCompositionAnalyzerImpl = Application.AI.Common.Services.Governance.ToolCompositionAnalyzer;
+
+namespace Application.AI.Common.Tests.Services.Governance;
+
+/// <summary>
+/// Tests for <see cref="ToolCompositionAnalyzerImpl"/> — the build-time check for a source-capable
+/// tool co-resident with a sink-capable tool in the same tool set.
+/// </summary>
+/// <remarks>
+/// Findings are asserted independently of posture throughout: <see cref="ToolCompositionAnalyzerImpl"/>
+/// reports every co-resident fact regardless of the configured posture — see
+/// <see cref="ToolCompositionFinding"/>'s remarks for why filtering by posture happens later, live, at
+/// the reporter and governor instead.
+/// </remarks>
+public sealed class ToolCompositionAnalyzerTests
+{
+    private const string SourceTool = "web_fetch";
+    private const string SinkTool = "send_email";
+
+    [Fact]
+    public void Analyze_SourceAndSinkCoResident_ReturnsFindingNamingBothTools()
+    {
+        var analyzer = BuildAnalyzer(
+            (SourceTool, ToolCompositionCapability.IngestsUntrustedInput),
+            (SinkTool, ToolCompositionCapability.SendsOutbound));
+
+        var assessment = analyzer.Analyze(Tools(SourceTool, SinkTool));
+
+        assessment.Findings.Should().ContainSingle();
+        var finding = assessment.Findings[0];
+        finding.SourceTool.Should().Be(SourceTool);
+        finding.SinkTool.Should().Be(SinkTool);
+        finding.SourceCapability.Should().Be(ToolCompositionCapability.IngestsUntrustedInput);
+        finding.SinkCapability.Should().Be(ToolCompositionCapability.SendsOutbound);
+        finding.Path.Should().Contain(SourceTool).And.Contain(SinkTool);
+    }
+
+    [Fact]
+    public void Analyze_SourceToolOnly_ReturnsNoFindings()
+    {
+        // Mandated control (acceptance criteria): an agent holding only the untrusted-input tool must
+        // produce nothing. Mutation to run against this test: make an unclassified tool resolve to
+        // ToolCompositionCapability's every bit rather than None — this test (and its sink-only sibling
+        // below) must then fail, or the "universal taint destroys signal" failure is unguarded.
+        var analyzer = BuildAnalyzer((SourceTool, ToolCompositionCapability.IngestsUntrustedInput));
+
+        var assessment = analyzer.Analyze(Tools(SourceTool));
+
+        assessment.Findings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_SinkToolOnly_ReturnsNoFindings()
+    {
+        // The other half of the mandated control — see the source-only test's remarks.
+        var analyzer = BuildAnalyzer((SinkTool, ToolCompositionCapability.SendsOutbound));
+
+        var assessment = analyzer.Analyze(Tools(SinkTool));
+
+        assessment.Findings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_UnclassifiedTools_ReturnNoFindingsAndAreReportedAsUnclassified()
+    {
+        // The fail-open in practice: two unclassified tools together must not fire, and the analyzer
+        // must say so was WHY nothing fired, rather than staying silent about the blind spot.
+        var analyzer = BuildAnalyzer(
+            (SourceTool, ToolCompositionCapability.None),
+            (SinkTool, ToolCompositionCapability.None));
+
+        var assessment = analyzer.Analyze(Tools(SourceTool, SinkTool));
+
+        assessment.Findings.Should().BeEmpty();
+        assessment.UnclassifiedTools.Should().BeEquivalentTo([SourceTool, SinkTool]);
+    }
+
+    [Fact]
+    public void Analyze_ToolThatIsBothSourceAndSink_ProducesNoSelfFinding()
+    {
+        // Self-pairs are #324's job (behaviour gating for one tool), not a composition risk — see
+        // ToolCompositionCapability's remarks.
+        var analyzer = BuildAnalyzer(
+            (SourceTool, ToolCompositionCapability.IngestsUntrustedInput | ToolCompositionCapability.SendsOutbound));
+
+        var assessment = analyzer.Analyze(Tools(SourceTool));
+
+        assessment.Findings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Analyze_ToolThatIsBothSourceAndSink_StillCombinesWithADifferentTool()
+    {
+        // The self-pair exclusion must not also swallow a genuine cross-tool pairing involving the
+        // same dual-capability tool.
+        const string dualTool = "file_system";
+        var analyzer = BuildAnalyzer(
+            (dualTool, ToolCompositionCapability.IngestsUntrustedInput | ToolCompositionCapability.WritesFiles),
+            (SinkTool, ToolCompositionCapability.SendsOutbound));
+
+        var assessment = analyzer.Analyze(Tools(dualTool, SinkTool));
+
+        assessment.Findings.Should().ContainSingle(f => f.SourceTool == dualTool && f.SinkTool == SinkTool);
+    }
+
+    [Fact]
+    public void Analyze_ExactlyTheCapInRealPairings_IsNotReportedAsTruncated()
+    {
+        // The cap coinciding with the true last pairing must not be mislabelled as truncated — a false
+        // "more were dropped" warning on a complete result is itself a wrong report, on a feature whose
+        // whole design goal is accuracy about what is and is not present.
+        var sourceNames = Enumerable.Range(0, 50).Select(i => $"source_{i}").ToArray();
+        var profiles = sourceNames
+            .Select(n => (n, ToolCompositionCapability.IngestsUntrustedInput))
+            .Append((SinkTool, ToolCompositionCapability.SendsOutbound))
+            .ToArray();
+        var analyzer = BuildAnalyzer(profiles);
+
+        var assessment = analyzer.Analyze(Tools([.. sourceNames, SinkTool]));
+
+        assessment.Findings.Should().HaveCount(50);
+        assessment.Truncated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Analyze_MoreThanTheCap_IsReportedAsTruncated()
+    {
+        var sourceNames = Enumerable.Range(0, 51).Select(i => $"source_{i}").ToArray();
+        var profiles = sourceNames
+            .Select(n => (n, ToolCompositionCapability.IngestsUntrustedInput))
+            .Append((SinkTool, ToolCompositionCapability.SendsOutbound))
+            .ToArray();
+        var analyzer = BuildAnalyzer(profiles);
+
+        var assessment = analyzer.Analyze(Tools([.. sourceNames, SinkTool]));
+
+        assessment.Findings.Should().HaveCount(50);
+        assessment.Truncated.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Analyze_EmptyToolSet_ReturnsEmptyAssessment()
+    {
+        var analyzer = BuildAnalyzer();
+
+        var assessment = analyzer.Analyze([]);
+
+        assessment.Should().Be(Application.AI.Common.Interfaces.Governance.ToolCompositionAssessment.Empty);
+    }
+
+    /// <summary>Builds a real analyzer over a resolver stubbed to answer exactly the given profiles.</summary>
+    private static ToolCompositionAnalyzerImpl BuildAnalyzer(params (string Name, ToolCompositionCapability Capabilities)[] profiles)
+    {
+        var resolver = new Mock<IToolCapabilityResolver>();
+        foreach (var (name, capabilities) in profiles)
+        {
+            var origin = capabilities == ToolCompositionCapability.None
+                ? ToolCapabilityOrigin.Unclassified
+                : ToolCapabilityOrigin.FirstParty;
+            resolver
+                .Setup(r => r.Resolve(name))
+                .Returns(new ToolCapabilityProfile(name, capabilities, origin));
+        }
+
+        return new ToolCompositionAnalyzerImpl(resolver.Object);
+    }
+
+    private static IReadOnlyList<AITool> Tools(params string[] names) =>
+        names.Select(n => (AITool)AIFunctionFactory.Create(() => "ok", n)).ToList();
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -828,7 +828,8 @@ public sealed class DirectToolInvokerTests
     {
         public async ValueTask<ToolInvocationDecision> AuthorizeAsync(
             string toolName, CancellationToken cancellationToken,
-            IReadOnlyDictionary<string, object?>? arguments = null)
+            IReadOnlyDictionary<string, object?>? arguments = null,
+            Domain.AI.Governance.ToolCompositionTaint? composition = null)
         {
             record.AgentIdWhenAuthorizing = executionContext.AgentId;
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolCapabilityResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolCapabilityResolverTests.cs
@@ -1,0 +1,179 @@
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Tools;
+
+/// <summary>
+/// Tests for <see cref="ToolCapabilityResolver"/> — the precedence chain (operator override → MCP
+/// annotation → first-party declaration/keyword heuristic) and, most importantly, the narrow keyword
+/// vocabulary's refusal to classify ordinary tool names.
+/// </summary>
+public sealed class ToolCapabilityResolverTests
+{
+    [Theory]
+    [InlineData("read_file")]
+    [InlineData("search_documents")]
+    [InlineData("list_issues")]
+    [InlineData("get_user")]
+    [InlineData("run_skill_script")]
+    [InlineData("load_skill")]
+    [InlineData("create_label")]
+    [InlineData("update_draft")]
+    public void Resolve_CommonBenignNames_ReturnsUnclassified(string toolName)
+    {
+        // The whole design of the keyword vocabulary in one test. Every name here is deliberately
+        // ordinary — the kind of tool that makes up most of any real estate — and none may classify.
+        // Mutation to run: add "read" or "write" to the keyword rules; every case here must then fail.
+        var resolver = BuildResolver();
+
+        var profile = resolver.Resolve(toolName);
+
+        profile.Capabilities.Should().Be(ToolCompositionCapability.None);
+        profile.Origin.Should().Be(ToolCapabilityOrigin.Unclassified);
+    }
+
+    [Theory]
+    [InlineData("web_fetch", ToolCompositionCapability.IngestsUntrustedInput)]
+    [InlineData("browse_page", ToolCompositionCapability.IngestsUntrustedInput)]
+    [InlineData("send_email", ToolCompositionCapability.SendsOutbound)]
+    [InlineData("run_shell", ToolCompositionCapability.ExecutesCode)]
+    [InlineData("read_credential", ToolCompositionCapability.ReadsCredentials)]
+    [InlineData("write_file", ToolCompositionCapability.WritesFiles)]
+    public void Resolve_ClearlyDangerousNames_ClassifiesByKeyword(string toolName, ToolCompositionCapability expected)
+    {
+        var resolver = BuildResolver();
+
+        var profile = resolver.Resolve(toolName);
+
+        profile.Capabilities.Should().HaveFlag(expected);
+        profile.Origin.Should().Be(ToolCapabilityOrigin.KeywordHeuristic);
+    }
+
+    [Fact]
+    public void Resolve_FirstPartyDeclaration_BeatsKeywordHeuristic()
+    {
+        // A tool named like a fetcher but declared otherwise by its own registration must be believed
+        // over the keyword guess — the declaration is the stronger signal.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("web_fetch", (_, _) => Mock.Of<ITool>(
+            t => t.Capabilities == ToolCompositionCapability.None));
+        var resolver = BuildResolver(services.BuildServiceProvider(), registeredKeys: new HashSet<string> { "web_fetch" });
+
+        var profile = resolver.Resolve("web_fetch");
+
+        profile.Origin.Should().Be(ToolCapabilityOrigin.Unclassified);
+    }
+
+    [Fact]
+    public void Resolve_OperatorToolOverride_BeatsEverythingElse()
+    {
+        var gating = new ToolCompositionGatingConfig
+        {
+            ToolCapabilities =
+            [
+                new ToolCapabilityOverride
+                {
+                    Tool = "search_pages",
+                    Capabilities = [ToolCompositionCapability.IngestsUntrustedInput],
+                    Reason = "returns third-party page content despite the benign name",
+                },
+            ],
+        };
+        var resolver = BuildResolver(governance: Governance(gating));
+
+        var profile = resolver.Resolve("search_pages");
+
+        profile.Capabilities.Should().Be(ToolCompositionCapability.IngestsUntrustedInput);
+        profile.Origin.Should().Be(ToolCapabilityOrigin.OperatorOverride);
+    }
+
+    [Fact]
+    public void Resolve_ServerOverride_AddsBitsButNeverClearsTheKeywordFinding()
+    {
+        // A per-server override is additive-only. This is a resolver-level guarantee independent of
+        // config shape — the server override config type has no way to express "clear", so the
+        // resolver's OR-in behaviour is what the type system already enforces; this test pins that the
+        // resolver never subtracts, even if a caller of ToolCapabilityResolver constructed one that did.
+        var behaviorRegistry = new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider());
+        behaviorRegistry.RecordAdvertised("web_fetch", new ToolBehavior(ToolBehaviorSource.UntrustedMcpServer, ServerName: "web"));
+
+        var gating = new ToolCompositionGatingConfig
+        {
+            ServerCapabilities =
+            [
+                new ToolCapabilityServerOverride
+                {
+                    Server = "web",
+                    Capabilities = [ToolCompositionCapability.ReadsCredentials],
+                    Reason = "this server's tools also relay stored API keys",
+                },
+            ],
+        };
+        var resolver = BuildResolver(governance: Governance(gating), behaviorRegistry: behaviorRegistry);
+
+        var profile = resolver.Resolve("web_fetch");
+
+        // The keyword hit (IngestsUntrustedInput, from "fetch") survives, and the server addition
+        // (ReadsCredentials) is layered on top — neither replaces the other.
+        profile.Capabilities.Should().HaveFlag(ToolCompositionCapability.IngestsUntrustedInput);
+        profile.Capabilities.Should().HaveFlag(ToolCompositionCapability.ReadsCredentials);
+    }
+
+    [Fact]
+    public void Resolve_OpenWorldMcpAnnotation_AddsIngestsUntrustedInput()
+    {
+        var behaviorRegistry = new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider());
+        behaviorRegistry.RecordAdvertised(
+            "list_records", new ToolBehavior(ToolBehaviorSource.UntrustedMcpServer, OpenWorld: true, ServerName: "crm"));
+        var resolver = BuildResolver(behaviorRegistry: behaviorRegistry);
+
+        var profile = resolver.Resolve("list_records");
+
+        profile.Capabilities.Should().HaveFlag(ToolCompositionCapability.IngestsUntrustedInput);
+        profile.Origin.Should().Be(ToolCapabilityOrigin.McpAnnotation);
+    }
+
+    [Fact]
+    public void Resolve_KeywordMatchThenMcpAnnotation_ReportsTheStrongerOrigin()
+    {
+        // A profile is one record describing possibly-several bits from possibly-several sources, and
+        // Origin can only report one of them. When a stronger source (the MCP annotation) contributes
+        // on top of a weaker one (the keyword guess), the reported Origin must upgrade — an approver
+        // shown "keyword guess" for a bit a real server annotation actually backs is a mislabelled
+        // audit trail, not just a cosmetic detail.
+        var behaviorRegistry = new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider());
+        behaviorRegistry.RecordAdvertised(
+            "run_shell", new ToolBehavior(ToolBehaviorSource.UntrustedMcpServer, OpenWorld: true, ServerName: "ci"));
+        var resolver = BuildResolver(behaviorRegistry: behaviorRegistry);
+
+        var profile = resolver.Resolve("run_shell");
+
+        // "run_shell" keyword-matches ExecutesCode; the OpenWorld hint additionally contributes
+        // IngestsUntrustedInput. McpAnnotation outranks KeywordHeuristic, so it must win the label.
+        profile.Capabilities.Should().HaveFlag(ToolCompositionCapability.ExecutesCode);
+        profile.Capabilities.Should().HaveFlag(ToolCompositionCapability.IngestsUntrustedInput);
+        profile.Origin.Should().Be(ToolCapabilityOrigin.McpAnnotation);
+    }
+
+    private static ToolCapabilityResolver BuildResolver(
+        IServiceProvider? serviceProvider = null,
+        GovernanceConfig? governance = null,
+        IToolBehaviorRegistry? behaviorRegistry = null,
+        IReadOnlySet<string>? registeredKeys = null) =>
+        new(
+            serviceProvider ?? new ServiceCollection().BuildServiceProvider(),
+            behaviorRegistry ?? new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider()),
+            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == (governance ?? new GovernanceConfig())),
+            registeredKeys ?? new HashSet<string>());
+
+    private static GovernanceConfig Governance(ToolCompositionGatingConfig gating) =>
+        new() { ToolCompositionGating = gating };
+}

--- a/src/Content/Tests/Application.Core.Tests/Validation/GovernanceConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/GovernanceConfigValidatorTests.cs
@@ -275,4 +275,232 @@ public class GovernanceConfigValidatorTests
         result.IsValid.Should().BeTrue();
         result.Errors.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task Validate_DefaultConfig_LeavesCompositionPostureOff()
+    {
+        // A default is untested unless a test builds the config with nothing set. The acceptance
+        // criteria for #332 require this explicitly.
+        var config = new GovernanceConfig();
+
+        config.ToolCompositionGating.DefaultPosture.Should().Be(CompositionPosture.Allow);
+        config.ToolCompositionGating.Pairings.Should().BeEmpty();
+
+        var result = await _validator.ValidateAsync(config);
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_CompositionPairingRequireApprovalWithoutInvocationEnforcement_HasError()
+    {
+        // Same dead-control shape as the tool-behaviour posture guard above: composition RequireApproval
+        // is applied inside the same governor, so it needs the same company.
+        var config = new GovernanceConfig
+        {
+            EnforceToolInvocation = false,
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                Pairings =
+                [
+                    new ToolCompositionPairing
+                    {
+                        Source = ToolCompositionCapability.IngestsUntrustedInput,
+                        Sink = ToolCompositionCapability.SendsOutbound,
+                        Posture = CompositionPosture.RequireApproval,
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(GovernanceConfig.EnforceToolInvocation));
+    }
+
+    [Fact]
+    public async Task Validate_CompositionPairingRequireApprovalWithInvocationEnforcement_IsValid()
+    {
+        // The control: the rule must reject only the inert combination, not the working one.
+        var config = new GovernanceConfig
+        {
+            EnforceToolInvocation = true,
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                Pairings =
+                [
+                    new ToolCompositionPairing
+                    {
+                        Source = ToolCompositionCapability.IngestsUntrustedInput,
+                        Sink = ToolCompositionCapability.SendsOutbound,
+                        Posture = CompositionPosture.RequireApproval,
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_CompositionPairingWithSourceAndSinkSwapped_HasError()
+    {
+        // A pairing names one source bit and one sink bit — a swapped entry would never match anything
+        // the analyzer produces, silently doing nothing while looking configured.
+        var config = new GovernanceConfig
+        {
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                Pairings =
+                [
+                    new ToolCompositionPairing
+                    {
+                        Source = ToolCompositionCapability.SendsOutbound,
+                        Sink = ToolCompositionCapability.IngestsUntrustedInput,
+                        Posture = CompositionPosture.Warn,
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_DuplicateCompositionPairing_HasError()
+    {
+        var config = new GovernanceConfig
+        {
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                Pairings =
+                [
+                    new ToolCompositionPairing
+                    {
+                        Source = ToolCompositionCapability.IngestsUntrustedInput,
+                        Sink = ToolCompositionCapability.SendsOutbound,
+                        Posture = CompositionPosture.Warn,
+                    },
+                    new ToolCompositionPairing
+                    {
+                        Source = ToolCompositionCapability.IngestsUntrustedInput,
+                        Sink = ToolCompositionCapability.SendsOutbound,
+                        Posture = CompositionPosture.RequireApproval,
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_ToolCapabilityOverrideClearingBitsWithNoServer_HasError()
+    {
+        // Mirrors ToolBehaviorExemption.Server: clearing a name-keyed tool's capabilities without
+        // naming its server hands back the bypass that rule exists to prevent.
+        var config = new GovernanceConfig
+        {
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                ToolCapabilities =
+                [
+                    new ToolCapabilityOverride
+                    {
+                        Tool = "notion_search",
+                        Capabilities = [],
+                        Reason = "verified it does not ingest untrusted content",
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_ToolCapabilityOverrideClearingBitsWithServerNamed_IsValid()
+    {
+        var config = new GovernanceConfig
+        {
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                ToolCapabilities =
+                [
+                    new ToolCapabilityOverride
+                    {
+                        Tool = "notion_search",
+                        Server = "notion",
+                        Capabilities = [],
+                        Reason = "verified it does not ingest untrusted content",
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Validate_ServerCapabilityOverrideWithEmptyCapabilities_HasError()
+    {
+        // A server override may only ADD bits — an empty list adds nothing, so the entry does nothing
+        // while looking configured.
+        var config = new GovernanceConfig
+        {
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                ServerCapabilities =
+                [
+                    new ToolCapabilityServerOverride
+                    {
+                        Server = "web",
+                        Capabilities = [],
+                        Reason = "every tool on this server returns fetched page content",
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Validate_FullyStatedServerCapabilityOverride_IsValid()
+    {
+        var config = new GovernanceConfig
+        {
+            ToolCompositionGating = new ToolCompositionGatingConfig
+            {
+                ServerCapabilities =
+                [
+                    new ToolCapabilityServerOverride
+                    {
+                        Server = "web",
+                        Capabilities = [ToolCompositionCapability.IngestsUntrustedInput],
+                        Reason = "every tool on this server returns fetched page content",
+                    },
+                ],
+            },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
## Summary

- Adds a build-time check that flags an agent holding both a tool that can ingest untrusted/sensitive content (a web-fetch tool, an inbound-email tool) and a tool that can act on it in a costly way (write files, execute code, send data outbound) — the shape an indirect-prompt-injection exfiltration primitive actually takes, which no existing per-tool control (allow/deny lists, per-agent authorization, #324 behaviour gating) can see.
- Capability classification follows a strict precedence: operator override → first-party `ITool` declaration → MCP open-world annotation → a deliberately narrow keyword heuristic. Off by default; every pairing defaults to `Allow`.
- Enforcement is folded into `ToolInvocationGovernor`'s existing single approval question (never a second gate), with the posture resolved live at call time — a config change takes effect on an already-built agent without a rebuild.
- Full design and known limits: `documentation/security/tool-composition-analysis.md`.

## Review

Both `/code-review` (10 findings, including a HIGH-severity DI memory-growth leak from bundle-owned tool names — fixed) and `/simplify` (4 parallel passes: reuse, simplification, efficiency, altitude) ran against this diff; all actionable findings were fixed or explicitly documented as known limits (`DirectToolInvoker`'s single-tool invocation path structurally cannot be covered; `ConnectorToolAdapter` needs per-deployment operator overrides rather than a per-class declaration).

## Test plan

- [x] Full solution build green
- [x] Full solution test suite green (only pre-existing Docker/Postgres-dependent failures unrelated to this change)
- [x] Mandated control test (source-only / sink-only tool set produces no finding) mutation-verified against the "unclassified resolves to all bits" regression
- [x] `NoFactoryDecidesAPerRunFactAtConstructionTime` and the admission-chain chokepoint scans still pass — composition analysis stamps a fact at build time, never a posture verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW