### PR TITLE
fix: redact and size-cap streaming tool-call arguments (#389-#392)

### DIFF
--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -1176,7 +1176,7 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                             <tr><td><code>TEXT_MESSAGE_CONTENT</code></td><td><code>messageId</code>, <code>delta</code></td><td>Per token batch. Append to your buffer.</td></tr>
                             <tr><td><code>TEXT_MESSAGE_END</code></td><td><code>messageId</code></td><td>Once, if the message was opened.</td></tr>
                             <tr><td><code>TOOL_CALL_START</code></td><td><code>toolCallId</code>, <code>toolCallName</code></td><td>When the agent decides to call a tool. May arrive before the first <code>TEXT_MESSAGE_START</code>.</td></tr>
-                            <tr><td><code>TOOL_CALL_ARGS</code></td><td><code>toolCallId</code>, <code>delta</code></td><td>Immediately after <code>TOOL_CALL_START</code> — the complete arguments JSON in one frame, not an incremental delta.</td></tr>
+                            <tr><td><code>TOOL_CALL_ARGS</code></td><td><code>toolCallId</code>, <code>delta</code>, <code>withheld</code> (only present when <code>true</code>)</td><td>Immediately after <code>TOOL_CALL_START</code> — the complete arguments JSON in one frame, not an incremental delta.</td></tr>
                             <tr><td><code>TOOL_CALL_END</code></td><td><code>toolCallId</code></td><td>Immediately after <code>TOOL_CALL_ARGS</code>.</td></tr>
                             <tr><td><code>TOOL_CALL_RESULT</code></td><td><code>toolCallId</code>, <code>result</code> (redacted preview)</td><td>Once the tool has actually run.</td></tr>
                             <tr><td><code>RUN_FINISHED</code></td><td><code>threadId</code>, <code>runId</code></td><td>Terminal, on success.</td></tr>
@@ -1194,9 +1194,15 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                     </p>
                     <p>
                         <code>TOOL_CALL_ARGS.delta</code> and <code>TOOL_CALL_RESULT.result</code> are never the raw
-                        payload — both pass through the same secret-redaction and length-truncation the harness
-                        applies before persisting tool activity to its observability store, since a live stream to
-                        a browser is just as much an exposure point as disk. If a tool call fails,
+                        payload — both pass through the same secret-redaction the harness applies before persisting
+                        tool activity to its observability store, since a live stream to a browser is just as much
+                        an exposure point as disk. They differ in how they bound size: <code>result</code> is
+                        truncated to a fixed preview length, which is safe for free text. <code>delta</code> is
+                        never truncated — cutting JSON mid-token would hand the client invalid data — so above a
+                        size ceiling the real arguments are <strong>withheld</strong> instead: <code>delta</code>
+                        becomes the fixed placeholder <code>"{}"</code> and <code>withheld</code> is <code>true</code>.
+                        A client should treat a <code>withheld</code> frame as "arguments unavailable," not attempt
+                        to interpret <code>"{}"</code> as the tool's real (empty) arguments. If a tool call fails,
                         <code>result</code> is a generic failure message, not the underlying exception text.
                     </p>
                     <div class="code-block">

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -1319,14 +1319,22 @@ components:
         incremental delta — the underlying model-provider integration only ever exposes a tool
         call's arguments once fully assembled, so this frame always carries the complete JSON
         payload in one shot, immediately followed by `TOOL_CALL_END`. The field is still named
-        `delta` to match the AG-UI wire vocabulary exactly.
+        `delta` to match the AG-UI wire vocabulary exactly. Above a server-side size ceiling the
+        real arguments are withheld rather than truncated — `delta` is the fixed placeholder `"{}"`
+        and `withheld` is `true` — since cutting a JSON payload mid-token would hand the client
+        invalid data.
       required: [type, toolCallId, delta]
       properties:
         type: { type: string, const: TOOL_CALL_ARGS }
         toolCallId: { type: string }
         delta:
           type: string
-          description: The tool call's complete arguments, serialized as JSON.
+          description: The tool call's complete arguments, serialized as JSON, or `"{}"` if withheld.
+        withheld:
+          type: boolean
+          description: >-
+            Present and `true` only when the real arguments exceeded the streaming size ceiling and
+            were withheld. Absent on every normal frame.
 
     ToolCallEndEvent:
       type: object

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
@@ -31,6 +31,22 @@ public static class ToolPayloadRedactor
     public const int MaxStreamedToolCallArgsLength = 16 * 1024;
 
     /// <summary>
+    /// Mirrors <c>PatternSecretRedactor.MaxStructuralRedactionLength</c> (Infrastructure layer,
+    /// private) — the length above which that redactor's JSON-aware structural pass is skipped in
+    /// favor of a regex-only scan. Duplicated as a separate constant rather than a shared reference
+    /// because Application must not depend on Infrastructure (Clean Architecture); the two values
+    /// must be changed together.
+    /// </summary>
+    /// <remarks>
+    /// The persistence path (<c>ToolDiagnosticsMiddleware</c>) has no size ceiling of its own, unlike
+    /// the streaming path (<see cref="MaxStreamedToolCallArgsLength"/>, 16KB). Above this size,
+    /// <see cref="Redact"/> silently falls back to regex-only redaction, which cannot see through
+    /// escaped-nested JSON (the #391 shape) — so a payload larger than this must be withheld rather
+    /// than previewed, or the persisted record's 500-char prefix could contain an unredacted secret.
+    /// </remarks>
+    public const int MaxStructuralRedactionCeiling = 64 * 1024;
+
+    /// <summary>
     /// Redacts <paramref name="payload"/> via <paramref name="redactor"/> (a no-op when
     /// <paramref name="redactor"/> is <see langword="null"/>), then truncates the result to
     /// <paramref name="maxLength"/> characters. Only safe for free-text previews (a log line, a
@@ -81,22 +97,40 @@ public static class ToolPayloadRedactor
     /// <param name="json">The tool call's arguments, already serialized as JSON.</param>
     /// <param name="redactor">Optional secret redactor; a no-op when <see langword="null"/>.</param>
     /// <param name="logger">Logs a warning if redaction throws.</param>
-    /// <param name="failureMessage">The message logged if redaction throws.</param>
+    /// <param name="toolName">
+    /// The tool name, logged as a structured field (<c>{ToolName}</c>) rather than interpolated into
+    /// the message text — <paramref name="toolName"/> is model/registry-chosen, and interpolating it
+    /// into a plain-text log line lets a name containing a newline forge a second log entry on a
+    /// plain-text sink.
+    /// </param>
+    /// <param name="callId">The provider-assigned call id, logged as a structured field (<c>{CallId}</c>).</param>
     public static StreamedToolCallArguments RedactForStreaming(
-        string json, ISecretRedactor? redactor, ILogger logger, string failureMessage)
+        string json, ISecretRedactor? redactor, ILogger logger, string toolName, string? callId)
     {
         if (json.Length > MaxStreamedToolCallArgsLength)
             return new StreamedToolCallArguments("{}", Withheld: true);
 
+        StreamedToolCallArguments result;
         try
         {
-            return new StreamedToolCallArguments(Redact(json, redactor), Withheld: false);
+            result = new StreamedToolCallArguments(Redact(json, redactor), Withheld: false);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "{FailureMessage}", failureMessage);
+            logger.LogWarning(ex,
+                "Failed to redact streamed tool-call arguments for {ToolName} CallId={CallId}",
+                toolName, callId);
             return new StreamedToolCallArguments("{}", Withheld: true);
         }
+
+        // The pre-check above bounds the INPUT, but PatternSecretRedactor's structural pass
+        // re-serializes via ToJsonString(), whose default encoder escapes every non-ASCII character
+        // (and HTML-sensitive ones) to \uXXXX — a redacted payload of mostly non-ASCII text can come
+        // back several times longer than it went in. Re-check the OUTPUT so the ceiling is actually a
+        // wire-size ceiling, not just an input-size one.
+        return result.Json.Length > MaxStreamedToolCallArgsLength
+            ? new StreamedToolCallArguments("{}", Withheld: true)
+            : result;
     }
 
     /// <summary>
@@ -115,6 +149,13 @@ public static class ToolPayloadRedactor
     /// template — this failure path is rare (a misbehaving redactor or an unserializable value) and
     /// shared across call sites with different natural template arguments, so a caller-formatted
     /// message is simpler than plumbing per-call structured fields through a generic helper.
+    /// <see cref="RedactForStreaming"/> does NOT use this helper, despite an identical
+    /// try/catch/log/fallback shape: it needs <c>toolName</c> and <c>callId</c> logged as separate
+    /// structured fields (not pre-interpolated into one string) so a model-chosen tool name
+    /// containing control characters can't forge a second entry on a plain-text log sink — a need
+    /// this helper's single-preformatted-string contract deliberately doesn't support. Widening this
+    /// helper to take structured args instead of a plain string was considered and rejected: doing so
+    /// for one caller would force every other caller to plumb a template + args pair for no benefit.
     /// </remarks>
     public static string TryOrFallback(Func<string> produce, ILogger logger, string failureMessage, string fallback)
     {

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
@@ -17,6 +17,20 @@ public static class ToolPayloadRedactor
     public const int MaxPayloadSummaryLength = 500;
 
     /// <summary>
+    /// The length, in UTF-16 characters of the serialized (pre-redaction) JSON, above which a
+    /// streamed tool call's arguments are withheld rather than sent. Unlike
+    /// <see cref="MaxPayloadSummaryLength"/>, arguments are never truncated — truncating mid-JSON
+    /// would hand a client invalid, unparseable data (see <see cref="Redact"/>'s remarks) — so
+    /// oversized arguments are withheld whole instead of cut. Checked against the pre-redaction
+    /// length deliberately: it is a resource ceiling, not a secrecy decision, so there is no reason
+    /// to pay for redaction on a payload that is about to be discarded. Sits comfortably below
+    /// <c>PatternSecretRedactor</c>'s own structural-redaction size ceiling (64KB), so any payload
+    /// that actually reaches a client has had the full structural JSON-aware redaction pass applied
+    /// to it — never just the regex-only fallback.
+    /// </summary>
+    public const int MaxStreamedToolCallArgsLength = 16 * 1024;
+
+    /// <summary>
     /// Redacts <paramref name="payload"/> via <paramref name="redactor"/> (a no-op when
     /// <paramref name="redactor"/> is <see langword="null"/>), then truncates the result to
     /// <paramref name="maxLength"/> characters. Only safe for free-text previews (a log line, a
@@ -51,6 +65,38 @@ public static class ToolPayloadRedactor
         return redactor.Redact(payload) ?? throw new InvalidOperationException(
             $"{redactor.GetType().Name}.Redact(string) returned null for non-null input, violating " +
             $"{nameof(ISecretRedactor)}'s contract.");
+    }
+
+    /// <summary>
+    /// Redacts and size-caps <paramref name="json"/> for a live tool-call-arguments stream —
+    /// consolidates the identical "check the ceiling, redact, wrap the result" shape that shipped
+    /// independently (and inconsistently) in both <c>ExecuteAgentTurnCommandHandler</c> (bundle SSE)
+    /// and <c>AgUiClientToolBridge</c> (AG-UI client round-trip). Above
+    /// <see cref="MaxStreamedToolCallArgsLength"/>, or if redaction itself throws (a redactor-contract
+    /// violation), the result is withheld: <c>Json</c> is <c>"{}"</c> and <c>Withheld</c> is
+    /// <see langword="true"/> — both failure modes collapse to the same client-visible signal, since
+    /// either way the real arguments never reach the consumer and must not be mistaken for the tool's
+    /// real (empty) input.
+    /// </summary>
+    /// <param name="json">The tool call's arguments, already serialized as JSON.</param>
+    /// <param name="redactor">Optional secret redactor; a no-op when <see langword="null"/>.</param>
+    /// <param name="logger">Logs a warning if redaction throws.</param>
+    /// <param name="failureMessage">The message logged if redaction throws.</param>
+    public static StreamedToolCallArguments RedactForStreaming(
+        string json, ISecretRedactor? redactor, ILogger logger, string failureMessage)
+    {
+        if (json.Length > MaxStreamedToolCallArgsLength)
+            return new StreamedToolCallArguments("{}", Withheld: true);
+
+        try
+        {
+            return new StreamedToolCallArguments(Redact(json, redactor), Withheld: false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "{FailureMessage}", failureMessage);
+            return new StreamedToolCallArguments("{}", Withheld: true);
+        }
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
@@ -6,12 +6,25 @@ namespace Application.AI.Common.Interfaces;
 /// the Application layer taking a dependency on any transport.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The transport (the Presentation-layer orchestrator) attaches a sink before
 /// dispatching the turn; the handler reads the ambient sink to decide between
 /// streaming (<c>RunStreamingAsync</c>) and blocking (<c>RunAsync</c>) execution.
 /// When no sink is attached the handler runs blocking, so non-interactive callers
 /// (tests, batch jobs) keep their existing behaviour. Mirrors the ambient pattern of
 /// <see cref="Services.LlmUsageCapture.Current"/>.
+/// </para>
+/// <para>
+/// <strong>Ordering contract for tool-call activity:</strong> a caller must never invoke
+/// <see cref="EmitToolCallResultAsync"/> for a <c>toolCallId</c> it has not already passed to
+/// <see cref="EmitToolCallAsync"/>, and must never invoke <see cref="EmitToolCallAsync"/> twice for
+/// the same <c>toolCallId</c> within one turn. A conforming implementation may assume both hold and
+/// is not required to defend against a violation — <see cref="Services.ToolCallOrderingSink"/> is the
+/// enforcement point that guarantees them for its wrapped sink, constructed fresh per turn by
+/// <c>ExecuteAgentTurnCommandHandler</c>. A future second implementation of this interface that is
+/// reached some other way (not through that decorator) must independently uphold the same contract,
+/// not just replicate the method shapes.
+/// </para>
 /// </remarks>
 public interface IAgentTurnStreamSink
 {
@@ -28,7 +41,7 @@ public interface IAgentTurnStreamSink
     /// Emits one complete tool call the model has decided to make — its id, name, and arguments — as a
     /// single unit. Default no-op, so a sink that only cares about assistant text (or a transport that
     /// predates tool-call streaming) needs no changes. Unlike <see cref="EmitAsync"/>, <paramref
-    /// name="argsJson"/> is never an incremental delta: the underlying chat-client abstraction only ever
+    /// name="args"/> is never an incremental delta: the underlying chat-client abstraction only ever
     /// exposes a tool call's arguments once fully assembled (the provider connector buffers raw
     /// per-chunk argument JSON internally and never surfaces a partial parse), so every field here is
     /// already complete and stable by the time this fires. A consumer that must publish start/args/end as
@@ -39,9 +52,14 @@ public interface IAgentTurnStreamSink
     /// </summary>
     /// <param name="toolCallId">The provider-assigned id for this call.</param>
     /// <param name="toolCallName">The name of the tool being called.</param>
-    /// <param name="argsJson">The complete tool-call arguments, serialized as JSON.</param>
+    /// <param name="args">
+    /// The tool call's arguments. <see cref="StreamedToolCallArguments.Json"/> is always complete,
+    /// parseable JSON — never truncated — and is the fixed placeholder <c>"{}"</c> when
+    /// <see cref="StreamedToolCallArguments.Withheld"/> is <see langword="true"/> (the real arguments
+    /// exceeded the streaming size ceiling, or serialization/redaction failed).
+    /// </param>
     /// <param name="cancellationToken">Cancels emission when the consumer goes away.</param>
-    Task EmitToolCallAsync(string toolCallId, string toolCallName, string argsJson, CancellationToken cancellationToken) =>
+    Task EmitToolCallAsync(string toolCallId, string toolCallName, StreamedToolCallArguments args, CancellationToken cancellationToken) =>
         Task.CompletedTask;
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/StreamedToolCallArguments.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/StreamedToolCallArguments.cs
@@ -1,0 +1,19 @@
+namespace Application.AI.Common.Interfaces;
+
+/// <summary>
+/// A tool call's arguments as streamed to a live client via <see cref="IAgentTurnStreamSink.EmitToolCallAsync"/>.
+/// </summary>
+/// <param name="Json">
+/// The tool call's arguments, serialized as JSON. Always complete, parseable JSON — never
+/// truncated, and never an incremental delta. When <paramref name="Withheld"/> is <see langword="true"/>,
+/// this is the fixed placeholder <c>"{}"</c>, not a partial or truncated version of the real
+/// arguments.
+/// </param>
+/// <param name="Withheld">
+/// <see langword="true"/> when the real arguments were not sent — either because their serialized
+/// length exceeded <c>ToolPayloadRedactor.MaxStreamedToolCallArgsLength</c> (arguments are withheld
+/// whole rather than truncated, since truncating mid-JSON would hand the client invalid data), or
+/// because serialization/redaction itself failed. <see langword="false"/> for a normal call, where
+/// <see cref="Json"/> carries the complete, redacted arguments.
+/// </param>
+public readonly record struct StreamedToolCallArguments(string Json, bool Withheld);

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs
@@ -113,7 +113,10 @@ public sealed class ToolOutputCompressionBehavior<TRequest, TResponse>
         // and tokens included — even when the sanitizer later blocks the response. Redact secrets
         // at this persistence boundary so they never land at rest. ISecretRedactor is idempotent,
         // so the model-visible summary the sanitizer later scans is unaffected by also redacting here.
-        var redactedOutput = _secretRedactor.Redact(toolOutput) ?? toolOutput;
+        // Routed through ToolPayloadRedactor.Redact (not a bare `?? toolOutput`) so a redaction-contract
+        // violation fails loudly instead of silently persisting the raw, unredacted output — the same
+        // fail-closed rule this helper enforces at every other redaction boundary.
+        var redactedOutput = ToolPayloadRedactor.Redact(toolOutput, _secretRedactor);
 
         var reference = await _resultStore.StoreIfLargeAsync(
             sessionId,

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -93,13 +93,28 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
             // which is just as much an exposure point as the streamed SSE frame, so it gets the same
             // generic-message substitution, not just redaction of the raw text.
             var rawPayload = ToolPayloadRedactor.SafeResultText(result);
-            // A redaction-contract violation from _redactor must degrade this trace record, not
-            // abort the chat call this diagnostics middleware is only observing.
-            var trimmedPayload = ToolPayloadRedactor.TryOrFallback(
-                () => ToolPayloadRedactor.RedactAndTruncate(rawPayload, _redactor),
-                _logger,
-                $"[ToolDiag] Failed to redact tool result for CallId={result.CallId}",
-                fallback: "[unavailable]");
+
+            string trimmedPayload;
+            if (rawPayload.Length > ToolPayloadRedactor.MaxStructuralRedactionCeiling)
+            {
+                // Above this size PatternSecretRedactor falls back to its regex-only pass, which
+                // cannot see through the escaped-nested-JSON secret shape #391 closed for smaller
+                // payloads — a 500-char slice of an oversized, only-partially-redacted result could
+                // still contain an unredacted secret persisted to the trace store indefinitely. Same
+                // guard ExecuteAgentTurnCommandHandler.RedactedResultPreview applies to the identical
+                // exposure on the streamed path.
+                trimmedPayload = "[result too large to preview safely]";
+            }
+            else
+            {
+                // A redaction-contract violation from _redactor must degrade this trace record, not
+                // abort the chat call this diagnostics middleware is only observing.
+                trimmedPayload = ToolPayloadRedactor.TryOrFallback(
+                    () => ToolPayloadRedactor.RedactAndTruncate(rawPayload, _redactor),
+                    _logger,
+                    $"[ToolDiag] Failed to redact tool result for CallId={result.CallId}",
+                    fallback: "[unavailable]");
+            }
 
             // Always record the stdout against the matching call id so the
             // observability pipeline can render it on the per-invocation page
@@ -241,7 +256,15 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
             {
                 try
                 {
-                    argsJson = ToolPayloadRedactor.RedactAndTruncate(System.Text.Json.JsonSerializer.Serialize(args), _redactor);
+                    var serialized = System.Text.Json.JsonSerializer.Serialize(args);
+                    // Above the structural-redaction ceiling, PatternSecretRedactor falls back to its
+                    // regex-only pass, which cannot see through the escaped-nested-JSON secret shape
+                    // #391 closed for smaller payloads — a 500-char preview sliced from this path could
+                    // then still contain an unredacted secret. Withhold rather than preview, since this
+                    // path (unlike the streaming path's 16KB ceiling) has no size cap of its own.
+                    argsJson = serialized.Length > ToolPayloadRedactor.MaxStructuralRedactionCeiling
+                        ? "[args too large to preview safely]"
+                        : ToolPayloadRedactor.RedactAndTruncate(serialized, _redactor);
                 }
                 catch (Exception ex)
                 {

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -227,6 +227,15 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
 
             capture?.RecordToolCall(call.Name);
 
+            // Deliberately independent of ExecuteAgentTurnCommandHandler.RedactedArgsJson, which
+            // redacts the same call.Arguments a second time for the streaming SSE path (#389,
+            // investigated and closed as won't-fix): the two values have different truncation
+            // contracts — this one is capped to MaxPayloadSummaryLength for the persisted
+            // observability record, the streamed one is never truncated (only withheld whole above
+            // a size ceiling, since cutting mid-JSON would hand a client invalid data). A shared
+            // cache would have to store the uncapped value and rely on every consumer remembering to
+            // re-cap it — a footgun, not a saving — for a cost (one extra serialize + four redaction
+            // passes per tool call) that is negligible next to an LLM round trip.
             string? argsJson = null;
             if (call.Arguments is { Count: > 0 } args)
             {

--- a/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
@@ -25,7 +25,7 @@ public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
     }
 
     private readonly Func<string, CancellationToken, Task> _onDelta;
-    private readonly Func<string, string, string, CancellationToken, Task>? _onToolCall;
+    private readonly Func<string, string, StreamedToolCallArguments, CancellationToken, Task>? _onToolCall;
     private readonly Func<string, string, CancellationToken, Task>? _onToolCallResult;
 
     /// <summary>
@@ -41,7 +41,7 @@ public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
     /// <param name="onToolCallResult">Invoked with a tool call's result, or <see langword="null"/> to ignore it.</param>
     public AgentTurnStreamSink(
         Func<string, CancellationToken, Task> onDelta,
-        Func<string, string, string, CancellationToken, Task>? onToolCall = null,
+        Func<string, string, StreamedToolCallArguments, CancellationToken, Task>? onToolCall = null,
         Func<string, string, CancellationToken, Task>? onToolCallResult = null)
     {
         ArgumentNullException.ThrowIfNull(onDelta);
@@ -55,8 +55,8 @@ public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
         string.IsNullOrEmpty(delta) ? Task.CompletedTask : _onDelta(delta, cancellationToken);
 
     /// <inheritdoc />
-    public Task EmitToolCallAsync(string toolCallId, string toolCallName, string argsJson, CancellationToken cancellationToken) =>
-        _onToolCall?.Invoke(toolCallId, toolCallName, argsJson, cancellationToken) ?? Task.CompletedTask;
+    public Task EmitToolCallAsync(string toolCallId, string toolCallName, StreamedToolCallArguments args, CancellationToken cancellationToken) =>
+        _onToolCall?.Invoke(toolCallId, toolCallName, args, cancellationToken) ?? Task.CompletedTask;
 
     /// <inheritdoc />
     public Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken) =>

--- a/src/Content/Application/Application.AI.Common/Services/ToolCallOrderingSink.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ToolCallOrderingSink.cs
@@ -1,0 +1,70 @@
+using Application.AI.Common.Interfaces;
+
+namespace Application.AI.Common.Services;
+
+/// <summary>
+/// Per-turn decorator around an <see cref="IAgentTurnStreamSink"/> that enforces the tool-call
+/// ordering invariant structurally, for every caller of the wrapped sink: a
+/// <see cref="EmitToolCallResultAsync"/> call is silently dropped unless a matching
+/// <see cref="EmitToolCallAsync"/> for the same <c>toolCallId</c> already streamed through this
+/// instance, and a duplicate <see cref="EmitToolCallAsync"/> for an id already started is silently
+/// dropped rather than double-emitted (guards a provider connector surfacing the same call twice).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Must be constructed fresh for every turn — never reused across turns, and never held as a
+/// long-lived instance.</strong> The bundle SSE path arms one ambient <see cref="AgentTurnStreamSink"/>
+/// for an entire (potentially multi-turn) run (see <c>BundleRunStreamer</c>), but some provider
+/// connectors number tool-call ids per-turn (e.g. <c>call_0</c>, <c>call_1</c>, resetting each turn).
+/// If this decorator's started-id set lived for the whole run instead of one turn, turn 2's
+/// <c>call_0</c> would look like a duplicate of turn 1's — silently dropping its
+/// <c>TOOL_CALL_START</c> while its result still streamed, reproducing the exact orphaned-result bug
+/// this type exists to prevent. <c>ExecuteAgentTurnCommandHandler.RunStreamingTurnAsync</c> (in
+/// <c>Application.Core</c>) constructs a new instance inside each turn's streaming loop for exactly
+/// this reason.
+/// </para>
+/// <para>
+/// <see cref="EmitToolCallAsync"/> records the id <em>before</em> delegating to the inner sink, so a
+/// transport that only supplied an <c>onToolCallResult</c> callback (and left <c>onToolCall</c> as a
+/// no-op) still correlates correctly — registration does not depend on the inner sink actually doing
+/// anything with the call.
+/// </para>
+/// <para>
+/// Not thread-safe by design, not by oversight: a turn's streaming loop processes updates from one
+/// <c>await foreach</c> sequentially, so the one instance wrapping it is never called concurrently.
+/// </para>
+/// </remarks>
+public sealed class ToolCallOrderingSink : IAgentTurnStreamSink
+{
+    private readonly IAgentTurnStreamSink _inner;
+    private readonly HashSet<string> _startedCallIds = new(StringComparer.Ordinal);
+
+    /// <summary>Wraps <paramref name="inner"/>, enforcing tool-call ordering on every call through this instance.</summary>
+    public ToolCallOrderingSink(IAgentTurnStreamSink inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public Task EmitAsync(string delta, CancellationToken cancellationToken) =>
+        _inner.EmitAsync(delta, cancellationToken);
+
+    /// <inheritdoc />
+    public Task EmitToolCallAsync(string toolCallId, string toolCallName, StreamedToolCallArguments args, CancellationToken cancellationToken)
+    {
+        if (!_startedCallIds.Add(toolCallId))
+            return Task.CompletedTask;
+
+        return _inner.EmitToolCallAsync(toolCallId, toolCallName, args, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken)
+    {
+        if (!_startedCallIds.Contains(toolCallId))
+            return Task.CompletedTask;
+
+        return _inner.EmitToolCallResultAsync(toolCallId, result, cancellationToken);
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -458,9 +458,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			return new StreamedToolCallArguments("{}", Withheld: true);
 		}
 
-		return ToolPayloadRedactor.RedactForStreaming(
-			serialized, redactor, logger,
-			$"Failed to redact streamed tool-call arguments for {call.Name} CallId={call.CallId}");
+		return ToolPayloadRedactor.RedactForStreaming(serialized, redactor, logger, call.Name, call.CallId);
 	}
 
 	/// <summary>
@@ -471,11 +469,20 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// <c>ToolDiagnosticsMiddleware</c> applies before persisting to the trace store a dashboard later
 	/// renders, since that is just as much an exposure point as this client-facing SSE frame. A
 	/// redaction-contract violation from <paramref name="redactor"/> degrades the same way, via
-	/// <see cref="ToolPayloadRedactor.TryOrFallback"/>.
+	/// <see cref="ToolPayloadRedactor.TryOrFallback"/>. Above
+	/// <see cref="ToolPayloadRedactor.MaxStructuralRedactionCeiling"/>, <c>PatternSecretRedactor</c>
+	/// falls back to its regex-only pass, which cannot see through the escaped-nested-JSON secret
+	/// shape #391 closed for smaller payloads — so a 500-char preview sliced from a redact-and-truncate
+	/// call on an oversized result could still contain an unredacted secret. A generic message is
+	/// streamed instead of attempting a preview at all, rather than silently degrading the redaction
+	/// guarantee this method otherwise provides.
 	/// </summary>
 	private static string RedactedResultPreview(FunctionResultContent result, ISecretRedactor? redactor, ILogger logger)
 	{
 		var resultText = ToolPayloadRedactor.SafeResultText(result);
+
+		if (resultText.Length > ToolPayloadRedactor.MaxStructuralRedactionCeiling)
+			return "[result too large to preview safely]";
 
 		return ToolPayloadRedactor.TryOrFallback(
 			() => ToolPayloadRedactor.RedactAndTruncate(resultText, redactor),

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -348,11 +348,13 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// <c>update.Contents</c> stream. Both are redacted via <see cref="ToolPayloadRedactor"/> before
 	/// reaching the sink — the same treatment <c>ToolDiagnosticsMiddleware</c> applies before the
 	/// identical data is persisted, since a live SSE stream is just as much an exposure point for
-	/// secrets as the observability store is. Arguments are redacted only, never truncated —
-	/// <see cref="IAgentTurnStreamSink.EmitToolCallAsync"/> documents its JSON as always complete, and a
-	/// preview-length cap would silently hand a client invalid, unparseable JSON instead; the result
-	/// text has no such contract and gets the same redact-and-truncate preview treatment the middleware
-	/// uses — except when the tool failed, where a generic message is streamed instead of
+	/// secrets as the observability store is. Arguments are redacted, never truncated — truncating
+	/// mid-JSON would silently hand a client invalid, unparseable data — but above
+	/// <see cref="ToolPayloadRedactor.MaxStreamedToolCallArgsLength"/> they are withheld whole instead
+	/// (<see cref="StreamedToolCallArguments.Withheld"/>), since a size cap and a truncation cap are
+	/// not the same thing; the result text has no such contract and gets the same redact-and-truncate
+	/// preview treatment the middleware uses — except when the tool failed, where a generic message is
+	/// streamed instead of
 	/// <see cref="FunctionResultContent.Result"/>'s raw text, since <c>IncludeDetailedErrors</c> bakes
 	/// the exception message into that string (see <see cref="RedactedResultPreview"/>). Usage and
 	/// tool-call capture still flow through the chat-client middleware, so the caller's post-turn
@@ -368,26 +370,23 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		CancellationToken cancellationToken)
 	{
 		var builder = new StringBuilder();
-		// Tracks which CallIds actually got a TOOL_CALL_START streamed — two jobs. (1) A matching
-		// result can't stream on its own merits (a non-empty CallId) alone: a call skipped for missing
-		// Name but carrying a valid CallId would otherwise leave its result to stream unmatched, a
-		// TOOL_CALL_RESULT with no preceding TOOL_CALL_START a client could place. (2) A provider
-		// connector that surfaces the same call twice must not double-emit a START/ARGS/END triple —
-		// HashSet.Add's bool return doubles as that guard. Deliberately scoped to this one call — the
-		// invariant it enforces is local to a single turn's stream, not something a second
-		// IAgentTurnStreamSink elsewhere in the codebase needs to share.
-		var startedCallIds = new HashSet<string>();
+		// Wraps the ambient sink for the lifetime of this one turn only — never held past this method
+		// or reused across turns. See ToolCallOrderingSink's remarks for why per-turn construction
+		// (not, say, wrapping once per run) is load-bearing: some providers reuse simple call ids
+		// across turns, and a wrapper that lived longer than one turn would misidentify a reused id as
+		// a duplicate.
+		var orderedSink = new ToolCallOrderingSink(sink);
 		await foreach (var update in agent.RunStreamingAsync(messages, cancellationToken: cancellationToken))
 		{
 			var delta = update.Text;
 			if (!string.IsNullOrEmpty(delta))
 			{
 				builder.Append(delta);
-				await sink.EmitAsync(delta, cancellationToken);
+				await orderedSink.EmitAsync(delta, cancellationToken);
 			}
 
 			foreach (var content in update.Contents)
-				await EmitToolCallActivityAsync(content, sink, startedCallIds, redactor, logger, cancellationToken);
+				await EmitToolCallActivityAsync(content, orderedSink, redactor, logger, cancellationToken);
 		}
 
 		return builder.ToString();
@@ -397,12 +396,15 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// Handles one item from a streaming update's <c>Contents</c> — a tool-call decision or a tool's
 	/// result — forwarding it to <paramref name="sink"/> when it's one of the two content types this
 	/// stream cares about. Extracted from <see cref="RunStreamingTurnAsync"/> to keep that method under
-	/// the 50-line convention.
+	/// the 50-line convention. <paramref name="sink"/> is expected to be a
+	/// <see cref="ToolCallOrderingSink"/> (or another sink honoring the same ordering contract), so this
+	/// method applies only the semantic guards a well-formed frame requires — a non-empty
+	/// <c>CallId</c>, and a non-empty <c>Name</c> for the call side — and leaves duplicate-start and
+	/// orphaned-result enforcement to the sink.
 	/// </summary>
 	private static async Task EmitToolCallActivityAsync(
 		AIContent content,
 		IAgentTurnStreamSink sink,
-		HashSet<string> startedCallIds,
 		ISecretRedactor? redactor,
 		ILogger logger,
 		CancellationToken cancellationToken)
@@ -412,18 +414,14 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			// Guards on both CallId and Name: a call with no id can't be matched to its later
 			// result (an empty toolCallId would violate the wire contract's required field), and
 			// a call with no name has nothing meaningful to announce.
-			// startedCallIds.Add returning false means this CallId already started — a provider
-			// connector surfacing the same call twice must not double-emit a TOOL_CALL_START/ARGS/END
-			// triple to the client.
-			case FunctionCallContent { CallId.Length: > 0 } call when !string.IsNullOrEmpty(call.Name) && startedCallIds.Add(call.CallId):
+			case FunctionCallContent { CallId.Length: > 0 } call when !string.IsNullOrEmpty(call.Name):
 				await sink.EmitToolCallAsync(
 					call.CallId, call.Name, RedactedArgsJson(call, redactor, logger), cancellationToken);
 				break;
 
-			// Guards on CallId AND on having actually streamed a matching TOOL_CALL_START — a
-			// non-empty CallId alone isn't enough, since the call side can be skipped (e.g. empty
-			// Name) while still carrying a CallId this result shares.
-			case FunctionResultContent { CallId.Length: > 0 } result when startedCallIds.Contains(result.CallId):
+			// A non-empty CallId is the only guard needed here — the sink itself drops a result with
+			// no matching preceding TOOL_CALL_START (e.g. a call skipped above for an empty Name).
+			case FunctionResultContent { CallId.Length: > 0 } result:
 				await sink.EmitToolCallResultAsync(
 					result.CallId, RedactedResultPreview(result, redactor, logger), cancellationToken);
 				break;
@@ -432,21 +430,37 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 
 	/// <summary>
 	/// Serializes and redacts a tool call's arguments for streaming. An unserializable argument value
-	/// (an unsupported CLR type from a poorly-behaved tool), or a redaction-contract violation from
-	/// <paramref name="redactor"/>, must degrade to a logged warning via
-	/// <see cref="ToolPayloadRedactor.TryOrFallback"/>, not abort the whole turn — text already
-	/// streamed to the client before this tool call must not be thrown away over either failure.
+	/// (an unsupported CLR type from a poorly-behaved tool) must degrade to a withheld result, not
+	/// abort the whole turn — text already streamed to the client before this tool call must not be
+	/// thrown away over it. Redaction failure and the size ceiling are both handled by
+	/// <see cref="ToolPayloadRedactor.RedactForStreaming"/>, which this method shares with
+	/// <c>AgUiClientToolBridge</c>'s identical need on the AG-UI client round-trip transport.
+	/// Deliberately independent of <c>ToolDiagnosticsMiddleware.LogToolCallsInResponse</c>, which
+	/// redacts the same <see cref="FunctionCallContent.Arguments"/> a second time for the persisted
+	/// observability record (#389, investigated and closed as won't-fix) — see that method's comment
+	/// for why.
 	/// </summary>
-	private static string RedactedArgsJson(FunctionCallContent call, ISecretRedactor? redactor, ILogger logger)
+	private static StreamedToolCallArguments RedactedArgsJson(FunctionCallContent call, ISecretRedactor? redactor, ILogger logger)
 	{
 		if (call.Arguments is not { Count: > 0 } args)
-			return "{}";
+			return new StreamedToolCallArguments("{}", Withheld: false);
 
-		return ToolPayloadRedactor.TryOrFallback(
-			() => ToolPayloadRedactor.Redact(JsonSerializer.Serialize(args), redactor),
-			logger,
-			$"Failed to serialize or redact streamed tool-call arguments for {call.Name} CallId={call.CallId}",
-			fallback: "{}");
+		string serialized;
+		try
+		{
+			serialized = JsonSerializer.Serialize(args);
+		}
+		catch (Exception ex)
+		{
+			logger.LogWarning(ex,
+				"Failed to serialize streamed tool-call arguments for {ToolName} CallId={CallId}",
+				call.Name, call.CallId);
+			return new StreamedToolCallArguments("{}", Withheld: true);
+		}
+
+		return ToolPayloadRedactor.RedactForStreaming(
+			serialized, redactor, logger,
+			$"Failed to redact streamed tool-call arguments for {call.Name} CallId={call.CallId}");
 	}
 
 	/// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
@@ -298,7 +298,17 @@ public sealed class PatternSecretRedactor : ISecretRedactor
     // set is expected to keep growing. None of today's patterns has a super-linear backtracking path,
     // but a timeout is cheap insurance that a future addition can't turn a large tool result into a
     // CPU stall on the request thread.
-    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+    //
+    // 100ms was too tight in practice: reproduced RegexMatchTimeoutException on a 20-CHARACTER input
+    // ("AccountKey=[REDACTED]") under nothing more exotic than a full-solution parallel test run —
+    // CPU scheduling contention alone, not backtracking, pushed a trivial match past the deadline.
+    // RegexMatchTimeoutException propagates uncaught from RedactFreeText (the regex-only path has no
+    // exception handling of its own — see Redact's fail-loud contract), so a timeout this tight risks
+    // throwing out of every caller under ordinary production load, not just synthetic pathological
+    // input. 2 seconds still bounds a genuinely catastrophic pattern (today's patterns would need
+    // orders of magnitude worse backtracking to approach even the old 100ms) while sitting far clear
+    // of realistic scheduling jitter.
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromSeconds(2);
 
     // Keys covered by both the JSON-quoted pattern and the generic key=value/key:value pattern below —
     // kept as one shared alternation so the two patterns can't drift out of sync (a key redacted in one

--- a/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using Application.AI.Common.Interfaces;
 using Domain.Common.Config.MetaHarness;
@@ -50,17 +52,200 @@ public sealed class PatternSecretRedactor : ISecretRedactor
         _redactionPatterns = Array.AsReadOnly(BuildRedactionPatterns());
     }
 
+    /// <summary>
+    /// Above this length the structural JSON pass in <see cref="Redact"/> is skipped in favor of the
+    /// regex-only fallback. <see cref="Redact"/> is called on tool outputs specifically <em>above</em>
+    /// a token-compression threshold (see <c>ToolOutputCompressionBehavior</c>), so nothing bounds
+    /// how large an input reaches this method — parsing an unbounded payload into a full
+    /// <see cref="JsonNode"/> tree on that path would trade a bounded regex scan for unbounded
+    /// allocation. Payloads above this size keep only regex-based protection: a secret escaped inside
+    /// nested JSON in a payload this large goes unredacted by the structural pass, but every
+    /// unescaped/URL-embedded shape the regex patterns already cover is still caught.
+    /// </summary>
+    private const int MaxStructuralRedactionLength = 64 * 1024;
+
+    /// <summary>
+    /// How many levels of "a string value that is itself JSON" <see cref="RedactNode"/> will parse
+    /// and recurse into. Bounds work against adversarial input (a string containing a JSON-escaped
+    /// string containing a JSON-escaped string, arbitrarily deep) — real tool payloads nest at most
+    /// one level (a request body serialized as a string field), so 2 is generous headroom, not a
+    /// tight fit.
+    /// </summary>
+    private const int MaxEmbeddedJsonDepth = 2;
+
+    private static readonly JsonDocumentOptions StructuralParseOptions = new() { MaxDepth = 32 };
+
     /// <inheritdoc />
+    /// <remarks>
+    /// When <paramref name="input"/> looks like JSON (starts with <c>{</c> or <c>[</c>, after
+    /// trimming) and is under <see cref="MaxStructuralRedactionLength"/>, redaction walks the parsed
+    /// structure instead of scanning the raw text: a value whose parent key names a secret is
+    /// replaced outright, and a string value that is itself JSON (the escaped-nested-payload shape,
+    /// e.g. a request body serialized as a string field, up to <see cref="MaxEmbeddedJsonDepth"/>
+    /// levels deep) is recursively parsed and redacted the same way. This closes the gap the
+    /// regex-only pass cannot: a key/value pair whose surrounding quotes are escaped
+    /// (<c>\"api_key\":\"secret\"</c>) never matches a pattern written for the unescaped shape. Every
+    /// leaf string — JSON or not — still runs through the regex passes below, so free-text secrets
+    /// embedded in an otherwise ordinary value (a token in a URL query string) are still caught.
+    /// Falls back to the regex-only pass for non-JSON input, oversized input, or input that merely
+    /// looks like JSON but fails to parse (unchanged from before this pass existed).
+    /// </remarks>
     public string? Redact(string? input)
     {
         if (string.IsNullOrEmpty(input))
             return input;
 
+        if (!LooksLikeJson(input) || input.Length > MaxStructuralRedactionLength)
+            return RedactFreeText(input);
+
+        JsonNode? node;
+        try
+        {
+            node = JsonNode.Parse(input, documentOptions: StructuralParseOptions);
+        }
+        catch (JsonException)
+        {
+            return RedactFreeText(input);
+        }
+
+        var (changed, redacted) = RedactNode(node, depth: 0);
+        // Only re-serialize when something was actually redacted — otherwise a JSON payload with no
+        // secrets would be silently reformatted (whitespace normalized, non-ASCII escaped by the
+        // default encoder) on every call, which is unnecessary churn and breaks the "return the
+        // original reference when nothing matched" no-allocation guarantee this method documents.
+        return changed ? redacted!.ToJsonString() : input;
+    }
+
+    /// <summary>
+    /// Cheap pre-check before attempting a JSON parse: does the trimmed input start with an object or
+    /// array opener? Exception-driven control flow (attempting <see cref="JsonNode"/>.Parse on every
+    /// plain-text log line or config value just to catch the failure) costs far more than the regex
+    /// passes this structural pass exists to supplement, so ordinary non-JSON input is rejected with
+    /// a character comparison instead of a parse attempt.
+    /// </summary>
+    private static bool LooksLikeJson(string input)
+    {
+        var trimmed = input.AsSpan().Trim();
+        return trimmed.Length > 0 && (trimmed[0] == '{' || trimmed[0] == '[');
+    }
+
+    /// <summary>
+    /// Applies the free-text regex pattern set to <paramref name="input"/>. This is the entire
+    /// pre-JSON-aware behavior of <see cref="Redact"/>, extracted so it can serve both as the
+    /// fallback for non-JSON/oversized input and as the leaf-level scan <see cref="RedactNode"/> runs
+    /// over each JSON string value.
+    /// </summary>
+    private string RedactFreeText(string input)
+    {
         var result = input;
         foreach (var (pattern, replacement) in _redactionPatterns)
             result = pattern.Replace(result, replacement);
-
         return result;
+    }
+
+    /// <summary>
+    /// Recursively redacts a parsed JSON node — dispatches to the shape-specific helper for an
+    /// object, array, or string leaf; a number/bool/null leaf is left untouched.
+    /// </summary>
+    /// <returns>
+    /// Whether anything in the subtree changed, and the (possibly same, possibly replaced) node.
+    /// </returns>
+    private (bool Changed, JsonNode? Node) RedactNode(JsonNode? node, int depth) => node switch
+    {
+        JsonObject obj => RedactObject(obj, depth),
+        JsonArray array => RedactArray(array, depth),
+        JsonValue value when value.TryGetValue<string>(out var text) => RedactStringLeaf(value, text, depth),
+        _ => (false, node),
+    };
+
+    /// <summary>
+    /// A property whose key names a secret (<see cref="IsSecretKeyName"/>) has its value replaced
+    /// with <c>"[REDACTED]"</c> — unless it is already exactly that placeholder, in which case it is
+    /// left alone so an already-redacted document reports no change; every other property is
+    /// recursed into via <see cref="RedactNode"/>.
+    /// </summary>
+    private (bool Changed, JsonNode? Node) RedactObject(JsonObject obj, int depth)
+    {
+        var changed = false;
+        // ToArray() first: mutating a JsonObject's values in place while enumerating it throws,
+        // since JsonObject is itself the enumerable being walked.
+        foreach (var (key, value) in obj.ToArray())
+        {
+            if (IsSecretKeyName(key))
+            {
+                if (value is JsonValue existing && existing.TryGetValue<string>(out var existingText)
+                    && existingText == "[REDACTED]")
+                    continue;
+
+                obj[key] = JsonValue.Create("[REDACTED]");
+                changed = true;
+            }
+            else
+            {
+                var (childChanged, childNode) = RedactNode(value, depth);
+                if (childChanged)
+                {
+                    changed = true;
+                    // An object/array child that changed was mutated in place (RedactNode returns
+                    // the SAME instance for those cases) and is therefore still correctly parented
+                    // under obj — reassigning it to its own slot throws "the node already has a
+                    // parent". Only a genuinely new node (the JsonValue leaf-replacement case) needs
+                    // to be written back.
+                    if (!ReferenceEquals(childNode, value))
+                        obj[key] = childNode;
+                }
+            }
+        }
+        return (changed, obj);
+    }
+
+    /// <summary>Each element is recursed into positionally via <see cref="RedactNode"/>.</summary>
+    private (bool Changed, JsonNode? Node) RedactArray(JsonArray array, int depth)
+    {
+        var changed = false;
+        for (var i = 0; i < array.Count; i++)
+        {
+            var existingElement = array[i];
+            var (childChanged, childNode) = RedactNode(existingElement, depth);
+            if (childChanged)
+            {
+                changed = true;
+                if (!ReferenceEquals(childNode, existingElement))
+                    array[i] = childNode;
+            }
+        }
+        return (changed, array);
+    }
+
+    /// <summary>
+    /// A string leaf that itself looks like and parses as JSON is redacted recursively and
+    /// re-serialized back into the string slot (the escaped-nested-payload case), up to
+    /// <paramref name="depth"/> reaching <see cref="MaxEmbeddedJsonDepth"/>; any other string leaf is
+    /// scanned via <see cref="RedactFreeText"/>.
+    /// </summary>
+    private (bool Changed, JsonNode? Node) RedactStringLeaf(JsonValue value, string text, int depth)
+    {
+        if (depth < MaxEmbeddedJsonDepth && LooksLikeJson(text))
+        {
+            JsonNode? nested;
+            try
+            {
+                nested = JsonNode.Parse(text, documentOptions: StructuralParseOptions);
+            }
+            catch (JsonException)
+            {
+                nested = null;
+            }
+
+            if (nested is not null)
+            {
+                var (childChanged, childNode) = RedactNode(nested, depth + 1);
+                return childChanged ? (true, JsonValue.Create(childNode!.ToJsonString())) : (false, value);
+            }
+        }
+
+        var redactedText = RedactFreeText(text);
+        return redactedText == text ? (false, value) : (true, JsonValue.Create(redactedText));
     }
 
     /// <inheritdoc />
@@ -90,6 +275,17 @@ public sealed class PatternSecretRedactor : ISecretRedactor
     private const string SecretKeyAlternation =
         "api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd|" +
         "account[_-]?key|shared[_-]?access[_-]?key|connection[_-]?string|sas[_-]?token";
+
+    // Anchored (whole-key) match for the structural JSON walk in RedactNode — deliberately distinct
+    // from IsSecretKey/_denylistPatterns, which is a separate, config-driven, substring-match
+    // denylist used only for filtering config-snapshot keys. Conflating the two would change
+    // IsSecretKey's contract for its existing callers. Built once from the same SecretKeyAlternation
+    // the free-text patterns use, so a JSON object key and the equivalent free-text "key=value" shape
+    // can never redact one and miss the other.
+    private static readonly Regex SecretKeyNameRegex = new(
+        $"^(?:{SecretKeyAlternation})$", RegexOptions.Compiled | RegexOptions.IgnoreCase, MatchTimeout);
+
+    private static bool IsSecretKeyName(string key) => SecretKeyNameRegex.IsMatch(key);
 
     private static (Regex Pattern, string Replacement)[] BuildRedactionPatterns() =>
     [

--- a/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Security/PatternSecretRedactor.cs
@@ -60,7 +60,11 @@ public sealed class PatternSecretRedactor : ISecretRedactor
     /// <see cref="JsonNode"/> tree on that path would trade a bounded regex scan for unbounded
     /// allocation. Payloads above this size keep only regex-based protection: a secret escaped inside
     /// nested JSON in a payload this large goes unredacted by the structural pass, but every
-    /// unescaped/URL-embedded shape the regex patterns already cover is still caught.
+    /// unescaped/URL-embedded shape the regex patterns already cover is still caught. Mirrored as
+    /// <c>ToolPayloadRedactor.MaxStructuralRedactionCeiling</c> (Application layer) so a caller with
+    /// no size cap of its own — <c>ToolDiagnosticsMiddleware</c>'s persisted-record path — can
+    /// withhold rather than preview a payload this large, instead of risking an unredacted secret in
+    /// what it persists. Keep the two values in sync if either changes.
     /// </summary>
     private const int MaxStructuralRedactionLength = 64 * 1024;
 
@@ -108,7 +112,29 @@ public sealed class PatternSecretRedactor : ISecretRedactor
             return RedactFreeText(input);
         }
 
-        var (changed, redacted) = RedactNode(node, depth: 0);
+        bool changed;
+        JsonNode? redacted;
+        try
+        {
+            (changed, redacted) = RedactNode(node, depth: 0);
+        }
+        catch (Exception ex) when (ex is ArgumentException or RegexMatchTimeoutException)
+        {
+            // Two independent risks the walk can hit, both handled the same way — degrade to the
+            // regex-only pass rather than let a redaction attempt throw uncaught:
+            //  - ArgumentException: duplicate property names are legal JSON (RFC 8259) that
+            //    JsonNode.Parse tolerates but JsonObject's dictionary backing rejects the moment it's
+            //    materialized (RedactObject's ToArray() call) — a genuinely third-party-controlled
+            //    shape (an MCP server or HTTP tool response), not something to fail the caller over.
+            //  - RegexMatchTimeoutException: RedactStringLeaf's RedactFreeText call scans every JSON
+            //    string leaf against every pattern in _redactionPatterns, each with its own
+            //    MatchTimeout — a large tree has many leaves, so the walk's aggregate exposure to a
+            //    single pathological leaf tripping a timeout is real, where the single flat scan this
+            //    pass supplements only ever risked it once per Redact() call.
+            // Regex-only still redacts what it can either way.
+            return RedactFreeText(input);
+        }
+
         // Only re-serialize when something was actually redacted — otherwise a JSON payload with no
         // secrets would be silently reformatted (whitespace normalized, non-ASCII escaped by the
         // default encoder) on every call, which is unnecessary churn and breaks the "return the
@@ -117,16 +143,21 @@ public sealed class PatternSecretRedactor : ISecretRedactor
     }
 
     /// <summary>
-    /// Cheap pre-check before attempting a JSON parse: does the trimmed input start with an object or
-    /// array opener? Exception-driven control flow (attempting <see cref="JsonNode"/>.Parse on every
-    /// plain-text log line or config value just to catch the failure) costs far more than the regex
-    /// passes this structural pass exists to supplement, so ordinary non-JSON input is rejected with
-    /// a character comparison instead of a parse attempt.
+    /// Cheap pre-check before attempting a JSON parse: does the trimmed input start with an object,
+    /// array, or string opener? The string case matters as much as the other two: a tool's result (or
+    /// a request-body value serialized as a string field) that is itself a JSON-encoded string —
+    /// <c>"{\"api_key\":\"sk-1\"}"</c>, exactly what <c>JsonSerializer.Serialize(someString)</c>
+    /// produces — parses as a <see cref="JsonValue"/> whose text is the nested document; without this
+    /// case that whole document is treated as plain text and only the regex-only fallback ever sees
+    /// it. Exception-driven control flow (attempting <see cref="JsonNode"/>.Parse on every plain-text
+    /// log line or config value just to catch the failure) costs far more than the regex passes this
+    /// structural pass exists to supplement, so ordinary non-JSON input is rejected with a character
+    /// comparison instead of a parse attempt.
     /// </summary>
     private static bool LooksLikeJson(string input)
     {
         var trimmed = input.AsSpan().Trim();
-        return trimmed.Length > 0 && (trimmed[0] == '{' || trimmed[0] == '[');
+        return trimmed.Length > 0 && (trimmed[0] == '{' || trimmed[0] == '[' || trimmed[0] == '"');
     }
 
     /// <summary>
@@ -271,21 +302,30 @@ public sealed class PatternSecretRedactor : ISecretRedactor
 
     // Keys covered by both the JSON-quoted pattern and the generic key=value/key:value pattern below —
     // kept as one shared alternation so the two patterns can't drift out of sync (a key redacted in one
-    // shape but not the other was exactly the bug that motivated this constant).
+    // shape but not the other was exactly the bug that motivated this constant). Extended (security
+    // review on #391/#392) after measuring that common real-world secret key names were missing:
+    // x-api-key, refresh/id/bearer tokens, private/secret-access keys, authorization, credentials,
+    // passphrases, and subscription-key headers (Ocp-Apim-Subscription-Key) all passed through
+    // unredacted before this list included them.
     private const string SecretKeyAlternation =
-        "api[_-]?key|access[_-]?token|secret[_-]?key|client[_-]?secret|password|pwd|" +
-        "account[_-]?key|shared[_-]?access[_-]?key|connection[_-]?string|sas[_-]?token";
+        "api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|bearer[_-]?token|token|" +
+        "secret[_-]?key|secret[_-]?access[_-]?key|client[_-]?secret|private[_-]?key|secret|" +
+        "password|pwd|passphrase|credentials?|authorization|auth[_-]?token|" +
+        "account[_-]?key|shared[_-]?access[_-]?key|connection[_-]?string|sas[_-]?token|" +
+        "subscription[_-]?key|x[_-]api[_-]key|ocp[_-]apim[_-]subscription[_-]key";
 
     // Anchored (whole-key) match for the structural JSON walk in RedactNode — deliberately distinct
     // from IsSecretKey/_denylistPatterns, which is a separate, config-driven, substring-match
     // denylist used only for filtering config-snapshot keys. Conflating the two would change
     // IsSecretKey's contract for its existing callers. Built once from the same SecretKeyAlternation
     // the free-text patterns use, so a JSON object key and the equivalent free-text "key=value" shape
-    // can never redact one and miss the other.
+    // can never redact one and miss the other. The key is trimmed before matching — a key with
+    // incidental leading/trailing whitespace (a sloppily-serialized tool argument) is still exactly
+    // "api_key" as far as an attacker or a careless tool author is concerned.
     private static readonly Regex SecretKeyNameRegex = new(
         $"^(?:{SecretKeyAlternation})$", RegexOptions.Compiled | RegexOptions.IgnoreCase, MatchTimeout);
 
-    private static bool IsSecretKeyName(string key) => SecretKeyNameRegex.IsMatch(key);
+    private static bool IsSecretKeyName(string key) => SecretKeyNameRegex.IsMatch(key.Trim());
 
     private static (Regex Pattern, string Replacement)[] BuildRedactionPatterns() =>
     [
@@ -332,10 +372,15 @@ public sealed class PatternSecretRedactor : ISecretRedactor
         // The separator is captured (not hardcoded) so the replacement preserves whichever of "=" or
         // ":" the input actually used, rather than silently rewriting "api_key: value" into
         // "api_key=value" and potentially invalidating the surrounding document.
-        // Negative lookahead (?!\[REDACTED\]) ensures idempotency.
+        // Negative lookahead (?!\[REDACTED\]) ensures idempotency. A second negative lookahead,
+        // (?!Bearer\s), defers to the Bearer-token pattern above for a value shaped "Bearer <token>" —
+        // added when SecretKeyAlternation grew "authorization"/"auth_token": without it, this pattern's
+        // unquoted-value branch (which stops at the first whitespace) matched just the word "Bearer" as
+        // the "value" for a key like "Authorization", corrupting "Authorization: Bearer [REDACTED]"
+        // (correctly redacted by the pattern above) into "Authorization: [REDACTED] [REDACTED]".
         (
             new Regex(
-                $@"(?i)({SecretKeyAlternation})(\s*[=:]\s*)(?!\[REDACTED\])(?:""[^""]*""|'[^']*'|[^;""'\s]+)",
+                $@"(?i)({SecretKeyAlternation})(\s*[=:]\s*)(?!\[REDACTED\])(?!Bearer\s)(?:""[^""]*""|'[^']*'|[^;""'\s]+)",
                 RegexOptions.Compiled, MatchTimeout),
             "$1$2[REDACTED]"
         ),

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Tools;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -34,15 +36,22 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
     private readonly IConversationStore _conversationStore;
     private readonly ClientWidgetCatalog _widgetCatalog;
     private readonly ILogger<AgUiClientToolBridge> _logger;
+    private readonly ISecretRedactor? _redactor;
 
     /// <summary>Initializes a new <see cref="AgUiClientToolBridge"/>.</summary>
+    /// <param name="redactor">
+    /// Optional secret redactor applied to tool-call arguments before they stream to the browser or
+    /// get persisted as a widget message — the same treatment the bundle SSE path
+    /// (<c>ExecuteAgentTurnCommandHandler</c>) applies, since this is an equally live exposure point.
+    /// </param>
     public AgUiClientToolBridge(
         IAgUiEventWriterAccessor writerAccessor,
         PendingToolCallRegistry registry,
         IOptionsMonitor<AgentHubConfig> config,
         IConversationStore conversationStore,
         ClientWidgetCatalog widgetCatalog,
-        ILogger<AgUiClientToolBridge> logger)
+        ILogger<AgUiClientToolBridge> logger,
+        ISecretRedactor? redactor = null)
     {
         _writerAccessor = writerAccessor;
         _registry = registry;
@@ -50,6 +59,7 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
         _conversationStore = conversationStore;
         _widgetCatalog = widgetCatalog;
         _logger = logger;
+        _redactor = redactor;
     }
 
     /// <inheritdoc />
@@ -81,8 +91,17 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
         // ahead of the pending entry, and so only a caller who owns this thread can complete it.
         var resultTask = _registry.RegisterAsync(callId, threadId, timeout, cancellationToken);
 
+        // Redacted and size-capped the same way the bundle SSE path treats streamed tool-call
+        // arguments (ExecuteAgentTurnCommandHandler.RedactedArgsJson) — this is an equally live
+        // client-facing exposure point, just on a different transport. The redacted (not raw) value
+        // also feeds the widget persisted below, so a reload never surfaces a secret the live stream
+        // withheld.
+        var streamedArgs = RedactAndCapArguments(toolName, callId, argumentsJson);
+
         await writer.WriteAsync(new ToolCallStartEvent(callId, toolName), cancellationToken).ConfigureAwait(false);
-        await writer.WriteAsync(new ToolCallArgsEvent(callId, argumentsJson ?? "{}"), cancellationToken).ConfigureAwait(false);
+        await writer.WriteAsync(
+            new ToolCallArgsEvent(callId, streamedArgs.Json, streamedArgs.Withheld ? true : null),
+            cancellationToken).ConfigureAwait(false);
         await writer.WriteAsync(new ToolCallEndEvent(callId), cancellationToken).ConfigureAwait(false);
 
         var result = await resultTask.ConfigureAwait(false);
@@ -94,10 +113,22 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
         // final assistant-text append, so the widget lands in the right position. A persistence failure
         // must not break the turn, so it is logged and swallowed.
         if (_widgetCatalog.IsWidget(toolName))
-            await PersistWidgetAsync(threadId, callerId, toolName, argumentsJson, cancellationToken).ConfigureAwait(false);
+            await PersistWidgetAsync(threadId, callerId, toolName, streamedArgs.Json, cancellationToken).ConfigureAwait(false);
 
         return result;
     }
+
+    /// <summary>
+    /// Redacts and size-caps <paramref name="argumentsJson"/> via
+    /// <see cref="ToolPayloadRedactor.RedactForStreaming"/> — the same helper
+    /// <c>ExecuteAgentTurnCommandHandler</c> uses for the bundle SSE path, so a redaction failure or
+    /// an oversized payload withholds the arguments here exactly the same way it does there, rather
+    /// than the two transports drifting to different failure behavior.
+    /// </summary>
+    private StreamedToolCallArguments RedactAndCapArguments(string toolName, string callId, string? argumentsJson) =>
+        ToolPayloadRedactor.RedactForStreaming(
+            argumentsJson ?? "{}", _redactor, _logger,
+            $"Failed to redact client tool-call arguments for {toolName} CallId={callId}");
 
     /// <summary>
     /// Appends an assistant message carrying the widget spec (empty text, so it renders as the widget

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiClientToolBridge.cs
@@ -111,8 +111,11 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
         // disconnected round-trip that never displayed the widget throws above, so we do not leave a
         // phantom that reappears on reload contradicting the agent. This still precedes the run handler's
         // final assistant-text append, so the widget lands in the right position. A persistence failure
-        // must not break the turn, so it is logged and swallowed.
-        if (_widgetCatalog.IsWidget(toolName))
+        // must not break the turn, so it is logged and swallowed. Skipped entirely when withheld: the
+        // live widget never rendered real arguments (streamedArgs.Json is the "{}" placeholder), so
+        // persisting it would reload as a widget with no signal that its arguments were withheld — the
+        // exact confusion useAgentStream.ts/useDashboardAgent.ts were changed to prevent on the live path.
+        if (_widgetCatalog.IsWidget(toolName) && !streamedArgs.Withheld)
             await PersistWidgetAsync(threadId, callerId, toolName, streamedArgs.Json, cancellationToken).ConfigureAwait(false);
 
         return result;
@@ -126,9 +129,7 @@ public sealed class AgUiClientToolBridge : IClientToolBridge
     /// than the two transports drifting to different failure behavior.
     /// </summary>
     private StreamedToolCallArguments RedactAndCapArguments(string toolName, string callId, string? argumentsJson) =>
-        ToolPayloadRedactor.RedactForStreaming(
-            argumentsJson ?? "{}", _redactor, _logger,
-            $"Failed to redact client tool-call arguments for {toolName} CallId={callId}");
+        ToolPayloadRedactor.RedactForStreaming(argumentsJson ?? "{}", _redactor, _logger, toolName, callId);
 
     /// <summary>
     /// Appends an assistant message carrying the widget spec (empty text, so it renders as the widget

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs
@@ -25,13 +25,21 @@ public sealed record ToolCallStartEvent(
 /// <summary>
 /// A streaming arguments chunk (delta) for an in-progress tool call. The full argument
 /// payload is assembled by concatenating all <see cref="Delta"/> values for the same
-/// <see cref="ToolCallId"/>. The blocking proxy emits the arguments as a single JSON delta.
+/// <see cref="ToolCallId"/>. The blocking proxy emits the arguments as a single JSON delta —
+/// unless <see cref="Withheld"/> is true, in which case <see cref="Delta"/> is the fixed
+/// placeholder <c>"{}"</c> because the real arguments exceeded the streaming size ceiling.
 /// </summary>
 public sealed record ToolCallArgsEvent(
     /// <summary>The tool call these arguments belong to.</summary>
     [property: JsonPropertyName("toolCallId")] string ToolCallId,
-    /// <summary>The incremental arguments text (JSON) to append to the call's argument buffer.</summary>
-    [property: JsonPropertyName("delta")] string Delta
+    /// <summary>The incremental arguments text (JSON) to append to the call's argument buffer, or <c>"{}"</c> if withheld.</summary>
+    [property: JsonPropertyName("delta")] string Delta,
+    /// <summary>
+    /// <see langword="true"/> when the real arguments were withheld for exceeding the size ceiling.
+    /// Nullable, and only ever constructed as <see langword="true"/> or <see langword="null"/> — never
+    /// <see langword="false"/> — so the field is omitted from the wire on every normal frame.
+    /// </summary>
+    [property: JsonPropertyName("withheld")] bool? Withheld = null
 ) : AgUiEvent;
 
 /// <summary>

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.test.tsx
@@ -149,6 +149,24 @@ describe('useDashboardAgent', () => {
     expect(useChatStore.getState().error).toBe('boom');
   });
 
+  it('never dispatches the dashboard action when the server withholds oversized arguments', async () => {
+    runWith([
+      { type: EventType.TOOL_CALL_START, toolCallId: 'call-w', toolCallName: 'dashboard_control' },
+      { type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-w', delta: '{}', withheld: true },
+      { type: EventType.TOOL_CALL_END, toolCallId: 'call-w' },
+    ]);
+
+    const { result } = renderHook(() => useDashboardAgent());
+    await act(async () => {
+      await result.current.sendMessage('do something huge');
+    });
+
+    await waitFor(() =>
+      expect(postToolResult).toHaveBeenCalledWith('thread-1', 'call-w', expect.stringContaining('withheld')),
+    );
+    expect(dispatchDashboardAction).not.toHaveBeenCalled();
+  });
+
   it('ignores empty input and does not start a run', async () => {
     const { result } = renderHook(() => useDashboardAgent());
     await act(async () => {

--- a/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/hooks/useDashboardAgent.ts
@@ -19,6 +19,10 @@ const RENDER_CHART = 'render_chart';
 interface PendingCall {
   name: string;
   args: string;
+  /** True once a TOOL_CALL_ARGS frame arrived with `withheld: true` — the real arguments exceeded
+   *  the server's streaming size ceiling and were never sent, so `args` is not "{}" as the real
+   *  (empty) arguments, it is a placeholder that must not be parsed and acted on as such. */
+  withheld: boolean;
 }
 
 /** Executes a `dashboard_control` call and returns the result string the agent should observe. */
@@ -82,6 +86,10 @@ export function useDashboardAgent() {
     let result: string;
     if (!pending) {
       result = `No client handler matched tool call ${callId}.`;
+    } else if (pending.withheld) {
+      // The real arguments exceeded the streaming size ceiling and were withheld — "{}" here is a
+      // placeholder, not the tool's real (empty) input, so it must never reach the action runners.
+      result = `The ${pending.name} arguments were too large to stream and were withheld.`;
     } else {
       switch (pending.name) {
         case DASHBOARD_CONTROL:
@@ -122,13 +130,16 @@ export function useDashboardAgent() {
         }
         case EventType.TOOL_CALL_START: {
           const e = event as BaseEvent & { toolCallId: string; toolCallName: string };
-          pendingCallsRef.current.set(e.toolCallId, { name: e.toolCallName, args: '' });
+          pendingCallsRef.current.set(e.toolCallId, { name: e.toolCallName, args: '', withheld: false });
           break;
         }
         case EventType.TOOL_CALL_ARGS: {
-          const e = event as BaseEvent & { toolCallId: string; delta: string };
+          const e = event as BaseEvent & { toolCallId: string; delta: string; withheld?: boolean };
           const pending = pendingCallsRef.current.get(e.toolCallId);
-          if (pending) pending.args += e.delta;
+          if (pending) {
+            if (e.withheld) pending.withheld = true;
+            else pending.args += e.delta;
+          }
           break;
         }
         case EventType.TOOL_CALL_END: {

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleRunStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleRunStreamer.cs
@@ -70,14 +70,16 @@ public sealed class BundleRunStreamer
 
                 await writer.WriteAsync(new BundleTextMessageContentEvent(messageId, delta), ct).ConfigureAwait(false);
             },
-            onToolCall: async (toolCallId, toolCallName, argsJson, ct) =>
+            onToolCall: async (toolCallId, toolCallName, args, ct) =>
             {
                 // The AG-UI wire protocol wants three separate frames; the sink itself only ever
                 // reports one complete tool call, so this is where that single call fans out into
                 // start/args/end — see IAgentTurnStreamSink.EmitToolCallAsync's remarks for why the
                 // seam doesn't carry that split.
                 await writer.WriteAsync(new BundleToolCallStartEvent(toolCallId, toolCallName), ct).ConfigureAwait(false);
-                await writer.WriteAsync(new BundleToolCallArgsEvent(toolCallId, argsJson), ct).ConfigureAwait(false);
+                await writer.WriteAsync(
+                    new BundleToolCallArgsEvent(toolCallId, args.Json, args.Withheld ? true : null),
+                    ct).ConfigureAwait(false);
                 await writer.WriteAsync(new BundleToolCallEndEvent(toolCallId), ct).ConfigureAwait(false);
             },
             onToolCallResult: (toolCallId, result, ct) =>

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
@@ -75,13 +75,25 @@ public sealed record BundleToolCallStartEvent(
 /// Carries a tool call's arguments. Unlike <see cref="BundleTextMessageContentEvent"/>, this is NOT an
 /// incremental delta — the underlying chat-client abstraction only ever exposes a tool call's
 /// arguments once fully assembled, so <see cref="Delta"/> always carries the complete JSON payload in
-/// one frame, immediately followed by <see cref="BundleToolCallEndEvent"/>.
+/// one frame, immediately followed by <see cref="BundleToolCallEndEvent"/>. Unless <see cref="Withheld"/>
+/// is true, in which case <see cref="Delta"/> is the fixed placeholder <c>"{}"</c> — the real arguments
+/// exceeded the streaming size ceiling and were withheld whole rather than truncated (truncating mid-JSON
+/// would hand the client invalid data).
 /// </summary>
 public sealed record BundleToolCallArgsEvent(
     /// <summary>The call this payload belongs to.</summary>
     [property: JsonPropertyName("toolCallId")] string ToolCallId,
-    /// <summary>The tool call's complete arguments, serialized as JSON.</summary>
-    [property: JsonPropertyName("delta")] string Delta) : BundleStreamEvent;
+    /// <summary>The tool call's complete arguments, serialized as JSON, or <c>"{}"</c> if withheld.</summary>
+    [property: JsonPropertyName("delta")] string Delta,
+    /// <summary>
+    /// <see langword="true"/> when the real arguments were withheld for exceeding the size ceiling.
+    /// Nullable, and only ever constructed as <see langword="true"/> or <see langword="null"/> — never
+    /// <see langword="false"/> — so the field is omitted from the wire (via
+    /// <see cref="System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull"/>, the writer's
+    /// existing serializer setting) on every normal frame instead of serializing <c>"withheld":false</c>
+    /// on all of them.
+    /// </summary>
+    [property: JsonPropertyName("withheld")] bool? Withheld = null) : BundleStreamEvent;
 
 /// <summary>Signals that a tool call's arguments are complete.</summary>
 public sealed record BundleToolCallEndEvent(

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useAgentStream.test.tsx
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/__tests__/useAgentStream.test.tsx
@@ -119,4 +119,19 @@ describe('useAgentStream — render_image round-trip', () => {
 
     await waitFor(() => { expect(postToolResult).toHaveBeenCalledWith('conv-1', 'orphan', expect.stringContaining('No client handler')); });
   });
+
+  it('never renders a widget or interprets "{}" as real args when the server withholds oversized arguments', async () => {
+    const events$ = await startRun();
+
+    act(() => {
+      events$.next({ type: EventType.TOOL_CALL_START, toolCallId: 'call-w', toolCallName: 'render_image' });
+      events$.next({ type: EventType.TOOL_CALL_ARGS, toolCallId: 'call-w', delta: '{}', withheld: true });
+      events$.next({ type: EventType.TOOL_CALL_END, toolCallId: 'call-w' });
+    });
+
+    await waitFor(() => {
+      expect(postToolResult).toHaveBeenCalledWith('conv-1', 'call-w', expect.stringContaining('withheld'));
+    });
+    expect(useChatStore.getState().messages.some((m) => m.widget?.type === 'render_image')).toBe(false);
+  });
 });

--- a/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
+++ b/src/Content/Presentation/Presentation.WebUI/src/hooks/useAgentStream.ts
@@ -29,6 +29,10 @@ export interface UseAgentStreamReturn {
 interface PendingCall {
   name: string;
   args: string;
+  /** True once a TOOL_CALL_ARGS frame arrived with `withheld: true` — the real arguments exceeded
+   *  the server's streaming size ceiling and were never sent, so `args` is not "{}" as the real
+   *  (empty) arguments, it is a placeholder that must not be parsed and acted on as such. */
+  withheld: boolean;
 }
 
 /**
@@ -36,11 +40,14 @@ interface PendingCall {
  * renders the widget as an assistant message on success, and returns the acknowledgement the agent
  * observes. Everything widget-specific (validation, component, ack text) lives in the widget registry,
  * so this stays generic across all widgets and is unchanged when a new one is added. On invalid args it
- * returns the validator's reason and renders nothing, so the agent can recover.
+ * returns the validator's reason and renders nothing, so the agent can recover. Withheld arguments
+ * short-circuit before the widget ever sees them — `"{}"` is a placeholder, not real (empty) input.
  */
-function runWidgetToolCall(name: string, argsJson: string): string {
+function runWidgetToolCall(name: string, argsJson: string, withheld: boolean): string {
   const widget = getWidget(name);
   if (!widget) return `The client has no handler for widget "${name}".`;
+
+  if (withheld) return `The ${name} arguments were too large to stream and were withheld.`;
 
   let args: Record<string, unknown>;
   try {
@@ -72,7 +79,7 @@ function runWidgetToolCall(name: string, argsJson: string): string {
  */
 async function finishToolCall(threadId: string, callId: string, pending: PendingCall | undefined): Promise<void> {
   const result = pending
-    ? runWidgetToolCall(pending.name, pending.args)
+    ? runWidgetToolCall(pending.name, pending.args, pending.withheld)
     : `No client handler matched tool call ${callId}.`;
 
   try {
@@ -160,13 +167,16 @@ export function useAgentStream(): UseAgentStreamReturn {
             }
             case EventType.TOOL_CALL_START: {
               const e = event as BaseEvent & { toolCallId: string; toolCallName: string };
-              activePendingCalls.set(e.toolCallId, { name: e.toolCallName, args: '' });
+              activePendingCalls.set(e.toolCallId, { name: e.toolCallName, args: '', withheld: false });
               break;
             }
             case EventType.TOOL_CALL_ARGS: {
-              const e = event as BaseEvent & { toolCallId: string; delta: string };
+              const e = event as BaseEvent & { toolCallId: string; delta: string; withheld?: boolean };
               const pending = activePendingCalls.get(e.toolCallId);
-              if (pending) pending.args += e.delta;
+              if (pending) {
+                if (e.withheld) pending.withheld = true;
+                else pending.args += e.delta;
+              }
               break;
             }
             case EventType.TOOL_CALL_END: {

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Helpers;
@@ -76,5 +77,46 @@ public sealed class ToolPayloadRedactorTests
         var result = ToolPayloadRedactor.RedactAndTruncate(payload, redactor: null, maxLength: 10);
 
         result.Should().Be(new string('a', 10));
+    }
+
+    [Fact]
+    public void RedactForStreaming_UnderCeiling_RedactsAndIsNotWithheld()
+    {
+        var redactor = new MarkerRedactor();
+        var payload = $"before {MarkerRedactor.Secret} after";
+
+        var result = ToolPayloadRedactor.RedactForStreaming(payload, redactor, NullLogger.Instance, "unused");
+
+        result.Withheld.Should().BeFalse();
+        result.Json.Should().Contain(MarkerRedactor.Replacement).And.NotContain("super-secret");
+    }
+
+    [Fact]
+    public void RedactForStreaming_AboveCeiling_WithholdsWithoutRedacting()
+    {
+        var payload = new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength + 1);
+
+        var result = ToolPayloadRedactor.RedactForStreaming(payload, redactor: null, NullLogger.Instance, "unused");
+
+        result.Withheld.Should().BeTrue();
+        result.Json.Should().Be("{}");
+    }
+
+    /// <summary>
+    /// A redaction-contract violation must withhold, not silently pass through as a normal
+    /// (Withheld: false) empty-object result — the two failure modes ("too large" and "redaction
+    /// broke") must be indistinguishable to the client precisely because both mean "the real
+    /// arguments never arrived," and a caller must never mistake either for genuinely empty
+    /// arguments.
+    /// </summary>
+    [Fact]
+    public void RedactForStreaming_RedactorThrows_WithholdsRatherThanReturningNormalEmptyObject()
+    {
+        var redactor = new NullReturningRedactor();
+
+        var result = ToolPayloadRedactor.RedactForStreaming("api_key=super-secret", redactor, NullLogger.Instance, "unused");
+
+        result.Withheld.Should().BeTrue();
+        result.Json.Should().Be("{}");
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
@@ -29,6 +29,19 @@ public sealed class ToolPayloadRedactorTests
         public bool IsSecretKey(string configKey) => false;
     }
 
+    /// <summary>
+    /// Simulates PatternSecretRedactor's real behavior of returning a LONGER string than it was given
+    /// (its structural pass re-serializes via a JSON encoder that escapes every non-ASCII character to
+    /// `\uXXXX`) — without depending on Infrastructure.AI from this Application-layer test project.
+    /// Isolates RedactForStreaming's own post-redaction ceiling check from the specific mechanism
+    /// (JSON escaping) that can trigger it in production.
+    /// </summary>
+    private sealed class InflatingRedactor : ISecretRedactor
+    {
+        public string? Redact(string? input) => input + new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength);
+        public bool IsSecretKey(string configKey) => false;
+    }
+
     [Fact]
     public void Redact_NullRedactor_ReturnsPayloadUnchanged()
     {
@@ -85,7 +98,7 @@ public sealed class ToolPayloadRedactorTests
         var redactor = new MarkerRedactor();
         var payload = $"before {MarkerRedactor.Secret} after";
 
-        var result = ToolPayloadRedactor.RedactForStreaming(payload, redactor, NullLogger.Instance, "unused");
+        var result = ToolPayloadRedactor.RedactForStreaming(payload, redactor, NullLogger.Instance, "search", "call-1");
 
         result.Withheld.Should().BeFalse();
         result.Json.Should().Contain(MarkerRedactor.Replacement).And.NotContain("super-secret");
@@ -96,7 +109,27 @@ public sealed class ToolPayloadRedactorTests
     {
         var payload = new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength + 1);
 
-        var result = ToolPayloadRedactor.RedactForStreaming(payload, redactor: null, NullLogger.Instance, "unused");
+        var result = ToolPayloadRedactor.RedactForStreaming(payload, redactor: null, NullLogger.Instance, "search", "call-1");
+
+        result.Withheld.Should().BeTrue();
+        result.Json.Should().Be("{}");
+    }
+
+    /// <summary>
+    /// Redaction can inflate a payload past the ceiling even when the INPUT was under it —
+    /// PatternSecretRedactor's structural pass re-serializes via a JSON encoder that escapes every
+    /// non-ASCII character to `\uXXXX`, so a payload of mostly non-ASCII text can come back several
+    /// times longer than it went in. The ceiling must be checked on the OUTPUT too, or the "16KB
+    /// ceiling" the OpenAPI spec documents isn't actually true.
+    /// </summary>
+    [Fact]
+    public void RedactForStreaming_RedactionInflatesOutputPastCeiling_Withholds()
+    {
+        var payload = "small input, well under the ceiling";
+        payload.Length.Should().BeLessThan(ToolPayloadRedactor.MaxStreamedToolCallArgsLength,
+            "the test must exercise the OUTPUT check, not the input pre-check");
+
+        var result = ToolPayloadRedactor.RedactForStreaming(payload, new InflatingRedactor(), NullLogger.Instance, "search", "call-1");
 
         result.Withheld.Should().BeTrue();
         result.Json.Should().Be("{}");
@@ -114,7 +147,7 @@ public sealed class ToolPayloadRedactorTests
     {
         var redactor = new NullReturningRedactor();
 
-        var result = ToolPayloadRedactor.RedactForStreaming("api_key=super-secret", redactor, NullLogger.Instance, "unused");
+        var result = ToolPayloadRedactor.RedactForStreaming("api_key=super-secret", redactor, NullLogger.Instance, "search", "call-1");
 
         result.Withheld.Should().BeTrue();
         result.Json.Should().Be("{}");

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Services;
 using FluentAssertions;
 using Xunit;
@@ -60,14 +61,14 @@ public class AgentTurnStreamSinkTests
     [Fact]
     public async Task EmitToolCallAsync_ForwardsToTheCallback()
     {
-        (string Id, string Name, string Args)? received = null;
+        (string Id, string Name, StreamedToolCallArguments Args)? received = null;
         var sink = new AgentTurnStreamSink(
             (_, _) => Task.CompletedTask,
             onToolCall: (id, name, args, _) => { received = (id, name, args); return Task.CompletedTask; });
 
-        await sink.EmitToolCallAsync("call-1", "search", "{\"q\":\"x\"}", CancellationToken.None);
+        await sink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{\"q\":\"x\"}", false), CancellationToken.None);
 
-        received.Should().Be(("call-1", "search", "{\"q\":\"x\"}"));
+        received.Should().Be(("call-1", "search", new StreamedToolCallArguments("{\"q\":\"x\"}", false)));
     }
 
     [Fact]
@@ -75,9 +76,26 @@ public class AgentTurnStreamSinkTests
     {
         var sink = new AgentTurnStreamSink((_, _) => Task.CompletedTask);
 
-        var act = () => sink.EmitToolCallAsync("call-1", "search", "{}", CancellationToken.None);
+        var act = () => sink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
 
         await act.Should().NotThrowAsync();
+    }
+
+    /// <summary>
+    /// Proves the sink forwards the withheld flag unchanged — a duplicate-signaling mechanism (#392)
+    /// distinct from the ordering guarantees tested elsewhere in this file.
+    /// </summary>
+    [Fact]
+    public async Task EmitToolCallAsync_ArgsWithheld_ForwardsTheFlag()
+    {
+        StreamedToolCallArguments? received = null;
+        var sink = new AgentTurnStreamSink(
+            (_, _) => Task.CompletedTask,
+            onToolCall: (_, _, args, _) => { received = args; return Task.CompletedTask; });
+
+        await sink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", true), CancellationToken.None);
+
+        received.Should().Be(new StreamedToolCallArguments("{}", true));
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ToolCallOrderingSinkTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ToolCallOrderingSinkTests.cs
@@ -1,0 +1,147 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="ToolCallOrderingSink"/> — the per-turn decorator enforcing that a
+/// TOOL_CALL_RESULT never streams without a preceding TOOL_CALL_START, and a duplicate start for an
+/// already-started id is dropped.
+/// </summary>
+public class ToolCallOrderingSinkTests
+{
+    private sealed class RecordingSink : IAgentTurnStreamSink
+    {
+        public List<string> Calls { get; } = new();
+
+        public Task EmitAsync(string delta, CancellationToken cancellationToken)
+        {
+            Calls.Add($"delta:{delta}");
+            return Task.CompletedTask;
+        }
+
+        public Task EmitToolCallAsync(string toolCallId, string toolCallName, StreamedToolCallArguments args, CancellationToken cancellationToken)
+        {
+            Calls.Add($"start:{toolCallId}");
+            return Task.CompletedTask;
+        }
+
+        public Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken)
+        {
+            Calls.Add($"result:{toolCallId}");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task DuplicateCallId_SecondStartIsDropped()
+    {
+        var inner = new RecordingSink();
+        var sut = new ToolCallOrderingSink(inner);
+
+        await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+
+        inner.Calls.Should().Equal("start:call-1");
+    }
+
+    [Fact]
+    public async Task ResultWithoutStart_IsDropped()
+    {
+        var inner = new RecordingSink();
+        var sut = new ToolCallOrderingSink(inner);
+
+        await sut.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+
+        inner.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResultAfterStart_IsForwarded()
+    {
+        var inner = new RecordingSink();
+        var sut = new ToolCallOrderingSink(inner);
+
+        await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+
+        inner.Calls.Should().Equal("start:call-1", "result:call-1");
+    }
+
+    [Fact]
+    public async Task TwoDistinctCallIds_BothForwarded()
+    {
+        var inner = new RecordingSink();
+        var sut = new ToolCallOrderingSink(inner);
+
+        await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await sut.EmitToolCallAsync("call-2", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-1", "a", CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-2", "b", CancellationToken.None);
+
+        inner.Calls.Should().Equal("start:call-1", "start:call-2", "result:call-1", "result:call-2");
+    }
+
+    /// <summary>
+    /// A sink whose onToolCall callback is a no-op (only onToolCallResult is wired) must still
+    /// register the call id for later correlation — proves the decorator records BEFORE delegating,
+    /// not only when the inner sink actually does something with the start.
+    /// </summary>
+    [Fact]
+    public async Task StartWithInnerSinkThatNoOpsOnStart_StillRegistersForLaterResult()
+    {
+        var inner = new AgentTurnStreamSink(
+            onDelta: (_, _) => Task.CompletedTask,
+            onToolCall: null,
+            onToolCallResult: (id, result, _) => { CapturedResult = (id, result); return Task.CompletedTask; });
+        var sut = new ToolCallOrderingSink(inner);
+
+        await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+
+        CapturedResult.Should().Be(("call-1", "42"));
+    }
+
+    private (string Id, string Result)? CapturedResult { get; set; }
+
+    /// <summary>
+    /// Two separate instances (one per turn) must not share state — pins the per-turn scoping that
+    /// makes this decorator safe for a multi-turn bundle run, where a provider may reuse call ids
+    /// across turns.
+    /// </summary>
+    [Fact]
+    public async Task SeparateInstances_DoNotShareState()
+    {
+        var innerA = new RecordingSink();
+        var innerB = new RecordingSink();
+        var turnA = new ToolCallOrderingSink(innerA);
+        var turnB = new ToolCallOrderingSink(innerB);
+
+        await turnA.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        // A fresh instance for the next turn must not treat "call-1" as already started.
+        await turnB.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+
+        innerA.Calls.Should().Equal("start:call-1");
+        innerB.Calls.Should().Equal("start:call-1");
+    }
+
+    [Fact]
+    public void Constructor_NullInner_Throws()
+    {
+        var act = () => new ToolCallOrderingSink(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task EmitAsync_PassesThroughUnchanged()
+    {
+        var inner = new RecordingSink();
+        var sut = new ToolCallOrderingSink(inner);
+
+        await sut.EmitAsync("hello", CancellationToken.None);
+
+        inner.Calls.Should().Equal("delta:hello");
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Categorization;
+using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Notifications;
@@ -141,7 +142,7 @@ public class ExecuteAgentTurnCommandHandlerTests
         Application.AI.Common.Services.AgentTurnStreamSink.Current =
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (delta, _) => { events.Add($"delta:{delta}"); return Task.CompletedTask; },
-                onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args}"); return Task.CompletedTask; },
+                onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args.Json}"); return Task.CompletedTask; },
                 onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result}"); return Task.CompletedTask; });
 
         try
@@ -224,7 +225,7 @@ public class ExecuteAgentTurnCommandHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(agent);
 
-        var toolCallArgs = string.Empty;
+        StreamedToolCallArguments toolCallArgs = default;
         Application.AI.Common.Services.AgentTurnStreamSink.Current =
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (_, _) => Task.CompletedTask,
@@ -236,10 +237,14 @@ public class ExecuteAgentTurnCommandHandlerTests
             var result = await _handler.Handle(CreateCommand(), CancellationToken.None);
 
             // Assert — the turn still completes and streams the surrounding text; the tool call is
-            // reported with a safe fallback instead of the handler throwing.
+            // reported with a safe fallback instead of the handler throwing. Withheld must be true —
+            // "{}" here is a degraded fallback, not the tool's real (empty) arguments, and a client
+            // must be able to tell the two apart (a prior version of this code set Withheld: false
+            // on this exact path).
             result.Success.Should().BeTrue();
             result.Response.Should().Be("Looking that up — done.");
-            toolCallArgs.Should().Be("{}");
+            toolCallArgs.Json.Should().Be("{}");
+            toolCallArgs.Withheld.Should().BeTrue();
         }
         finally
         {
@@ -252,7 +257,8 @@ public class ExecuteAgentTurnCommandHandlerTests
     {
         // BundleToolCallArgsEvent.Delta is documented as always carrying the complete JSON payload.
         // Truncating it at the same preview-length cap used for log strings would hand a client
-        // invalid, unparseable JSON — arguments must be redacted only, never truncated.
+        // invalid, unparseable JSON — arguments must be redacted only, never truncated. 600 chars is
+        // well under the streaming size ceiling (16 KB), so this must stream whole and un-withheld.
         var longValue = new string('x', 600);
         var agent = TestableAIAgent.StreamingContent(
             [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = longValue })]);
@@ -264,7 +270,7 @@ public class ExecuteAgentTurnCommandHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(agent);
 
-        var toolCallArgs = string.Empty;
+        StreamedToolCallArguments toolCallArgs = default;
         Application.AI.Common.Services.AgentTurnStreamSink.Current =
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (_, _) => Task.CompletedTask,
@@ -276,9 +282,48 @@ public class ExecuteAgentTurnCommandHandlerTests
             await _handler.Handle(CreateCommand(), CancellationToken.None);
 
             // Assert
-            toolCallArgs.Length.Should().BeGreaterThan(500);
-            var act = () => System.Text.Json.JsonDocument.Parse(toolCallArgs);
+            toolCallArgs.Withheld.Should().BeFalse();
+            toolCallArgs.Json.Length.Should().BeGreaterThan(500);
+            var act = () => System.Text.Json.JsonDocument.Parse(toolCallArgs.Json);
             act.Should().NotThrow("the streamed args must remain valid, complete JSON");
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_OversizedToolCallArgs_StreamsWithheldPlaceholder_NotRawPayload()
+    {
+        // Above ToolPayloadRedactor.MaxStreamedToolCallArgsLength (16 KB), the real arguments must
+        // never reach the client — withheld whole (Json="{}", Withheld=true), not truncated.
+        var oversizedValue = new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength + 1);
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = oversizedValue })]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        StreamedToolCallArguments toolCallArgs = default;
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCall: (_, _, args, _) => { toolCallArgs = args; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            toolCallArgs.Withheld.Should().BeTrue();
+            toolCallArgs.Json.Should().Be("{}");
+            toolCallArgs.Json.Should().NotContain("x");
         }
         finally
         {
@@ -379,7 +424,7 @@ public class ExecuteAgentTurnCommandHandlerTests
         Application.AI.Common.Services.AgentTurnStreamSink.Current =
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (_, _) => Task.CompletedTask,
-                onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args}"); return Task.CompletedTask; },
+                onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args.Json}"); return Task.CompletedTask; },
                 onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result}"); return Task.CompletedTask; });
 
         try
@@ -437,7 +482,7 @@ public class ExecuteAgentTurnCommandHandlerTests
         Application.AI.Common.Services.AgentTurnStreamSink.Current =
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (_, _) => Task.CompletedTask,
-                onToolCall: (_, _, a, _) => { args = a; return Task.CompletedTask; },
+                onToolCall: (_, _, a, _) => { args = a.Json; return Task.CompletedTask; },
                 onToolCallResult: (_, r, _) => { toolResult = r; return Task.CompletedTask; });
 
         try

--- a/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
@@ -522,4 +522,110 @@ public class PatternSecretRedactorTests
         var innerDoc = System.Text.Json.JsonDocument.Parse(middleDoc.RootElement.GetProperty("inner").GetString()!);
         innerDoc.RootElement.GetProperty("api_key").GetString().Should().Be("[REDACTED]");
     }
+
+    /// <summary>
+    /// Common real-world secret key names — security-review finding H1 — measured as leaking
+    /// unredacted before <see cref="PatternSecretRedactor"/>'s key alternation covered them. Each of
+    /// these is a shape a real HTTP tool call or header dictionary would plausibly carry.
+    /// </summary>
+    [Theory]
+    [InlineData("x-api-key")]
+    [InlineData("refresh_token")]
+    [InlineData("id_token")]
+    [InlineData("private_key")]
+    [InlineData("secret_access_key")]
+    [InlineData("authorization")]
+    [InlineData("auth_token")]
+    [InlineData("credential")]
+    [InlineData("credentials")]
+    [InlineData("passphrase")]
+    [InlineData("subscription_key")]
+    [InlineData("Ocp-Apim-Subscription-Key")]
+    public void Redact_CommonSecretKeyNames_AreRedacted(string key)
+    {
+        var sut = CreateRedactor();
+        var input = $$"""{"{{key}}":"LEAKME"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("LEAKME");
+    }
+
+    /// <summary>
+    /// Duplicate JSON property names are legal per RFC 8259 and <see cref="System.Text.Json.Nodes.JsonNode"/>.Parse
+    /// tolerates them, but materializing a <see cref="System.Text.Json.Nodes.JsonObject"/>'s backing
+    /// dictionary rejects the duplicate with an <see cref="ArgumentException"/> — security-review
+    /// finding M2, a regression this structural pass would otherwise introduce into
+    /// <c>ToolOutputCompressionBehavior</c>, which redacts fully third-party-controlled tool output.
+    /// Must degrade to the regex-only fallback, not throw out of the caller.
+    /// </summary>
+    [Fact]
+    public void Redact_JsonWithDuplicatePropertyNames_FallsBackToRegexOnly_DoesNotThrow()
+    {
+        var sut = CreateRedactor();
+        var input = """{"a":1,"a":2,"api_key":"LEAKME"}""";
+
+        var act = () => sut.Redact(input);
+
+        act.Should().NotThrow();
+        act().Should().NotContain("LEAKME");
+    }
+
+    /// <summary>
+    /// Bare "token" and bare "secret" — not the compound shapes
+    /// <see cref="Redact_CommonSecretKeyNames_AreRedacted"/> already covers — are common real key
+    /// names on their own (a session store keyed just "token", a config value keyed just "secret").
+    /// </summary>
+    [Theory]
+    [InlineData("token")]
+    [InlineData("secret")]
+    public void Redact_BareTokenOrSecretKeyName_IsRedacted(string key)
+    {
+        var sut = CreateRedactor();
+        var input = $$"""{"{{key}}":"LEAKME"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("LEAKME");
+    }
+
+    /// <summary>
+    /// A secret key with incidental leading/trailing whitespace (a sloppily-serialized tool argument,
+    /// not necessarily adversarial) is still recognized — the anchored key match trims before
+    /// comparing, or "api_key " (trailing space) would silently fail the whole-key match.
+    /// </summary>
+    [Fact]
+    public void Redact_SecretKeyWithSurroundingWhitespace_IsStillRedacted()
+    {
+        var sut = CreateRedactor();
+        var input = """{"api_key ":"LEAKME"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("LEAKME");
+    }
+
+    /// <summary>
+    /// A top-level JSON-encoded STRING — exactly what <c>JsonSerializer.Serialize(someString)</c>
+    /// produces for a string value, e.g. a tool result that is itself a JSON document serialized as
+    /// text — previously bypassed the structural pass entirely: LooksLikeJson only accepted the
+    /// object/array openers `{`/`[`, so this shape fell straight to the regex-only fallback, which
+    /// cannot see through an escaped-nested secret. The structural walk already handles a top-level
+    /// JsonValue string via RedactStringLeaf; only the entry-point prefix check was missing the case
+    /// — security-review finding M3.
+    /// </summary>
+    [Fact]
+    public void Redact_TopLevelJsonEncodedString_RedactsNestedSecret()
+    {
+        var sut = CreateRedactor();
+        var input = System.Text.Json.JsonSerializer.Serialize(
+            System.Text.Json.JsonSerializer.Serialize(new { api_key = "sk-topstring" }));
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("sk-topstring");
+        var nestedJson = System.Text.Json.JsonSerializer.Deserialize<string>(result!)!;
+        using var doc = System.Text.Json.JsonDocument.Parse(nestedJson);
+        doc.RootElement.GetProperty("api_key").GetString().Should().Be("[REDACTED]");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Security/PatternSecretRedactorTests.cs
@@ -329,4 +329,197 @@ public class PatternSecretRedactorTests
         result.Should().Contain("[REDACTED]");
         result.Should().NotContain("b64-super-secret-value");
     }
+
+    /// <summary>
+    /// A secret key nested inside a JSON string value whose quotes are escaped — e.g. a tool argument
+    /// carrying an HTTP request body serialized as a string field — is redacted. Neither the
+    /// JSON-quoted pattern (which needs an unescaped <c>"key"</c>) nor the generic key=value pattern
+    /// (whose separator can't span the escaped <c>\":</c>) can match this shape; only a structural
+    /// walk that re-parses the string value as its own JSON document catches it.
+    /// </summary>
+    [Fact]
+    public void Redact_SecretKeyInsideEscapedNestedJsonString_RedactsValue()
+    {
+        var sut = CreateRedactor();
+        var input = """{"body":"{\"api_key\":\"sk-1\"}"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("sk-1");
+        using var doc = System.Text.Json.JsonDocument.Parse(result!);
+        var nested = System.Text.Json.JsonDocument.Parse(doc.RootElement.GetProperty("body").GetString()!);
+        nested.RootElement.GetProperty("api_key").GetString().Should().Be("[REDACTED]");
+    }
+
+    /// <summary>
+    /// A non-JSON leaf string (a URL) inside an otherwise valid, non-nested JSON document still gets
+    /// its embedded secret keyword redacted via the free-text fallback the structural walk applies to
+    /// every leaf — proving the leaf-level regex scan still fires, not just the top-level one.
+    /// </summary>
+    [Fact]
+    public void Redact_SecretKeywordInsideUnparseableStringInsideValidJson_StillRedacted()
+    {
+        var sut = CreateRedactor();
+        var input = """{"headers":"Authorization: Bearer eyABC123xyz==","method":"GET"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("eyABC123xyz==");
+        using var doc = System.Text.Json.JsonDocument.Parse(result!);
+        doc.RootElement.GetProperty("headers").GetString().Should().Be("Authorization: Bearer [REDACTED]");
+        doc.RootElement.GetProperty("method").GetString().Should().Be("GET");
+    }
+
+    /// <summary>
+    /// A secret key inside an object nested in a JSON array is redacted — proves array elements are
+    /// recursed into, not just object properties.
+    /// </summary>
+    [Fact]
+    public void Redact_ArrayOfObjectsWithSecretKeys_RedactsEach()
+    {
+        var sut = CreateRedactor();
+        var input = """{"items":[{"name":"a","api_key":"k1"},{"name":"b","api_key":"k2"}]}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("k1");
+        result.Should().NotContain("k2");
+        using var doc = System.Text.Json.JsonDocument.Parse(result!);
+        var items = doc.RootElement.GetProperty("items");
+        items[0].GetProperty("api_key").GetString().Should().Be("[REDACTED]");
+        items[1].GetProperty("api_key").GetString().Should().Be("[REDACTED]");
+        items[0].GetProperty("name").GetString().Should().Be("a");
+    }
+
+    /// <summary>
+    /// Valid JSON with no secrets anywhere is returned as the exact same string reference — the
+    /// structural walk must not silently reformat a clean payload on every call. Mutation-tested: a
+    /// version of RedactNode that always reports "changed" (even when nothing was replaced) fails
+    /// this test while still passing every value-bearing test above.
+    /// </summary>
+    [Fact]
+    public void Redact_ValidJsonWithNoSecrets_ReturnsOriginalReferenceUnchanged()
+    {
+        var sut = CreateRedactor();
+        var input = """{"toolName":"http_call","timeout":30,"tags":["a","b"]}""";
+
+        var result = sut.Redact(input);
+
+        ReferenceEquals(result, input).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Already-redacted JSON (the structural shape, not just the regex-pattern shape covered by
+    /// <see cref="Redact_AlreadyRedactedJsonQuotedSecret_ReturnsUnchanged"/>) reports no change and
+    /// returns the original reference — the secret-key branch must compare against the existing
+    /// value, not unconditionally overwrite and only happen to reserialize identically.
+    /// </summary>
+    [Fact]
+    public void Redact_JsonAlreadyStructurallyRedacted_ReturnsOriginalReferenceUnchanged()
+    {
+        var sut = CreateRedactor();
+        var input = """{"api_key":"[REDACTED]","timeout":30}""";
+
+        var result = sut.Redact(input);
+
+        ReferenceEquals(result, input).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A non-object, non-array JSON value under a secret key (a number, not a string) is still
+    /// replaced with the string placeholder — the structural pass redacts by key, regardless of the
+    /// value's original JSON type.
+    /// </summary>
+    [Fact]
+    public void Redact_NonStringValueUnderSecretKey_IsRedacted()
+    {
+        var sut = CreateRedactor();
+        var input = """{"secret_key":123456}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("123456");
+        using var doc = System.Text.Json.JsonDocument.Parse(result!);
+        doc.RootElement.GetProperty("secret_key").GetString().Should().Be("[REDACTED]");
+    }
+
+    /// <summary>
+    /// Malformed JSON that merely starts with <c>{</c> (so it passes the cheap prefix pre-check) but
+    /// fails to actually parse falls back to the regex-only pass rather than throwing.
+    /// </summary>
+    [Fact]
+    public void Redact_MalformedJsonStartingWithBrace_FallsBackToRegexOnly()
+    {
+        var sut = CreateRedactor();
+        var input = "{not valid json, api_key=superSecret123";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("[REDACTED]");
+        result.Should().NotContain("superSecret123");
+    }
+
+    /// <summary>
+    /// A JSON payload larger than the structural pass's size ceiling still gets its unescaped secret
+    /// redacted, via the regex-only fallback rather than the structural walk.
+    /// </summary>
+    [Fact]
+    public void Redact_JsonAboveSizeCeiling_FallsBackToRegexOnly()
+    {
+        var sut = CreateRedactor();
+        var padding = new string('x', 70 * 1024);
+        var input = $$"""{"padding":"{{padding}}","api_key":"sk-oversized"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("[REDACTED]");
+        result.Should().NotContain("sk-oversized");
+    }
+
+    /// <summary>
+    /// Proves the size ceiling is actually active (not just harmlessly redundant): an oversized
+    /// payload whose secret is only reachable via the structural walk (escaped-nested-JSON, the
+    /// #391 shape) is NOT redacted once input exceeds the ceiling, because only the structural pass
+    /// — not the regex fallback — can see through the escaping. Documents the residual gap rather
+    /// than hiding it. If the ceiling check were ever removed, this secret would start being
+    /// redacted and this test would fail, distinguishing it from
+    /// <see cref="Redact_JsonAboveSizeCeiling_FallsBackToRegexOnly"/>, which passes whether or not
+    /// the ceiling exists.
+    /// </summary>
+    [Fact]
+    public void Redact_EscapedNestedSecretAboveSizeCeiling_IsNotRedacted_DocumentingTheResidualGap()
+    {
+        var sut = CreateRedactor();
+        var padding = new string('x', 70 * 1024);
+        var input = $$"""{"padding":"{{padding}}","body":"{\"api_key\":\"sk-deep-oversized\"}"}""";
+
+        var result = sut.Redact(input);
+
+        result.Should().Contain("sk-deep-oversized",
+            "above the size ceiling only the regex fallback runs, which cannot see through the " +
+            "escaped nesting — this is the documented residual gap, not a regression");
+    }
+
+    /// <summary>
+    /// A secret nested two levels deep in escaped JSON-in-a-string-in-a-string — within the embedded
+    /// JSON depth cap — is redacted at the innermost level. Payloads are built via
+    /// <see cref="System.Text.Json.JsonSerializer"/> rather than hand-written escaping so the exact
+    /// backslash nesting is generated correctly instead of guessed at.
+    /// </summary>
+    [Fact]
+    public void Redact_SecretTwoLevelsDeepInEscapedJson_IsRedacted()
+    {
+        var sut = CreateRedactor();
+        var innermost = System.Text.Json.JsonSerializer.Serialize(new { api_key = "sk-deep" });
+        var middle = System.Text.Json.JsonSerializer.Serialize(new { inner = innermost });
+        var input = System.Text.Json.JsonSerializer.Serialize(new { body = middle });
+
+        var result = sut.Redact(input);
+
+        result.Should().NotContain("sk-deep");
+        using var doc = System.Text.Json.JsonDocument.Parse(result!);
+        var middleDoc = System.Text.Json.JsonDocument.Parse(doc.RootElement.GetProperty("body").GetString()!);
+        var innerDoc = System.Text.Json.JsonDocument.Parse(middleDoc.RootElement.GetProperty("inner").GetString()!);
+        innerDoc.RootElement.GetProperty("api_key").GetString().Should().Be("[REDACTED]");
+    }
 }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
@@ -5,6 +5,8 @@ using Moq;
 using Presentation.AgentHub.AgUi;
 using Presentation.AgentHub.Config;
 using Xunit;
+using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Models.Conversations;
 
@@ -29,9 +31,10 @@ public sealed class AgUiClientToolBridgeTests
         IAgUiEventWriterAccessor accessor,
         PendingToolCallRegistry registry,
         IConversationStore? store = null,
-        int timeoutSeconds = 30) =>
+        int timeoutSeconds = 30,
+        ISecretRedactor? redactor = null) =>
         new(accessor, registry, Options(timeoutSeconds), store ?? new RecordingConversationStore(),
-            new ClientWidgetCatalog(), NullLogger<AgUiClientToolBridge>.Instance);
+            new ClientWidgetCatalog(), NullLogger<AgUiClientToolBridge>.Instance, redactor);
 
     [Fact]
     public async Task InvokeAsync_EmitsToolCallSequence_BlocksUntilCompleted_ThenReturnsResult()
@@ -118,6 +121,87 @@ public sealed class AgUiClientToolBridgeTests
         message.Widget.Should().NotBeNull();
         message.Widget!.Type.Should().Be("render_table");
         message.Widget.Args.GetProperty("columns").GetArrayLength().Should().Be(1);
+    }
+
+    /// <summary>
+    /// Client round-trip tool arguments are redacted before they stream to the browser — the same
+    /// treatment the bundle SSE path applies, since this is an equally live exposure point that
+    /// previously streamed arguments completely unredacted.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_RedactsArgumentsBeforeStreaming()
+    {
+        var writer = new CapturingEventWriter();
+        var accessor = new AgUiEventWriterAccessor { Writer = writer, ThreadId = "thread-r", CallerId = "user-r" };
+        var registry = new PendingToolCallRegistry();
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(It.Is<string>(s => s.Contains("secret-value"))))
+            .Returns<string>(s => s.Replace("secret-value", "[REDACTED]"));
+        var bridge = Bridge(accessor, registry, redactor: redactor.Object);
+
+        var invokeTask = bridge.InvokeAsync("dashboard_control", "{\"token\":\"secret-value\"}");
+
+        await WaitForAsync(() => writer.Events.Count >= 3);
+        var callId = ((ToolCallStartEvent)writer.Events[0]).ToolCallId;
+        registry.TryComplete(callId, "thread-r", "ok").Should().BeTrue();
+        await invokeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var args = (ToolCallArgsEvent)writer.Events[1];
+        args.Delta.Should().NotContain("secret-value").And.Contain("[REDACTED]");
+        args.Withheld.Should().BeNull("a normal frame carries null, never false, so the field is omitted from the wire");
+    }
+
+    /// <summary>
+    /// Arguments above the streaming size ceiling are withheld whole (Delta="{}", Withheld=true), and
+    /// the raw oversized payload never reaches the wire.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_OversizedArguments_WithholdsRawPayload()
+    {
+        var writer = new CapturingEventWriter();
+        var accessor = new AgUiEventWriterAccessor { Writer = writer, ThreadId = "thread-o", CallerId = "user-o" };
+        var registry = new PendingToolCallRegistry();
+        var bridge = Bridge(accessor, registry);
+        var oversized = $$"""{"q":"{{new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength + 1)}}"}""";
+
+        var invokeTask = bridge.InvokeAsync("dashboard_control", oversized);
+
+        await WaitForAsync(() => writer.Events.Count >= 3);
+        var callId = ((ToolCallStartEvent)writer.Events[0]).ToolCallId;
+        registry.TryComplete(callId, "thread-o", "ok").Should().BeTrue();
+        await invokeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var args = (ToolCallArgsEvent)writer.Events[1];
+        args.Delta.Should().Be("{}");
+        args.Withheld.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A widget's persisted spec carries the redacted arguments, not the raw ones — a reload must
+    /// never surface a secret the live stream had already withheld.
+    /// </summary>
+    [Fact]
+    public async Task InvokeAsync_WidgetTool_PersistsRedactedArguments_NotRawPayload()
+    {
+        var writer = new CapturingEventWriter();
+        var accessor = new AgUiEventWriterAccessor { Writer = writer, ThreadId = "thread-wr", CallerId = "user-wr" };
+        var registry = new PendingToolCallRegistry();
+        var store = new RecordingConversationStore();
+        var redactor = new Mock<ISecretRedactor>();
+        redactor.Setup(r => r.Redact(It.Is<string>(s => s.Contains("secret-value"))))
+            .Returns<string>(s => s.Replace("secret-value", "[REDACTED]"));
+        var bridge = Bridge(accessor, registry, store, redactor: redactor.Object);
+
+        var invokeTask = bridge.InvokeAsync("render_form", "{\"apiKey\":\"secret-value\"}");
+
+        await WaitForAsync(() => writer.Events.Count >= 3);
+        var callId = ((ToolCallStartEvent)writer.Events[0]).ToolCallId;
+        registry.TryComplete(callId, "thread-wr", "ok").Should().BeTrue();
+        await invokeTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        store.Appended.Should().HaveCount(1);
+        var message = store.Appended[0].Message;
+        message.Widget!.Args.GetProperty("apiKey").GetString().Should().Be("[REDACTED]");
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolCallEventSerializationTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiToolCallEventSerializationTests.cs
@@ -37,6 +37,28 @@ public sealed class AgUiToolCallEventSerializationTests
         json.Should().Contain("navigate");
     }
 
+    /// <summary>
+    /// The <c>withheld</c> field is absent from the wire on a normal (non-withheld) frame — pins
+    /// against a future refactor that constructs it as <c>false</c> instead of <c>null</c>, which
+    /// would start serializing <c>"withheld":false</c> on every frame.
+    /// </summary>
+    [Fact]
+    public void ToolCallArgsEvent_NotWithheld_OmitsWithheldFieldFromWire()
+    {
+        var json = JsonSerializer.Serialize<AgUiEvent>(new ToolCallArgsEvent("call-1", "{}"), JsonOptions);
+
+        json.Should().NotContain("withheld");
+    }
+
+    /// <summary>A withheld frame carries an explicit <c>"withheld":true</c> on the wire.</summary>
+    [Fact]
+    public void ToolCallArgsEvent_Withheld_SerializesTheFlag()
+    {
+        var json = JsonSerializer.Serialize<AgUiEvent>(new ToolCallArgsEvent("call-1", "{}", true), JsonOptions);
+
+        json.Should().Contain("\"withheld\":true");
+    }
+
     [Fact]
     public void ToolCallEndEvent_Serializes_WithId()
     {

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleRunStreamerTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleRunStreamerTests.cs
@@ -138,7 +138,7 @@ public sealed class BundleRunStreamerTests
         var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), async (sink, ct) =>
         {
             await sink.EmitAsync("Looking that up", ct);
-            await sink.EmitToolCallAsync("call-1", "search", "{\"q\":\"docs\"}", ct);
+            await sink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{\"q\":\"docs\"}", false), ct);
             await sink.EmitToolCallResultAsync("call-1", "42 results", ct);
             await sink.EmitAsync(" — found it.", ct);
         });
@@ -167,13 +167,33 @@ public sealed class BundleRunStreamerTests
     {
         var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), async (sink, ct) =>
         {
-            await sink.EmitToolCallAsync("call-1", "search", "{}", ct);
+            await sink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), ct);
         });
 
         var frames = await RunAndParseAsync(executor, Record());
 
         frames.Select(Type).Should().Equal(
             "RUN_STARTED", "TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "RUN_FINISHED");
+    }
+
+    /// <summary>
+    /// A withheld tool-call args emission (real arguments exceeded the streaming size ceiling) sets
+    /// the wire frame's <c>withheld</c> flag and streams the placeholder, never the raw payload —
+    /// #392.
+    /// </summary>
+    [Fact]
+    public async Task StreamAsync_OversizedToolCallArgs_EmitsWithheldFrame_NotRawPayload()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), async (sink, ct) =>
+        {
+            await sink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", true), ct);
+        });
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        var argsFrame = frames.Single(f => Type(f) == "TOOL_CALL_ARGS");
+        argsFrame.GetProperty("delta").GetString().Should().Be("{}");
+        argsFrame.GetProperty("withheld").GetBoolean().Should().BeTrue();
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleStreamEventsSerializationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleStreamEventsSerializationTests.cs
@@ -54,6 +54,28 @@ public sealed class BundleStreamEventsSerializationTests
         element.GetProperty("delta").GetString().Should().Be("{\"q\":\"docs\"}");
     }
 
+    /// <summary>
+    /// The <c>withheld</c> field is absent from the wire on a normal (non-withheld) frame — a future
+    /// refactor that starts constructing it as <c>false</c> instead of <c>null</c> would start
+    /// serializing <c>"withheld":false</c> on every frame, which this pins against.
+    /// </summary>
+    [Fact]
+    public async Task ToolCallArgsEvent_NotWithheld_OmitsWithheldFieldFromWire()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallArgsEvent("call-1", "{}"));
+
+        element.TryGetProperty("withheld", out _).Should().BeFalse();
+    }
+
+    /// <summary>A withheld frame carries an explicit <c>"withheld":true</c> on the wire.</summary>
+    [Fact]
+    public async Task ToolCallArgsEvent_Withheld_SerializesTheFlag()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallArgsEvent("call-1", "{}", true));
+
+        element.GetProperty("withheld").GetBoolean().Should().BeTrue();
+    }
+
     [Fact]
     public async Task ToolCallEndEvent_SerializesWithDiscriminatorAndFields()
     {


### PR DESCRIPTION
## Summary

Closes #389, #390, #391, #392 — four follow-ups from PR #375 (bundle SSE tool-call streaming), plus a fifth, unfiled exposure point (`AgUiClientToolBridge`, the AG-UI client round-trip tool path) discovered while tracing every consumer of the `TOOL_CALL_ARGS` wire frame.

- **#391 (security)** — `PatternSecretRedactor` gains a JSON-aware structural pass so a secret nested in escaped JSON (a request body serialized as a string field) is redacted, not just the unescaped shape the regex patterns could already see. Gated by a size ceiling, a cheap prefix check, and a bounded recursion depth.
- **#392 (security)** — streamed tool-call arguments are withheld whole (not truncated) above a 16KB ceiling, since cutting JSON mid-token hands the client invalid data. The same fix closes the unfiled `AgUiClientToolBridge` gap, which previously streamed and persisted arguments completely unredacted and uncapped. Both frontend hooks (WebUI, Dashboard) now honor the wire's `withheld` signal instead of silently treating withheld arguments as the tool's real (empty) input.
- **#390** — the no-orphaned-result / no-duplicate-start invariant moves from a handler-local `HashSet` into `ToolCallOrderingSink`, a per-turn decorator — enforced structurally for any caller of the sink, not just the one that happened to need it first. (The original design — moving the set into the long-lived sink instance — was wrong: a bundle run is multi-turn and some providers reuse call ids across turns, which would have reproduced the exact bug being fixed. Caught before implementation by an independent design review.)
- **#389** — investigated and closed as won't-fix. The two independent redaction computations have different truncation contracts, and a shared cache risks leaking the uncapped value into the capped persisted field for negligible perf gain. Documented at both call sites instead.

## Review findings closed

`/code-review` (high effort) found 5 real defects before the first push, including two contract-violation bugs (`Withheld: false` on serialization/redaction failure, contradicting the type's own documented contract) and a missing frontend consumer update. All fixed and covered by new tests.

An independent `security-reviewer` pass on the resulting commit found 7 more, measured findings — 1 HIGH (common secret key names like `x-api-key`, `refresh_token`, `private_key` weren't in the redaction alternation), 1 merge-blocking (duplicate JSON property names throw an uncaught `ArgumentException`, a regression this PR would otherwise have introduced into `ToolOutputCompressionBehavior`, which redacts fully third-party tool output), and 5 more (persistence-path secrets above the structural ceiling, a streaming ceiling that didn't bound post-redaction output size, a withheld widget persisted as real empty args on reload, log-injection via an unescaped tool name, and a fail-open bypass of the redaction contract this PR established elsewhere). All fixed in a follow-up commit.

A third commit widens the redactor's regex match timeout (100ms → 2s) after full-solution test runs reproduced a spurious `RegexMatchTimeoutException` on trivial input under CI scheduling contention.

## Test plan

- [x] Full solution build: 0 errors
- [x] Full backend test suite green (Application.Core.Tests, Application.AI.Common.Tests, Infrastructure.AI.Tests, Presentation.AgentHub.Tests, Presentation.ExecutionApi.Tests) — every project touched by this change is 100% passing; the only full-solution failures are the repo's known Docker-dependent integration tests (Neo4j/Postgres/Prometheus), unrelated to this diff
- [x] Frontend: `tsc -b` clean on both Presentation.WebUI and Presentation.Dashboard; new Vitest regression tests for the `withheld` wire signal in both `useAgentStream.ts` and `useDashboardAgent.ts`
- [x] Mutation-tested every load-bearing branch across all three commits (the JSON structural redaction gates, the size ceilings, the ordering decorator, the duplicate-key exception guard) — each observed to fail when the guard was removed, then reverted
- [x] `/code-review` and `/simplify` run and receipts recorded; independent `security-reviewer` pass run and all findings closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW