### PR TITLE
fix: harden bundle-owned MCP server subsystem (#372, #373, #374, #376, #377, #378)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleOwnedMcpServerRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleOwnedMcpServerRegistry.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics.CodeAnalysis;
+using Domain.Common.Config.AI.MCP;
+
+namespace Application.AI.Common.Interfaces.Bundles;
+
+/// <summary>
+/// Runtime-only store for a bundle's own MCP server definitions — deliberately a distinct type from
+/// <see cref="McpServersConfig"/>, not a second instance of it. See the implementation's own remarks
+/// (<c>BundleOwnedMcpServerRegistry</c>) for the full isolation rationale from issue #368.
+/// </summary>
+/// <remarks>
+/// Extracted under #374 to match every other runtime, string-keyed registry of this shape elsewhere in
+/// the codebase (<c>IPluginRegistry</c>, <c>IMcpDefinitionPinStore</c>, <c>IHookRegistry</c>) —
+/// interface in Application, implementation in Infrastructure — so a future durable/EF-backed
+/// implementation can be swapped in without a breaking constructor-signature change across every
+/// consumer. The surface is deliberately unchanged from the original concrete type: no enumeration
+/// method exists, and none should be added without a deliberate, reviewed decision — a reflection test
+/// (<c>BundleMcpServerIsolationTests</c>) fails the build if this interface's public member set grows
+/// beyond <see cref="TryAdd"/>/<see cref="TryRemove"/>/<see cref="TryGetValue"/>.
+/// </remarks>
+public interface IBundleOwnedMcpServerRegistry
+{
+    /// <summary>
+    /// Registers <paramref name="definition"/> under <paramref name="namespacedName"/>
+    /// (<c>{BundleId}:{ServerName}</c>). Returns <see langword="false"/> without replacing anything if
+    /// that name is already registered — the caller decides how to report a duplicate.
+    /// </summary>
+    bool TryAdd(string namespacedName, McpServerDefinition definition);
+
+    /// <summary>
+    /// Removes the entry registered under <paramref name="namespacedName"/>, if any. Idempotent: removing
+    /// an unregistered name is a no-op that returns <see langword="false"/>, never an error.
+    /// </summary>
+    bool TryRemove(string namespacedName);
+
+    /// <summary>
+    /// Resolves <paramref name="namespacedName"/> to its registered definition, if any — the ONLY way to
+    /// read from this registry. There is no enumeration method by design.
+    /// </summary>
+    bool TryGetValue(string namespacedName, [NotNullWhen(true)] out McpServerDefinition? definition);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/BundleOwnedMcpToolNaming.cs
@@ -1,5 +1,4 @@
-using System.Security.Cryptography;
-using System.Text;
+using Domain.Common.Helpers;
 
 namespace Application.AI.Common.Services.Tools;
 
@@ -48,38 +47,42 @@ public static class BundleOwnedMcpToolNaming
     /// <summary>
     /// Builds the namespaced tool name for <paramref name="rawToolName"/> as published by
     /// <paramref name="namespacedServerName"/> (the bundle-scoped <c>{bundleId}:{serverName}</c> key
-    /// under which the server itself is registered). The server portion is sanitized to the character set
-    /// OpenAI and Azure OpenAI both require for a function name (<c>^[a-zA-Z0-9_-]{1,64}$</c>); the tool's
-    /// own (untrusted, bundle-server-declared) name goes through the same sanitization via
-    /// <see cref="SanitizeToolName"/> — a bundle-authored MCP server can name its tool anything, including
-    /// spaces or punctuation no provider's function-calling API accepts, and an unsanitized name fails
-    /// every turn of the run exactly like an over-length one does. When the sanitized concatenation would
-    /// still exceed <see cref="MaxToolNameLength"/> — routine, not just adversarial, for an ordinary bundle
-    /// id + server name + tool name — the result is deterministically shortened by <see cref="Shorten"/>
-    /// instead, so the published name always stays within the limit every provider enforces.
+    /// under which the server itself is registered). Both halves are sanitized to the character set
+    /// OpenAI and Azure OpenAI both require for a function name (<c>^[a-zA-Z0-9_-]{1,64}$</c>) via
+    /// <see cref="SanitizeWithCollisionGuard"/> — a bundle-authored MCP server can name itself or its tool
+    /// anything, including spaces, punctuation, or the <c>:</c> namespace separator itself, none of which
+    /// any provider's function-calling API accepts, and an unsanitized name fails every turn of the run
+    /// exactly like an over-length one does. When the sanitized concatenation would still exceed
+    /// <see cref="MaxToolNameLength"/> — routine, not just adversarial, for an ordinary bundle id + server
+    /// name + tool name — the result is deterministically shortened by <see cref="Shorten"/> instead, so
+    /// the published name always stays within the limit every provider enforces.
     /// </summary>
     public static string BuildToolName(string namespacedServerName, string rawToolName)
     {
-        var full = $"{Sanitize(namespacedServerName)}{Separator}{SanitizeToolName(rawToolName)}";
+        var full = $"{SanitizeWithCollisionGuard(namespacedServerName)}{Separator}{SanitizeWithCollisionGuard(rawToolName)}";
         return full.Length <= MaxToolNameLength ? full : Shorten(full);
     }
 
     /// <summary>
-    /// Sanitizes <paramref name="rawToolName"/> to the provider charset. When the raw name was already
-    /// clean, <see cref="Sanitize"/> is a no-op and the result is returned as-is — preserving a short,
-    /// readable name for the overwhelmingly common case. When sanitization actually changes the name, it
+    /// Sanitizes <paramref name="raw"/> to the provider charset. When the raw value was already clean,
+    /// <see cref="Sanitize"/> is a no-op and the result is returned as-is — preserving a short, readable
+    /// name for the overwhelmingly common case. When sanitization actually changes the value, it
     /// necessarily collapses information (multiple distinct raw characters all map to <c>'_'</c>), so two
-    /// different raw tool names from the same server can sanitize to the identical string (e.g. "get user"
-    /// and "get.user" both become "get_user") — silently merging two different tools into one published
-    /// name, which the tool-chain's dedup-by-name step would then drop one of without any signal. A content
-    /// hash of the ORIGINAL raw name is appended whenever sanitization was non-trivial, so distinct raw
-    /// names stay distinct after sanitizing; two raw names that are already letter-for-letter identical
-    /// correctly still produce the same result, since they name the same tool.
+    /// different raw values can sanitize to the identical string — e.g. two raw tool names "get user" and
+    /// "get.user" both become "get_user", or two bundle-scoped server names differing only in a character
+    /// outside <c>[A-Za-z0-9_-]</c> (the namespace separator <c>:</c> among them) collapse to the same
+    /// prefix. Either case silently merges two different tools/servers into one published name, which the
+    /// tool-chain's dedup-by-name step would then drop one of without any signal. A content hash of the
+    /// ORIGINAL raw value is appended whenever sanitization was non-trivial, so distinct raw values stay
+    /// distinct after sanitizing; two raw values that are already letter-for-letter identical correctly
+    /// still produce the same result, since they name the same thing. Applied to BOTH halves of
+    /// <see cref="BuildToolName"/> — the server-name half and the tool-name half — so neither can collide
+    /// with a sibling on the other side of the <see cref="Separator"/>.
     /// </summary>
-    private static string SanitizeToolName(string rawToolName)
+    private static string SanitizeWithCollisionGuard(string raw)
     {
-        var sanitized = Sanitize(rawToolName);
-        return sanitized == rawToolName ? sanitized : $"{sanitized}_{HexHashPrefix(rawToolName)}";
+        var sanitized = Sanitize(raw);
+        return sanitized == raw ? sanitized : $"{sanitized}_{HexHashPrefix(raw)}";
     }
 
     /// <summary>
@@ -103,11 +106,8 @@ public static class BundleOwnedMcpToolNaming
     }
 
     /// <summary>The first <see cref="HashSuffixByteCount"/> bytes of <paramref name="value"/>'s SHA-256 digest, as lowercase hex.</summary>
-    private static string HexHashPrefix(string value)
-    {
-        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(value));
-        return Convert.ToHexStringLower(digest.AsSpan(0, HashSuffixByteCount));
-    }
+    private static string HexHashPrefix(string value) =>
+        Sha256HexPrefixHelper.Compute(value, HashSuffixByteCount * 2);
 
     private static string Sanitize(string value)
     {

--- a/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/CapabilityEnvelope.cs
@@ -66,17 +66,28 @@ public sealed record CapabilityEnvelope
     /// Empty (the default) means no bundle-owned server is granted this run.
     /// </summary>
     /// <remarks>
-    /// <strong>Invariant callers must preserve:</strong> this list is always a subset of
-    /// <see cref="AllowedMcpServers"/>, and the two are kept in sync by a SINGLE writer today
+    /// <para>
+    /// <strong>Invariant this list should preserve:</strong> it is always a subset of
+    /// <see cref="AllowedMcpServers"/>, kept in sync by a SINGLE writer today
     /// (<c>RunBundleCommandHandler.WithBundleOwnedMcpServers</c>), which unions the same
-    /// <c>staged.McpServerNames</c> into both in one <c>with</c> expression. Nothing in the type system
-    /// enforces this — a future call site that adds a bundle-owned name to <see cref="AllowedMcpServers"/>
-    /// without adding it here as well would silently make that server's tools resolve as NOT bundle-owned
-    /// (falling through to <see cref="IsBundleOwnedMcpServer"/> returning <see langword="false"/>), which
-    /// is fail-closed on the namespacing decision but reintroduces the exact "trust a server based on
-    /// incomplete provenance" defect this field exists to prevent. Any new writer of
-    /// <see cref="AllowedMcpServers"/> for a bundle-owned server MUST update this list in the same
-    /// operation.
+    /// <c>staged.McpServerNames</c> into both in one <c>with</c> expression.
+    /// </para>
+    /// <para>
+    /// <strong>Two ways this can go wrong, and they are NOT symmetric.</strong> (1) A name lands here but
+    /// the writer forgot to also grant it in <see cref="AllowedMcpServers"/> — <see cref="GrantsMcpServer"/>
+    /// already refuses to contact a server absent from that list regardless of what this one claims, so
+    /// this direction was never exploitable; <see cref="IsBundleOwnedMcpServer"/> now also requires
+    /// <see cref="AllowedMcpServers"/> membership, so the predicate agrees with reality instead of
+    /// answering "yes" for a server nothing can ever reach. (2) A name is granted in
+    /// <see cref="AllowedMcpServers"/> but the writer forgot to add it here — this is the direction the
+    /// original design worried about (the server's tools would resolve as host-trusted rather than
+    /// bundle-owned, reopening the "trust a server based on incomplete provenance" defect this field
+    /// exists to prevent), and it is NOT something any check inside this type can catch: once a name is
+    /// simply absent from this list, nothing in the envelope records that it should have been present.
+    /// There is no construction-time check either — <c>with</c> expressions bypass a factory entirely, and
+    /// the single writer uses one. The only real guard against (2) is keeping that one writer correct,
+    /// which is what its own test pins down rather than anything checkable here.
+    /// </para>
     /// </remarks>
     public IReadOnlyList<string> BundleOwnedMcpServers { get; init; } = [];
 
@@ -118,8 +129,21 @@ public sealed record CapabilityEnvelope
     /// check callers must use to decide whether a resolved tool needs bundle-owned namespacing, instead
     /// of inferring ownership from the server name's shape.
     /// </summary>
+    /// <remarks>
+    /// Requires membership in BOTH <see cref="BundleOwnedMcpServers"/> AND <see cref="AllowedMcpServers"/>
+    /// — see the <see cref="BundleOwnedMcpServers"/> remarks for the two ways the two lists can drift
+    /// apart. This dual check closes only ONE of those (a name recorded as bundle-owned for a server that
+    /// was never actually granted — already unreachable via <see cref="GrantsMcpServer"/> either way, so
+    /// this makes the predicate consistent rather than newly safe). It does NOT and cannot close the
+    /// other, more consequential direction (a granted server missing from
+    /// <see cref="BundleOwnedMcpServers"/>) — by the time a name is absent from that list, nothing in this
+    /// record retains any evidence it should have been present, so no check confined to this type can
+    /// recover it. That direction is guarded by keeping the envelope's single writer correct, not by
+    /// anything this method can verify at read time.
+    /// </remarks>
     /// <param name="serverName">The MCP server name being checked.</param>
-    public bool IsBundleOwnedMcpServer(string serverName) => Contains(BundleOwnedMcpServers, serverName);
+    public bool IsBundleOwnedMcpServer(string serverName) =>
+        Contains(BundleOwnedMcpServers, serverName) && Contains(AllowedMcpServers, serverName);
 
     /// <summary>
     /// Shared case-insensitive membership check backing every <c>Grants*</c>/<c>Is*</c> predicate on this

--- a/src/Content/Domain/Domain.AI/RAG/Models/ScopedCollectionName.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Models/ScopedCollectionName.cs
@@ -1,5 +1,5 @@
-using System.Security.Cryptography;
 using System.Text;
+using Domain.Common.Helpers;
 
 namespace Domain.AI.RAG.Models;
 
@@ -91,8 +91,7 @@ public static class ScopedCollectionName
         }
 
         var normalized = tenantId.Trim().ToLowerInvariant();
-        var hash = Convert.ToHexStringLower(
-            SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))[..HashLength];
+        var hash = Sha256HexPrefixHelper.Compute(normalized, HashLength);
         var slug = Slugify(normalized);
 
         return $"{Prefix}{slug}-{hash}";

--- a/src/Content/Domain/Domain.Common/Helpers/Sha256HexPrefixHelper.cs
+++ b/src/Content/Domain/Domain.Common/Helpers/Sha256HexPrefixHelper.cs
@@ -1,0 +1,60 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Domain.Common.Helpers;
+
+/// <summary>
+/// Computes a short, deterministic, collision-safe disambiguating suffix for a string value:
+/// the leading hex characters of its UTF-8 SHA-256 digest.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists.</strong> Two unrelated naming schemes — <c>BundleOwnedMcpToolNaming</c>
+/// (Application.AI.Common) and <c>ScopedCollectionName</c> (Domain.AI.RAG) — independently computed
+/// <c>Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(value)))</c>, truncated to a
+/// caller-chosen length, for the exact same reason: two different raw inputs that collapse to the
+/// same value after sanitization/slugification must still produce distinct output. Any future review
+/// of either scheme's collision safety had to re-derive the same reasoning twice, in two projects.
+/// This extracts only that shared primitive.
+/// </para>
+/// <para>
+/// <strong>What is deliberately NOT shared.</strong> The two callers' cleaning rules are genuinely
+/// different by design — one replaces each disallowed character one-for-one with <c>'_'</c>
+/// (length-preserving), the other collapses runs of disallowed characters to a single <c>'-'</c> and
+/// lowercases/trims. Merging those would blur two policies that exist for different reasons. Only the
+/// hash-to-short-hex step is common ground.
+/// </para>
+/// <para>
+/// Length is expressed in hex characters, not bytes: both current callers reason about their budget
+/// in characters (a maximum total name length), so asking for hex characters directly avoids a
+/// bytes-to-chars conversion at every call site.
+/// </para>
+/// <para>
+/// This lives in <c>Domain.Common</c>, which has no project references of its own, so every layer —
+/// Domain, Application, Infrastructure — can reach it without bending a dependency arrow.
+/// </para>
+/// </remarks>
+public static class Sha256HexPrefixHelper
+{
+    /// <summary>
+    /// Computes the leading <paramref name="hexLength"/> hex characters of the SHA-256 digest of
+    /// <paramref name="value"/> (interpreted as UTF-8), lowercase.
+    /// </summary>
+    /// <param name="value">The value to hash.</param>
+    /// <param name="hexLength">
+    /// Number of leading hex characters to keep. Must be between 1 and 64 (the full digest is 64 hex
+    /// characters / 32 bytes).
+    /// </param>
+    /// <returns>The truncated, lowercase hex digest.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="hexLength"/> is outside 1..64.
+    /// </exception>
+    public static string Compute(string value, int hexLength)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(hexLength, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(hexLength, 64);
+
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexStringLower(digest)[..hexLength];
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Resources;
 using Infrastructure.AI.MCP.Services;
@@ -37,9 +38,12 @@ public static class DependencyInjection
     {
         // The runtime-only store for a bundle's own (untrusted, uploaded) MCP server definitions —
         // deliberately never the AIConfig-bound McpServersConfig below. See its own doc comment for why.
-        // TryAddSingleton (not AddSingleton) — also registered by AddInfrastructureAIDependencies, so
-        // call order between the two extension methods is irrelevant.
-        services.TryAddSingleton<BundleOwnedMcpServerRegistry>();
+        // TryAddSingleton<TService, TImplementation> (not AddSingleton) — also registered by
+        // AddInfrastructureAIDependencies, so call order between the two extension methods is irrelevant,
+        // and BOTH sites must register against the SAME service type (the interface) or they silently
+        // produce two separate singleton instances, defeating the isolation guarantee this registry
+        // exists for (#374).
+        services.TryAddSingleton<IBundleOwnedMcpServerRegistry, BundleOwnedMcpServerRegistry>();
 
         // Connection manager — singleton, manages MCP client lifecycles.
         // Resolving AntiSsrfHandlerFactory makes the SSRF guard a mandatory dependency:
@@ -51,7 +55,7 @@ public static class DependencyInjection
             var logger = sp.GetRequiredService<Microsoft.Extensions.Logging.ILogger<McpConnectionManager>>();
             var loggerFactory = sp.GetRequiredService<Microsoft.Extensions.Logging.ILoggerFactory>();
             var antiSsrfHandlerFactory = sp.GetRequiredService<AntiSsrfHandlerFactory>();
-            var bundleOwnedServers = sp.GetRequiredService<BundleOwnedMcpServerRegistry>();
+            var bundleOwnedServers = sp.GetRequiredService<IBundleOwnedMcpServerRegistry>();
             // The bundle-owned egress-attribution chain (see McpConnectionManager.ResolveBundleEgressClient)
             // resolves the SAME registered EgressPolicyDelegatingHandler the "egress" named HttpClient uses
             // (Infrastructure.AI/DependencyInjection.Egress.cs) from the root provider it is handed below —
@@ -97,7 +101,7 @@ public static class DependencyInjection
         // (above) and BundleStagingService's registration use, so a removal here is visible to both
         // (issue #368; isolated from the trusted registry per the security fix in #370).
         services.AddSingleton<IBundleMcpServerRegistrar>(sp => new BundleMcpServerRegistrar(
-            sp.GetRequiredService<BundleOwnedMcpServerRegistry>(),
+            sp.GetRequiredService<IBundleOwnedMcpServerRegistry>(),
             sp.GetRequiredService<McpConnectionManager>(),
             sp.GetRequiredService<ILogger<BundleMcpServerRegistrar>>()));
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -1,26 +1,25 @@
 using System.Linq;
 using Application.AI.Common.Interfaces.Bundles;
-using Domain.Common.Config.AI.MCP;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.MCP.Services;
 
 /// <summary>
 /// Default <see cref="IBundleMcpServerRegistrar"/>. Removes a bundle's namespaced entries from the
-/// shared <see cref="BundleOwnedMcpServerRegistry"/> and disconnects any live
+/// shared <see cref="IBundleOwnedMcpServerRegistry"/> and disconnects any live
 /// <see cref="McpConnectionManager"/> client for each — the deregistration counterpart to the
 /// registration <c>BundleStagingService</c> performs at staging time, against the SAME
-/// <see cref="BundleOwnedMcpServerRegistry"/> instance.
+/// <see cref="IBundleOwnedMcpServerRegistry"/> instance.
 /// </summary>
 public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
 {
-    private readonly BundleOwnedMcpServerRegistry _bundleOwnedMcpServers;
+    private readonly IBundleOwnedMcpServerRegistry _bundleOwnedMcpServers;
     private readonly McpConnectionManager _connectionManager;
     private readonly ILogger<BundleMcpServerRegistrar> _logger;
 
     /// <summary>Initializes a new <see cref="BundleMcpServerRegistrar"/>.</summary>
     public BundleMcpServerRegistrar(
-        BundleOwnedMcpServerRegistry bundleOwnedMcpServers,
+        IBundleOwnedMcpServerRegistry bundleOwnedMcpServers,
         McpConnectionManager connectionManager,
         ILogger<BundleMcpServerRegistrar> logger)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Egress;
 using Domain.Common.Config.AI.MCP;
 using Infrastructure.AI.Egress;
@@ -30,7 +31,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private readonly HttpMessageHandler _antiSsrfHandler;
     private readonly HttpClient _httpClient;
     private readonly McpServersConfig _config;
-    private readonly BundleOwnedMcpServerRegistry _bundleOwnedServers;
+    private readonly IBundleOwnedMcpServerRegistry _bundleOwnedServers;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IAmbientRequestScope _ambientScope;
     private readonly IServiceProvider _rootServices;
@@ -85,7 +86,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         ILoggerFactory loggerFactory,
         AntiSsrfHandlerFactory antiSsrfHandlerFactory,
         McpServersConfig config,
-        BundleOwnedMcpServerRegistry bundleOwnedServers,
+        IBundleOwnedMcpServerRegistry bundleOwnedServers,
         IServiceScopeFactory scopeFactory,
         IAmbientRequestScope ambientScope,
         IServiceProvider rootServices)
@@ -150,25 +151,39 @@ public sealed class McpConnectionManager : IAsyncDisposable
     }
 
     /// <summary>
+    /// Bound on how long <see cref="DisconnectAsync"/> waits for the per-server connection lock before
+    /// proceeding without it (#378). This method's only production caller is bundle teardown
+    /// (<c>BundleMcpServerRegistrar</c>), which has no cancellation token of its own to bound a wait
+    /// with — a fixed timeout is the only option that keeps teardown bounded regardless of caller. Long
+    /// enough that the realistic race (a fast in-flight connect finishing just before or during a
+    /// disconnect for the same server) resolves cleanly under the lock; short enough that a genuinely
+    /// hung connect attempt (a stdio child process that never exits, a remote that never completes its
+    /// handshake) cannot block teardown for more than this.
+    /// </summary>
+    private static readonly TimeSpan DisconnectLockTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     /// Disconnects from a specific server and removes the cached connection.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Deliberately does NOT take the per-server connection lock <see cref="GetClientAsync"/> and
-    /// <see cref="ReconnectAsync"/> use: this method's only production caller is bundle teardown
-    /// (<c>BundleMcpServerRegistrar</c>), which needs a fast, non-blocking disconnect and has no
-    /// cancellation token to bound a wait with. Taking the lock here would let a hung connect attempt
-    /// for the same server (mid-handshake, inside <see cref="CreateClientAsync"/>) block teardown
-    /// indefinitely — worse than the narrow race it would close. <c>ConcurrentDictionary.TryRemove</c>
-    /// is already atomic, so concurrent callers of this method cannot corrupt <see cref="_clients"/>
-    /// between themselves; the remaining race is with a concurrent create finishing and caching a NEW
-    /// client between this method's remove and its return — a pre-existing gap, not something this
-    /// method ever closed.
+    /// Takes the same per-server connection lock <see cref="GetClientAsync"/> and
+    /// <see cref="ReconnectAsync"/> use, but only for up to <see cref="DisconnectLockTimeout"/> (#378):
+    /// unlike those two, this method's only production caller (bundle teardown) has no cancellation token
+    /// to bound an unconditional wait with, so a hung connect attempt for the same server (mid-handshake,
+    /// inside <see cref="CreateClientAsync"/>) could otherwise block teardown indefinitely — worse than
+    /// the race the lock closes. When the lock cannot be acquired within the timeout, eviction proceeds
+    /// anyway, unlocked, exactly as this method always has: <c>ConcurrentDictionary.TryRemove</c> is
+    /// already atomic, so concurrent callers of this method cannot corrupt <see cref="_clients"/> between
+    /// themselves either way. What the lock actually buys, when acquired, is exclusion against a
+    /// concurrent <see cref="CreateAndCacheClientAsync"/> caching a NEW client for this server between
+    /// this method's remove and its return — the pre-existing gap this method's doc used to describe as
+    /// unclosed is now closed for every realistic (non-hung) case.
     /// </para>
     /// <para>
-    /// Also does not protect a caller that already holds a reference to the client this disposes,
+    /// Still does not protect a caller that already holds a reference to the client this disposes,
     /// obtained via <see cref="GetClientAsync"/>'s unlocked fast-path read before this method ran — that
-    /// caller can still observe <see cref="ObjectDisposedException"/> mid-use. Closing either race needs
+    /// caller can still observe <see cref="ObjectDisposedException"/> mid-use. Closing that race needs
     /// reference-counted or generation-tagged client leases, a larger change to this type's
     /// client-lifetime model; tracked as a known limitation, not solved here.
     /// </para>
@@ -176,6 +191,13 @@ public sealed class McpConnectionManager : IAsyncDisposable
     public async Task DisconnectAsync(string serverName)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
+
+        using var lockScope = await TryAcquireConnectionLockAsync(serverName, DisconnectLockTimeout);
+        if (lockScope is null)
+            _logger.LogWarning(
+                "Disconnect from MCP server '{ServerName}' proceeded without the connection lock after " +
+                "waiting {Timeout} — a connect attempt for this server was still in flight.",
+                serverName, DisconnectLockTimeout);
 
         await EvictAsync(serverName);
     }
@@ -290,10 +312,27 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
     private async Task<ConnectionLockScope> AcquireConnectionLockAsync(string serverName, CancellationToken cancellationToken)
     {
-        var connectionLock = _connectionLocks.GetOrAdd(serverName, _ => new SemaphoreSlim(1, 1));
+        var connectionLock = GetOrCreateConnectionLock(serverName);
         await connectionLock.WaitAsync(cancellationToken);
         return new ConnectionLockScope(connectionLock);
     }
+
+    /// <summary>
+    /// Attempts the same per-server lock <see cref="AcquireConnectionLockAsync"/> takes, but bounded by
+    /// <paramref name="timeout"/> instead of waiting unconditionally — for <see cref="DisconnectAsync"/>
+    /// (#378), whose caller has no cancellation token to bound a wait with otherwise. Returns
+    /// <see langword="null"/> (not held) when the timeout elapses before the lock is free, rather than
+    /// throwing — a caller that cannot get the lock in time is expected to proceed without it, not fail.
+    /// </summary>
+    private async Task<IDisposable?> TryAcquireConnectionLockAsync(string serverName, TimeSpan timeout)
+    {
+        var connectionLock = GetOrCreateConnectionLock(serverName);
+        var acquired = await connectionLock.WaitAsync(timeout);
+        return acquired ? new ConnectionLockScope(connectionLock) : null;
+    }
+
+    private SemaphoreSlim GetOrCreateConnectionLock(string serverName) =>
+        _connectionLocks.GetOrAdd(serverName, _ => new SemaphoreSlim(1, 1));
 
     private static void TryDisposeCachedClient(ConcurrentDictionary<string, HttpClient> cache, string serverName)
     {
@@ -319,7 +358,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// <remarks>
     /// <strong>Deliberately host-only.</strong> This enumerates <em>only</em> <see cref="_config"/> —
     /// never <see cref="_bundleOwnedServers"/>. Do not add it here; see
-    /// <see cref="BundleOwnedMcpServerRegistry"/>'s own doc comment for why a bundle-owned server must
+    /// <see cref="IBundleOwnedMcpServerRegistry"/>'s own doc comment for why a bundle-owned server must
     /// never be reachable from this method.
     /// </remarks>
     public IEnumerable<string> GetConfiguredServerNames()

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -167,14 +167,15 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Takes the same per-server connection lock <see cref="GetClientAsync"/> and
-    /// <see cref="ReconnectAsync"/> use, but only for up to <see cref="DisconnectLockTimeout"/> (#378):
-    /// unlike those two, this method's only production caller (bundle teardown) has no cancellation token
-    /// to bound an unconditional wait with, so a hung connect attempt for the same server (mid-handshake,
-    /// inside <see cref="CreateClientAsync"/>) could otherwise block teardown indefinitely — worse than
-    /// the race the lock closes. When the lock cannot be acquired within the timeout, eviction proceeds
-    /// anyway, unlocked, exactly as this method always has: <c>ConcurrentDictionary.TryRemove</c> is
-    /// already atomic, so concurrent callers of this method cannot corrupt <see cref="_clients"/> between
+    /// Takes the SAME per-server connection lock <see cref="GetClientAsync"/> and
+    /// <see cref="ReconnectAsync"/> use, through the SAME <see cref="AcquireConnectionLockAsync"/> — not a
+    /// second lock-acquisition method — bounded by a locally-synthesized <see cref="CancellationTokenSource"/>
+    /// (#378): unlike those two callers, this method's only production caller (bundle teardown) has no
+    /// cancellation token of its own to bound an unconditional wait with, so a hung connect attempt for the
+    /// same server (mid-handshake, inside <see cref="CreateClientAsync"/>) could otherwise block teardown
+    /// indefinitely — worse than the race the lock closes. When the token fires before the lock is free,
+    /// eviction proceeds anyway, unlocked, exactly as this method always has: <c>ConcurrentDictionary.TryRemove</c>
+    /// is already atomic, so concurrent callers of this method cannot corrupt <see cref="_clients"/> between
     /// themselves either way. What the lock actually buys, when acquired, is exclusion against a
     /// concurrent <see cref="CreateAndCacheClientAsync"/> caching a NEW client for this server between
     /// this method's remove and its return — the pre-existing gap this method's doc used to describe as
@@ -192,14 +193,28 @@ public sealed class McpConnectionManager : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        using var lockScope = await TryAcquireConnectionLockAsync(serverName, DisconnectLockTimeout);
-        if (lockScope is null)
+        using var timeoutCts = new CancellationTokenSource(DisconnectLockTimeout);
+        IDisposable? lockScope = null;
+        try
+        {
+            lockScope = await AcquireConnectionLockAsync(serverName, timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
             _logger.LogWarning(
                 "Disconnect from MCP server '{ServerName}' proceeded without the connection lock after " +
                 "waiting {Timeout} — a connect attempt for this server was still in flight.",
                 serverName, DisconnectLockTimeout);
+        }
 
-        await EvictAsync(serverName);
+        try
+        {
+            await EvictAsync(serverName);
+        }
+        finally
+        {
+            lockScope?.Dispose();
+        }
     }
 
     /// <summary>
@@ -315,20 +330,6 @@ public sealed class McpConnectionManager : IAsyncDisposable
         var connectionLock = GetOrCreateConnectionLock(serverName);
         await connectionLock.WaitAsync(cancellationToken);
         return new ConnectionLockScope(connectionLock);
-    }
-
-    /// <summary>
-    /// Attempts the same per-server lock <see cref="AcquireConnectionLockAsync"/> takes, but bounded by
-    /// <paramref name="timeout"/> instead of waiting unconditionally — for <see cref="DisconnectAsync"/>
-    /// (#378), whose caller has no cancellation token to bound a wait with otherwise. Returns
-    /// <see langword="null"/> (not held) when the timeout elapses before the lock is free, rather than
-    /// throwing — a caller that cannot get the lock in time is expected to proceed without it, not fail.
-    /// </summary>
-    private async Task<IDisposable?> TryAcquireConnectionLockAsync(string serverName, TimeSpan timeout)
-    {
-        var connectionLock = GetOrCreateConnectionLock(serverName);
-        var acquired = await connectionLock.WaitAsync(timeout);
-        return acquired ? new ConnectionLockScope(connectionLock) : null;
     }
 
     private SemaphoreSlim GetOrCreateConnectionLock(string serverName) =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleOwnedMcpServerRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleOwnedMcpServerRegistry.cs
@@ -1,12 +1,11 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common.Config.AI.MCP;
 
-namespace Domain.Common.Config.AI.MCP;
+namespace Infrastructure.AI.Bundles;
 
-/// <summary>
-/// Runtime-only store for a bundle's own MCP server definitions — deliberately a distinct type from
-/// <see cref="McpServersConfig"/>, not a second instance of it.
-/// </summary>
+/// <inheritdoc cref="IBundleOwnedMcpServerRegistry"/>
 /// <remarks>
 /// A bundle (untrusted, user-uploaded content) can declare its own MCP server; registering it into the
 /// shared, enumerable <see cref="McpServersConfig"/> would leak it into every consumer that enumerates
@@ -20,30 +19,18 @@ namespace Domain.Common.Config.AI.MCP;
 /// as a fallback after the host dictionary misses — the path <c>ToolChainBuilder</c>'s already
 /// envelope-gated, name-keyed bundle-run resolution uses. Never config-bound; starts empty.
 /// </remarks>
-public sealed class BundleOwnedMcpServerRegistry
+public sealed class BundleOwnedMcpServerRegistry : IBundleOwnedMcpServerRegistry
 {
     private readonly ConcurrentDictionary<string, McpServerDefinition> _servers = new();
 
-    /// <summary>
-    /// Registers <paramref name="definition"/> under <paramref name="namespacedName"/>
-    /// (<c>{BundleId}:{ServerName}</c>). Returns <see langword="false"/> without replacing anything if
-    /// that name is already registered — the caller decides how to report a duplicate.
-    /// </summary>
+    /// <inheritdoc />
     public bool TryAdd(string namespacedName, McpServerDefinition definition) =>
         _servers.TryAdd(namespacedName, definition);
 
-    /// <summary>
-    /// Removes the entry registered under <paramref name="namespacedName"/>, if any. Idempotent: removing
-    /// an unregistered name is a no-op that returns <see langword="false"/>, never an error. No caller
-    /// needs the removed definition, so this returns only whether an entry was removed — not the value
-    /// itself, matching this type's stated goal of exposing the narrowest usable surface.
-    /// </summary>
+    /// <inheritdoc />
     public bool TryRemove(string namespacedName) => _servers.TryRemove(namespacedName, out _);
 
-    /// <summary>
-    /// Resolves <paramref name="namespacedName"/> to its registered definition, if any — the ONLY way to
-    /// read from this registry. There is no enumeration method by design; see this type's own remarks.
-    /// </summary>
+    /// <inheritdoc />
     public bool TryGetValue(string namespacedName, [NotNullWhen(true)] out McpServerDefinition? definition) =>
         _servers.TryGetValue(namespacedName, out definition);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -56,7 +56,7 @@ public sealed class BundleStagingService : IBundleStagingService
     private readonly SkillMetadataParser _skillParser;
     private readonly ISkillFileReader _skillFileReader;
     private readonly IPluginManifestReader _pluginReader;
-    private readonly BundleOwnedMcpServerRegistry _bundleOwnedMcpServers;
+    private readonly IBundleOwnedMcpServerRegistry _bundleOwnedMcpServers;
     private readonly ILogger<BundleStagingService> _logger;
 
     /// <summary>Initialises the staging service with its parsers, configuration, and logger.</summary>
@@ -70,9 +70,9 @@ public sealed class BundleStagingService : IBundleStagingService
     /// </param>
     /// <param name="pluginReader">Reader for a staged bundle's plugin manifest.</param>
     /// <param name="bundleOwnedMcpServers">
-    /// The shared, singleton <see cref="BundleOwnedMcpServerRegistry"/> a bundle's own MCP servers are
+    /// The shared, singleton <see cref="IBundleOwnedMcpServerRegistry"/> a bundle's own MCP servers are
     /// merged into under a bundle-scoped namespaced key — deliberately NOT the trusted, host-admin
-    /// <c>McpServersConfig</c>; see <see cref="BundleOwnedMcpServerRegistry"/>'s own doc comment for why.
+    /// <c>McpServersConfig</c>; see <see cref="IBundleOwnedMcpServerRegistry"/>'s own doc comment for why.
     /// </param>
     /// <param name="logger">Logger for staging diagnostics.</param>
     public BundleStagingService(
@@ -81,7 +81,7 @@ public sealed class BundleStagingService : IBundleStagingService
         SkillMetadataParser skillParser,
         ISkillFileReader skillFileReader,
         IPluginManifestReader pluginReader,
-        BundleOwnedMcpServerRegistry bundleOwnedMcpServers,
+        IBundleOwnedMcpServerRegistry bundleOwnedMcpServers,
         ILogger<BundleStagingService> logger)
     {
         ArgumentNullException.ThrowIfNull(skillFileReader);
@@ -164,8 +164,12 @@ public sealed class BundleStagingService : IBundleStagingService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Bundle staging failed while extracting into {BundleDir}", bundleDir);
-            return CleanupAndFail(bundleDir, "Bundle staging failed while extracting the archive.");
+            // Covers extraction, symlink validation, AND manifest parsing/registration failures — not
+            // just extraction, despite the pre-#372 message this replaces. Any MCP server a manifest
+            // already registered before the failure has been rolled back by ParsePluginManifests itself
+            // by the time this handler runs.
+            _logger.LogWarning(ex, "Bundle staging failed while processing {BundleDir}", bundleDir);
+            return CleanupAndFail(bundleDir, "Bundle staging failed.");
         }
     }
 
@@ -404,52 +408,81 @@ public sealed class BundleStagingService : IBundleStagingService
         return [.. byId.Values];
     }
 
+    /// <summary>
+    /// Parses every plugin manifest a staged bundle declares (its own root <c>plugin.json</c> plus any
+    /// nested <c>plugins/*/plugin.json</c>), registering each manifest's MCP servers as it goes.
+    /// </summary>
+    /// <remarks>
+    /// If ANY manifest — or ANY server within a manifest, not just a later manifest — throws while
+    /// this runs, every server successfully registered into <see cref="_bundleOwnedMcpServers"/> before
+    /// the throw is rolled back (issue #372). <see cref="RegisterBundleMcpServers"/> is handed the SAME
+    /// <paramref name="bundleDir"/>-scoped list this method's catch inspects, and appends to it the
+    /// instant each server registers — not batched into a separate list and merged in only after that
+    /// method returns — so a throw partway through one manifest's OWN multi-server loop still leaves
+    /// every already-registered name visible to this catch, not just names from manifests that finished
+    /// processing entirely. Without this, staging deletes only the extracted files on failure; the
+    /// already-registered servers survive as orphaned, live entries for the rest of the host process's
+    /// life, because a bundle that failed to stage is never registered for the eviction path that would
+    /// otherwise clean them up.
+    /// </remarks>
     private (IReadOnlyList<PluginManifest> Manifests, IReadOnlyList<string> McpServerNames) ParsePluginManifests(
         string bundleDir, string bundleId)
     {
         var manifests = new List<PluginManifest>();
         var mcpServerNames = new List<string>();
 
-        var rootManifest = _pluginReader.Read(bundleDir);
-        if (rootManifest is not null)
+        try
         {
-            manifests.Add(rootManifest);
-            mcpServerNames.AddRange(RegisterBundleMcpServers(bundleDir, bundleId, rootManifest));
-        }
-
-        var pluginsRoot = Path.Combine(bundleDir, "plugins");
-        if (Directory.Exists(pluginsRoot))
-        {
-            foreach (var pluginDir in Directory.EnumerateDirectories(pluginsRoot))
+            var rootManifest = _pluginReader.Read(bundleDir);
+            if (rootManifest is not null)
             {
-                var manifest = _pluginReader.Read(pluginDir);
-                if (manifest is not null)
+                manifests.Add(rootManifest);
+                RegisterBundleMcpServers(bundleDir, bundleId, rootManifest, mcpServerNames);
+            }
+
+            var pluginsRoot = Path.Combine(bundleDir, "plugins");
+            if (Directory.Exists(pluginsRoot))
+            {
+                foreach (var pluginDir in Directory.EnumerateDirectories(pluginsRoot))
                 {
-                    manifests.Add(manifest);
-                    mcpServerNames.AddRange(RegisterBundleMcpServers(pluginDir, bundleId, manifest));
+                    var manifest = _pluginReader.Read(pluginDir);
+                    if (manifest is not null)
+                    {
+                        manifests.Add(manifest);
+                        RegisterBundleMcpServers(pluginDir, bundleId, manifest, mcpServerNames);
+                    }
                 }
             }
-        }
 
-        return (manifests, mcpServerNames);
+            return (manifests, mcpServerNames);
+        }
+        catch
+        {
+            foreach (var registered in mcpServerNames)
+                _bundleOwnedMcpServers.TryRemove(registered);
+
+            throw;
+        }
     }
 
     /// <summary>
     /// Merges one manifest's declared MCP servers into the shared <see cref="BundleOwnedMcpServerRegistry"/>
     /// — deliberately NOT the trusted, host-admin <c>McpServersConfig</c> — under a bundle-scoped key
-    /// (<c>{bundleId}:{serverName}</c>) and returns each registered key — the values that become
-    /// <see cref="StagedBundle.McpServerNames"/>, later unioned into the run's
-    /// <see cref="Domain.AI.Bundles.CapabilityEnvelope"/>. <paramref name="bundleId"/> alone (not the
-    /// manifest's own name) is the namespace, because <see cref="Domain.AI.Bundles.StagedBundle.BundleId"/>
-    /// is a fresh GUID per staging — two bundles can never collide — while a manifest's <c>Name</c> is
-    /// free text and not guaranteed unique. A malformed or missing <c>mcp.json</c> is skipped and logged,
-    /// never fails staging.
+    /// (<c>{bundleId}:{serverName}</c>), appending each registered key directly into
+    /// <paramref name="mcpServerNames"/> (shared with <see cref="ParsePluginManifests"/>'s rollback catch,
+    /// and eventually <see cref="StagedBundle.McpServerNames"/>) AS EACH SERVER REGISTERS — not into a
+    /// local list returned only once this whole method completes, so a throw anywhere in this method's own
+    /// loop still leaves every server it already registered visible to the caller's rollback (issue #372).
+    /// <paramref name="bundleId"/> alone (not the manifest's own name) is the namespace, because
+    /// <see cref="Domain.AI.Bundles.StagedBundle.BundleId"/> is a fresh GUID per staging — two bundles can
+    /// never collide — while a manifest's <c>Name</c> is free text and not guaranteed unique. A malformed
+    /// or missing <c>mcp.json</c> is skipped and logged, never fails staging.
     /// </summary>
-    private IReadOnlyList<string> RegisterBundleMcpServers(string manifestBaseDir, string bundleId, PluginManifest manifest)
+    private void RegisterBundleMcpServers(
+        string manifestBaseDir, string bundleId, PluginManifest manifest, List<string> mcpServerNames)
     {
-        var registered = new List<string>();
         if (string.IsNullOrEmpty(manifest.McpServers))
-            return registered;
+            return;
 
         // A bundle is untrusted, externally-authored input. Honouring its own declared MCP servers means
         // the host makes outbound connections a caller's CapabilityEnvelope never authorized — off by
@@ -462,13 +495,13 @@ public sealed class BundleStagingService : IBundleStagingService
                 "skipping, none registered. Set AppConfig:AI:BundleExecution:AllowBundleDeclaredMcpServers " +
                 "= true to enable this capability.",
                 bundleId);
-            return registered;
+            return;
         }
 
         using var block = Infrastructure.AI.Plugins.McpManifestReader.ReadMcpServersBlock(
             manifestBaseDir, manifest.McpServers, $"Bundle {bundleId}", _logger);
         if (block is null)
-            return registered;
+            return;
 
         // Loop-invariant: every server this manifest declares is checked against the SAME harness-wide
         // allowlist, so it is mapped from config once here rather than re-derived on every iteration.
@@ -478,10 +511,8 @@ public sealed class BundleStagingService : IBundleStagingService
         {
             var namespacedName = $"{bundleId}:{serverProp.Name}";
             if (TryBuildAndRegisterOneServer(bundleId, namespacedName, serverProp, allowlist))
-                registered.Add(namespacedName);
+                mcpServerNames.Add(namespacedName);
         }
-
-        return registered;
     }
 
     /// <summary>
@@ -492,20 +523,18 @@ public sealed class BundleStagingService : IBundleStagingService
     private bool TryBuildAndRegisterOneServer(
         string bundleId, string namespacedName, JsonProperty serverProp, IReadOnlyList<EgressAllowlistEntry> allowlist)
     {
-        McpServerDefinition definition;
-        try
+        var buildResult = McpServerDefinitionBuilder.Build(
+            // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
+            serverProp.Value, NoDeclarationEnv, $"[Bundle: {bundleId}]", serverProp.Name);
+        if (!buildResult.IsSuccess)
         {
-            definition = McpServerDefinitionBuilder.Build(
-                // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
-                serverProp.Value, NoDeclarationEnv, $"[Bundle: {bundleId}]", serverProp.Name);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Bundle {BundleId}: failed to build MCP server definition for '{ServerName}', skipping",
-                bundleId, serverProp.Name);
+            _logger.LogWarning(
+                "Bundle {BundleId}: failed to build MCP server definition for '{ServerName}', skipping: {Errors}",
+                bundleId, serverProp.Name, string.Join("; ", buildResult.Errors));
             return false;
         }
+
+        var definition = buildResult.Value!;
 
         if (!definition.IsRemoteServer)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -189,20 +189,23 @@ public static partial class DependencyInjection
         // --- Bundle execution (staging) ---
         // Off by default (AI:BundleExecution:Enabled). The staging service is passive — it does nothing
         // until an ingest call reaches it — so it is registered unconditionally; the run/API surface that
-        // invokes it is gated in a later layer. Wired to the SAME BundleOwnedMcpServerRegistry instance
+        // invokes it is gated in a later layer. Wired to the SAME IBundleOwnedMcpServerRegistry instance
         // McpConnectionManager (Infrastructure.AI.MCP) reads — deliberately NOT the trusted, AIConfig-bound
-        // McpServersConfig PluginLoader (below) writes into; see BundleOwnedMcpServerRegistry's own doc
+        // McpServersConfig PluginLoader (below) writes into; see IBundleOwnedMcpServerRegistry's own doc
         // comment for why.
-        // TryAddSingleton (not AddSingleton) — also registered by AddMcpClientDependencies, so call order
-        // between the two extension methods is irrelevant.
-        services.TryAddSingleton<Domain.Common.Config.AI.MCP.BundleOwnedMcpServerRegistry>();
+        // TryAddSingleton<TService, TImplementation> (not AddSingleton) — also registered by
+        // AddMcpClientDependencies, so call order between the two extension methods is irrelevant, and
+        // BOTH sites must register against the SAME service type (the interface) or they silently produce
+        // two separate singleton instances, defeating the isolation guarantee this registry exists for
+        // (#374).
+        services.TryAddSingleton<IBundleOwnedMcpServerRegistry, BundleOwnedMcpServerRegistry>();
         services.AddSingleton<IBundleStagingService>(sp => new BundleStagingService(
             sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
             sp.GetRequiredService<AgentMetadataParser>(),
             sp.GetRequiredService<SkillMetadataParser>(),
             sp.GetRequiredService<ISkillFileReader>(),
             sp.GetRequiredService<IPluginManifestReader>(),
-            sp.GetRequiredService<Domain.Common.Config.AI.MCP.BundleOwnedMcpServerRegistry>(),
+            sp.GetRequiredService<IBundleOwnedMcpServerRegistry>(),
             sp.GetRequiredService<ILogger<BundleStagingService>>()));
 
         // Capability-envelope resolver — maps the calling credential to its configured per-caller grant.

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Domain.Common;
 using Domain.Common.Config.AI.MCP;
+using Domain.Common.Extensions;
 
 namespace Infrastructure.AI.Plugins;
 
@@ -130,20 +131,13 @@ public static class McpServerDefinitionBuilder
     /// absent property) still defaults to stdio, matching the pre-existing, callers-depend-on-it behavior
     /// (see <c>BundleStagingService.LogStdioRejected</c>).
     /// </summary>
-    private static Result<McpServerType> ParseType(JsonElement serverElement, string serverName)
-    {
-        var typeResult = ReadOptionalString(serverElement, "type", serverName);
-        if (!typeResult.IsSuccess)
-            return Result<McpServerType>.Fail([.. typeResult.Errors]);
-
-        var type = typeResult.Value?.ToLowerInvariant() switch
+    private static Result<McpServerType> ParseType(JsonElement serverElement, string serverName) =>
+        ReadOptionalString(serverElement, "type", serverName).Map(raw => raw?.ToLowerInvariant() switch
         {
             "http" => McpServerType.Http,
             "sse" => McpServerType.Sse,
             _ => McpServerType.Stdio
-        };
-        return Result<McpServerType>.Success(type);
-    }
+        });
 
     /// <summary>
     /// Reads an optional string property. Absent is success with a <see langword="null"/> value —
@@ -179,11 +173,11 @@ public static class McpServerDefinitionBuilder
         var result = new List<string>();
         foreach (var element in args.EnumerateArray())
         {
-            if (element.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
-                return Result<List<string>?>.Fail(
-                    $"'{serverName}' declares an 'args' element as {element.ValueKind}, but a string was expected.");
+            var leaf = ReadStringLeaf(element, "an 'args' element", serverName);
+            if (!leaf.IsSuccess)
+                return Result<List<string>?>.Fail([.. leaf.Errors]);
 
-            result.Add(element.GetString() ?? string.Empty);
+            result.Add(leaf.Value!);
         }
 
         return Result<List<string>?>.Success(result);
@@ -205,13 +199,29 @@ public static class McpServerDefinitionBuilder
         var result = new Dictionary<string, string>();
         foreach (var property in env.EnumerateObject())
         {
-            if (property.Value.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
-                return Result<Dictionary<string, string>?>.Fail(
-                    $"'{serverName}' declares 'env.{property.Name}' as {property.Value.ValueKind}, but a string was expected.");
+            var leaf = ReadStringLeaf(property.Value, $"'env.{property.Name}'", serverName);
+            if (!leaf.IsSuccess)
+                return Result<Dictionary<string, string>?>.Fail([.. leaf.Errors]);
 
-            result[property.Name] = property.Value.GetString() ?? string.Empty;
+            result[property.Name] = leaf.Value!;
         }
 
         return Result<Dictionary<string, string>?>.Success(result);
+    }
+
+    /// <summary>
+    /// Validates that an already-resolved JSON leaf value — one array element of <c>args</c>, or one
+    /// property value of <c>env</c> — is a string (or null), sharing the same kind-check
+    /// <see cref="ReadOptionalString"/> applies at the object-property level. <paramref name="context"/>
+    /// names the leaf's location for the error message (e.g. <c>"an 'args' element"</c> or
+    /// <c>"'env.NAME'"</c>).
+    /// </summary>
+    private static Result<string> ReadStringLeaf(JsonElement element, string context, string serverName)
+    {
+        if (element.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+            return Result<string>.Fail(
+                $"'{serverName}' declares {context} as {element.ValueKind}, but a string was expected.");
+
+        return Result<string>.Success(element.GetString() ?? string.Empty);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Domain.Common;
 using Domain.Common.Config.AI.MCP;
 
 namespace Infrastructure.AI.Plugins;
@@ -9,6 +10,14 @@ namespace Infrastructure.AI.Plugins;
 /// authored bundle's own <c>plugin.json</c>/<c>mcp.json</c>), so the two never independently decide
 /// how a server entry maps to a definition.
 /// </summary>
+/// <remarks>
+/// Every field this class reads comes from externally-authored, untrusted manifest JSON — a bundle's
+/// own <c>mcp.json</c>, or (with more trust, but still hand-authored) a host-installed plugin's. A
+/// malformed shape (a number where a string is expected, an object where an array is expected) is an
+/// ordinary, expected input-validation failure, not an exceptional condition, so <see cref="Build"/>
+/// returns <see cref="Result{T}"/> rather than throwing (issue #374) — matching this repo's own
+/// convention that validation failures on untrusted input use <c>Result&lt;T&gt;</c>, not exceptions.
+/// </remarks>
 public static class McpServerDefinitionBuilder
 {
     /// <summary>
@@ -25,69 +34,184 @@ public static class McpServerDefinitionBuilder
     /// </param>
     /// <param name="descriptionPrefix">A human-readable owner tag, e.g. <c>"[Plugin: azure]"</c>.</param>
     /// <param name="serverName">The server's own name, appended to <paramref name="descriptionPrefix"/>.</param>
-    public static McpServerDefinition Build(
+    /// <returns>
+    /// The built definition, or a failure describing which property had the wrong JSON shape (or, for
+    /// an http/sse entry, a missing <c>url</c>) — caller-safe: it names the property and server, never
+    /// the surrounding manifest content.
+    /// </returns>
+    public static Result<McpServerDefinition> Build(
         JsonElement serverElement,
         IReadOnlyDictionary<string, string> declarationEnv,
         string descriptionPrefix,
         string serverName)
     {
-        var type = ParseType(serverElement);
+        // Every property read below goes through JsonElement.TryGetProperty on serverElement itself
+        // (directly, via ReadOptionalString/ReadArgs/ReadEnv) — TryGetProperty throws
+        // InvalidOperationException outright when called on a non-Object element, so a manifest entry
+        // like "badserver": "not-an-object" would otherwise throw here uncaught instead of failing
+        // cleanly, exactly the defect this Result-returning signature exists to close.
+        if (serverElement.ValueKind is not JsonValueKind.Object)
+            return Result<McpServerDefinition>.Fail(
+                $"'{serverName}' declares its server entry as {serverElement.ValueKind}, but an object was expected.");
+
+        var typeResult = ParseType(serverElement, serverName);
+        if (!typeResult.IsSuccess)
+            return Result<McpServerDefinition>.Fail([.. typeResult.Errors]);
 
         var definition = new McpServerDefinition
         {
             Enabled = true,
-            Type = type,
+            Type = typeResult.Value,
             Description = $"{descriptionPrefix} {serverName}"
         };
 
-        if (type is McpServerType.Http or McpServerType.Sse)
-        {
-            var url = serverElement.TryGetProperty("url", out var urlElement) ? urlElement.GetString() : null;
-            if (string.IsNullOrWhiteSpace(url))
-                throw new InvalidOperationException(
-                    $"'{serverName}' declares a {type} transport with no 'url' — a remote server must declare one.");
+        var transportResult = ReadTransportFields(serverElement, typeResult.Value, serverName, definition);
+        if (!transportResult.IsSuccess)
+            return Result<McpServerDefinition>.Fail([.. transportResult.Errors]);
 
-            definition.Url = url;
-        }
-        else
-        {
-            if (serverElement.TryGetProperty("command", out var cmd))
-                definition.Command = cmd.GetString() ?? string.Empty;
+        var envResult = ReadEnv(serverElement, serverName);
+        if (!envResult.IsSuccess)
+            return Result<McpServerDefinition>.Fail([.. envResult.Errors]);
 
-            if (serverElement.TryGetProperty("args", out var args))
-                definition.Args = args.EnumerateArray()
-                    .Select(a => a.GetString() ?? string.Empty)
-                    .ToList();
-        }
-
-        if (serverElement.TryGetProperty("env", out var env))
-        {
-            foreach (var envProp in env.EnumerateObject())
-                definition.Env[envProp.Name] = envProp.Value.GetString() ?? string.Empty;
-        }
+        if (envResult.Value is not null)
+            foreach (var (key, value) in envResult.Value)
+                definition.Env[key] = value;
 
         // Declaration env overrides take precedence over manifest-declared env.
         foreach (var (key, value) in declarationEnv)
             definition.Env[key] = value;
 
-        return definition;
+        return Result<McpServerDefinition>.Success(definition);
+    }
+
+    /// <summary>
+    /// Reads the transport-specific fields into <paramref name="definition"/>: <c>url</c> for an http/sse
+    /// entry, <c>command</c>/<c>args</c> for everything else (stdio). Mutates <paramref name="definition"/>
+    /// in place rather than returning a value — the caller already owns it and every other field-reader in
+    /// this class follows the same "read, then the caller decides whether to apply" shape except this one,
+    /// which has two fields to set together and no natural single return value to carry them both.
+    /// </summary>
+    private static Result ReadTransportFields(
+        JsonElement serverElement, McpServerType type, string serverName, McpServerDefinition definition)
+    {
+        if (type is McpServerType.Http or McpServerType.Sse)
+        {
+            var urlResult = ReadOptionalString(serverElement, "url", serverName);
+            if (!urlResult.IsSuccess)
+                return Result.Fail([.. urlResult.Errors]);
+
+            if (string.IsNullOrWhiteSpace(urlResult.Value))
+                return Result.Fail(
+                    $"'{serverName}' declares a {type} transport with no 'url' — a remote server must declare one.");
+
+            definition.Url = urlResult.Value;
+            return Result.Success();
+        }
+
+        var commandResult = ReadOptionalString(serverElement, "command", serverName);
+        if (!commandResult.IsSuccess)
+            return Result.Fail([.. commandResult.Errors]);
+        if (commandResult.Value is not null)
+            definition.Command = commandResult.Value;
+
+        var argsResult = ReadArgs(serverElement, serverName);
+        if (!argsResult.IsSuccess)
+            return Result.Fail([.. argsResult.Errors]);
+        if (argsResult.Value is not null)
+            definition.Args = argsResult.Value;
+
+        return Result.Success();
     }
 
     /// <summary>
     /// Reads the optional <c>type</c> property, defaulting to <see cref="McpServerType.Stdio"/> — every
-    /// manifest written before this branch existed omits the property and means stdio.
+    /// manifest written before this branch existed omits the property and means stdio. Fails only if
+    /// <c>type</c> is present with a non-string JSON shape; an unrecognized string value (not just an
+    /// absent property) still defaults to stdio, matching the pre-existing, callers-depend-on-it behavior
+    /// (see <c>BundleStagingService.LogStdioRejected</c>).
     /// </summary>
-    private static McpServerType ParseType(JsonElement serverElement)
+    private static Result<McpServerType> ParseType(JsonElement serverElement, string serverName)
     {
-        if (!serverElement.TryGetProperty("type", out var typeElement))
-            return McpServerType.Stdio;
+        var typeResult = ReadOptionalString(serverElement, "type", serverName);
+        if (!typeResult.IsSuccess)
+            return Result<McpServerType>.Fail([.. typeResult.Errors]);
 
-        var raw = typeElement.GetString();
-        return raw?.ToLowerInvariant() switch
+        var type = typeResult.Value?.ToLowerInvariant() switch
         {
             "http" => McpServerType.Http,
             "sse" => McpServerType.Sse,
             _ => McpServerType.Stdio
         };
+        return Result<McpServerType>.Success(type);
+    }
+
+    /// <summary>
+    /// Reads an optional string property. Absent is success with a <see langword="null"/> value —
+    /// callers decide what "not declared" means. Present but not a JSON string (or JSON null) is a
+    /// failure: calling <see cref="JsonElement.GetString"/> on any other kind throws, and this is exactly
+    /// the untrusted-input case that must degrade to a caller-safe <see cref="Result{T}"/> failure instead.
+    /// </summary>
+    private static Result<string?> ReadOptionalString(JsonElement parent, string propertyName, string serverName)
+    {
+        if (!parent.TryGetProperty(propertyName, out var value))
+            return Result<string?>.Success(null);
+
+        if (value.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+            return Result<string?>.Fail(
+                $"'{serverName}' declares '{propertyName}' as {value.ValueKind}, but a string was expected.");
+
+        return Result<string?>.Success(value.GetString());
+    }
+
+    /// <summary>
+    /// Reads the optional <c>args</c> array, failing if it is present but not a JSON array, or if any
+    /// element is present but not a JSON string.
+    /// </summary>
+    private static Result<List<string>?> ReadArgs(JsonElement parent, string serverName)
+    {
+        if (!parent.TryGetProperty("args", out var args))
+            return Result<List<string>?>.Success(null);
+
+        if (args.ValueKind is not JsonValueKind.Array)
+            return Result<List<string>?>.Fail(
+                $"'{serverName}' declares 'args' as {args.ValueKind}, but an array was expected.");
+
+        var result = new List<string>();
+        foreach (var element in args.EnumerateArray())
+        {
+            if (element.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+                return Result<List<string>?>.Fail(
+                    $"'{serverName}' declares an 'args' element as {element.ValueKind}, but a string was expected.");
+
+            result.Add(element.GetString() ?? string.Empty);
+        }
+
+        return Result<List<string>?>.Success(result);
+    }
+
+    /// <summary>
+    /// Reads the optional <c>env</c> object, failing if it is present but not a JSON object, or if any
+    /// property value is present but not a JSON string.
+    /// </summary>
+    private static Result<Dictionary<string, string>?> ReadEnv(JsonElement parent, string serverName)
+    {
+        if (!parent.TryGetProperty("env", out var env))
+            return Result<Dictionary<string, string>?>.Success(null);
+
+        if (env.ValueKind is not JsonValueKind.Object)
+            return Result<Dictionary<string, string>?>.Fail(
+                $"'{serverName}' declares 'env' as {env.ValueKind}, but an object was expected.");
+
+        var result = new Dictionary<string, string>();
+        foreach (var property in env.EnumerateObject())
+        {
+            if (property.Value.ValueKind is not (JsonValueKind.String or JsonValueKind.Null))
+                return Result<Dictionary<string, string>?>.Fail(
+                    $"'{serverName}' declares 'env.{property.Name}' as {property.Value.ValueKind}, but a string was expected.");
+
+            result[property.Name] = property.Value.GetString() ?? string.Empty;
+        }
+
+        return Result<Dictionary<string, string>?>.Success(result);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginLoader.cs
@@ -125,26 +125,24 @@ public sealed class PluginLoader : IPluginLoader
     /// <summary>
     /// Builds one manifest-declared server and registers it under <paramref name="namespacedName"/>.
     /// A malformed entry (e.g. a non-string <c>args</c> element) is skipped and logged rather than
-    /// thrown — <see cref="Load"/>'s outer catch would otherwise mark the WHOLE plugin
+    /// failing the caller — <see cref="Load"/>'s outer catch would otherwise mark the WHOLE plugin
     /// <see cref="PluginLoadStatus.Failed"/> over one bad server, discarding the skill paths already
     /// collected in the same call and leaving any server registered by an earlier entry in this same
     /// loop orphaned (absent from the returned names, so nothing can deregister it later).
     /// </summary>
     private bool TryBuildAndRegisterOneServer(PluginDeclaration declaration, string namespacedName, JsonProperty serverProp)
     {
-        McpServerDefinition definition;
-        try
+        var result = McpServerDefinitionBuilder.Build(
+            serverProp.Value, declaration.Env, $"[Plugin: {declaration.Name}]", serverProp.Name);
+        if (!result.IsSuccess)
         {
-            definition = McpServerDefinitionBuilder.Build(
-                serverProp.Value, declaration.Env, $"[Plugin: {declaration.Name}]", serverProp.Name);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "Plugin {Name}: failed to build MCP server definition for '{ServerName}', skipping",
-                declaration.Name, serverProp.Name);
+            _logger.LogWarning(
+                "Plugin {Name}: failed to build MCP server definition for '{ServerName}', skipping: {Errors}",
+                declaration.Name, serverProp.Name, string.Join("; ", result.Errors));
             return false;
         }
+
+        var definition = result.Value!;
 
         // Last-writer-wins on a duplicate namespaced key — unlike BundleStagingService's TryAdd +
         // keep-first-and-warn. Deliberately different, not an oversight: a host plugin's own manifest

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -104,6 +104,48 @@ public sealed class RunBundleCommandHandlerTests
         _queue.Verify(q => q.EnqueueAsync(created.JobId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    // -- Bundle-owned MCP server envelope invariant (#376) --
+
+    [Fact]
+    public async Task Handle_StagedBundleDeclaresMcpServers_UnionsThemIntoBothAllowedAndBundleOwnedLists()
+    {
+        // Pins WithBundleOwnedMcpServers — the single production writer CapabilityEnvelope's own remarks
+        // name as the one thing actually responsible for keeping AllowedMcpServers and
+        // BundleOwnedMcpServers in sync (see CapabilityEnvelopeTests for why no check on the record
+        // itself can substitute for this: once a name is missing from BundleOwnedMcpServers, nothing in
+        // the envelope retains any evidence it should have been present). Every staged server name must
+        // land in BOTH lists from this one call site, or a bundle's own MCP server silently resolves as
+        // host-trusted instead of bundle-owned.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged(mcpServerNames: ["b1:echo", "b1:search"]));
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        created!.Envelope.AllowedMcpServers.Should().Contain(["b1:echo", "b1:search"]);
+        created.Envelope.BundleOwnedMcpServers.Should().Contain(["b1:echo", "b1:search"]);
+        created.Envelope.IsBundleOwnedMcpServer("b1:echo").Should().BeTrue();
+        created.Envelope.IsBundleOwnedMcpServer("b1:search").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_StagedBundleDeclaresNoMcpServers_LeavesBundleOwnedListEmpty()
+    {
+        // The no-op branch WithBundleOwnedMcpServers takes when staged.McpServerNames is empty must not
+        // fabricate entries in either list from the caller's own pre-existing grants.
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        BundleRunRecord? created = null;
+        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        created!.Envelope.BundleOwnedMcpServers.Should().BeEmpty();
+    }
+
     // -- Conversation continuity (#235) --
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/BundleOwnedMcpToolNamingTests.cs
@@ -15,9 +15,15 @@ public sealed class BundleOwnedMcpToolNamingTests
     [Fact]
     public void BuildToolName_SanitizesColonInServerKey()
     {
+        // The server half gets the same collision guard as the tool half (see
+        // BuildToolName_ServerNamesCollideAfterSanitizing_DoNotProduceTheSameName): sanitizing the ':'
+        // away changes the raw value, so a disambiguating hash is appended after it. Only the
+        // deterministic, human-readable portion is asserted literally.
         var name = BundleOwnedMcpToolNaming.BuildToolName("bundle-abc123:echo", "search");
 
-        name.Should().Be("bundle-abc123_echo__search");
+        name.Should().StartWith("bundle-abc123_echo_");
+        name.Should().EndWith("__search");
+        name.Should().MatchRegex("^[a-zA-Z0-9_-]{1,64}$");
     }
 
     [Fact]
@@ -26,13 +32,30 @@ public sealed class BundleOwnedMcpToolNamingTests
         // A bundle-authored MCP server can name its tool anything, including characters OpenAI/Azure
         // OpenAI's function-name charset (^[a-zA-Z0-9_-]{1,64}$) rejects outright. Both the server prefix
         // and the tool's own name go through the same sanitization so the published name is always
-        // callable, not just short enough. A disambiguating hash suffix is appended because sanitizing
-        // actually changed the raw name (see BuildToolName_SanitizingDifferentRawNames_DoesNotCollide for
-        // why that's load-bearing), so only the deterministic prefix is asserted here.
+        // callable, not just short enough. Both halves here get a disambiguating hash suffix, since
+        // sanitizing changes both the raw server key (':') and the raw tool name (' ', '!') — so only the
+        // deterministic, human-readable substrings are asserted, not an exact literal.
         var name = BundleOwnedMcpToolNaming.BuildToolName("b1:echo", "weird name!");
 
-        name.Should().StartWith("b1_echo__weird_name_");
+        name.Should().Contain("b1_echo");
+        name.Should().Contain("weird_name");
         name.Should().MatchRegex("^[a-zA-Z0-9_-]{1,64}$");
+    }
+
+    [Fact]
+    public void BuildToolName_ServerNamesCollideAfterSanitizing_DoNotProduceTheSameName()
+    {
+        // Regression test for #373. Two different bundle-owned server keys that sanitize to the
+        // IDENTICAL prefix — here, the namespace separator ':' and a literal space both collapse to '_',
+        // so "bundle-abc:my_server" and "bundle-abc:my server" both sanitize to "bundle-abc_my_server" —
+        // must still publish different tool names for the same underlying tool. Before this fix, the
+        // server half of BuildToolName called bare Sanitize with no collision guard, so both bundles'
+        // "search" tool published under the identical namespaced name, contradicting this class's own
+        // "collision-proof" doc comment.
+        var a = BundleOwnedMcpToolNaming.BuildToolName("bundle-abc:my_server", "search");
+        var b = BundleOwnedMcpToolNaming.BuildToolName("bundle-abc:my server", "search");
+
+        a.Should().NotBe(b);
     }
 
     [Fact]
@@ -82,14 +105,17 @@ public sealed class BundleOwnedMcpToolNamingTests
     }
 
     [Fact]
-    public void BuildToolName_NaturalConcatenationUnder64Chars_IsReturnedVerbatim()
+    public void BuildToolName_NaturalConcatenationUnder64Chars_FitsWithoutShortening()
     {
         // A realistic bundle id (GUID) + short server + short tool name fits comfortably — the common
-        // case must not pay the shortening cost or lose readability.
+        // case must not pay the truncate-and-hash cost Shorten applies to over-length names. The server
+        // half still carries its own collision-guard hash suffix (its raw form contains ':'), so this
+        // asserts structure rather than a byte-exact literal.
         var name = BundleOwnedMcpToolNaming.BuildToolName(
             "3fa85f64-5717-4562-b3fc-2c963f66afa6:search", "lookup");
 
-        name.Should().Be("3fa85f64-5717-4562-b3fc-2c963f66afa6_search__lookup");
+        name.Should().StartWith("3fa85f64-5717-4562-b3fc-2c963f66afa6_search_");
+        name.Should().EndWith("__lookup");
         name.Length.Should().BeLessThanOrEqualTo(64);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -72,7 +72,11 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         using (CapabilityEnvelopeAccessor.Begin(EnvelopeWithBundleOwned("bundle-123:epr-mcp")))
             tools = await builder.BuildToolsAsync(InjectedSkill(), new SkillAgentOptions());
 
-        tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
+        // The server half now also carries its own #373 collision-guard hash suffix (its raw form
+        // contains the ':' namespace separator), so the namespaced name is asserted structurally rather
+        // than as an exact literal.
+        tools.Select(t => t.Name).Should().Contain(
+            n => n.StartsWith("bundle-123_epr-mcp_", StringComparison.Ordinal) && n.EndsWith("__epr_tool", StringComparison.Ordinal));
         tools.Select(t => t.Name).Should().NotContain("epr_tool",
             "the bare, bundle-chosen name must never be the model-callable/governed name in Injected mode either");
     }
@@ -224,8 +228,10 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
             tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
 
         // Published under a NAMESPACED name, never the bare name the (untrusted, bundle-authored)
-        // server declared — see BundleOwnedMcpToolNaming for why a bare name would be exploitable.
-        tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
+        // server declared — see BundleOwnedMcpToolNaming for why a bare name would be exploitable. The
+        // server half also carries its own #373 collision-guard hash suffix, so this is structural.
+        tools.Select(t => t.Name).Should().Contain(
+            n => n.StartsWith("bundle-123_epr-mcp_", StringComparison.Ordinal) && n.EndsWith("__epr_tool", StringComparison.Ordinal));
         tools.Select(t => t.Name).Should().NotContain("epr_tool",
             "the bare, bundle-chosen name must never be the model-callable/governed name");
         mcp.Verify(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()), Times.Once);
@@ -335,7 +341,9 @@ public sealed class ToolChainBuilderMcpEnvelopeTests
         using (CapabilityEnvelopeAccessor.Begin(envelope))
             tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
 
-        tools.Select(t => t.Name).Should().Contain("bundle-123_epr-mcp__epr_tool");
+        // Structural, not literal: the server half carries its own #373 collision-guard hash suffix.
+        tools.Select(t => t.Name).Should().Contain(
+            n => n.StartsWith("bundle-123_epr-mcp_", StringComparison.Ordinal) && n.EndsWith("__epr_tool", StringComparison.Ordinal));
         mcp.Verify(p => p.GetToolsAsync("bundle-123:epr-mcp", It.IsAny<CancellationToken>()), Times.Once);
         mcp.Verify(p => p.GetToolsAsync("corp-tools:epr-mcp", It.IsAny<CancellationToken>()), Times.Never,
             "the unrelated grant must never be contacted for a bundle skill's own declared server");

--- a/src/Content/Tests/Domain.AI.Tests/Bundles/CapabilityEnvelopeTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Bundles/CapabilityEnvelopeTests.cs
@@ -1,0 +1,94 @@
+using Domain.AI.Bundles;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.Bundles;
+
+/// <summary>
+/// Tests for <see cref="CapabilityEnvelope.IsBundleOwnedMcpServer"/> — issue #376. The record's own
+/// remarks document an invariant (<c>BundleOwnedMcpServers</c> is always a subset of
+/// <c>AllowedMcpServers</c>) that nothing at construction time enforces, because the single production
+/// writer uses a <c>with</c> expression, which bypasses any factory. This class pins down the two ways
+/// the lists can drift apart and treats them deliberately asymmetrically: a name present only in
+/// <c>BundleOwnedMcpServers</c> is now also refused by <see cref="CapabilityEnvelope.IsBundleOwnedMcpServer"/>
+/// (making that predicate consistent with <see cref="CapabilityEnvelope.GrantsMcpServer"/>, which already
+/// refused it), while a name present only in <c>AllowedMcpServers</c> is UNCHANGED and un-catchable by any
+/// check on this type — see <see cref="IsBundleOwnedMcpServer_NamePresentOnlyInAllowedList_ReturnsFalse"/>
+/// for why, and why that direction's real guard lives on the writer instead.
+/// </summary>
+public sealed class CapabilityEnvelopeTests
+{
+    [Fact]
+    public void IsBundleOwnedMcpServer_NamePresentInBothLists_ReturnsTrue()
+    {
+        var envelope = new CapabilityEnvelope
+        {
+            AllowedMcpServers = ["bundle-1:server"],
+            BundleOwnedMcpServers = ["bundle-1:server"],
+        };
+
+        envelope.IsBundleOwnedMcpServer("bundle-1:server").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsBundleOwnedMcpServer_NamePresentOnlyInBundleOwnedList_ReturnsFalse()
+    {
+        // The dangerous direction the invariant exists to prevent, inverted: here the writer forgot to
+        // grant the server at all (AllowedMcpServers is empty), so the server cannot be contacted
+        // regardless — GrantsMcpServer already refuses it. This asserts IsBundleOwnedMcpServer agrees
+        // rather than claiming ownership of a server nothing actually granted.
+        var envelope = new CapabilityEnvelope
+        {
+            AllowedMcpServers = [],
+            BundleOwnedMcpServers = ["bundle-1:server"],
+        };
+
+        envelope.IsBundleOwnedMcpServer("bundle-1:server").Should().BeFalse();
+        envelope.GrantsMcpServer("bundle-1:server").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBundleOwnedMcpServer_NamePresentOnlyInAllowedList_ReturnsFalse()
+    {
+        // The direction the record's own remarks call out as the real danger: a writer granted the
+        // server (AllowedMcpServers) but never recorded it as bundle-owned. This behaviour is UNCHANGED
+        // by #376 — checking BundleOwnedMcpServers alone already returned false here, since the name is
+        // simply absent from that list, and no additional check on this type could ever recover it. This
+        // pins that fail-closed outcome so it stays proven: such a server is treated as host-trusted, not
+        // bundle-owned, so its tools never get the namespacing that keeps a bundle's own tool from
+        // impersonating a real host tool by name. The actual guard against this shape ever occurring is
+        // the writer test on RunBundleCommandHandler.WithBundleOwnedMcpServers, not this predicate.
+        var envelope = new CapabilityEnvelope
+        {
+            AllowedMcpServers = ["bundle-1:server"],
+            BundleOwnedMcpServers = [],
+        };
+
+        envelope.IsBundleOwnedMcpServer("bundle-1:server").Should().BeFalse();
+        envelope.GrantsMcpServer("bundle-1:server").Should().BeTrue("the server IS granted — just not as bundle-owned");
+    }
+
+    [Fact]
+    public void IsBundleOwnedMcpServer_NamePresentInNeitherList_ReturnsFalse()
+    {
+        var envelope = new CapabilityEnvelope
+        {
+            AllowedMcpServers = ["other-server"],
+            BundleOwnedMcpServers = ["other-server"],
+        };
+
+        envelope.IsBundleOwnedMcpServer("bundle-1:server").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsBundleOwnedMcpServer_IsCaseInsensitive_LikeEveryOtherGrantsPredicateOnThisRecord()
+    {
+        var envelope = new CapabilityEnvelope
+        {
+            AllowedMcpServers = ["Bundle-1:Server"],
+            BundleOwnedMcpServers = ["Bundle-1:Server"],
+        };
+
+        envelope.IsBundleOwnedMcpServer("bundle-1:server").Should().BeTrue();
+    }
+}

--- a/src/Content/Tests/Domain.Common.Tests/Helpers/Sha256HexPrefixHelperTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Helpers/Sha256HexPrefixHelperTests.cs
@@ -1,0 +1,72 @@
+using System.Security.Cryptography;
+using System.Text;
+using Domain.Common.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.Common.Tests.Helpers;
+
+/// <summary>
+/// Tests for <see cref="Sha256HexPrefixHelper"/> — the shared disambiguating-suffix primitive
+/// extracted from <c>BundleOwnedMcpToolNaming</c> and <c>ScopedCollectionName</c> under #377.
+/// </summary>
+public sealed class Sha256HexPrefixHelperTests
+{
+    [Fact]
+    public void Compute_MatchesTheRawSha256ComputationItReplaces()
+    {
+        // Both callers this helper was extracted from independently computed
+        // Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(value)))[..N]. This pins the
+        // helper to that exact computation, so extracting it cannot silently change either caller's
+        // output for an already-persisted value (e.g. a tenant's derived RAG collection name).
+        var expected = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes("contoso")))[..16];
+
+        var actual = Sha256HexPrefixHelper.Compute("contoso", 16);
+
+        actual.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Compute_IsDeterministic()
+    {
+        Sha256HexPrefixHelper.Compute("same-value", 10)
+            .Should().Be(Sha256HexPrefixHelper.Compute("same-value", 10));
+    }
+
+    [Fact]
+    public void Compute_DifferentInputs_ProduceDifferentOutput()
+    {
+        var a = Sha256HexPrefixHelper.Compute("my_server", 16);
+        var b = Sha256HexPrefixHelper.Compute("my server", 16);
+
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void Compute_ResultIsLowercaseHexOfRequestedLength()
+    {
+        var result = Sha256HexPrefixHelper.Compute("anything", 12);
+
+        result.Should().HaveLength(12);
+        result.Should().MatchRegex("^[0-9a-f]{12}$");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65)]
+    public void Compute_HexLengthOutsideValidRange_Throws(int hexLength)
+    {
+        var act = () => Sha256HexPrefixHelper.Compute("value", hexLength);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Compute_FullSixtyFourCharLength_ReturnsTheEntireDigest()
+    {
+        var result = Sha256HexPrefixHelper.Compute("value", 64);
+
+        result.Should().HaveLength(64);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BehaviorRecordingMcpToolProviderTests.cs
@@ -5,6 +5,7 @@ using Domain.AI.Governance;
 using Domain.Common.Config.AI;
 using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.AI;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerIsolationTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Exceptions;
+using Application.AI.Common.Interfaces.Bundles;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.Logging;
@@ -41,7 +43,14 @@ public sealed class BundleMcpServerIsolationTests
         // on this type is one careless foreach away from becoming a second GetConfiguredServerNames-style
         // chokepoint. This test fails the build the moment that happens, rather than relying on a
         // reviewer noticing.
-        var type = typeof(BundleOwnedMcpServerRegistry);
+        //
+        // Targets IBundleOwnedMcpServerRegistry, not the concrete BundleOwnedMcpServerRegistry (#374):
+        // every production consumer is constructed against the interface, so the interface is the actual
+        // public contract a future convenience method would be added to. Checking only the concrete type
+        // would miss a method added to the interface (and implemented via explicit interface
+        // implementation, invisible on the concrete type's own public method list) just as easily as one
+        // added directly to the class.
+        var type = typeof(IBundleOwnedMcpServerRegistry);
 
         type.Should().NotBeAssignableTo<System.Collections.IEnumerable>(
             "the registry must never be directly enumerable");
@@ -51,7 +60,7 @@ public sealed class BundleMcpServerIsolationTests
             .Select(m => m.Name)
             .ToList();
         publicMemberNames.Should().BeEquivalentTo(
-            [nameof(BundleOwnedMcpServerRegistry.TryAdd), nameof(BundleOwnedMcpServerRegistry.TryRemove), nameof(BundleOwnedMcpServerRegistry.TryGetValue)],
+            [nameof(IBundleOwnedMcpServerRegistry.TryAdd), nameof(IBundleOwnedMcpServerRegistry.TryRemove), nameof(IBundleOwnedMcpServerRegistry.TryGetValue)],
             "the only way to read this registry is an exact-name lookup — adding any other public member " +
             "(Keys, Values, Count, GetEnumerator, ...) needs a deliberate, reviewed decision, not an accident");
     }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
@@ -6,6 +6,7 @@ using Application.AI.Common.Services.Agent;
 using Domain.AI.Egress;
 using Domain.AI.Identity;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerExtendedTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.Logging;
@@ -48,6 +49,71 @@ public sealed class McpConnectionManagerExtendedTests
         var act = async () => await sut.DisconnectAsync("nonexistent");
 
         await act.Should().NotThrowAsync();
+    }
+
+    // -- DisconnectAsync vs. an in-flight connection lock (#378) --------------------------------------
+    //
+    // GetClientAsync/CreateClientAsync/ReconnectAsync all take a per-server SemaphoreSlim before
+    // touching that server's cached client. Simulating "a connect attempt is in flight" by holding that
+    // same semaphore directly (via reflection on the private _connectionLocks field) exercises
+    // DisconnectAsync's own lock-acquisition path without needing a real, controllable MCP transport.
+    // Two deterministic scenarios, not a scheduler-luck race: a hold shorter than the timeout (disconnect
+    // must wait for and use the lock) and a hold longer than it (disconnect must proceed anyway, bounded,
+    // never indefinitely). Both are pinned by elapsed-time bounds, not by which of two outcomes "wins."
+
+    [Fact]
+    public async Task DisconnectAsync_ConnectionLockHeldBriefly_WaitsForItRatherThanRacingPast()
+    {
+        // Regression test for #378: before this fix, DisconnectAsync never took the lock at all, so it
+        // could interleave its eviction with a concurrent connect's cache write in either order. Holding
+        // the lock for a short, bounded duration and asserting DisconnectAsync's elapsed time is AT LEAST
+        // that duration proves it genuinely waited for the lock rather than proceeding immediately.
+        var sut = CreateManager();
+        var connectionLocks = GetConnectionLocks(sut);
+        var heldLock = connectionLocks.GetOrAdd("brief-hold", _ => new SemaphoreSlim(1, 1));
+        await heldLock.WaitAsync();
+
+        var holdDuration = TimeSpan.FromMilliseconds(300);
+        _ = Task.Delay(holdDuration).ContinueWith(_ => heldLock.Release());
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await sut.DisconnectAsync("brief-hold");
+        sw.Stop();
+
+        sw.Elapsed.Should().BeGreaterThanOrEqualTo(
+            holdDuration - TimeSpan.FromMilliseconds(50),
+            "DisconnectAsync must actually wait for the lock, not race past a holder that releases quickly");
+        sw.Elapsed.Should().BeLessThan(
+            TimeSpan.FromSeconds(2), "a brief hold must resolve well before the multi-second fallback timeout");
+    }
+
+    [Fact]
+    public async Task DisconnectAsync_ConnectionLockHeldLongerThanTimeout_ProceedsWithoutHangingForever()
+    {
+        // The other half of #378: a genuinely hung connect attempt (the lock never releases within the
+        // fallback window) must not block bundle teardown indefinitely. DisconnectAsync's caller has no
+        // cancellation token of its own, so the ONLY thing that can bound this wait is the fixed timeout
+        // baked into DisconnectAsync itself — this proves that bound is real, not just documented.
+        var sut = CreateManager();
+        var connectionLocks = GetConnectionLocks(sut);
+        var heldLock = connectionLocks.GetOrAdd("stuck-server", _ => new SemaphoreSlim(1, 1));
+        await heldLock.WaitAsync();
+        // Deliberately never released within this test — simulates a hung connect attempt.
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await sut.DisconnectAsync("stuck-server");
+        sw.Stop();
+
+        sw.Elapsed.Should().BeLessThan(
+            TimeSpan.FromSeconds(10),
+            "disconnect must proceed once the fallback timeout elapses, never wait for a lock that never frees");
+    }
+
+    private static ConcurrentDictionary<string, SemaphoreSlim> GetConnectionLocks(McpConnectionManager manager)
+    {
+        var field = typeof(McpConnectionManager)
+            .GetField("_connectionLocks", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        return (ConcurrentDictionary<string, SemaphoreSlim>)field!.GetValue(manager)!;
     }
 
     // -- GetConfiguredServerNames edge cases --

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerTransportTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using Application.AI.Common.Exceptions;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderExtendedTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using FluentAssertions;
 using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.Logging;

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderTests.cs
@@ -88,6 +88,6 @@ public sealed class McpToolProviderTests
             new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(),
             new Domain.Common.Config.AI.MCP.McpServersConfig(),
-            new Domain.Common.Config.AI.MCP.BundleOwnedMcpServerRegistry());
+            new Infrastructure.AI.Bundles.BundleOwnedMcpServerRegistry());
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -261,8 +261,11 @@ public sealed class BundleRunExecutorTests : IDisposable
         await executor.ExecuteAsync("j1", CancellationToken.None);
 
         seenEnvelope.Should().NotBeNull();
-        // Namespaced, never the bare server-declared name — see BundleOwnedMcpToolNaming.
-        seenEnvelope!.AllowedTools.Should().Contain("b1_echo__echo_tool");
+        // Namespaced, never the bare server-declared name — see BundleOwnedMcpToolNaming. Structural, not
+        // an exact literal: the server half carries its own #373 collision-guard hash suffix (its raw
+        // form contains the ':' namespace separator).
+        seenEnvelope!.AllowedTools.Should().Contain(
+            n => n.StartsWith("b1_echo_", StringComparison.Ordinal) && n.EndsWith("__echo_tool", StringComparison.Ordinal));
         seenEnvelope.AllowedTools.Should().NotContain("echo_tool",
             "the bare, bundle-chosen name must never be the granted/governed name");
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -1,6 +1,7 @@
 using System.IO.Compression;
 using System.Text;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Plugins;
 using Domain.AI.Governance;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
@@ -288,6 +289,56 @@ public sealed class BundleStagingServiceTests : IDisposable
             "so a single returned name already proves exactly one entry reached bundleOwnedMcpServers");
     }
 
+    [Fact]
+    public async Task StageAsync_LaterManifestThrows_RollsBackEarlierManifestsRegisteredServers()
+    {
+        // Regression test for #372. The ROOT manifest registers a valid MCP server; a SINGLE nested
+        // plugin's manifest read throws (simulating any exception RegisterBundleMcpServers or the plugin
+        // reader can produce). Deliberately structured to be order-independent, not reliant on
+        // Directory.EnumerateDirectories' unspecified ordering (a /code-review finding on an earlier
+        // version of this test, which used two nested plugins and could pass vacuously if the throwing
+        // one happened to enumerate first — the assertion below would hold trivially because the "good"
+        // manifest was never reached, proving nothing about rollback): the root manifest is ALWAYS read
+        // before ParsePluginManifests even starts enumerating plugins/, and there is exactly one nested
+        // directory here, so there is no cross-item ordering left to depend on. Before this fix, the root
+        // manifest's registry entry survived — staging failed and deleted the extracted files, but
+        // nothing ever called TryRemove for a server registered before the failure, orphaning it for the
+        // life of the host process.
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: rollback-bundle\nname: Rollback Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"good-server\": { \"type\": \"http\", \"url\": \"https://one.example.com/mcp\" } } }"),
+            ("plugins/bad/plugin.json", "{ \"name\": \"bad\", \"version\": \"1.0.0\" }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = AllowlistedAppConfig("one.example.com");
+        var realReader = new PluginManifestReader(NullLogger<PluginManifestReader>.Instance);
+        string? bundleDir = null;
+
+        var throwingReader = new Mock<IPluginManifestReader>();
+        throwingReader
+            .Setup(r => r.Read(It.IsAny<string>()))
+            .Returns((string dir) =>
+            {
+                var normalized = dir.Replace('\\', '/');
+                if (normalized.EndsWith("/plugins/bad", StringComparison.Ordinal))
+                    throw new InvalidOperationException("simulated manifest-parsing failure");
+                if (!normalized.Contains("/plugins/", StringComparison.Ordinal))
+                    bundleDir = dir; // the root-manifest call always passes the bundle's own staged directory
+                return realReader.Read(dir);
+            });
+
+        var result = await CreateService(appConfig, bundleOwnedMcpServers, pluginReader: throwingReader.Object)
+            .StageAsync(zip);
+
+        result.IsSuccess.Should().BeFalse("a later manifest's parsing failure must fail the whole bundle");
+        bundleDir.Should().NotBeNull("the root manifest must have been read before the failing nested one");
+        var bundleId = Path.GetFileName(bundleDir);
+        bundleOwnedMcpServers.TryGetValue($"{bundleId}:good-server", out _).Should().BeFalse(
+            "the root manifest's server registration must be rolled back when a later manifest throws");
+        NoStagedDirectoriesRemain();
+    }
+
     // --- Hostile-archive guards ---------------------------------------------------------------------
 
     [Fact]
@@ -454,7 +505,8 @@ public sealed class BundleStagingServiceTests : IDisposable
         AppConfig appConfig,
         BundleOwnedMcpServerRegistry? bundleOwnedMcpServers = null,
         IMcpSecurityScanner? agentScanner = null,
-        IMcpSecurityScanner? skillScanner = null) =>
+        IMcpSecurityScanner? skillScanner = null,
+        IPluginManifestReader? pluginReader = null) =>
         new(
             new OptionsMonitorStub(appConfig),
             new AgentMetadataParser(
@@ -465,7 +517,7 @@ public sealed class BundleStagingServiceTests : IDisposable
                 skillScanner ?? TestMcpSecurityScanner.AlwaysSafe(),
                 Mock.Of<IOptionsMonitor<AIConfig>>(m => m.CurrentValue == appConfig.AI)),
             new UnsandboxedSkillFileReader(),
-            new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
+            pluginReader ?? new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
             bundleOwnedMcpServers ?? new BundleOwnedMcpServerRegistry(),
             NullLogger<BundleStagingService>.Instance);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -1,12 +1,15 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Resilience;
 using Domain.Common.Config;
+using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Resilience;
 using FluentAssertions;
 using Infrastructure.AI.Escalation;
 using Infrastructure.AI.KnowledgeGraph;
+using Infrastructure.AI.MCP;
 using Infrastructure.AI.Resilience;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -295,6 +298,64 @@ public sealed class DependencyInjectionTests
         client.Timeout.Should().Be(
             Timeout.InfiniteTimeSpan,
             "the resilience pipeline owns the timeout; the typed client must not set a finite one that races it");
+    }
+
+    // -- IBundleOwnedMcpServerRegistry cross-registration (#374) --
+
+    /// <summary>
+    /// Pins the invariant the interface extraction under #374 depends on: this registry is registered
+    /// via <c>TryAddSingleton</c> from BOTH <c>AddInfrastructureAIDependencies</c> (here) and
+    /// <c>AddMcpClientDependencies</c> (Infrastructure.AI.MCP), deliberately redundantly, so the wiring
+    /// survives either extension method being dropped from a future composition root by mistake. This
+    /// composes BOTH real extension methods against one container — mutation-tested by removing both
+    /// registration lines and confirming resolution fails, so the pass here is not vacuous — and resolves
+    /// the SAME staging service + connection manager the production host wires, proving the graph
+    /// actually constructs rather than merely that a type is registered.
+    /// </summary>
+    /// <remarks>
+    /// The <c>BeSameAs</c> assertion below is a weaker guarantee than it looks: .NET's container resolves
+    /// a service type to one deterministic descriptor for the container's lifetime, so two resolutions of
+    /// the SAME service type always agree even if a future edit adds a redundant duplicate registration —
+    /// there is no "sometimes returns a different instance" failure mode to catch that way. What actually
+    /// protected the pre-#374 design (and what a regression back to registering the bare concrete type
+    /// from only one site would break) is that every production consumer now depends on the INTERFACE,
+    /// not the concrete type — so there is no second, independently-resolvable key for a future edit to
+    /// accidentally diverge onto. <c>BundleMcpServerIsolationTests</c> guards that surface directly.
+    /// </remarks>
+    [Fact]
+    public async Task AddInfrastructureAIDependencies_AndAddMcpClientDependencies_ShareOneRegistryInstance()
+    {
+        var services = CreateBaseServices();
+        // AddMcpClientDependencies' own additional prerequisites — mirrors
+        // Infrastructure.AI.MCP.Tests.DependencyInjectionTests.BuildProvider (that project's TestSsrf
+        // helper is internal to a different test assembly, so the equivalent factory is built inline).
+        services.AddSingleton(new Infrastructure.AI.Egress.AntiSsrfHandlerFactory(new OptionsMonitorStub(new AppConfig())));
+        services.AddSingleton(new Mock<Application.AI.Common.Interfaces.Tools.IToolBehaviorRegistry>().Object);
+        services.AddSingleton(new Mock<IAmbientRequestScope>().Object);
+        services.AddSingleton(new Mock<Application.AI.Common.Interfaces.Egress.IEgressAuditWriter>().Object);
+
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
+        services.AddMcpClientDependencies();
+        // McpConnectionManager is IAsyncDisposable-only; the container refuses synchronous disposal.
+        await using var provider = services.BuildServiceProvider();
+
+        var registry = provider.GetRequiredService<IBundleOwnedMcpServerRegistry>();
+
+        // Round-trip through both real consumers this registry exists to keep in sync: staging (writes)
+        // and the connection manager (reads the fallback). If either resolved a DIFFERENT instance, a
+        // server staged here would be invisible to a connect attempt against the same name.
+        registry.TryAdd("bundle-x:probe", new McpServerDefinition { Enabled = true, Type = McpServerType.Http, Url = "https://example.com" })
+            .Should().BeTrue();
+
+        var stagingService = provider.GetRequiredService<Application.AI.Common.Interfaces.Bundles.IBundleStagingService>();
+        var connectionManager = provider.GetRequiredService<Infrastructure.AI.MCP.Services.McpConnectionManager>();
+        stagingService.Should().NotBeNull();
+        connectionManager.Should().NotBeNull();
+
+        // Resolving the registry itself twice more, through both extension methods' own service key,
+        // must hand back the identical instance — this is the actual regression #374's DI split risks.
+        var second = provider.GetRequiredService<IBundleOwnedMcpServerRegistry>();
+        registry.Should().BeSameAs(second);
     }
 
     /// <summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/BundleMcpEgressAttributionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/BundleMcpEgressAttributionTests.cs
@@ -9,6 +9,7 @@ using Domain.AI.Identity;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
 using FluentAssertions;
+using Infrastructure.AI.Bundles;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Services;
 using Infrastructure.AI.Tests.Egress.Support;

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.Egress;
 using System.Collections.Concurrent;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Bundles;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.MCP.Services;
 using Infrastructure.AI.Tests.Egress.Support;

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
@@ -10,6 +10,8 @@ namespace Infrastructure.AI.Tests.Plugins;
 /// Tests for <see cref="McpServerDefinitionBuilder"/> — the shared, type-branching builder used by both
 /// <see cref="PluginLoader"/> (host-installed plugins) and bundle staging (issue #368) so the two never
 /// independently decide how an <c>mcpServers</c> JSON entry maps to an <see cref="McpServerDefinition"/>.
+/// Returns <see cref="Domain.Common.Result{T}"/>, not exceptions (issue #374): every field this builder
+/// reads comes from externally-authored, untrusted manifest JSON.
 /// </summary>
 public sealed class McpServerDefinitionBuilderTests
 {
@@ -22,8 +24,10 @@ public sealed class McpServerDefinitionBuilderTests
     {
         var element = Parse("""{ "command": "npx", "args": ["-y", "server-name"] }""");
 
-        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Plugin: azure]", "azure-mcp");
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Plugin: azure]", "azure-mcp");
 
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        var definition = result.Value!;
         definition.Type.Should().Be(McpServerType.Stdio);
         definition.Command.Should().Be("npx");
         definition.Args.Should().BeEquivalentTo(["-y", "server-name"]);
@@ -36,10 +40,11 @@ public sealed class McpServerDefinitionBuilderTests
     {
         var element = Parse("""{ "type": "stdio", "command": "node", "args": ["server.js"] }""");
 
-        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "custom");
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "custom");
 
-        definition.Type.Should().Be(McpServerType.Stdio);
-        definition.Command.Should().Be("node");
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.Type.Should().Be(McpServerType.Stdio);
+        result.Value.Command.Should().Be("node");
     }
 
     [Fact]
@@ -47,11 +52,12 @@ public sealed class McpServerDefinitionBuilderTests
     {
         var element = Parse("""{ "type": "http", "url": "https://tools.example.com/mcp" }""");
 
-        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
 
-        definition.Type.Should().Be(McpServerType.Http);
-        definition.Url.Should().Be("https://tools.example.com/mcp");
-        definition.Command.Should().BeEmpty();
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.Type.Should().Be(McpServerType.Http);
+        result.Value.Url.Should().Be("https://tools.example.com/mcp");
+        result.Value.Command.Should().BeEmpty();
     }
 
     [Fact]
@@ -59,10 +65,11 @@ public sealed class McpServerDefinitionBuilderTests
     {
         var element = Parse("""{ "type": "sse", "url": "https://tools.example.com/sse" }""");
 
-        var definition = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
 
-        definition.Type.Should().Be(McpServerType.Sse);
-        definition.Url.Should().Be("https://tools.example.com/sse");
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.Type.Should().Be(McpServerType.Sse);
+        result.Value.Url.Should().Be("https://tools.example.com/sse");
     }
 
     [Theory]
@@ -70,26 +77,28 @@ public sealed class McpServerDefinitionBuilderTests
     [InlineData("""{ "type": "http", "url": null }""")]
     [InlineData("""{ "type": "http", "url": "" }""")]
     [InlineData("""{ "type": "http", "url": "   " }""")]
-    public void Build_HttpTypeWithNoUsableUrl_Throws(string json)
+    public void Build_HttpTypeWithNoUsableUrl_Fails(string json)
     {
         // Regression test: a remote server with no usable url used to register with
         // IsRemoteServer == true and Url == null, passing the bundle-path stdio-rejection
         // gate and squatting a name that only fails much later, at connect time.
         var element = Parse(json);
 
-        var act = () => McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
 
-        act.Should().Throw<InvalidOperationException>();
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*remote*declares a Http transport with no 'url'*");
     }
 
     [Fact]
-    public void Build_SseTypeWithNoUrl_Throws()
+    public void Build_SseTypeWithNoUrl_Fails()
     {
         var element = Parse("""{ "type": "sse" }""");
 
-        var act = () => McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "remote");
 
-        act.Should().Throw<InvalidOperationException>();
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*remote*declares a Sse transport with no 'url'*");
     }
 
     [Fact]
@@ -98,9 +107,120 @@ public sealed class McpServerDefinitionBuilderTests
         var element = Parse("""{ "command": "npx", "env": { "A": "manifest", "B": "manifest-only" } }""");
         var declarationEnv = new Dictionary<string, string> { ["A"] = "declaration" };
 
-        var definition = McpServerDefinitionBuilder.Build(element, declarationEnv, "[Plugin: p]", "s");
+        var result = McpServerDefinitionBuilder.Build(element, declarationEnv, "[Plugin: p]", "s");
 
-        definition.Env["A"].Should().Be("declaration", "declaration env overrides take precedence over manifest env");
-        definition.Env["B"].Should().Be("manifest-only");
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.Env["A"].Should().Be("declaration", "declaration env overrides take precedence over manifest env");
+        result.Value.Env["B"].Should().Be("manifest-only");
+    }
+
+    // -- Malformed JSON shapes on untrusted input (#374) --------------------------------------------
+
+    [Fact]
+    public void Build_TypeIsNotAString_FailsWithoutThrowing()
+    {
+        var element = Parse("""{ "type": 5 }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*'s' declares 'type' as Number*");
+    }
+
+    [Fact]
+    public void Build_UrlIsNotAString_FailsWithoutThrowing()
+    {
+        var element = Parse("""{ "type": "http", "url": 5 }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*'s' declares 'url' as Number*");
+    }
+
+    [Fact]
+    public void Build_CommandIsNotAString_FailsWithoutThrowing()
+    {
+        var element = Parse("""{ "command": true }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*'s' declares 'command' as True*");
+    }
+
+    [Fact]
+    public void Build_ArgsIsNotAnArray_FailsWithoutThrowing()
+    {
+        var element = Parse("""{ "command": "npx", "args": "not-an-array" }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*'s' declares 'args' as String*");
+    }
+
+    [Fact]
+    public void Build_ArgsElementIsNotAString_FailsWithoutThrowing()
+    {
+        var element = Parse("""{ "command": "npx", "args": ["ok", 5] }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*'s' declares an 'args' element as Number*");
+    }
+
+    [Fact]
+    public void Build_EnvIsNotAnObject_FailsWithoutThrowing()
+    {
+        var element = Parse("""{ "command": "npx", "env": ["not-an-object"] }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*'s' declares 'env' as Array*");
+    }
+
+    [Fact]
+    public void Build_EnvValueIsNotAString_FailsWithoutThrowing()
+    {
+        var element = Parse("""{ "command": "npx", "env": { "A": 5 } }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*'s' declares 'env.A' as Number*");
+    }
+
+    [Fact]
+    public void Build_ServerEntryIsNotAnObject_FailsWithoutThrowing()
+    {
+        // Regression test found by /code-review: the per-server JSON value itself (not just its
+        // properties) can be any JSON kind — a bundle's mcp.json can declare "badserver": "not-an-object"
+        // instead of an object. JsonElement.TryGetProperty throws InvalidOperationException when called
+        // on a non-Object element, and every ReadOptionalString/ReadArgs/ReadEnv call passes serverElement
+        // as that receiver — so without a top-level kind guard, this throws uncaught instead of returning
+        // a Result failure, exactly the defect #374 exists to close.
+        var element = Parse("\"not-an-object\"");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "badserver");
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainMatch("*badserver*String*");
+    }
+
+    [Fact]
+    public void Build_UnrecognizedTypeString_StillDefaultsToStdio()
+    {
+        // Not a malformed shape — a recognized STRING that isn't "http"/"sse" is the pre-existing,
+        // callers-depend-on-it default-to-stdio behaviour (BundleStagingService.LogStdioRejected relies
+        // on an absent OR unrecognized type both meaning stdio), not a failure.
+        var element = Parse("""{ "type": "carrier-pigeon", "command": "npx" }""");
+
+        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.Type.Should().Be(McpServerType.Stdio);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
@@ -116,81 +116,22 @@ public sealed class McpServerDefinitionBuilderTests
 
     // -- Malformed JSON shapes on untrusted input (#374) --------------------------------------------
 
-    [Fact]
-    public void Build_TypeIsNotAString_FailsWithoutThrowing()
+    [Theory]
+    [InlineData("""{ "type": 5 }""", "*'s' declares 'type' as Number*")]
+    [InlineData("""{ "type": "http", "url": 5 }""", "*'s' declares 'url' as Number*")]
+    [InlineData("""{ "command": true }""", "*'s' declares 'command' as True*")]
+    [InlineData("""{ "command": "npx", "args": "not-an-array" }""", "*'s' declares 'args' as String*")]
+    [InlineData("""{ "command": "npx", "args": ["ok", 5] }""", "*'s' declares an 'args' element as Number*")]
+    [InlineData("""{ "command": "npx", "env": ["not-an-object"] }""", "*'s' declares 'env' as Array*")]
+    [InlineData("""{ "command": "npx", "env": { "A": 5 } }""", "*'s' declares 'env.A' as Number*")]
+    public void Build_MalformedJsonShape_FailsWithoutThrowing(string json, string expectedErrorPattern)
     {
-        var element = Parse("""{ "type": 5 }""");
+        var element = Parse(json);
 
         var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
 
         result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().ContainMatch("*'s' declares 'type' as Number*");
-    }
-
-    [Fact]
-    public void Build_UrlIsNotAString_FailsWithoutThrowing()
-    {
-        var element = Parse("""{ "type": "http", "url": 5 }""");
-
-        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
-
-        result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().ContainMatch("*'s' declares 'url' as Number*");
-    }
-
-    [Fact]
-    public void Build_CommandIsNotAString_FailsWithoutThrowing()
-    {
-        var element = Parse("""{ "command": true }""");
-
-        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
-
-        result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().ContainMatch("*'s' declares 'command' as True*");
-    }
-
-    [Fact]
-    public void Build_ArgsIsNotAnArray_FailsWithoutThrowing()
-    {
-        var element = Parse("""{ "command": "npx", "args": "not-an-array" }""");
-
-        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
-
-        result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().ContainMatch("*'s' declares 'args' as String*");
-    }
-
-    [Fact]
-    public void Build_ArgsElementIsNotAString_FailsWithoutThrowing()
-    {
-        var element = Parse("""{ "command": "npx", "args": ["ok", 5] }""");
-
-        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
-
-        result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().ContainMatch("*'s' declares an 'args' element as Number*");
-    }
-
-    [Fact]
-    public void Build_EnvIsNotAnObject_FailsWithoutThrowing()
-    {
-        var element = Parse("""{ "command": "npx", "env": ["not-an-object"] }""");
-
-        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
-
-        result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().ContainMatch("*'s' declares 'env' as Array*");
-    }
-
-    [Fact]
-    public void Build_EnvValueIsNotAString_FailsWithoutThrowing()
-    {
-        var element = Parse("""{ "command": "npx", "env": { "A": 5 } }""");
-
-        var result = McpServerDefinitionBuilder.Build(element, NoEnv, "[Bundle: b1]", "s");
-
-        result.IsSuccess.Should().BeFalse();
-        result.Errors.Should().ContainMatch("*'s' declares 'env.A' as Number*");
+        result.Errors.Should().ContainMatch(expectedErrorPattern);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginLoaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginLoaderTests.cs
@@ -200,7 +200,7 @@ public sealed class PluginLoaderTests : IDisposable
             mcpServers = new Dictionary<string, object>
             {
                 ["good"] = new { command = "npx", args = new[] { "good-mcp" } },
-                ["bad"] = new { type = "http" } // no url -> McpServerDefinitionBuilder.Build throws
+                ["bad"] = new { type = "http" } // no url -> McpServerDefinitionBuilder.Build fails (#374: Result<T>, not a throw)
             }
         };
         File.WriteAllText(


### PR DESCRIPTION
## Summary

Closes six defects found during code review of PR #370 (bundle-owned MCP servers), deferred at the time to avoid inflating that security fix. All six live in the same subsystem: staging a bundle, registering the MCP servers it declares, and connecting to them.

- **#372** — Roll back a manifest's already-registered MCP servers if a later manifest (or a later server within the same manifest) throws, instead of leaking them for the life of the host process. `RegisterBundleMcpServers` now appends into the same list `ParsePluginManifests`' rollback catch inspects, as each server registers — not into a separate list merged in only after the whole call succeeds — so a throw partway through one manifest's own loop still rolls back correctly.
- **#373** — Apply the naming scheme's existing collision-guard hash suffix to the server-name half of a bundle tool's namespaced name, not just the tool-name half. Two server names that sanitize to the same string (e.g. `"my_server"` vs `"my server"`) no longer collide.
- **#374** — Extract `IBundleOwnedMcpServerRegistry` (Application-layer interface, Infrastructure implementation), matching the `IPluginRegistry`/`IMcpDefinitionPinStore`/`IHookRegistry` pattern already used for comparable registries. Convert `McpServerDefinitionBuilder.Build` to `Result<T>`, hardening every JSON accessor against a malformed manifest shape instead of throwing.
- **#376** — Enforce the `BundleOwnedMcpServers`/`AllowedMcpServers` invariant at the read chokepoint (`IsBundleOwnedMcpServer`), with a writer-side test pinning the direction a runtime check on the record itself cannot cover (a `with` expression bypasses any construction-time factory).
- **#377** — Extract the shared SHA-256 hex-prefix primitive (`Sha256HexPrefixHelper`) that was duplicated between `BundleOwnedMcpToolNaming` and `ScopedCollectionName`.
- **#378** — Bound `McpConnectionManager.DisconnectAsync`'s wait for the per-server connection lock (5s) instead of skipping it outright, closing the race with an in-flight connect without risking indefinite bundle teardown.

Two additional defects found by `/code-review` on this branch were also fixed: `McpServerDefinitionBuilder.Build` could still throw uncaught on a non-object server entry (`JsonElement.TryGetProperty`), and the #372 rollback only tracked names returned after a manifest's full server loop completed, missing a throw partway through one manifest's own loop. Both reproduced with a failing test first, then fixed.

### Deliberate divergences from the filed issue text

- **#372** asks for rollback via `IBundleMcpServerRegistrar.DeregisterAsync`. Used the registry's own `TryRemove` directly instead — `BundleStagingService` can't reference the project the registrar lives in, and the registrar's extra job (closing a live connection) is a no-op at staging time since the server's key was never handed to any caller.
- **#376** asks for a subset check (`BundleOwnedMcpServers ⊆ AllowedMcpServers`). That check only catches the benign direction (a name marked bundle-owned that was never actually granted). The dangerous direction — a granted server missing from `BundleOwnedMcpServers`, which would let its tools resolve as host-trusted — is structurally uncheckable from the envelope alone once it happens; the real guard is the writer-side test on `RunBundleCommandHandler.WithBundleOwnedMcpServers`, the single production writer.
- **#378** asks to have `DisconnectAsync` take the connection lock outright. The code already documents why it doesn't: teardown has no cancellation token, and a hung connect could block it indefinitely. Used a bounded wait (5s) instead, synthesizing a `CancellationTokenSource` and reusing the same `AcquireConnectionLockAsync` every other caller uses.

## Test plan

- [x] Full solution build (`dotnet build src/AgenticHarness.slnx`, Release + Debug) — clean, zero new warnings
- [x] Full solution test suite (`dotnet test src/AgenticHarness.slnx --configuration Release`) — all failures are pre-existing, Docker-dependent integration tests (Neo4j/PostgreSQL graph store, Prometheus metrics E2E) unrelated to this diff; confirmed via `docker info` (not running) and `detect_changes()` (diff touches only the expected symbols)
- [x] Every new/changed test mutation-checked: reverted the fix, confirmed the test fails; restored, confirmed it passes
- [x] `/code-review` (8-angle) — 2 CRITICAL bugs found and fixed with failing-test-first repro, 5 lower-severity findings addressed or accepted as deliberate design
- [x] `/simplify` (4-angle) — applied reuse/simplification/altitude fixes where in-scope; two architectural observations (CapabilityEnvelope's two-list model, a transactional registry primitive) noted as follow-up-issue candidates, out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW