### PR TITLE
fix: DefaultAzureCredential VDI managed-identity diagnostics (#383)

### DIFF
--- a/documentation/security/02-identity-and-access.html
+++ b/documentation/security/02-identity-and-access.html
@@ -364,10 +364,12 @@
                     <div class="code-block">
                         <div class="code-block-header"><span class="code-block-lang">json</span></div>
                         <pre><code>{
-  "AI": {
-    "AIFoundry": {
-      "Entra": {
-        "ExcludeManagedIdentityCredential": true
+  "AppConfig": {
+    "AI": {
+      "AIFoundry": {
+        "Entra": {
+          "ExcludeManagedIdentityCredential": true
+        }
       }
     }
   }

--- a/documentation/security/02-identity-and-access.html
+++ b/documentation/security/02-identity-and-access.html
@@ -312,6 +312,68 @@
                         </div>
                     </div>
 
+                    <h2 id="vdi-managed-identity">Local development gotcha: DefaultAzureCredential on a VDI</h2>
+                    <p>
+                        <code>AzureCredentialFactory</code>
+                        (<code>src/Content/Application/Application.Common/Factories/AzureCredentialFactory.cs</code>)
+                        falls back to <code>DefaultAzureCredential</code> whenever an
+                        <code>EntraCredentialConfig</code> doesn't carry a full client-secret or
+                        certificate credential — the normal case for local development, where
+                        <code>DefaultAzureCredential</code> is expected to fall through to your own
+                        Azure CLI or Visual Studio login.
+                    </p>
+                    <p>
+                        On a corporate VDI (virtual desktop), that assumption can quietly break. The VDI
+                        host itself often has its own managed identity. <code>DefaultAzureCredential</code>
+                        walks a fixed list of credential sources and stops at the first one that succeeds
+                        — and a VDI-provisioned managed identity succeeds before your own CLI or
+                        interactive login ever gets a turn. The app boots and runs normally, but every
+                        call authenticates as the VDI host, not as you.
+                    </p>
+
+                    <div class="callout callout-warn">
+                        <span class="callout-icon">!</span>
+                        <div class="callout-body">
+                            <div class="callout-title">Symptom: 403s that look like a permissions bug</div>
+                            <p style="margin: 0">
+                                If you have real access to a resource via your own Entra role assignments
+                                but still get <code>403 Forbidden</code> when running locally on a VDI,
+                                suspect this before suspecting your role assignments. Check the
+                                <code>Azure.Identity</code> log category — the harness surfaces
+                                <code>DefaultAzureCredential credential selected: {CredentialType}</code>
+                                at <code>Information</code> level by default (via
+                                <code>AzureIdentityDiagnosticsExtensions.AddAzureIdentityDiagnostics</code>),
+                                so you no longer need full Azure SDK EventSource tracing to see which
+                                credential won. If it reports
+                                <code>ManagedIdentityCredential</code> when you expected your own login,
+                                that's the VDI host's identity, not yours.
+                            </p>
+                        </div>
+                    </div>
+
+                    <p>
+                        <strong>Workaround:</strong> set
+                        <code>ExcludeManagedIdentityCredential</code> on the relevant
+                        <code>EntraCredentialConfig</code> section — for example, in
+                        <code>appsettings.Development.json</code> — to skip the VDI's managed identity
+                        and let the chain reach your own credential. Every consumer of
+                        <code>AzureCredentialFactory</code> embeds an <code>EntraCredentialConfig</code>
+                        the same way; <code>AIFoundryConfig.Entra</code> is one example:
+                    </p>
+
+                    <div class="code-block">
+                        <div class="code-block-header"><span class="code-block-lang">json</span></div>
+                        <pre><code>{
+  "AI": {
+    "AIFoundry": {
+      "Entra": {
+        "ExcludeManagedIdentityCredential": true
+      }
+    }
+  }
+}</code></pre>
+                    </div>
+
                     <h2 id="a2a">Agent-to-agent (A2A) authentication</h2>
                     <p>
                         <strong>The attack this stops:</strong> one agent impersonating another to inherit its

--- a/src/Content/Application/Application.Common/Application.Common.csproj
+++ b/src/Content/Application/Application.Common/Application.Common.csproj
@@ -16,8 +16,10 @@
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="OpenTelemetry" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />

--- a/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
@@ -12,6 +12,18 @@ namespace Application.Common.Extensions;
 public static class AzureIdentityDiagnosticsExtensions
 {
     /// <summary>
+    /// The (category, level) pairs applied by <see cref="AddAzureIdentityDiagnostics"/> — a
+    /// single source of truth shared by the global rule set and the
+    /// <see cref="OpenTelemetryLoggerProvider"/>-scoped rule set, so the two can never drift
+    /// out of sync with each other.
+    /// </summary>
+    private static readonly (string Category, LogLevel Level)[] DefaultCategoryLevels =
+    [
+        ("Azure", LogLevel.Warning),
+        ("Azure.Identity", LogLevel.Information),
+    ];
+
+    /// <summary>
     /// Bridges Azure SDK EventSource diagnostics into <see cref="ILogger"/>, so which credential
     /// <c>DefaultAzureCredential</c> selected is visible at normal log-Information level instead
     /// of requiring full EventSource tracing.
@@ -30,15 +42,17 @@ public static class AzureIdentityDiagnosticsExtensions
     /// "DefaultAzureCredential credential selected: {0}" line this exists for.
     /// </para>
     /// <para>
-    /// These are <em>defaults</em>, not overrides: registered via <c>PostConfigure&lt;LoggerFilterOptions&gt;</c>,
+    /// These are <em>defaults</em>, not overrides, for both the global rules and the
+    /// OpenTelemetry-scoped rules below: registered via <c>PostConfigure&lt;LoggerFilterOptions&gt;</c>,
     /// which the Options pattern guarantees runs after every <c>Configure&lt;LoggerFilterOptions&gt;</c>
     /// call — including a host's own <c>Logging</c> configuration-section binding, when the host
-    /// binds one. Each rule is added only if no <em>global</em> (provider-unscoped) rule already
-    /// targets that exact category name, so a consumer's own <c>Logging:LogLevel:Azure</c> /
-    /// <c>Logging:LogLevel:Azure.Identity</c> configuration — or an earlier code-registered filter —
-    /// is left in place rather than silently replaced. A bare <see cref="IServiceCollection"/> with
-    /// no configuration source bound has nothing to override in the first place; the defaults simply
-    /// apply.
+    /// binds one. Each rule is added only if no rule already targets that exact
+    /// (provider, category) pair, so a consumer's own <c>Logging:LogLevel:Azure</c> /
+    /// <c>Logging:LogLevel:Azure.Identity</c> configuration, or an earlier code-registered filter
+    /// — global or provider-scoped — is left in place rather than silently replaced in either
+    /// direction (more permissive or more restrictive). A bare <see cref="IServiceCollection"/>
+    /// with no configuration source bound has nothing to override in the first place; the
+    /// defaults simply apply.
     /// </para>
     /// <para>
     /// <strong>OpenTelemetry export is filtered separately, on purpose:</strong> the OTel logging
@@ -48,10 +62,8 @@ public static class AzureIdentityDiagnosticsExtensions
     /// for that provider — so the global "Azure"/"Azure.Identity" rules above never apply to the OTel
     /// export sink at all, regardless of specificity or registration order, and Azure SDK diagnostics
     /// (which can carry resource identifiers, e.g. Key Vault secret names in request URIs) would
-    /// otherwise reach exported telemetry unfiltered. This method adds matching rules scoped
-    /// explicitly to <see cref="OpenTelemetryLoggerProvider"/> to close that gap; they are always
-    /// applied (not gated by the "already configured" check above) since nothing else in this
-    /// codebase registers a provider-scoped rule for this exact provider/category pair.
+    /// otherwise reach exported telemetry unfiltered. This method adds matching default rules scoped
+    /// explicitly to <see cref="OpenTelemetryLoggerProvider"/> to close that gap.
     /// </para>
     /// </remarks>
     public static IServiceCollection AddAzureIdentityDiagnostics(this IServiceCollection services)
@@ -60,12 +72,13 @@ public static class AzureIdentityDiagnosticsExtensions
 
         services.PostConfigure<LoggerFilterOptions>(options =>
         {
-            AddGlobalDefaultUnlessConfigured(options, "Azure", LogLevel.Warning);
-            AddGlobalDefaultUnlessConfigured(options, "Azure.Identity", LogLevel.Information);
-
             var openTelemetryProvider = typeof(OpenTelemetryLoggerProvider).FullName;
-            options.Rules.Add(new LoggerFilterRule(openTelemetryProvider, "Azure", LogLevel.Warning, null));
-            options.Rules.Add(new LoggerFilterRule(openTelemetryProvider, "Azure.Identity", LogLevel.Information, null));
+
+            foreach (var (category, level) in DefaultCategoryLevels)
+            {
+                AddDefaultUnlessConfigured(options, providerName: null, category, level);
+                AddDefaultUnlessConfigured(options, openTelemetryProvider, category, level);
+            }
         });
 
         services.AddSingleton<AzureEventSourceLogForwarder>();
@@ -74,11 +87,12 @@ public static class AzureIdentityDiagnosticsExtensions
         return services;
     }
 
-    private static void AddGlobalDefaultUnlessConfigured(LoggerFilterOptions options, string category, LogLevel level)
+    private static void AddDefaultUnlessConfigured(
+        LoggerFilterOptions options, string? providerName, string category, LogLevel level)
     {
-        if (options.Rules.Any(r => r.ProviderName == null && r.CategoryName == category))
+        if (options.Rules.Any(r => r.ProviderName == providerName && r.CategoryName == category))
             return;
 
-        options.Rules.Add(new LoggerFilterRule(providerName: null, categoryName: category, logLevel: level, filter: null));
+        options.Rules.Add(new LoggerFilterRule(providerName, category, level, filter: null));
     }
 }

--- a/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
@@ -26,8 +26,17 @@ public static class AzureIdentityDiagnosticsExtensions
     /// Azure SDK this template uses, so the <c>Azure</c> category defaults to
     /// <see cref="LogLevel.Warning"/> here, with <c>Azure.Identity</c> carved back out to
     /// <see cref="LogLevel.Information"/> — the one category carrying the
-    /// "DefaultAzureCredential credential selected: {0}" line this exists for. Consumers can
-    /// still override either category from configuration.
+    /// "DefaultAzureCredential credential selected: {0}" line this exists for.
+    /// </para>
+    /// <para>
+    /// <strong>Not overridable from <c>appsettings.json</c>:</strong> these two filters are
+    /// registered here, in code, after the host's own configuration-bound logging filters — and
+    /// .NET's rule selection picks the last-registered rule when two rules match a category with
+    /// equal specificity. An operator setting <c>Logging:LogLevel:Azure</c> in configuration will
+    /// not change the effective level; this method's <see cref="LogLevel.Warning"/> always wins.
+    /// That's the deliberate, safer direction — it can't be accidentally relaxed — but it means a
+    /// genuine need for deeper Azure SDK tracing has to go through the full EventSource listener
+    /// this class exists to make unnecessary for the common case, not through configuration.
     /// </para>
     /// </remarks>
     public static IServiceCollection AddAzureIdentityDiagnostics(this IServiceCollection services)

--- a/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
@@ -2,6 +2,7 @@ using Application.Common.Logging;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Logs;
 
 namespace Application.Common.Extensions;
 
@@ -29,27 +30,55 @@ public static class AzureIdentityDiagnosticsExtensions
     /// "DefaultAzureCredential credential selected: {0}" line this exists for.
     /// </para>
     /// <para>
-    /// <strong>Not overridable from <c>appsettings.json</c>:</strong> these two filters are
-    /// registered here, in code, after the host's own configuration-bound logging filters — and
-    /// .NET's rule selection picks the last-registered rule when two rules match a category with
-    /// equal specificity. An operator setting <c>Logging:LogLevel:Azure</c> in configuration will
-    /// not change the effective level; this method's <see cref="LogLevel.Warning"/> always wins.
-    /// That's the deliberate, safer direction — it can't be accidentally relaxed — but it means a
-    /// genuine need for deeper Azure SDK tracing has to go through the full EventSource listener
-    /// this class exists to make unnecessary for the common case, not through configuration.
+    /// These are <em>defaults</em>, not overrides: registered via <c>PostConfigure&lt;LoggerFilterOptions&gt;</c>,
+    /// which the Options pattern guarantees runs after every <c>Configure&lt;LoggerFilterOptions&gt;</c>
+    /// call — including a host's own <c>Logging</c> configuration-section binding, when the host
+    /// binds one. Each rule is added only if no <em>global</em> (provider-unscoped) rule already
+    /// targets that exact category name, so a consumer's own <c>Logging:LogLevel:Azure</c> /
+    /// <c>Logging:LogLevel:Azure.Identity</c> configuration — or an earlier code-registered filter —
+    /// is left in place rather than silently replaced. A bare <see cref="IServiceCollection"/> with
+    /// no configuration source bound has nothing to override in the first place; the defaults simply
+    /// apply.
+    /// </para>
+    /// <para>
+    /// <strong>OpenTelemetry export is filtered separately, on purpose:</strong> the OTel logging
+    /// pipeline registers its own provider-scoped rule (<c>AddFilter&lt;OpenTelemetryLoggerProvider&gt;</c>,
+    /// with <c>CategoryName = null</c>) for its export minimum level. .NET's <c>LoggerRuleSelector</c>
+    /// treats any provider-scoped rule as strictly better than a category-only rule when selecting
+    /// for that provider — so the global "Azure"/"Azure.Identity" rules above never apply to the OTel
+    /// export sink at all, regardless of specificity or registration order, and Azure SDK diagnostics
+    /// (which can carry resource identifiers, e.g. Key Vault secret names in request URIs) would
+    /// otherwise reach exported telemetry unfiltered. This method adds matching rules scoped
+    /// explicitly to <see cref="OpenTelemetryLoggerProvider"/> to close that gap; they are always
+    /// applied (not gated by the "already configured" check above) since nothing else in this
+    /// codebase registers a provider-scoped rule for this exact provider/category pair.
     /// </para>
     /// </remarks>
     public static IServiceCollection AddAzureIdentityDiagnostics(this IServiceCollection services)
     {
-        services.AddLogging(builder =>
+        services.AddLogging();
+
+        services.PostConfigure<LoggerFilterOptions>(options =>
         {
-            builder.AddFilter("Azure", LogLevel.Warning);
-            builder.AddFilter("Azure.Identity", LogLevel.Information);
+            AddGlobalDefaultUnlessConfigured(options, "Azure", LogLevel.Warning);
+            AddGlobalDefaultUnlessConfigured(options, "Azure.Identity", LogLevel.Information);
+
+            var openTelemetryProvider = typeof(OpenTelemetryLoggerProvider).FullName;
+            options.Rules.Add(new LoggerFilterRule(openTelemetryProvider, "Azure", LogLevel.Warning, null));
+            options.Rules.Add(new LoggerFilterRule(openTelemetryProvider, "Azure.Identity", LogLevel.Information, null));
         });
 
         services.AddSingleton<AzureEventSourceLogForwarder>();
         services.AddHostedService<AzureIdentityLogForwarderHostedService>();
 
         return services;
+    }
+
+    private static void AddGlobalDefaultUnlessConfigured(LoggerFilterOptions options, string category, LogLevel level)
+    {
+        if (options.Rules.Any(r => r.ProviderName == null && r.CategoryName == category))
+            return;
+
+        options.Rules.Add(new LoggerFilterRule(providerName: null, categoryName: category, logLevel: level, filter: null));
     }
 }

--- a/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
@@ -1,0 +1,45 @@
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Common.Extensions;
+
+/// <summary>
+/// Extension methods for wiring Azure SDK diagnostics into the harness's logging pipeline.
+/// </summary>
+public static class AzureIdentityDiagnosticsExtensions
+{
+    /// <summary>
+    /// Bridges Azure SDK EventSource diagnostics into <see cref="ILogger"/>, so which credential
+    /// <c>DefaultAzureCredential</c> selected is visible at normal log-Information level instead
+    /// of requiring full EventSource tracing.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// <see cref="AzureEventSourceLogForwarder"/> (from <c>Microsoft.Extensions.Azure</c>) always
+    /// listens at <c>EventLevel.Verbose</c> internally, so every Azure SDK EventSource in the
+    /// process — not just Azure Identity — starts flowing into <see cref="ILogger"/> once it
+    /// starts. Azure.Core's own per-HTTP-call logging is noisy at Information level across every
+    /// Azure SDK this template uses, so the <c>Azure</c> category defaults to
+    /// <see cref="LogLevel.Warning"/> here, with <c>Azure.Identity</c> carved back out to
+    /// <see cref="LogLevel.Information"/> — the one category carrying the
+    /// "DefaultAzureCredential credential selected: {0}" line this exists for. Consumers can
+    /// still override either category from configuration.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddAzureIdentityDiagnostics(this IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.AddFilter("Azure", LogLevel.Warning);
+            builder.AddFilter("Azure.Identity", LogLevel.Information);
+        });
+
+        services.AddSingleton<AzureEventSourceLogForwarder>();
+        services.AddHostedService<AzureIdentityLogForwarderHostedService>();
+
+        return services;
+    }
+}

--- a/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
@@ -65,6 +65,19 @@ public static class AzureIdentityDiagnosticsExtensions
     /// otherwise reach exported telemetry unfiltered. This method adds matching default rules scoped
     /// explicitly to <see cref="OpenTelemetryLoggerProvider"/> to close that gap.
     /// </para>
+    /// <para>
+    /// That OTel-scoped default is clamped to never be <em>more</em> permissive than the operator's
+    /// own export-level cap, not just skipped when an exact-category rule already exists: the
+    /// realistic way an operator restricts OTel export verbosity is the category-null
+    /// <c>MinExportLevel</c> rule above, not a category-specific one, and a category-specific rule
+    /// always wins provider selection over a category-null one regardless of which is stricter. A
+    /// hardcoded <see cref="LogLevel.Warning"/> default would silently let "Azure" export at Warning
+    /// even when an operator configured a stricter cap (e.g. Error-only, specifically to keep
+    /// resource identifiers out of exported telemetry) — the mirror-image of the bypass this method
+    /// exists to close. The effective OTel-scoped level is therefore the <em>stricter</em> (numerically
+    /// higher <see cref="LogLevel"/>) of this method's default and any category-null export-level rule
+    /// already present for <see cref="OpenTelemetryLoggerProvider"/>.
+    /// </para>
     /// </remarks>
     public static IServiceCollection AddAzureIdentityDiagnostics(this IServiceCollection services)
     {
@@ -73,11 +86,18 @@ public static class AzureIdentityDiagnosticsExtensions
         services.PostConfigure<LoggerFilterOptions>(options =>
         {
             var openTelemetryProvider = typeof(OpenTelemetryLoggerProvider).FullName;
+            var operatorExportLevel = options.Rules
+                .Where(r => r.ProviderName == openTelemetryProvider && r.CategoryName is null && r.LogLevel is not null)
+                .Select(r => r.LogLevel!.Value)
+                .DefaultIfEmpty()
+                .Max();
 
             foreach (var (category, level) in DefaultCategoryLevels)
             {
                 AddDefaultUnlessConfigured(options, providerName: null, category, level);
-                AddDefaultUnlessConfigured(options, openTelemetryProvider, category, level);
+
+                var otelLevel = operatorExportLevel > level ? operatorExportLevel : level;
+                AddDefaultUnlessConfigured(options, openTelemetryProvider, category, otelLevel);
             }
         });
 

--- a/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/AzureIdentityDiagnosticsExtensions.cs
@@ -1,3 +1,4 @@
+using Application.Common.Logging;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Application/Application.Common/Extensions/AzureIdentityLogForwarderHostedService.cs
+++ b/src/Content/Application/Application.Common/Extensions/AzureIdentityLogForwarderHostedService.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Common.Extensions;
+
+/// <summary>
+/// Starts the Azure SDK EventSource-to-<see cref="ILogger"/> bridge at host start.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AzureEventSourceLogForwarder"/> needs an <see cref="ILoggerFactory"/> that only
+/// exists once the DI container is built, so registration alone does not start forwarding —
+/// something has to resolve it and call <see cref="AzureEventSourceLogForwarder.Start"/>. This
+/// hosted service does that, and nothing else. In particular it makes the Azure Identity SDK's
+/// own "<c>DefaultAzureCredential credential selected: {0}</c>" message (emitted at
+/// <c>EventLevel.Informational</c>) visible through the harness's normal logging pipeline,
+/// under the <c>Azure.Identity</c> category — see <see cref="AzureIdentityDiagnosticsExtensions"/>
+/// for the category filters that keep this signal from being drowned out by other Azure SDK
+/// diagnostic traffic.
+/// </para>
+/// <para>
+/// The forwarder is owned by the DI container (registered as a singleton) and is disposed by
+/// the container on shutdown, which detaches the underlying event listener. This service only
+/// triggers the start.
+/// </para>
+/// </remarks>
+public sealed class AzureIdentityLogForwarderHostedService : IHostedService
+{
+    private readonly AzureEventSourceLogForwarder _logForwarder;
+    private readonly ILogger<AzureIdentityLogForwarderHostedService> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AzureIdentityLogForwarderHostedService"/> class.
+    /// </summary>
+    /// <param name="logForwarder">The Azure SDK EventSource-to-<see cref="ILogger"/> bridge to start.</param>
+    /// <param name="logger">Logger for startup diagnostics.</param>
+    public AzureIdentityLogForwarderHostedService(
+        AzureEventSourceLogForwarder logForwarder,
+        ILogger<AzureIdentityLogForwarderHostedService> logger)
+    {
+        _logForwarder = logForwarder;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Starts forwarding Azure SDK EventSource messages to <see cref="ILogger"/>.
+    /// </summary>
+    /// <param name="cancellationToken">Token to observe while starting.</param>
+    /// <returns>A completed task — starting the listener is synchronous.</returns>
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _logForwarder.Start();
+
+        _logger.LogInformation(
+            "Azure SDK diagnostics forwarder started — DefaultAzureCredential's selected " +
+            "credential now logs under the Azure.Identity category.");
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Application/Application.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/IServiceCollectionExtensions.cs
@@ -75,6 +75,10 @@ public static class IServiceCollectionExtensions
             builder.AddInMemoryRingBuffer();
         });
 
+        // Azure SDK EventSource-to-ILogger bridge (issue #383) — surfaces which credential
+        // DefaultAzureCredential selected at Information level, without full EventSource tracing.
+        services.AddAzureIdentityDiagnostics();
+
         return services;
     }
 }

--- a/src/Content/Application/Application.Common/Factories/AzureCredentialFactory.cs
+++ b/src/Content/Application/Application.Common/Factories/AzureCredentialFactory.cs
@@ -14,6 +14,13 @@ namespace Application.Common.Factories;
 ///   <item>If <c>ClientId</c> + <c>CertificatePath</c> + <c>TenantId</c> are all set: <see cref="ClientCertificateCredential"/>.</item>
 ///   <item>Otherwise: <see cref="DefaultAzureCredential"/> (managed identity, VS credential, CLI credential, etc.).</item>
 /// </list>
+/// <para>
+/// <strong>VDI gotcha:</strong> on a corporate VDI, the fallback <see cref="DefaultAzureCredential"/>
+/// chain can silently succeed via the VDI host's own <see cref="ManagedIdentityCredential"/>
+/// instead of reaching the developer's own credential — the app runs, but authenticates as the
+/// wrong identity. Set <see cref="EntraCredentialConfig.ExcludeManagedIdentityCredential"/> to
+/// skip that step on affected VDIs. See the identity-and-access documentation for details.
+/// </para>
 /// </remarks>
 public static class AzureCredentialFactory
 {
@@ -44,6 +51,19 @@ public static class AzureCredentialFactory
         }
 
         // Default credential chain (managed identity, VS, CLI, etc.)
+        return new DefaultAzureCredential(BuildDefaultAzureCredentialOptions(config));
+    }
+
+    /// <summary>
+    /// Maps <see cref="EntraCredentialConfig"/> onto the <see cref="DefaultAzureCredentialOptions"/>
+    /// used for the fallback credential chain.
+    /// </summary>
+    /// <param name="config">The Entra credential configuration.</param>
+    /// <returns>The mapped options.</returns>
+    public static DefaultAzureCredentialOptions BuildDefaultAzureCredentialOptions(EntraCredentialConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
         var options = new DefaultAzureCredentialOptions();
 
         if (!string.IsNullOrWhiteSpace(config.TenantId))
@@ -52,6 +72,8 @@ public static class AzureCredentialFactory
         if (!string.IsNullOrWhiteSpace(config.ClientId))
             options.ManagedIdentityClientId = config.ClientId;
 
-        return new DefaultAzureCredential(options);
+        options.ExcludeManagedIdentityCredential = config.ExcludeManagedIdentityCredential;
+
+        return options;
     }
 }

--- a/src/Content/Application/Application.Common/Logging/AzureIdentityLogForwarderHostedService.cs
+++ b/src/Content/Application/Application.Common/Logging/AzureIdentityLogForwarderHostedService.cs
@@ -1,8 +1,9 @@
+using Application.Common.Extensions;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Application.Common.Extensions;
+namespace Application.Common.Logging;
 
 /// <summary>
 /// Starts the Azure SDK EventSource-to-<see cref="ILogger"/> bridge at host start.

--- a/src/Content/Application/Application.Common/Logging/AzureIdentityLogForwarderHostedService.cs
+++ b/src/Content/Application/Application.Common/Logging/AzureIdentityLogForwarderHostedService.cs
@@ -49,13 +49,26 @@ public sealed class AzureIdentityLogForwarderHostedService : IHostedService
     /// </summary>
     /// <param name="cancellationToken">Token to observe while starting.</param>
     /// <returns>A completed task — starting the listener is synchronous.</returns>
+    /// <remarks>
+    /// This is diagnostics-only and must never fail host startup — <see cref="AzureEventSourceLogForwarder.Start"/>
+    /// constructs an <c>EventListener</c>, which can throw in a constrained hosting environment.
+    /// </remarks>
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        _logForwarder.Start();
+        try
+        {
+            _logForwarder.Start();
 
-        _logger.LogInformation(
-            "Azure SDK diagnostics forwarder started — DefaultAzureCredential's selected " +
-            "credential now logs under the Azure.Identity category.");
+            _logger.LogInformation(
+                "Azure SDK diagnostics forwarder started — DefaultAzureCredential's selected " +
+                "credential now logs under the Azure.Identity category.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Azure SDK diagnostics forwarder failed to start — DefaultAzureCredential's " +
+                "selected credential will not be logged. Host startup continues unaffected.");
+        }
 
         return Task.CompletedTask;
     }

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerAuthConfig.cs
@@ -77,6 +77,23 @@ public class McpServerAuthConfig
     public List<string> Scopes { get; set; } = [];
 
     /// <summary>
+    /// Gets or sets whether <c>ManagedIdentityCredential</c> is excluded from the fallback
+    /// credential chain when this config resolves to the managed-identity shape of
+    /// <see cref="McpServerAuthType.Entra"/> (see <see cref="IsValid"/>).
+    /// </summary>
+    /// <remarks>
+    /// On a corporate VDI, the VDI host itself often has a managed identity, which can win
+    /// that fallback chain before the developer's own credential gets a turn — the same
+    /// gotcha <see cref="Domain.Common.Config.Azure.EntraCredentialConfig.ExcludeManagedIdentityCredential"/>
+    /// exists for. This is the client-connection equivalent: managed identity is the
+    /// <em>preferred, secure-by-default</em> shape for outbound MCP Entra auth, so without
+    /// this switch a developer on an affected VDI has no way to reach their own credential
+    /// on that path. Set to <see langword="true"/> for local-dev configuration on affected
+    /// VDIs.
+    /// </remarks>
+    public bool ExcludeManagedIdentityCredential { get; set; }
+
+    /// <summary>
     /// Gets or sets the explicit opt-in that lets this application's own MCP server
     /// (<see cref="McpConfig.Auth"/>) serve anonymously when <see cref="Type"/> is
     /// <see cref="McpServerAuthType.None"/>.

--- a/src/Content/Domain/Domain.Common/Config/Azure/EntraCredentialConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/Azure/EntraCredentialConfig.cs
@@ -31,4 +31,21 @@ public class EntraCredentialConfig
     /// Gets or sets the path to the certificate for certificate-based authentication.
     /// </summary>
     public string? CertificatePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether <c>ManagedIdentityCredential</c> is excluded from the
+    /// <c>DefaultAzureCredential</c> fallback chain.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// On a corporate VDI, the VDI host itself often has a managed identity. When that's true,
+    /// <c>DefaultAzureCredential</c> can silently authenticate as the VDI host's identity instead
+    /// of falling through to the developer's own credential (Azure CLI, Visual Studio, etc.) —
+    /// the app runs, but every call is scoped to the wrong identity, producing 403s that look
+    /// like a permissions bug. Set this to <see langword="true"/> for local-dev configuration
+    /// (e.g. <c>appsettings.Development.json</c>) on affected VDIs to skip
+    /// <c>ManagedIdentityCredential</c> and let the chain reach the developer's credential.
+    /// </para>
+    /// </remarks>
+    public bool ExcludeManagedIdentityCredential { get; set; }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCPServer/Program.cs
@@ -1,6 +1,7 @@
 using System.Threading.RateLimiting;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Skills;
+using Application.Common.Extensions;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Infrastructure.AI.Governance;
@@ -60,6 +61,12 @@ public class Program
         // services rather than calling AddAIDependencies, so it registers the discovery trio through
         // the shared entry point instead of by hand (issue #247).
         builder.Services.AddSkillDiscovery();
+
+        // Azure SDK EventSource-to-ILogger bridge (issue #383). This host composes its own services
+        // rather than calling AddApplicationCommonDependencies (Clean Architecture — an
+        // Infrastructure-layer host must not depend on Presentation), so it must wire this
+        // explicitly rather than getting it for free from ConfigureLogging.
+        builder.Services.AddAzureIdentityDiagnostics();
 
         // SkillMetadataParser now depends on IMcpSecurityScanner to screen a skill manifest for
         // prompt-injection payloads before trusting it (issue #331). This host composes its own

--- a/src/Content/Infrastructure/Infrastructure.AI/Identity/EntraTokenAuthHandler.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Identity/EntraTokenAuthHandler.cs
@@ -73,7 +73,8 @@ public sealed class EntraTokenAuthHandler : DelegatingHandler
             TenantId = auth.TenantId,
             ClientId = auth.ClientId,
             ClientSecret = auth.ClientSecret,
-            CertificatePath = auth.CertificatePath
+            CertificatePath = auth.CertificatePath,
+            ExcludeManagedIdentityCredential = auth.ExcludeManagedIdentityCredential
         });
 
         return new EntraTokenAuthHandler(credential, auth.Scopes) { InnerHandler = innerHandler };

--- a/src/Content/Tests/Application.Common.Tests/Application.Common.Tests.csproj
+++ b/src/Content/Tests/Application.Common.Tests/Application.Common.Tests.csproj
@@ -16,8 +16,10 @@
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using OpenTelemetry.Logs;
 using Xunit;
 
 namespace Application.Common.Tests.Extensions;
@@ -49,7 +50,7 @@ public class AzureIdentityDiagnosticsExtensionsTests
         using var provider = services.BuildServiceProvider();
         var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
 
-        rules.Should().Contain(r => r.CategoryName == "Azure" && r.LogLevel == LogLevel.Warning);
+        rules.Should().Contain(r => r.ProviderName == null && r.CategoryName == "Azure" && r.LogLevel == LogLevel.Warning);
     }
 
     [Fact]
@@ -62,22 +63,22 @@ public class AzureIdentityDiagnosticsExtensionsTests
         using var provider = services.BuildServiceProvider();
         var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
 
-        rules.Should().Contain(r => r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Information);
+        rules.Should().Contain(r => r.ProviderName == null && r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Information);
     }
 
     [Fact]
-    public void AddAzureIdentityDiagnostics_CalledAfterAnEarlierAzureCategoryRule_OverridesIt()
+    public void AddAzureIdentityDiagnostics_CalledAfterAnEarlierAzureCategoryRule_DoesNotOverrideIt()
     {
-        // The generic host (WebApplication.CreateBuilder) binds "Logging:LogLevel" from
-        // appsettings.json into LoggerFilterOptions.Rules before this app's own DI composition
-        // runs. AddAzureIdentityDiagnostics() is called later, in ConfigureLogging — this test
-        // proves what that ordering means: an operator's own "Logging:LogLevel:Azure" override is
-        // NOT honored, because the code-registered Warning rule always wins the equal-specificity
-        // tie-break (.NET's LoggerRuleSelector picks the last-registered rule when two rules match
-        // a category with equal specificity). Simulated here with a hand-built rule instead of real
-        // configuration binding, since the outcome depends only on registration order, not on where
-        // the earlier rule came from. This is the opposite of what this class's XML doc remarks used
-        // to claim, and is documented there now.
+        // A naive `builder.AddFilter("Azure", Warning)` inside AddLogging would win an operator's
+        // own "Logging:LogLevel:Azure" configuration outright — .NET's LoggerRuleSelector picks the
+        // last-registered rule when two rules match a category with equal specificity, and
+        // AddAzureIdentityDiagnostics() runs after a host's own config-bound logging setup. This
+        // proves the actual implementation avoids that trap: PostConfigure<LoggerFilterOptions> only
+        // adds the "Azure" default when no global (provider-unscoped) rule already targets that
+        // exact category, so a pre-existing rule — from configuration or earlier code — is left in
+        // place. Simulated here with a hand-built rule instead of real configuration binding, since
+        // the outcome depends only on whether a rule for the category already exists, not on where
+        // it came from.
         var services = new ServiceCollection();
         // A provider must be registered for IsEnabled() to evaluate rules at all — with none, every
         // category reports disabled regardless of filter level, which would make this test vacuous.
@@ -90,11 +91,51 @@ public class AzureIdentityDiagnosticsExtensionsTests
         using var provider = services.BuildServiceProvider();
         var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("Azure");
 
-        logger.IsEnabled(LogLevel.Debug).Should().BeFalse(
-            "AddAzureIdentityDiagnostics's Warning filter is registered after the earlier rule " +
-            "and wins the equal-specificity tie-break");
+        logger.IsEnabled(LogLevel.Debug).Should().BeTrue(
+            "the operator's own pre-existing 'Azure' rule must be preserved, not silently replaced " +
+            "by AddAzureIdentityDiagnostics's Warning default");
+    }
+
+    [Fact]
+    public void AddAzureIdentityDiagnostics_NoPriorAzureCategoryRule_AppliesTheWarningDefault()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder => builder.AddConsole());
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("Azure");
+
+        logger.IsEnabled(LogLevel.Information).Should().BeFalse(
+            "with no pre-existing 'Azure' rule, the Warning default should apply");
         logger.IsEnabled(LogLevel.Warning).Should().BeTrue();
     }
+
+    [Fact]
+    public void AddAzureIdentityDiagnostics_RegistersProviderScopedRulesForOpenTelemetryExport()
+    {
+        // .NET's LoggerRuleSelector treats ANY provider-scoped rule as strictly better than a
+        // category-only rule when selecting for that provider — regardless of category specificity
+        // or registration order. OpenTelemetry's own AddFilter<OpenTelemetryLoggerProvider>(category:
+        // null, MinExportLevel) is exactly such a rule, so the global "Azure"/"Azure.Identity" rules
+        // above would never apply to the OTel export sink at all, letting Azure SDK diagnostics
+        // (which can carry resource identifiers) reach exported telemetry unfiltered. This proves the
+        // provider-scoped rules that close that gap actually exist.
+        var services = new ServiceCollection();
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
+        var otelProviderName = typeof(OpenTelemetryLoggerProvider).FullName;
+
+        rules.Should().Contain(r =>
+            r.ProviderName == otelProviderName && r.CategoryName == "Azure" && r.LogLevel == LogLevel.Warning);
+        rules.Should().Contain(r =>
+            r.ProviderName == otelProviderName && r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Information);
+    }
+
 
     [Fact]
     public async Task StartAsync_CallsLogForwarderStart()

--- a/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
@@ -1,0 +1,64 @@
+using Application.Common.Extensions;
+using FluentAssertions;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Application.Common.Tests.Extensions;
+
+public class AzureIdentityDiagnosticsExtensionsTests
+{
+    [Fact]
+    public void AddAzureIdentityDiagnostics_RegistersLogForwarderAsResolvableSingleton()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<AzureEventSourceLogForwarder>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void AddAzureIdentityDiagnostics_RegistersHostedServiceThatStartsTheForwarder()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var hostedServices = provider.GetServices<IHostedService>();
+
+        hostedServices.Should().ContainSingle(s => s is AzureIdentityLogForwarderHostedService);
+    }
+
+    [Fact]
+    public void AddAzureIdentityDiagnostics_FiltersAzureCategoryToWarningByDefault()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
+
+        rules.Should().Contain(r => r.CategoryName == "Azure" && r.LogLevel == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void AddAzureIdentityDiagnostics_CarvesAzureIdentityCategoryBackToInformation()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
+
+        rules.Should().Contain(r => r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Information);
+    }
+}

--- a/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
@@ -160,6 +160,55 @@ public class AzureIdentityDiagnosticsExtensionsTests
     }
 
     [Fact]
+    public void AddAzureIdentityDiagnostics_OperatorSetsStricterCategoryNullExportLevel_ClampsToIt()
+    {
+        // The realistic way an operator restricts OTel export verbosity is a category-null
+        // MinExportLevel rule (exactly what OpenTelemetryServiceCollectionExtensions.AddLogsSignal
+        // registers), not a category-specific one — and a category-specific rule always wins
+        // provider selection over a category-null one regardless of which is stricter. A hardcoded
+        // Warning/Information default would therefore silently let "Azure"/"Azure.Identity" export
+        // MORE verbosely than an operator's stricter category-null cap (e.g. Error-only, configured
+        // specifically to keep resource identifiers out of exported telemetry) — caught by this
+        // repo's correctness-review CI gate on the first version of this fix. The OTel-scoped level
+        // must clamp to the stricter of the two.
+        var services = new ServiceCollection();
+        var otelProviderName = typeof(OpenTelemetryLoggerProvider).FullName;
+        services.Configure<LoggerFilterOptions>(o =>
+            o.Rules.Add(new LoggerFilterRule(otelProviderName, categoryName: null, LogLevel.Error, filter: null)));
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
+
+        rules.Should().Contain(r => r.ProviderName == otelProviderName && r.CategoryName == "Azure" && r.LogLevel == LogLevel.Error,
+            "the operator's stricter Error-only export cap must win over this method's Warning default");
+        rules.Should().Contain(r => r.ProviderName == otelProviderName && r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Error,
+            "the operator's stricter Error-only export cap must win over this method's Information default");
+    }
+
+    [Fact]
+    public void AddAzureIdentityDiagnostics_OperatorSetsMorePermissiveCategoryNullExportLevel_KeepsTheSaferDefault()
+    {
+        // The mirror case of the clamp above: an operator's category-null export level that is MORE
+        // permissive than this method's defaults (e.g. Trace, to capture everything for a debugging
+        // session) must not loosen the "Azure"/"Azure.Identity" export levels below the safe
+        // defaults — that's the original bypass this method exists to close.
+        var services = new ServiceCollection();
+        var otelProviderName = typeof(OpenTelemetryLoggerProvider).FullName;
+        services.Configure<LoggerFilterOptions>(o =>
+            o.Rules.Add(new LoggerFilterRule(otelProviderName, categoryName: null, LogLevel.Trace, filter: null)));
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
+
+        rules.Should().Contain(r => r.ProviderName == otelProviderName && r.CategoryName == "Azure" && r.LogLevel == LogLevel.Warning);
+        rules.Should().Contain(r => r.ProviderName == otelProviderName && r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Information);
+    }
+
+    [Fact]
     public void AddApplicationCommonDependencies_ResolvesLogForwarderAndHostedServiceFromTheRealCompositionRoot()
     {
         // This repo's own CLAUDE.md documents a recurring defect class: a service registered but

--- a/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Application.Common;
 using Application.Common.Extensions;
 using Application.Common.Logging;
 using FluentAssertions;
@@ -136,6 +137,46 @@ public class AzureIdentityDiagnosticsExtensionsTests
             r.ProviderName == otelProviderName && r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Information);
     }
 
+    [Fact]
+    public void AddAzureIdentityDiagnostics_CalledAfterAnEarlierOpenTelemetryScopedRule_DoesNotOverrideIt()
+    {
+        // The OpenTelemetry-scoped defaults must respect an explicit prior rule for that exact
+        // (provider, category) pair too, not just the global rules — otherwise an operator who
+        // deliberately configures a STRICTER OTel export level for "Azure" (e.g. Error-only, to keep
+        // resource identifiers out of exported telemetry) would have this method silently loosen it
+        // back to Warning, which is the mirror-image of the bypass this method exists to close.
+        var services = new ServiceCollection();
+        var otelProviderName = typeof(OpenTelemetryLoggerProvider).FullName;
+        services.Configure<LoggerFilterOptions>(o =>
+            o.Rules.Add(new LoggerFilterRule(otelProviderName, "Azure", LogLevel.Error, filter: null)));
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
+
+        rules.Should().Contain(r => r.ProviderName == otelProviderName && r.CategoryName == "Azure" && r.LogLevel == LogLevel.Error);
+        rules.Should().NotContain(r => r.ProviderName == otelProviderName && r.CategoryName == "Azure" && r.LogLevel == LogLevel.Warning);
+    }
+
+    [Fact]
+    public void AddApplicationCommonDependencies_ResolvesLogForwarderAndHostedServiceFromTheRealCompositionRoot()
+    {
+        // This repo's own CLAUDE.md documents a recurring defect class: a service registered but
+        // never invoked from the real composition root, caught only by resolving it there rather than
+        // from a bare ServiceCollection built solely for a unit test (issues #247, #331). Every other
+        // test in this class calls AddAzureIdentityDiagnostics() directly; this one instead goes
+        // through the actual entry point (AddApplicationCommonDependencies -> ConfigureLogging) so a
+        // future refactor that drops the wiring call fails a test, not just silently ships dark.
+        var services = new ServiceCollection();
+
+        services.AddApplicationCommonDependencies();
+
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<AzureEventSourceLogForwarder>().Should().NotBeNull();
+        provider.GetServices<IHostedService>().Should().ContainSingle(s => s is AzureIdentityLogForwarderHostedService);
+    }
 
     [Fact]
     public async Task StartAsync_CallsLogForwarderStart()
@@ -144,6 +185,9 @@ public class AzureIdentityDiagnosticsExtensionsTests
         // reads its private listener field via reflection — the only way to catch a mutation that
         // silently drops the Start() call (this repo's "registered but never invoked" defect class,
         // see reference_security_control_has_a_caller.md), which every other assertion here would miss.
+        // Fragile by nature: pinned to Microsoft.Extensions.Azure 1.14.0's current internal layout
+        // (Directory.Packages.props) — a future package bump that renames or restructures the
+        // internal listener field will need this test updated alongside it.
         using var loggerFactory = NullLoggerFactory.Instance;
         var forwarder = new AzureEventSourceLogForwarder(loggerFactory);
         var service = new AzureIdentityLogForwarderHostedService(

--- a/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Application.Common.Extensions;
+using Application.Common.Logging;
 using FluentAssertions;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Extensions/AzureIdentityDiagnosticsExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Application.Common.Extensions;
 using Application.Common.Logging;
 using FluentAssertions;
@@ -5,6 +6,7 @@ using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -25,7 +27,7 @@ public class AzureIdentityDiagnosticsExtensionsTests
     }
 
     [Fact]
-    public void AddAzureIdentityDiagnostics_RegistersHostedServiceThatStartsTheForwarder()
+    public void AddAzureIdentityDiagnostics_RegistersHostedService()
     {
         var services = new ServiceCollection();
 
@@ -61,5 +63,57 @@ public class AzureIdentityDiagnosticsExtensionsTests
         var rules = provider.GetRequiredService<IOptions<LoggerFilterOptions>>().Value.Rules;
 
         rules.Should().Contain(r => r.CategoryName == "Azure.Identity" && r.LogLevel == LogLevel.Information);
+    }
+
+    [Fact]
+    public void AddAzureIdentityDiagnostics_CalledAfterAnEarlierAzureCategoryRule_OverridesIt()
+    {
+        // The generic host (WebApplication.CreateBuilder) binds "Logging:LogLevel" from
+        // appsettings.json into LoggerFilterOptions.Rules before this app's own DI composition
+        // runs. AddAzureIdentityDiagnostics() is called later, in ConfigureLogging — this test
+        // proves what that ordering means: an operator's own "Logging:LogLevel:Azure" override is
+        // NOT honored, because the code-registered Warning rule always wins the equal-specificity
+        // tie-break (.NET's LoggerRuleSelector picks the last-registered rule when two rules match
+        // a category with equal specificity). Simulated here with a hand-built rule instead of real
+        // configuration binding, since the outcome depends only on registration order, not on where
+        // the earlier rule came from. This is the opposite of what this class's XML doc remarks used
+        // to claim, and is documented there now.
+        var services = new ServiceCollection();
+        // A provider must be registered for IsEnabled() to evaluate rules at all — with none, every
+        // category reports disabled regardless of filter level, which would make this test vacuous.
+        services.AddLogging(builder => builder.AddConsole());
+        services.Configure<LoggerFilterOptions>(o =>
+            o.Rules.Add(new LoggerFilterRule(providerName: null, categoryName: "Azure", logLevel: LogLevel.Debug, filter: null)));
+
+        services.AddAzureIdentityDiagnostics();
+
+        using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILoggerFactory>().CreateLogger("Azure");
+
+        logger.IsEnabled(LogLevel.Debug).Should().BeFalse(
+            "AddAzureIdentityDiagnostics's Warning filter is registered after the earlier rule " +
+            "and wins the equal-specificity tie-break");
+        logger.IsEnabled(LogLevel.Warning).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task StartAsync_CallsLogForwarderStart()
+    {
+        // AzureEventSourceLogForwarder exposes no public way to observe whether Start() ran, so this
+        // reads its private listener field via reflection — the only way to catch a mutation that
+        // silently drops the Start() call (this repo's "registered but never invoked" defect class,
+        // see reference_security_control_has_a_caller.md), which every other assertion here would miss.
+        using var loggerFactory = NullLoggerFactory.Instance;
+        var forwarder = new AzureEventSourceLogForwarder(loggerFactory);
+        var service = new AzureIdentityLogForwarderHostedService(
+            forwarder, NullLogger<AzureIdentityLogForwarderHostedService>.Instance);
+
+        await service.StartAsync(CancellationToken.None);
+
+        var listenerField = typeof(AzureEventSourceLogForwarder).GetField(
+            "_listener", BindingFlags.NonPublic | BindingFlags.Instance);
+        listenerField.Should().NotBeNull("AzureEventSourceLogForwarder must expose a _listener field to assert against");
+        listenerField!.GetValue(forwarder).Should().NotBeNull(
+            "StartAsync must call AzureEventSourceLogForwarder.Start(), which sets this field");
     }
 }

--- a/src/Content/Tests/Application.Common.Tests/Factories/AzureCredentialFactoryTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Factories/AzureCredentialFactoryTests.cs
@@ -1,0 +1,78 @@
+using Application.Common.Factories;
+using Domain.Common.Config.Azure;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Common.Tests.Factories;
+
+public class AzureCredentialFactoryTests
+{
+    [Fact]
+    public void BuildDefaultAzureCredentialOptions_ExcludeManagedIdentityCredentialNotSet_DefaultsToFalse()
+    {
+        var config = new EntraCredentialConfig();
+
+        var options = AzureCredentialFactory.BuildDefaultAzureCredentialOptions(config);
+
+        options.ExcludeManagedIdentityCredential.Should().BeFalse(
+            "omitting the VDI workaround must preserve today's default DefaultAzureCredential behavior");
+    }
+
+    [Fact]
+    public void BuildDefaultAzureCredentialOptions_ExcludeManagedIdentityCredentialSet_ThreadsThrough()
+    {
+        var config = new EntraCredentialConfig { ExcludeManagedIdentityCredential = true };
+
+        var options = AzureCredentialFactory.BuildDefaultAzureCredentialOptions(config);
+
+        options.ExcludeManagedIdentityCredential.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildDefaultAzureCredentialOptions_TenantIdAndClientIdSet_MapsToChainOptions()
+    {
+        var config = new EntraCredentialConfig
+        {
+            TenantId = "tenant-123",
+            ClientId = "client-456"
+        };
+
+        var options = AzureCredentialFactory.BuildDefaultAzureCredentialOptions(config);
+
+        options.TenantId.Should().Be("tenant-123");
+        options.ManagedIdentityClientId.Should().Be("client-456");
+    }
+
+    [Fact]
+    public void CreateTokenCredential_ClientSecretConfigured_ReturnsClientSecretCredential()
+    {
+        var config = new EntraCredentialConfig
+        {
+            TenantId = "tenant-123",
+            ClientId = "client-456",
+            ClientSecret = "secret-789"
+        };
+
+        var credential = AzureCredentialFactory.CreateTokenCredential(config);
+
+        credential.Should().BeOfType<Azure.Identity.ClientSecretCredential>();
+    }
+
+    [Fact]
+    public void CreateTokenCredential_NoExplicitCredentialsConfigured_ReturnsDefaultAzureCredential()
+    {
+        var config = new EntraCredentialConfig();
+
+        var credential = AzureCredentialFactory.CreateTokenCredential(config);
+
+        credential.Should().BeOfType<Azure.Identity.DefaultAzureCredential>();
+    }
+
+    [Fact]
+    public void CreateTokenCredential_NullConfig_Throws()
+    {
+        var act = () => AzureCredentialFactory.CreateTokenCredential(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,6 +16,7 @@
 
     <!-- Application layer -->
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.14.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="MediatR" Version="12.4.1" />


### PR DESCRIPTION
## Summary

Closes #383. On a corporate VDI, `DefaultAzureCredential` can silently authenticate as the VDI host's own managed identity instead of falling through to the developer's own credential — the app runs, but every call is scoped to the wrong identity, producing 403s that look like a permissions bug.

- Adds `EntraCredentialConfig.ExcludeManagedIdentityCredential` (the workaround the issue names, previously unreachable without editing source) and threads it through `AzureCredentialFactory` and the outbound MCP-client Entra auth path (`McpServerAuthConfig` / `EntraTokenAuthHandler`).
- Wires Microsoft's own `AzureEventSourceLogForwarder` into the harness's logging pipeline so which credential was selected now logs at `Information` level, without needing full EventSource tracing. Registered as *defaults*, not overrides — via `PostConfigure<LoggerFilterOptions>`, a pre-existing rule for the same category (global or OpenTelemetry-export-scoped) is left in place rather than silently replaced, in either direction.
- Documents the gotcha in the security guide.

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 errors
- [x] `dotnet test` — `Application.Common.Tests` (221 passing, incl. new coverage for the log-filter precedence/OTel-export fix and a composition-root-level resolution test) and `Infrastructure.AI.Tests` `EntraTokenAuthHandler` suite (6 passing)
- [x] Manual: `mcp__gitnexus__detect_changes` blast-radius review before each commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW