### PR TITLE
fix: reconnect MCP tool provider after a stale cached session (#385)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -133,22 +133,14 @@ public sealed class McpConnectionManager : IAsyncDisposable
         if (_clients.TryGetValue(serverName, out var existing))
             return existing;
 
-        var connectionLock = _connectionLocks.GetOrAdd(serverName, _ => new SemaphoreSlim(1, 1));
-        await connectionLock.WaitAsync(cancellationToken);
+        using var _ = await AcquireConnectionLockAsync(serverName, cancellationToken);
 
-        try
-        {
-            if (_clients.TryGetValue(serverName, out existing))
-                return existing;
+        if (_clients.TryGetValue(serverName, out existing))
+            return existing;
 
-            var client = await CreateClientAsync(serverName, cancellationToken);
-            _clients[serverName] = client;
-            return client;
-        }
-        finally
-        {
-            connectionLock.Release();
-        }
+        var client = await CreateClientAsync(serverName, cancellationToken);
+        _clients[serverName] = client;
+        return client;
     }
 
     /// <summary>
@@ -162,7 +154,61 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// <summary>
     /// Disconnects from a specific server and removes the cached connection.
     /// </summary>
+    /// <remarks>
+    /// Takes the same per-server lock <see cref="GetClientAsync"/> uses around its own cache mutation, so
+    /// this can't interleave with a concurrent <see cref="GetClientAsync"/> or <see cref="ReconnectAsync"/>
+    /// call for the same server and corrupt <see cref="_clients"/>. It still does not protect a caller
+    /// that already holds a reference to the client this disposes, obtained via
+    /// <see cref="GetClientAsync"/>'s unlocked fast-path read before this method ran — that caller can
+    /// still observe <see cref="ObjectDisposedException"/> mid-use. Closing that needs reference-counted
+    /// or generation-tagged client leases, a larger change to this type's client-lifetime model; tracked
+    /// as a known limitation, not solved here.
+    /// </remarks>
     public async Task DisconnectAsync(string serverName)
+    {
+        using var _ = await AcquireConnectionLockAsync(serverName, CancellationToken.None);
+        await EvictLockedAsync(serverName);
+    }
+
+    /// <summary>
+    /// Evicts <paramref name="failedClient"/> and connects fresh, but only if it is still the cached
+    /// client for <paramref name="serverName"/>.
+    /// </summary>
+    /// <remarks>
+    /// A cached client that a previous call already used can go stale — the remote restarted or evicted
+    /// the session — and using it fails with no warning beyond the failed call itself (#385). The caller
+    /// that observed that failure calls this to recover. Without the reference check, two callers that
+    /// both saw the SAME stale client and both raced here would each run their own evict-then-reconnect:
+    /// the second would tear down the fresh connection the first just paid for and connect a third time.
+    /// The check collapses that to one reconnect — whichever caller acquires the per-server lock first
+    /// evicts and reconnects; every later caller finds the cache already holding a client that isn't the
+    /// one it saw fail, and simply returns that instead.
+    /// </remarks>
+    /// <param name="serverName">The server name from configuration.</param>
+    /// <param name="failedClient">The client instance the caller observed a failure on.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <exception cref="McpConnectionException">Thrown when the fresh connection attempt fails.</exception>
+    public async Task<McpClient> ReconnectAsync(string serverName, McpClient failedClient, CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        using var _ = await AcquireConnectionLockAsync(serverName, cancellationToken);
+
+        if (_clients.TryGetValue(serverName, out var current) && !ReferenceEquals(current, failedClient))
+            return current;
+
+        await EvictLockedAsync(serverName);
+
+        var client = await CreateClientAsync(serverName, cancellationToken);
+        _clients[serverName] = client;
+        return client;
+    }
+
+    /// <summary>
+    /// Removes and disposes the cached client and its associated per-server HTTP clients for
+    /// <paramref name="serverName"/>. Caller must hold that server's connection lock.
+    /// </summary>
+    private async Task EvictLockedAsync(string serverName)
     {
         if (_clients.TryRemove(serverName, out var client))
         {
@@ -170,12 +216,24 @@ public sealed class McpConnectionManager : IAsyncDisposable
             _logger.LogInformation("Disconnected from MCP server '{ServerName}'", serverName);
         }
 
-        // Release the per-server Entra and bundle-egress clients (and their pooled sockets) on explicit
-        // disconnect, mirroring the cleanup of _clients above. Both caches were built with
-        // disposeHandler:false, so this leaves the shared AntiSSRF handler intact; a later reconnect
-        // recreates a fresh token-injecting or attribution+egress-policy handler pair as needed.
+        // Release the per-server Entra and bundle-egress clients (and their pooled sockets) alongside the
+        // MCP client above. Both caches were built with disposeHandler:false, so this leaves the shared
+        // AntiSSRF handler intact; a later reconnect recreates a fresh token-injecting or
+        // attribution+egress-policy handler pair as needed.
         TryDisposeCachedClient(_entraClients, serverName);
         TryDisposeCachedClient(_bundleEgressClients, serverName);
+    }
+
+    private readonly struct ConnectionLockScope(SemaphoreSlim semaphore) : IDisposable
+    {
+        public void Dispose() => semaphore.Release();
+    }
+
+    private async Task<ConnectionLockScope> AcquireConnectionLockAsync(string serverName, CancellationToken cancellationToken)
+    {
+        var connectionLock = _connectionLocks.GetOrAdd(serverName, _ => new SemaphoreSlim(1, 1));
+        await connectionLock.WaitAsync(cancellationToken);
+        return new ConnectionLockScope(connectionLock);
     }
 
     private static void TryDisposeCachedClient(ConcurrentDictionary<string, HttpClient> cache, string serverName)

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -153,21 +153,31 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// Disconnects from a specific server and removes the cached connection.
     /// </summary>
     /// <remarks>
-    /// Takes the same per-server lock <see cref="GetClientAsync"/> uses around its own cache mutation, so
-    /// this can't interleave with a concurrent <see cref="GetClientAsync"/> or <see cref="ReconnectAsync"/>
-    /// call for the same server and corrupt <see cref="_clients"/>. It still does not protect a caller
-    /// that already holds a reference to the client this disposes, obtained via
-    /// <see cref="GetClientAsync"/>'s unlocked fast-path read before this method ran — that caller can
-    /// still observe <see cref="ObjectDisposedException"/> mid-use. Closing that needs reference-counted
-    /// or generation-tagged client leases, a larger change to this type's client-lifetime model; tracked
-    /// as a known limitation, not solved here.
+    /// <para>
+    /// Deliberately does NOT take the per-server connection lock <see cref="GetClientAsync"/> and
+    /// <see cref="ReconnectAsync"/> use: this method's only production caller is bundle teardown
+    /// (<c>BundleMcpServerRegistrar</c>), which needs a fast, non-blocking disconnect and has no
+    /// cancellation token to bound a wait with. Taking the lock here would let a hung connect attempt
+    /// for the same server (mid-handshake, inside <see cref="CreateClientAsync"/>) block teardown
+    /// indefinitely — worse than the narrow race it would close. <c>ConcurrentDictionary.TryRemove</c>
+    /// is already atomic, so concurrent callers of this method cannot corrupt <see cref="_clients"/>
+    /// between themselves; the remaining race is with a concurrent create finishing and caching a NEW
+    /// client between this method's remove and its return — a pre-existing gap, not something this
+    /// method ever closed.
+    /// </para>
+    /// <para>
+    /// Also does not protect a caller that already holds a reference to the client this disposes,
+    /// obtained via <see cref="GetClientAsync"/>'s unlocked fast-path read before this method ran — that
+    /// caller can still observe <see cref="ObjectDisposedException"/> mid-use. Closing either race needs
+    /// reference-counted or generation-tagged client leases, a larger change to this type's
+    /// client-lifetime model; tracked as a known limitation, not solved here.
+    /// </para>
     /// </remarks>
     public async Task DisconnectAsync(string serverName)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        using var _ = await AcquireConnectionLockAsync(serverName, CancellationToken.None);
-        await EvictLockedAsync(serverName);
+        await EvictAsync(serverName);
     }
 
     /// <summary>
@@ -197,7 +207,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         if (_clients.TryGetValue(serverName, out var current) && !ReferenceEquals(current, failedClient))
             return current;
 
-        await EvictLockedAsync(serverName);
+        await EvictAsync(serverName);
 
         return await CreateAndCacheClientAsync(serverName, cancellationToken);
     }
@@ -215,9 +225,10 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
     /// <summary>
     /// Removes and disposes the cached client and its associated per-server HTTP clients for
-    /// <paramref name="serverName"/>. Caller must hold that server's connection lock.
+    /// <paramref name="serverName"/>. Safe to call with or without the connection lock held — every
+    /// mutation here is an atomic <c>ConcurrentDictionary.TryRemove</c> call.
     /// </summary>
-    private async Task EvictLockedAsync(string serverName)
+    private async Task EvictAsync(string serverName)
     {
         if (_clients.TryRemove(serverName, out var client))
         {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -138,9 +138,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         if (_clients.TryGetValue(serverName, out existing))
             return existing;
 
-        var client = await CreateClientAsync(serverName, cancellationToken);
-        _clients[serverName] = client;
-        return client;
+        return await CreateAndCacheClientAsync(serverName, cancellationToken);
     }
 
     /// <summary>
@@ -166,6 +164,8 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// </remarks>
     public async Task DisconnectAsync(string serverName)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         using var _ = await AcquireConnectionLockAsync(serverName, CancellationToken.None);
         await EvictLockedAsync(serverName);
     }
@@ -199,6 +199,15 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
         await EvictLockedAsync(serverName);
 
+        return await CreateAndCacheClientAsync(serverName, cancellationToken);
+    }
+
+    /// <summary>
+    /// Connects to <paramref name="serverName"/> and caches the result. Caller must hold that server's
+    /// connection lock.
+    /// </summary>
+    private async Task<McpClient> CreateAndCacheClientAsync(string serverName, CancellationToken cancellationToken)
+    {
         var client = await CreateClientAsync(serverName, cancellationToken);
         _clients[serverName] = client;
         return client;

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -207,9 +207,19 @@ public sealed class McpConnectionManager : IAsyncDisposable
         if (_clients.TryGetValue(serverName, out var current) && !ReferenceEquals(current, failedClient))
             return current;
 
-        await EvictAsync(serverName);
+        var stale = DetachClient(serverName);
 
-        return await CreateAndCacheClientAsync(serverName, cancellationToken);
+        // Disposing the stale client and connecting fresh are independent once detach has happened — run
+        // them concurrently rather than paying dispose-then-connect serially. For a hung/misbehaving
+        // remote (exactly the case that got here), tearing down the old session — a stdio child-process
+        // exit or an HTTP/SSE session close against a remote that just rejected it — can be the slower
+        // half; every other caller of GetClientAsync for this server is already queued behind this same
+        // lock, so serializing it in front of the new connect only lengthens their wait for no benefit.
+        var disposeStale = stale is not null ? DisposeStaleClientAsync(stale, serverName) : Task.CompletedTask;
+        var connect = CreateAndCacheClientAsync(serverName, cancellationToken);
+        await Task.WhenAll(disposeStale, connect);
+
+        return await connect;
     }
 
     /// <summary>
@@ -230,18 +240,47 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// </summary>
     private async Task EvictAsync(string serverName)
     {
-        if (_clients.TryRemove(serverName, out var client))
+        var client = DetachClient(serverName);
+        if (client is not null)
         {
             await client.DisposeAsync();
             _logger.LogInformation("Disconnected from MCP server '{ServerName}'", serverName);
         }
+    }
 
-        // Release the per-server Entra and bundle-egress clients (and their pooled sockets) alongside the
-        // MCP client above. Both caches were built with disposeHandler:false, so this leaves the shared
-        // AntiSSRF handler intact; a later reconnect recreates a fresh token-injecting or
-        // attribution+egress-policy handler pair as needed.
+    /// <summary>
+    /// Removes the cached <see cref="McpClient"/> for <paramref name="serverName"/> from <see cref="_clients"/>
+    /// and, in the same call, releases its associated per-server Entra and bundle-egress HTTP clients (and
+    /// their pooled sockets). Both HTTP caches were built with <c>disposeHandler:false</c>, so this leaves
+    /// the shared AntiSSRF handler intact; a later reconnect recreates a fresh token-injecting or
+    /// attribution+egress-policy handler pair as needed. Does NOT dispose the returned <see cref="McpClient"/>
+    /// — the caller decides whether to await that or run it concurrently with other work.
+    /// </summary>
+    private McpClient? DetachClient(string serverName)
+    {
+        _clients.TryRemove(serverName, out var client);
         TryDisposeCachedClient(_entraClients, serverName);
         TryDisposeCachedClient(_bundleEgressClients, serverName);
+        return client;
+    }
+
+    /// <summary>
+    /// Disposes a client already detached from <see cref="_clients"/>. Swallows and logs its own
+    /// disposal failures rather than propagating them: this disposes something already being discarded
+    /// (a stale or superseded connection), so a failure to tear it down cleanly must not fail the
+    /// reconnect that is replacing it.
+    /// </summary>
+    private async Task DisposeStaleClientAsync(McpClient client, string serverName)
+    {
+        try
+        {
+            await client.DisposeAsync();
+            _logger.LogInformation("Disconnected from MCP server '{ServerName}'", serverName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to cleanly dispose the stale MCP client for '{ServerName}'", serverName);
+        }
     }
 
     private readonly struct ConnectionLockScope(SemaphoreSlim semaphore) : IDisposable

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -5,6 +5,7 @@ using Application.AI.Common.OpenTelemetry.Metrics;
 using Domain.AI.Telemetry.Conventions;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Client;
 
 namespace Infrastructure.AI.MCP.Services;
 
@@ -18,6 +19,19 @@ namespace Infrastructure.AI.MCP.Services;
 /// are discovered lazily on first request. Unavailable servers are logged
 /// and skipped rather than throwing — the agent operates with a reduced
 /// tool surface.
+/// </para>
+/// <para>
+/// <strong>A cached connection that a previous call already used is retried once, fresh, before
+/// giving up.</strong> <see cref="McpConnectionManager"/> caches one client per server for the
+/// process lifetime; if the remote restarts or evicts the session in between calls, the cached
+/// client is stale but <em>looks</em> fine — <c>GetClientAsync</c> has no health check, so the
+/// staleness surfaces only when a call actually reaches the remote and it rejects a session it no
+/// longer recognises (#385). Recovery — evicting the stale client and connecting fresh — is owned by
+/// <see cref="McpConnectionManager.ReconnectAsync"/>, not this class: it is the cache's job to decide
+/// whether a reconnect another caller already performed makes this one redundant. Retrying is scoped
+/// narrowly — only a failure that happens <em>after</em> a client was successfully obtained triggers
+/// this path; a server that was never reachable in the first place still fails exactly as fast as
+/// before, with no added attempt or timeout.
 /// </para>
 /// </remarks>
 public sealed class McpToolProvider : IMcpToolProvider
@@ -42,21 +56,79 @@ public sealed class McpToolProvider : IMcpToolProvider
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        McpClient client;
+        try
+        {
+            client = await _connectionManager.GetClientAsync(serverName, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Never reachable at all this call — no cached connection existed to go stale, so
+            // there is nothing a reconnect-and-retry would fix. Same behaviour as before this fix.
+            RecordOutcome(Stopwatch.StartNew(), serverName, McpConventions.StatusValues.Unavailable);
+            _logger.LogWarning(ex, "Failed to connect to MCP server '{ServerName}' — skipping", serverName);
+            return [];
+        }
+
+        try
+        {
+            return await ListToolsAsync(client, serverName, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller's own token fired — not a signal the connection is stale. Let it propagate
+            // rather than spending a reconnect attempt on a call nobody is waiting for.
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return await RetryAfterReconnectAsync(serverName, client, ex, cancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// The connection existed — possibly cached from an earlier turn — but using it just failed. That
+    /// is the shape a remote-restarted, server-evicted session takes (#385), not a server that is
+    /// genuinely unreachable, so ask <see cref="McpConnectionManager"/> to evict and reconnect before
+    /// falling back to "unavailable this turn". <see cref="McpConnectionManager.ReconnectAsync"/> owns
+    /// the eviction, not this method — it is the only place that can tell whether a concurrent caller
+    /// already recovered the same stale client, and returning here degrades to <c>[]</c> for any
+    /// failure the reconnect attempt raises, honoring this class's "skipped rather than throwing"
+    /// contract exactly as the first attempt does.
+    /// </summary>
+    private async Task<IList<AITool>> RetryAfterReconnectAsync(
+        string serverName, McpClient failedClient, Exception cause, CancellationToken cancellationToken)
+    {
+        try
+        {
+            _logger.LogInformation(cause,
+                "MCP server '{ServerName}' rejected a call on its existing connection — reconnecting and retrying once",
+                serverName);
+            var freshClient = await _connectionManager.ReconnectAsync(serverName, failedClient, cancellationToken);
+            return await ListToolsAsync(freshClient, serverName, cancellationToken);
+        }
+        catch (Exception retryEx)
+        {
+            RecordOutcome(Stopwatch.StartNew(), serverName, McpConventions.StatusValues.Error);
+            _logger.LogWarning(retryEx,
+                "Failed to get tools from MCP server '{ServerName}' after reconnecting — skipping",
+                serverName);
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Lists tools on an already-obtained client and projects them to <see cref="AITool"/>. Records
+    /// the outcome metric itself — for both success and failure — so a retried call's timing reflects
+    /// only the retry, never the failed attempt that preceded it.
+    /// </summary>
+    private async Task<IList<AITool>> ListToolsAsync(McpClient client, string serverName, CancellationToken cancellationToken)
+    {
         var sw = Stopwatch.StartNew();
         try
         {
-            var client = await _connectionManager.GetClientAsync(serverName, cancellationToken);
             var tools = await client.ListToolsAsync(cancellationToken: cancellationToken);
-            sw.Stop();
-
-            var successTags = new TagList
-            {
-                { McpConventions.ServerName, serverName },
-                { McpConventions.Operation, "list_tools" },
-                { McpConventions.Status, McpConventions.StatusValues.Available }
-            };
-            McpServerMetrics.RequestDuration.Record(sw.Elapsed.TotalMilliseconds, successTags);
-            McpServerMetrics.Requests.Add(1, successTags);
+            RecordOutcome(sw, serverName, McpConventions.StatusValues.Available);
 
             _logger.LogDebug(
                 "Retrieved {ToolCount} tools from MCP server '{ServerName}'",
@@ -65,23 +137,24 @@ public sealed class McpToolProvider : IMcpToolProvider
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            sw.Stop();
-            var errorTags = new TagList
-            {
-                { McpConventions.ServerName, serverName },
-                { McpConventions.Operation, "list_tools" },
-                { McpConventions.Status, McpConventions.StatusValues.Error }
-            };
-            McpServerMetrics.RequestDuration.Record(sw.Elapsed.TotalMilliseconds, errorTags);
-            McpServerMetrics.Requests.Add(1, errorTags);
-
-            _logger.LogWarning(ex,
-                "Failed to get tools from MCP server '{ServerName}' — skipping",
-                serverName);
-            return [];
+            RecordOutcome(sw, serverName, McpConventions.StatusValues.Error);
+            throw;
         }
+    }
+
+    private static void RecordOutcome(Stopwatch sw, string serverName, string status)
+    {
+        sw.Stop();
+        var tags = new TagList
+        {
+            { McpConventions.ServerName, serverName },
+            { McpConventions.Operation, "list_tools" },
+            { McpConventions.Status, status }
+        };
+        McpServerMetrics.RequestDuration.Record(sw.Elapsed.TotalMilliseconds, tags);
+        McpServerMetrics.Requests.Add(1, tags);
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -34,14 +34,20 @@ namespace Infrastructure.AI.MCP.Services;
 /// before, with no added attempt or timeout.
 /// </para>
 /// <para>
-/// <strong>Known limitation: this recovers tool discovery, not tool invocation.</strong> An
-/// <see cref="AITool"/> this method returns is bound to the specific <c>McpClient</c> it was listed
-/// from; once handed to the agent's tool chain, an actual tool <em>call</em> invokes that binding
-/// directly and never routes back through this class. A session that goes stale between discovery
-/// and invocation still fails unrecovered on the call itself — only the next discovery pass observes
-/// and repairs it. Extending recovery to invocation needs a retry-aware wrapper around every
-/// <see cref="AITool"/> this method returns, not a change here; tracked as a follow-up, not solved in
-/// this class.
+/// <strong>Known limitation: this recovers tool discovery, not tool invocation, and reconnect can now
+/// race an in-flight call.</strong> An <see cref="AITool"/> this method returns is bound to the
+/// specific <c>McpClient</c> it was listed from; once handed to the agent's tool chain, an actual tool
+/// <em>call</em> invokes that binding directly (e.g. via
+/// <c>Presentation.AgentHub/Controllers/McpController.InvokeTool</c> or the agent-turn pipeline in
+/// <c>Application.Core/CQRS/Agents/ExecuteAgentTurn</c>) and never routes back through this class. A
+/// session that goes stale between discovery and invocation still fails unrecovered on the call itself
+/// — only the next discovery pass observes and repairs it. Because reconnect now happens
+/// automatically on any discovery failure rather than only on an explicit admin disconnect, a call
+/// already in flight against a client another caller's reconnect is about to evict can observe
+/// <see cref="ObjectDisposedException"/> mid-invocation more often than before this fix. Closing this
+/// needs a retry-aware wrapper around every <see cref="AITool"/> this method returns plus
+/// reference-counted or generation-tagged client leases in <see cref="McpConnectionManager"/> — a
+/// materially larger change than this fix; tracked as a follow-up, not solved in this class.
 /// </para>
 /// </remarks>
 public sealed class McpToolProvider : IMcpToolProvider
@@ -66,19 +72,22 @@ public sealed class McpToolProvider : IMcpToolProvider
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        var connectSw = Stopwatch.StartNew();
+        var connectStart = Stopwatch.GetTimestamp();
         McpClient client;
         try
         {
             client = await _connectionManager.GetClientAsync(serverName, cancellationToken);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller gave up, not the server — nothing failed here worth logging or metering.
+            return [];
+        }
         catch (Exception ex)
         {
             // Never reachable at all this call — no cached connection existed to go stale, so
             // there is nothing a reconnect-and-retry would fix. Same behaviour as before this fix.
-            // Covers caller cancellation too: this class's contract is to degrade to [] rather than
-            // throw, for cancellation exactly as for every other failure — see RetryAfterReconnectAsync.
-            RecordOutcome(connectSw, serverName, McpConventions.StatusValues.Unavailable);
+            RecordOutcome(connectStart, serverName, McpConventions.StatusValues.Unavailable);
             _logger.LogWarning(ex, "Failed to connect to MCP server '{ServerName}' — skipping", serverName);
             return [];
         }
@@ -86,6 +95,19 @@ public sealed class McpToolProvider : IMcpToolProvider
         try
         {
             return await ListToolsAsync(client, serverName, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return [];
+        }
+        catch (ObjectDisposedException)
+        {
+            // The client itself is already gone — most likely a concurrent reconnect for this server
+            // (McpConnectionManager.ReconnectAsync's collapse behaviour) or an explicit DisconnectAsync
+            // beat this call to eviction. Reconnecting from an already-disposed reference fixes nothing
+            // this call could observe; ListToolsAsync already recorded the failure. Skip the wasted
+            // round trip rather than retrying — the caller that evicted it is the one making progress.
+            return [];
         }
         catch (Exception ex)
         {
@@ -106,10 +128,11 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// enclosing <c>try</c>: <see cref="ListToolsAsync"/> already records its own outcome (including
     /// <c>Error</c>, with real elapsed time) before rethrowing, so a single catch around both stages
     /// would record a second, misleading near-zero-duration <c>Error</c> for the SAME failed call. A
-    /// caller's own cancellation is caught in both stages and degrades to <c>[]</c> like every other
-    /// failure, never rethrown — this class's contract is "skipped rather than throwing" for every
-    /// caller (<see cref="GetAllToolsAsync"/> fans this out via <c>Task.WhenAll</c> with no per-task
-    /// guard; letting cancellation escape here would propagate out of that fan-out unhandled).
+    /// caller's own cancellation is caught in both stages and degrades to <c>[]</c> with no log or
+    /// metric — it isn't a server outcome — never rethrown, since this class's contract is "skipped
+    /// rather than throwing" for every caller (<see cref="GetAllToolsAsync"/> fans this out via
+    /// <c>Task.WhenAll</c> with no per-task guard; letting cancellation escape here would propagate out
+    /// of that fan-out unhandled).
     /// </remarks>
     private async Task<IList<AITool>> RetryAfterReconnectAsync(
         string serverName, McpClient failedClient, Exception cause, CancellationToken cancellationToken)
@@ -118,15 +141,19 @@ public sealed class McpToolProvider : IMcpToolProvider
             "MCP server '{ServerName}' rejected a call on its existing connection — reconnecting and retrying once",
             serverName);
 
-        var reconnectSw = Stopwatch.StartNew();
+        var reconnectStart = Stopwatch.GetTimestamp();
         McpClient freshClient;
         try
         {
             freshClient = await _connectionManager.ReconnectAsync(serverName, failedClient, cancellationToken);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return [];
+        }
         catch (Exception ex)
         {
-            RecordOutcome(reconnectSw, serverName, McpConventions.StatusValues.Unavailable);
+            RecordOutcome(reconnectStart, serverName, McpConventions.StatusValues.Unavailable);
             _logger.LogWarning(ex, "Failed to reconnect to MCP server '{ServerName}' — skipping", serverName);
             return [];
         }
@@ -134,6 +161,10 @@ public sealed class McpToolProvider : IMcpToolProvider
         try
         {
             return await ListToolsAsync(freshClient, serverName, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return [];
         }
         catch (Exception ex)
         {
@@ -153,11 +184,11 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// </summary>
     private async Task<IList<AITool>> ListToolsAsync(McpClient client, string serverName, CancellationToken cancellationToken)
     {
-        var sw = Stopwatch.StartNew();
+        var start = Stopwatch.GetTimestamp();
         try
         {
             var tools = await client.ListToolsAsync(cancellationToken: cancellationToken);
-            RecordOutcome(sw, serverName, McpConventions.StatusValues.Available);
+            RecordOutcome(start, serverName, McpConventions.StatusValues.Available);
 
             _logger.LogDebug(
                 "Retrieved {ToolCount} tools from MCP server '{ServerName}'",
@@ -166,23 +197,28 @@ public sealed class McpToolProvider : IMcpToolProvider
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller gave up — not a server-side outcome, so no metric for it. Let the caller decide.
+            throw;
+        }
         catch (Exception)
         {
-            RecordOutcome(sw, serverName, McpConventions.StatusValues.Error);
+            RecordOutcome(start, serverName, McpConventions.StatusValues.Error);
             throw;
         }
     }
 
-    private static void RecordOutcome(Stopwatch sw, string serverName, string status)
+    private static void RecordOutcome(long startTimestamp, string serverName, string status)
     {
-        sw.Stop();
+        var elapsed = Stopwatch.GetElapsedTime(startTimestamp);
         var tags = new TagList
         {
             { McpConventions.ServerName, serverName },
             { McpConventions.Operation, "list_tools" },
             { McpConventions.Status, status }
         };
-        McpServerMetrics.RequestDuration.Record(sw.Elapsed.TotalMilliseconds, tags);
+        McpServerMetrics.RequestDuration.Record(elapsed.TotalMilliseconds, tags);
         McpServerMetrics.Requests.Add(1, tags);
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -31,26 +31,20 @@ namespace Infrastructure.AI.MCP.Services;
 /// whether a reconnect another caller already performed makes this one redundant. Retrying is scoped
 /// narrowly — only a failure that happens <em>after</em> a client was successfully obtained triggers
 /// this path; a server that was never reachable in the first place still fails exactly as fast as
-/// before, with no added attempt or timeout.
+/// before, with no added attempt or timeout. <see cref="IsServerAvailableAsync"/> does NOT get this
+/// recovery — it still calls <c>GetClientAsync</c> directly and reports a stale cached client as
+/// available, exactly as before this fix; only <see cref="GetToolsAsync"/> and its callers
+/// (<see cref="GetAllToolsAsync"/>, <see cref="GetToolByNameAsync"/>) route through the retry path.
 /// </para>
 /// <para>
-/// <strong>Known limitation: this recovers tool discovery, not tool invocation, and reconnect can now
-/// race an in-flight call.</strong> An <see cref="AITool"/> this method returns is bound to the
-/// specific <c>McpClient</c> it was listed from; once handed to the agent's tool chain, an actual tool
-/// <em>call</em> invokes that binding directly and never routes back through this class. The exposure
-/// varies by caller: <c>Presentation.AgentHub/Controllers/McpController.InvokeTool</c> calls
-/// <see cref="GetToolByNameAsync"/> — and so gets this fix's recovery — immediately before invoking,
-/// leaving only the brief window between that lookup and the call itself; the agent-turn pipeline
-/// (<c>Application.Core/CQRS/Agents/ExecuteAgentTurn</c>) resolves tools once per turn and can hold that
-/// binding across a materially longer window before invoking it, with no re-lookup in between. Either
-/// way, a session that goes stale in that window still fails unrecovered on the call itself — only the
-/// next discovery pass observes and repairs it. Because reconnect now happens automatically on any
-/// discovery failure rather than only on an explicit admin disconnect, a call already in flight against
-/// a client another caller's reconnect is about to evict can observe
-/// <see cref="ObjectDisposedException"/> mid-invocation more often than before this fix. Closing this
-/// needs a retry-aware wrapper around every <see cref="AITool"/> this method returns plus
-/// reference-counted or generation-tagged client leases in <see cref="McpConnectionManager"/> — a
-/// materially larger change than this fix; tracked as a follow-up, not solved in this class.
+/// <strong>Known limitation: this recovers tool discovery, not tool invocation.</strong> An
+/// <see cref="AITool"/> this method returns is bound to the specific <c>McpClient</c> it was listed
+/// from; once handed to the agent's tool chain, an actual tool <em>call</em> invokes that binding
+/// directly and never routes back through this class, so a session that goes stale between discovery
+/// and invocation still fails unrecovered on the call itself. See
+/// <see cref="McpConnectionManager.DisconnectAsync"/>'s remarks for the client-lifetime race this
+/// implies and the design that would close both gaps at once — tracked as a follow-up, not solved in
+/// this class.
 /// </para>
 /// </remarks>
 public sealed class McpToolProvider : IMcpToolProvider
@@ -75,43 +69,17 @@ public sealed class McpToolProvider : IMcpToolProvider
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        var connectStart = Stopwatch.GetTimestamp();
-        McpClient client;
-        try
-        {
-            client = await _connectionManager.GetClientAsync(serverName, cancellationToken);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // The caller gave up, not the server — nothing failed here worth logging or metering.
+        var client = await TryConnectAsync(
+            ct => _connectionManager.GetClientAsync(serverName, ct), serverName, "connect", cancellationToken);
+        if (client is null)
             return [];
-        }
-        catch (Exception ex)
-        {
-            // Never reachable at all this call — no cached connection existed to go stale, so there is
-            // nothing a reconnect-and-retry would fix; still degrades to [] as before this fix, but now
-            // tagged Unavailable rather than Error, distinguishing "never reachable" from "a call on an
-            // established connection failed" — the two StatusValues this fix's retry decision hinges on.
-            RecordOutcome(connectStart, serverName, McpConventions.StatusValues.Unavailable);
-            _logger.LogWarning(ex, "Failed to connect to MCP server '{ServerName}' — skipping", serverName);
-            return [];
-        }
 
         try
         {
-            return await ListToolsAsync(client, serverName, cancellationToken);
+            return await DiscoverToolsAsync(client, serverName, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            return [];
-        }
-        catch (ObjectDisposedException)
-        {
-            // The client itself is already gone — most likely a concurrent reconnect for this server
-            // (McpConnectionManager.ReconnectAsync's collapse behaviour) or an explicit DisconnectAsync
-            // beat this call to eviction. Reconnecting from an already-disposed reference fixes nothing
-            // this call could observe; ListToolsAsync already recorded the failure. Skip the wasted
-            // round trip rather than retrying — the caller that evicted it is the one making progress.
             return [];
         }
         catch (Exception ex)
@@ -121,23 +89,58 @@ public sealed class McpToolProvider : IMcpToolProvider
     }
 
     /// <summary>
+    /// Obtains a client via <paramref name="connect"/>, returning <see langword="null"/> instead of
+    /// throwing on failure — the shared "get a client or degrade" decision behind both the initial
+    /// connect (<see cref="McpConnectionManager.GetClientAsync"/>) and the post-failure reconnect
+    /// (<see cref="McpConnectionManager.ReconnectAsync"/>), which differ only in which connection-manager
+    /// method they call and what to name in the log.
+    /// </summary>
+    private async Task<McpClient?> TryConnectAsync(
+        Func<CancellationToken, Task<McpClient>> connect, string serverName, string action, CancellationToken cancellationToken)
+    {
+        var start = Stopwatch.GetTimestamp();
+        try
+        {
+            return await connect(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller gave up, not the server — nothing failed here worth logging or metering.
+            return null;
+        }
+        catch (Exception ex)
+        {
+            // Tagged Unavailable, not Error: this call never reached a live session at all, distinct
+            // from a call that failed AFTER a client was successfully obtained (DiscoverToolsAsync's
+            // Error tag) — the distinction GetToolsAsync's retry decision hinges on.
+            RecordOutcome(start, serverName, McpConventions.StatusValues.Unavailable);
+            _logger.LogWarning(ex, "Failed to {Action} to MCP server '{ServerName}' — skipping", action, serverName);
+            return null;
+        }
+    }
+
+    /// <summary>
     /// The connection existed — possibly cached from an earlier turn — but using it just failed. That
     /// is the shape a remote-restarted, server-evicted session takes (#385), not a server that is
     /// genuinely unreachable, so ask <see cref="McpConnectionManager"/> to evict and reconnect before
     /// falling back to "unavailable this turn". <see cref="McpConnectionManager.ReconnectAsync"/> owns
     /// the eviction, not this method — it is the only place that can tell whether a concurrent caller
-    /// already recovered the same stale client.
+    /// already recovered the same stale client. That includes a call that failed with
+    /// <see cref="ObjectDisposedException"/> because a concurrent reconnect for this server disposed
+    /// <paramref name="failedClient"/> out from under it: <see cref="McpConnectionManager.ReconnectAsync"/>
+    /// only ever compares <paramref name="failedClient"/> by reference, never dereferences it, so calling
+    /// it with an already-disposed reference is safe and simply returns the concurrent reconnect's fresh
+    /// client instead of reconnecting a second time.
     /// </summary>
     /// <remarks>
     /// Reconnect and retry are two separate stages, each with its own outcome, rather than one
-    /// enclosing <c>try</c>: <see cref="ListToolsAsync"/> already records its own outcome (including
+    /// enclosing <c>try</c>: <see cref="DiscoverToolsAsync"/> already records its own outcome (including
     /// <c>Error</c>, with real elapsed time) before rethrowing, so a single catch around both stages
     /// would record a second, misleading near-zero-duration <c>Error</c> for the SAME failed call. A
-    /// caller's own cancellation is caught in both stages and degrades to <c>[]</c> with no log or
-    /// metric — it isn't a server outcome — never rethrown, since this class's contract is "skipped
-    /// rather than throwing" for every caller (<see cref="GetAllToolsAsync"/> fans this out via
-    /// <c>Task.WhenAll</c> with no per-task guard; letting cancellation escape here would propagate out
-    /// of that fan-out unhandled).
+    /// caller's own cancellation degrades to <c>[]</c> with no log or metric — it isn't a server outcome
+    /// — never rethrown, since this class's contract is "skipped rather than throwing" for every caller
+    /// (<see cref="GetAllToolsAsync"/> fans this out via <c>Task.WhenAll</c> with no per-task guard;
+    /// letting cancellation escape here would propagate out of that fan-out unhandled).
     /// </remarks>
     private async Task<IList<AITool>> RetryAfterReconnectAsync(
         string serverName, McpClient failedClient, Exception cause, CancellationToken cancellationToken)
@@ -146,26 +149,14 @@ public sealed class McpToolProvider : IMcpToolProvider
             "MCP server '{ServerName}' rejected a call on its existing connection — reconnecting and retrying once",
             serverName);
 
-        var reconnectStart = Stopwatch.GetTimestamp();
-        McpClient freshClient;
-        try
-        {
-            freshClient = await _connectionManager.ReconnectAsync(serverName, failedClient, cancellationToken);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
+        var freshClient = await TryConnectAsync(
+            ct => _connectionManager.ReconnectAsync(serverName, failedClient, ct), serverName, "reconnect", cancellationToken);
+        if (freshClient is null)
             return [];
-        }
-        catch (Exception ex)
-        {
-            RecordOutcome(reconnectStart, serverName, McpConventions.StatusValues.Unavailable);
-            _logger.LogWarning(ex, "Failed to reconnect to MCP server '{ServerName}' — skipping", serverName);
-            return [];
-        }
 
         try
         {
-            return await ListToolsAsync(freshClient, serverName, cancellationToken);
+            return await DiscoverToolsAsync(freshClient, serverName, cancellationToken);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -173,7 +164,7 @@ public sealed class McpToolProvider : IMcpToolProvider
         }
         catch (Exception ex)
         {
-            // ListToolsAsync already recorded the Error outcome (with real elapsed time) before
+            // DiscoverToolsAsync already recorded the Error outcome (with real elapsed time) before
             // rethrowing — do not record it again here.
             _logger.LogWarning(ex,
                 "Failed to get tools from MCP server '{ServerName}' after reconnecting — skipping",
@@ -185,9 +176,11 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// <summary>
     /// Lists tools on an already-obtained client and projects them to <see cref="AITool"/>. Records
     /// the outcome metric itself — for both success and failure — so a retried call's timing reflects
-    /// only the retry, never the failed attempt that preceded it.
+    /// only the retry, never the failed attempt that preceded it. Named distinctly from
+    /// <c>McpClient.ListToolsAsync</c>, which it wraps at line-of-call, to keep the two apart at
+    /// a glance.
     /// </summary>
-    private async Task<IList<AITool>> ListToolsAsync(McpClient client, string serverName, CancellationToken cancellationToken)
+    private async Task<IList<AITool>> DiscoverToolsAsync(McpClient client, string serverName, CancellationToken cancellationToken)
     {
         var start = Stopwatch.GetTimestamp();
         try
@@ -214,6 +207,13 @@ public sealed class McpToolProvider : IMcpToolProvider
         }
     }
 
+    /// <summary>
+    /// Records one outcome for the <c>list_tools</c> operation series. Deliberately shared across all
+    /// three sub-stages this class can fail at — initial connect, reconnect, and the actual list call —
+    /// rather than one series per sub-stage, so a dashboard sees one coherent "did GetToolsAsync work"
+    /// signal with <see cref="McpConventions.StatusValues.Unavailable"/> distinguishing "never reached a
+    /// session" from <see cref="McpConventions.StatusValues.Error"/> "reached one and it failed".
+    /// </summary>
     private static void RecordOutcome(long startTimestamp, string serverName, string status)
     {
         var elapsed = Stopwatch.GetElapsedTime(startTimestamp);

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -33,6 +33,16 @@ namespace Infrastructure.AI.MCP.Services;
 /// this path; a server that was never reachable in the first place still fails exactly as fast as
 /// before, with no added attempt or timeout.
 /// </para>
+/// <para>
+/// <strong>Known limitation: this recovers tool discovery, not tool invocation.</strong> An
+/// <see cref="AITool"/> this method returns is bound to the specific <c>McpClient</c> it was listed
+/// from; once handed to the agent's tool chain, an actual tool <em>call</em> invokes that binding
+/// directly and never routes back through this class. A session that goes stale between discovery
+/// and invocation still fails unrecovered on the call itself — only the next discovery pass observes
+/// and repairs it. Extending recovery to invocation needs a retry-aware wrapper around every
+/// <see cref="AITool"/> this method returns, not a change here; tracked as a follow-up, not solved in
+/// this class.
+/// </para>
 /// </remarks>
 public sealed class McpToolProvider : IMcpToolProvider
 {
@@ -56,6 +66,7 @@ public sealed class McpToolProvider : IMcpToolProvider
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        var connectSw = Stopwatch.StartNew();
         McpClient client;
         try
         {
@@ -65,7 +76,9 @@ public sealed class McpToolProvider : IMcpToolProvider
         {
             // Never reachable at all this call — no cached connection existed to go stale, so
             // there is nothing a reconnect-and-retry would fix. Same behaviour as before this fix.
-            RecordOutcome(Stopwatch.StartNew(), serverName, McpConventions.StatusValues.Unavailable);
+            // Covers caller cancellation too: this class's contract is to degrade to [] rather than
+            // throw, for cancellation exactly as for every other failure — see RetryAfterReconnectAsync.
+            RecordOutcome(connectSw, serverName, McpConventions.StatusValues.Unavailable);
             _logger.LogWarning(ex, "Failed to connect to MCP server '{ServerName}' — skipping", serverName);
             return [];
         }
@@ -73,12 +86,6 @@ public sealed class McpToolProvider : IMcpToolProvider
         try
         {
             return await ListToolsAsync(client, serverName, cancellationToken);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // The caller's own token fired — not a signal the connection is stale. Let it propagate
-            // rather than spending a reconnect attempt on a call nobody is waiting for.
-            throw;
         }
         catch (Exception ex)
         {
@@ -92,25 +99,47 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// genuinely unreachable, so ask <see cref="McpConnectionManager"/> to evict and reconnect before
     /// falling back to "unavailable this turn". <see cref="McpConnectionManager.ReconnectAsync"/> owns
     /// the eviction, not this method — it is the only place that can tell whether a concurrent caller
-    /// already recovered the same stale client, and returning here degrades to <c>[]</c> for any
-    /// failure the reconnect attempt raises, honoring this class's "skipped rather than throwing"
-    /// contract exactly as the first attempt does.
+    /// already recovered the same stale client.
     /// </summary>
+    /// <remarks>
+    /// Reconnect and retry are two separate stages, each with its own outcome, rather than one
+    /// enclosing <c>try</c>: <see cref="ListToolsAsync"/> already records its own outcome (including
+    /// <c>Error</c>, with real elapsed time) before rethrowing, so a single catch around both stages
+    /// would record a second, misleading near-zero-duration <c>Error</c> for the SAME failed call. A
+    /// caller's own cancellation is caught in both stages and degrades to <c>[]</c> like every other
+    /// failure, never rethrown — this class's contract is "skipped rather than throwing" for every
+    /// caller (<see cref="GetAllToolsAsync"/> fans this out via <c>Task.WhenAll</c> with no per-task
+    /// guard; letting cancellation escape here would propagate out of that fan-out unhandled).
+    /// </remarks>
     private async Task<IList<AITool>> RetryAfterReconnectAsync(
         string serverName, McpClient failedClient, Exception cause, CancellationToken cancellationToken)
     {
+        _logger.LogInformation(cause,
+            "MCP server '{ServerName}' rejected a call on its existing connection — reconnecting and retrying once",
+            serverName);
+
+        var reconnectSw = Stopwatch.StartNew();
+        McpClient freshClient;
         try
         {
-            _logger.LogInformation(cause,
-                "MCP server '{ServerName}' rejected a call on its existing connection — reconnecting and retrying once",
-                serverName);
-            var freshClient = await _connectionManager.ReconnectAsync(serverName, failedClient, cancellationToken);
+            freshClient = await _connectionManager.ReconnectAsync(serverName, failedClient, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            RecordOutcome(reconnectSw, serverName, McpConventions.StatusValues.Unavailable);
+            _logger.LogWarning(ex, "Failed to reconnect to MCP server '{ServerName}' — skipping", serverName);
+            return [];
+        }
+
+        try
+        {
             return await ListToolsAsync(freshClient, serverName, cancellationToken);
         }
-        catch (Exception retryEx)
+        catch (Exception ex)
         {
-            RecordOutcome(Stopwatch.StartNew(), serverName, McpConventions.StatusValues.Error);
-            _logger.LogWarning(retryEx,
+            // ListToolsAsync already recorded the Error outcome (with real elapsed time) before
+            // rethrowing — do not record it again here.
+            _logger.LogWarning(ex,
                 "Failed to get tools from MCP server '{ServerName}' after reconnecting — skipping",
                 serverName);
             return [];

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -37,13 +37,16 @@ namespace Infrastructure.AI.MCP.Services;
 /// <strong>Known limitation: this recovers tool discovery, not tool invocation, and reconnect can now
 /// race an in-flight call.</strong> An <see cref="AITool"/> this method returns is bound to the
 /// specific <c>McpClient</c> it was listed from; once handed to the agent's tool chain, an actual tool
-/// <em>call</em> invokes that binding directly (e.g. via
-/// <c>Presentation.AgentHub/Controllers/McpController.InvokeTool</c> or the agent-turn pipeline in
-/// <c>Application.Core/CQRS/Agents/ExecuteAgentTurn</c>) and never routes back through this class. A
-/// session that goes stale between discovery and invocation still fails unrecovered on the call itself
-/// — only the next discovery pass observes and repairs it. Because reconnect now happens
-/// automatically on any discovery failure rather than only on an explicit admin disconnect, a call
-/// already in flight against a client another caller's reconnect is about to evict can observe
+/// <em>call</em> invokes that binding directly and never routes back through this class. The exposure
+/// varies by caller: <c>Presentation.AgentHub/Controllers/McpController.InvokeTool</c> calls
+/// <see cref="GetToolByNameAsync"/> — and so gets this fix's recovery — immediately before invoking,
+/// leaving only the brief window between that lookup and the call itself; the agent-turn pipeline
+/// (<c>Application.Core/CQRS/Agents/ExecuteAgentTurn</c>) resolves tools once per turn and can hold that
+/// binding across a materially longer window before invoking it, with no re-lookup in between. Either
+/// way, a session that goes stale in that window still fails unrecovered on the call itself — only the
+/// next discovery pass observes and repairs it. Because reconnect now happens automatically on any
+/// discovery failure rather than only on an explicit admin disconnect, a call already in flight against
+/// a client another caller's reconnect is about to evict can observe
 /// <see cref="ObjectDisposedException"/> mid-invocation more often than before this fix. Closing this
 /// needs a retry-aware wrapper around every <see cref="AITool"/> this method returns plus
 /// reference-counted or generation-tagged client leases in <see cref="McpConnectionManager"/> — a
@@ -85,8 +88,10 @@ public sealed class McpToolProvider : IMcpToolProvider
         }
         catch (Exception ex)
         {
-            // Never reachable at all this call — no cached connection existed to go stale, so
-            // there is nothing a reconnect-and-retry would fix. Same behaviour as before this fix.
+            // Never reachable at all this call — no cached connection existed to go stale, so there is
+            // nothing a reconnect-and-retry would fix; still degrades to [] as before this fix, but now
+            // tagged Unavailable rather than Error, distinguishing "never reachable" from "a call on an
+            // established connection failed" — the two StatusValues this fix's retry decision hinges on.
             RecordOutcome(connectStart, serverName, McpConventions.StatusValues.Unavailable);
             _logger.LogWarning(ex, "Failed to connect to MCP server '{ServerName}' — skipping", serverName);
             return [];


### PR DESCRIPTION
## Summary

`McpConnectionManager` caches one client per MCP server for the process lifetime with no health check. If the remote server restarts or evicts the session between calls, the cached client is stale but looks fine — the staleness only surfaces when a call actually reaches the remote and gets rejected. Previously nothing ever recovered from this: the tool stayed unusable until the whole harness process restarted.

- `McpToolProvider.GetToolsAsync` now recovers from a failure on an existing connection by asking `McpConnectionManager` to evict and reconnect, then retries once.
- `McpConnectionManager.ReconnectAsync` is the new recovery primitive. It compares the failed client by reference before evicting, so concurrent callers that all observed the same stale session collapse onto one reconnect instead of each tearing down the connection the others just rebuilt.
- Stale-client disposal now runs concurrently with the fresh connect, rather than serially, since every other caller waiting on the same per-server lock pays for that serialization too.
- Caller cancellation degrades to an empty result with no log/metric noise at every stage, preserving this class's existing "skipped rather than throwing" contract.
- Known, documented limitations (not fixed here — tracked as follow-ups): recovery covers tool discovery, not tool invocation (an already-resolved `AITool` stays bound to its original client); `IsServerAvailableAsync` doesn't get this recovery either.

Closes #385.

## Test plan

- [x] Full-solution build: clean, zero warnings.
- [x] Full-solution test run: all MCP tests pass (111 total including throwaway proof tests, later deleted per repo convention); the only failures are 9 pre-existing Docker-dependent Prometheus E2E tests, unrelated to this change (confirmed via `docker info` — daemon not running locally).
- [x] Built a real, protocol-correct MCP stdio server as a throwaway subprocess to prove: (1) the fix recovers from a genuinely stale session, (2) two concurrent callers racing the same stale client collapse to exactly one reconnect, (3) `ReconnectAsync` handles an already-disposed `failedClient` reference correctly (mutation-verified: reverting the fix reproduces #385's exact symptom). Proof infrastructure deleted after verification.
- [x] `/code-review` (3 rounds) and `/simplify` (2 rounds) — all findings fixed or explicitly triaged as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW