### PR TITLE
feat: route a bundle-owned stdio MCP server through the sandbox (#371)

### DIFF
--- a/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
@@ -80,7 +80,9 @@ public sealed class BundleExecutionConfigValidator : AbstractValidator<BundleExe
             .WithMessage("StdioMcpServers:MaxConcurrentSessions must be > 0 — a non-positive cap would refuse every sandboxed stdio session host-wide.");
 
         RuleFor(x => x.StdioMcpServers.ContainerImage)
-            .Must(image => image.Length == 0 || image.Trim().Length > 0)
-            .WithMessage("StdioMcpServers:ContainerImage must not be whitespace-only — leave it empty to keep the capability inert, or set a real image reference.");
+            .Must(image => image.Length == 0 || (image.Trim().Length > 0 && image == image.Trim()))
+            .WithMessage("StdioMcpServers:ContainerImage must not be whitespace-only, and must not carry leading/trailing " +
+                "whitespace (nothing downstream trims it before it reaches Docker's image-reference parser) — leave it " +
+                "empty to keep the capability inert, or set a real image reference.");
     }
 }

--- a/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
@@ -70,5 +70,13 @@ public sealed class BundleExecutionConfigValidator : AbstractValidator<BundleExe
         RuleFor(x => x.MaxConcurrentStreamsPerCaller)
             .GreaterThanOrEqualTo(1)
             .WithMessage("MaxConcurrentStreamsPerCaller must be >= 1 — a non-positive cap would deny every stream.");
+
+        RuleFor(x => x.StdioMcpServers.MaxServersPerBundle)
+            .GreaterThan(0)
+            .WithMessage("StdioMcpServers:MaxServersPerBundle must be > 0 — a non-positive cap would let no bundle register a stdio server even when the capability is enabled.");
+
+        RuleFor(x => x.StdioMcpServers.ContainerImage)
+            .Must(image => image.Length == 0 || image.Trim().Length > 0)
+            .WithMessage("StdioMcpServers:ContainerImage must not be whitespace-only — leave it empty to keep the capability inert, or set a real image reference.");
     }
 }

--- a/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
@@ -75,6 +75,10 @@ public sealed class BundleExecutionConfigValidator : AbstractValidator<BundleExe
             .GreaterThan(0)
             .WithMessage("StdioMcpServers:MaxServersPerBundle must be > 0 — a non-positive cap would let no bundle register a stdio server even when the capability is enabled.");
 
+        RuleFor(x => x.StdioMcpServers.MaxConcurrentSessions)
+            .GreaterThan(0)
+            .WithMessage("StdioMcpServers:MaxConcurrentSessions must be > 0 — a non-positive cap would refuse every sandboxed stdio session host-wide.");
+
         RuleFor(x => x.StdioMcpServers.ContainerImage)
             .Must(image => image.Length == 0 || image.Trim().Length > 0)
             .WithMessage("StdioMcpServers:ContainerImage must not be whitespace-only — leave it empty to keep the capability inert, or set a real image reference.");

--- a/src/Content/Domain/Domain.AI/Sandbox/SandboxSessionRequest.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/SandboxSessionRequest.cs
@@ -47,4 +47,27 @@ public sealed record SandboxSessionRequest
     /// reserved-name rejection as <see cref="SandboxExecutionRequest.EnvironmentVariables"/>.
     /// </summary>
     public IReadOnlyDictionary<string, string>? EnvironmentVariables { get; init; }
+
+    /// <summary>
+    /// Container image to run the session in, overriding the sandbox's configured default image.
+    /// <strong>Docker-tier only</strong> — a factory for any other isolation level ignores this.
+    /// Still validated against <c>ContainerSandboxOptions.AllowedImagePrefixes</c> exactly like the
+    /// default image; a caller cannot use this to escape the operator's image allowlist, only to pick
+    /// among images the operator has already permitted. Null uses the sandbox's configured default.
+    /// </summary>
+    public string? ContainerImage { get; init; }
+
+    /// <summary>
+    /// Absolute path to a directory on the host whose contents are copied into the session's sandbox
+    /// workspace before it starts. <strong>Docker-tier only</strong> — a factory for any other
+    /// isolation level must refuse a request that sets this rather than silently ignore it, since the
+    /// process tier's workspace has no equivalent containment for caller-chosen content (see
+    /// <see cref="ToolPermissionProfile.MinimumIsolation"/>'s remarks on why untrusted, caller-supplied
+    /// commands require <see cref="SandboxIsolationLevel.Container"/>). Deliberately a copy contract,
+    /// not a bind-mount contract: the caller's source directory may be deleted by something outside
+    /// this session's lifetime (e.g. a bundle's staging directory on handle eviction), and a session
+    /// that depended on that directory staying mounted for its own duration would race that deletion.
+    /// Null starts with an empty workspace, as before this property existed.
+    /// </summary>
+    public string? WorkspaceSeedDirectory { get; init; }
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -20,12 +20,14 @@ namespace Domain.Common.Config.AI.BundleExecution;
 /// </para>
 /// <code>
 /// AppConfig.AI.BundleExecution
-/// ├── Enabled                     — Master toggle (default false)
-/// ├── TempRoot                    — Directory under which each bundle is staged in its own subfolder
-/// ├── MaxArchiveBytes             — Reject archives larger than this on the wire (compressed size)
-/// ├── MaxEntryCount               — Reject archives with more than this many entries
-/// ├── MaxTotalUncompressedBytes   — Reject when the sum of entry sizes exceeds this (bomb guard)
-/// └── MaxCompressionRatio         — Reject when uncompressed/compressed exceeds this (bomb guard)
+/// ├── Enabled                       — Master toggle (default false)
+/// ├── TempRoot                      — Directory under which each bundle is staged in its own subfolder
+/// ├── MaxArchiveBytes               — Reject archives larger than this on the wire (compressed size)
+/// ├── MaxEntryCount                 — Reject archives with more than this many entries
+/// ├── MaxTotalUncompressedBytes     — Reject when the sum of entry sizes exceeds this (bomb guard)
+/// ├── MaxCompressionRatio           — Reject when uncompressed/compressed exceeds this (bomb guard)
+/// ├── AllowBundleDeclaredMcpServers — Allow a bundle's own REMOTE (http/sse) MCP server declarations
+/// └── StdioMcpServers               — Allow + configure a bundle's own LOCAL (stdio) MCP servers, sandboxed
 /// </code>
 /// </remarks>
 public class BundleExecutionConfig
@@ -140,15 +142,28 @@ public class BundleExecutionConfig
     public BundleApiAuthConfig Auth { get; set; } = new();
 
     /// <summary>
-    /// Whether a bundle's own manifest may declare a remote (http/sse) MCP server that the host will connect
-    /// to on the bundle's behalf. Off by default: a bundle is untrusted, externally-authored input, and
-    /// honouring its own declared network endpoints means the host makes outbound requests a caller's
-    /// <c>CapabilityEnvelope</c> never authorized. When disabled, a bundle's declared <c>mcp.json</c> is
-    /// ignored entirely at staging time — the bundle registers no MCP servers, staging does not fail. Even
-    /// when enabled, a declared server's URL must still match <c>AppConfig.AI.Egress.DefaultAllowlist</c>
-    /// (checked at registration) and every connection is attributed and audited like any other outbound
-    /// request (checked live, on every call) — this flag only controls whether the capability exists at all.
+    /// Whether a bundle's own manifest may declare a <strong>remote</strong> (http/sse) MCP server that the
+    /// host will connect to on the bundle's behalf. Off by default: a bundle is untrusted, externally-authored
+    /// input, and honouring its own declared network endpoints means the host makes outbound requests a
+    /// caller's <c>CapabilityEnvelope</c> never authorized. When disabled, a bundle's declared <c>mcp.json</c>
+    /// is ignored entirely at staging time for remote servers — the bundle registers no remote MCP servers,
+    /// staging does not fail. Even when enabled, a declared server's URL must still match
+    /// <c>AppConfig.AI.Egress.DefaultAllowlist</c> (checked at registration) and every connection is
+    /// attributed and audited like any other outbound request (checked live, on every call) — this flag only
+    /// controls whether the capability exists at all.
     /// </summary>
+    /// <remarks>
+    /// Governs remote servers only. A <strong>local (stdio)</strong> server declaration is governed
+    /// independently by <see cref="StdioMcpServers"/> — the two are separate capabilities with separate risk
+    /// profiles, and enabling one does not enable the other.
+    /// </remarks>
     /// <value>Default: false</value>
     public bool AllowBundleDeclaredMcpServers { get; set; }
+
+    /// <summary>
+    /// Whether, and how, a bundle's own manifest may declare a <strong>local (stdio)</strong> MCP server —
+    /// run inside the sandbox rather than on the host. See <see cref="BundleStdioMcpServersConfig"/> for the
+    /// full contract. Defaults to a disabled configuration.
+    /// </summary>
+    public BundleStdioMcpServersConfig StdioMcpServers { get; set; } = new();
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleStdioMcpServersConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleStdioMcpServersConfig.cs
@@ -50,4 +50,15 @@ public sealed class BundleStdioMcpServersConfig
     /// </summary>
     /// <value>Default: 2</value>
     public int MaxServersPerBundle { get; set; } = 2;
+
+    /// <summary>
+    /// Maximum number of bundle-owned stdio sandbox sessions live across the WHOLE host at once —
+    /// distinct from <see cref="MaxServersPerBundle"/>, which bounds one bundle's own container count
+    /// but has nothing to say about how many bundles are concurrently staged. Enforced in
+    /// <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c> as a caller admitted with upload +
+    /// run permission could otherwise pin <see cref="MaxServersPerBundle"/> containers per bundle
+    /// times an unbounded number of concurrently-staged bundles. Must be positive.
+    /// </summary>
+    /// <value>Default: 8</value>
+    public int MaxConcurrentSessions { get; set; } = 8;
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleStdioMcpServersConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleStdioMcpServersConfig.cs
@@ -1,0 +1,53 @@
+namespace Domain.Common.Config.AI.BundleExecution;
+
+/// <summary>
+/// Whether a bundle's own manifest may declare a <c>stdio</c> (local-command) MCP server, and how the
+/// harness runs one when it does. Bound from <c>AppConfig:AI:BundleExecution:StdioMcpServers</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Off by default, and deliberately separate from <see cref="BundleExecutionConfig.AllowBundleDeclaredMcpServers"/>.</strong>
+/// That flag governs a remote (http/sse) server the host connects to over the network; this one governs a
+/// local command the host launches as a process — a materially larger risk surface, run only inside the
+/// Docker-tier sandbox (see <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c>), never on the
+/// host directly. An operator who has opted into remote bundle MCP servers has not thereby opted into
+/// sandboxed local ones; each capability needs its own deliberate opt-in.
+/// </para>
+/// <para>
+/// A bundle's stdio server is never given network access (see <c>ToolPermissionProfileResolver</c>'s
+/// <c>ToolCapability.None</c> base grant for a bundle-owned name) — it must be fully self-contained
+/// within the bundle's own staged files, which are copied into the sandbox workspace at session start.
+/// </para>
+/// </remarks>
+public sealed class BundleStdioMcpServersConfig
+{
+    /// <summary>
+    /// Master toggle for this capability. When disabled (the default), a bundle-declared <c>stdio</c>
+    /// server is rejected at staging exactly as it was before this capability existed — the manifest is
+    /// still parsed (to distinguish an explicit <c>stdio</c> declaration from a defaulted one for logging),
+    /// but nothing is registered and no container is ever created.
+    /// </summary>
+    /// <value>Default: false</value>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// The container image a bundle-owned stdio server's sandbox session runs in. There is no per-bundle
+    /// image override — a bundle's registered name contains a fresh GUID per staging, so the sandbox's
+    /// existing per-tool <c>SandboxExecutionOptions.ToolOverrides</c> image lookup can never match one —
+    /// so every bundle stdio server on a host shares this single operator-chosen runtime image. Still
+    /// validated against <c>ContainerSandboxOptions.AllowedImagePrefixes</c> like any other image. Left
+    /// empty, staging refuses to register a stdio server even when <see cref="Enabled"/> is true, since an
+    /// empty image resolves to the harness's own default (.NET runtime) image, which cannot run most MCP
+    /// servers.
+    /// </summary>
+    /// <value>Default: "" (no image configured — the capability stays inert until an operator sets one)</value>
+    public string ContainerImage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Maximum number of stdio MCP servers a single bundle may register. Each registered server becomes a
+    /// long-lived sandbox container for the life of the bundle's staged handle, so this bounds how many
+    /// concurrent containers one uploaded bundle can pin on the host. Must be positive.
+    /// </summary>
+    /// <value>Default: 2</value>
+    public int MaxServersPerBundle { get; set; } = 2;
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerDefinition.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/MCP/McpServerDefinition.cs
@@ -95,6 +95,17 @@ public class McpServerDefinition
     /// </remarks>
     public bool TrustToolAnnotations { get; set; }
 
+    /// <summary>
+    /// Absolute path to a bundle's staged directory, set only for a bundle-owned <c>stdio</c> server
+    /// at registration time (<c>BundleStagingService.TryBuildAndRegisterOneServer</c>) and read only by
+    /// <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c> to seed that server's sandbox
+    /// workspace. Deliberately distinct from <see cref="WorkingDirectory"/>, which already means "the
+    /// trusted host process's working directory" on the unsandboxed stdio arm — the two describe
+    /// different trust tiers and must never be conflated onto one field. Null on every host-configured
+    /// and bundle-owned-remote definition.
+    /// </summary>
+    public string? SandboxSeedDirectory { get; set; }
+
     /// <summary>Gets whether this server requires authentication.</summary>
     public bool RequiresAuth => Auth?.IsConfigured ?? false;
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -536,13 +536,21 @@ public sealed class McpConnectionManager : IAsyncDisposable
                 $"Host-wide bundle stdio sandbox session cap ({maxConcurrentSessions}) reached; refusing to start another.");
         }
 
-        var scope = _scopeFactory.CreateAsyncScope();
+        // Nullable, and assigned only once CreateAsyncScope() itself succeeds — that call is not
+        // guaranteed exception-free (e.g. an already-disposed root provider during host shutdown),
+        // and it sat outside this method's try/finally in an earlier draft, so a throw there
+        // leaked the slot claimed above for the rest of the process's life. Declaring it here and
+        // assigning inside the try means the finally below can tell "never created" (nothing to
+        // dispose) apart from "created but not yet transferred" (must dispose) via a single null
+        // check, without a second try/finally layer.
+        AsyncServiceScope? scope = null;
         var ownershipTransferred = false;
         try
         {
-            var sessionFactory = scope.ServiceProvider
+            scope = _scopeFactory.CreateAsyncScope();
+            var sessionFactory = scope.Value.ServiceProvider
                 .GetRequiredKeyedService<ISandboxSessionFactory>(SandboxIsolationLevel.Container);
-            var profileResolver = scope.ServiceProvider.GetRequiredService<ToolPermissionProfileResolver>();
+            var profileResolver = scope.Value.ServiceProvider.GetRequiredService<ToolPermissionProfileResolver>();
 
             var resolvedProfile = profileResolver.Resolve(serverName);
             var permissionProfile = resolvedProfile with
@@ -581,37 +589,42 @@ public sealed class McpConnectionManager : IAsyncDisposable
             if (!result.IsSuccess)
                 return result;
 
-            // From here on, ScopedSandboxSession owns BOTH the scope's lifetime and this session's
-            // claimed concurrency slot — its own DisposeAsync releases both once the session ends.
+            // From here on, ownership of both the scope AND this session's claimed concurrency slot
+            // transfers to the returned session — two composed decorators, each responsible for
+            // releasing exactly one of them on DisposeAsync, not one type juggling both.
             ownershipTransferred = true;
-            return Result<ISandboxSession>.Success(new ScopedSandboxSession(
-                result.Value!, scope, onDisposed: () => Interlocked.Decrement(ref _liveSandboxedStdioSessions)));
+            var scopedSession = new ScopedSandboxSession(result.Value!, scope.Value);
+            return Result<ISandboxSession>.Success(new SlotReleasingSandboxSession(
+                scopedSession, releaseSlot: () => Interlocked.Decrement(ref _liveSandboxedStdioSessions)));
         }
         finally
         {
             if (!ownershipTransferred)
             {
                 Interlocked.Decrement(ref _liveSandboxedStdioSessions);
-                await scope.DisposeAsync();
+                if (scope is { } createdScope)
+                    await createdScope.DisposeAsync();
             }
         }
     }
 
     /// <summary>
     /// Whether <paramref name="seedDirectory"/> resolves under the SAME bundle staging root
-    /// <c>BundleStagingService.ResolveStagingRoot</c> uses — the only tree a sandbox workspace may
+    /// <see cref="SkillContentRoots.BundleStaging"/> resolves — the only tree a sandbox workspace may
     /// ever be seeded from. Deliberately re-derives that resolution here rather than trusting the
     /// caller: see the containment-check remarks at this method's one call site.
     /// </summary>
-    private bool IsWithinConfiguredStagingRoot(string seedDirectory)
-    {
-        var bundleExecution = _appConfig.CurrentValue.AI.BundleExecution;
-        var stagingRoot = string.IsNullOrWhiteSpace(bundleExecution.TempRoot)
-            ? SkillContentRoots.BundleStaging(_appConfig.CurrentValue)
-            : SkillContentRoots.Resolve(bundleExecution.TempRoot);
-
-        return PathScope.IsSameOrUnderNormalized(PathScope.Normalize(seedDirectory), PathScope.Normalize(stagingRoot));
-    }
+    /// <remarks>
+    /// <see cref="SkillContentRoots.BundleStaging"/> already contains the "configured <c>TempRoot</c>,
+    /// or the system-temp fallback" branch internally — the ONE place that decision is made, per that
+    /// class's own doc comment — so this method must not (and no longer does) re-derive that branch a
+    /// second time itself; a caller re-deriving it is exactly the drift risk the class's own doc warns
+    /// about. A single containment check against one target uses <see cref="PathScope.IsSameOrUnder"/>,
+    /// which normalizes both sides internally, rather than the <c>*Normalized</c> overload meant for
+    /// comparing many targets against one already-normalized base.
+    /// </remarks>
+    private bool IsWithinConfiguredStagingRoot(string seedDirectory) =>
+        PathScope.IsSameOrUnder(seedDirectory, SkillContentRoots.BundleStaging(_appConfig.CurrentValue));
 
     private HttpClientTransport CreateHttpTransport(string serverName, McpServerDefinition definition, bool isBundleOwned)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -7,12 +7,14 @@ using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Services.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
+using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.Identity;
 using Infrastructure.AI.MCP.Egress;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModelContextProtocol.Client;
 
 namespace Infrastructure.AI.MCP.Services;
@@ -42,6 +44,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private readonly IEgressAuditWriter _egressAuditWriter;
     private readonly ILogger<EgressPolicyDelegatingHandler> _egressHandlerLogger;
     private readonly TimeProvider _timeProvider;
+    private readonly IOptionsMonitor<AppConfig> _appConfig;
 
     // A single flat cache keyed by bare serverName, shared across BOTH _config and _bundleOwnedServers —
     // safe today because the two namespacing schemes never collide (host names are plain or
@@ -122,6 +125,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         _egressAuditWriter = rootServices.GetRequiredService<IEgressAuditWriter>();
         _egressHandlerLogger = rootServices.GetRequiredService<ILogger<EgressPolicyDelegatingHandler>>();
         _timeProvider = rootServices.GetService<TimeProvider>() ?? TimeProvider.System;
+        _appConfig = rootServices.GetRequiredService<IOptionsMonitor<AppConfig>>();
     }
 
     /// <summary>
@@ -424,10 +428,10 @@ public sealed class McpConnectionManager : IAsyncDisposable
         return definition.Type switch
         {
             // A bundle-owned stdio server runs inside the sandbox, never directly on the host —
-            // see #371 and BundleStagingService.LogStdioRejected for the RCE rationale. This arm
-            // is currently unreachable in production: staging still rejects a bundle-declared
-            // stdio server outright, so isBundleOwned is never true here yet. The registration
-            // gate that makes it reachable is #371's follow-up PR, not this one.
+            // see #371 and BundleStagingService.LogStdioRejected for the RCE rationale. Reachable
+            // only when an operator has both opted into AppConfig.AI.BundleExecution.StdioMcpServers
+            // and configured a container image; BundleStagingService.TryBuildAndRegisterOneServer
+            // is the gate that decides whether isBundleOwned is ever true here for a stdio server.
             McpServerType.Stdio when isBundleOwned => new SandboxedStdioClientTransport(
                 serverName,
                 ct => StartSandboxedStdioSessionAsync(serverName, definition, ct),
@@ -458,11 +462,19 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// resolution, not the same one.
     /// </summary>
     /// <remarks>
-    /// Container isolation only, for now: the harness has no per-bundle Process-tier allowlist
-    /// concept yet (that path is only safe when an operator has explicitly trusted a specific
-    /// command — see the remarks on <c>ProcessSandboxSessionFactory</c>), and building that
-    /// policy surface belongs with the registration gate that makes this arm reachable at all,
-    /// not with the transport plumbing here. Resource limits use sandbox defaults.
+    /// Container isolation only: the harness has no per-bundle Process-tier allowlist concept, and
+    /// <c>ProcessSandboxSessionFactory</c> refuses a request that carries
+    /// <see cref="SandboxSessionRequest.WorkspaceSeedDirectory"/> outright, so this path could never
+    /// downgrade to that tier even by misconfiguration. Resource limits use sandbox defaults.
+    /// <para>
+    /// The container image comes from <c>AppConfig.AI.BundleExecution.StdioMcpServers.ContainerImage</c>
+    /// — an operator-set default shared by every bundle-owned stdio server on this host, not a
+    /// per-bundle choice: a bundle-owned name contains a fresh GUID per staging, so the sandbox's
+    /// existing per-tool image override lookup can never match one. The workspace is seeded from
+    /// <see cref="McpServerDefinition.SandboxSeedDirectory"/> — the bundle's own staged directory,
+    /// set only by <c>BundleStagingService</c> at registration — so the server's own files are
+    /// present when its process starts.
+    /// </para>
     /// <para>
     /// The permission profile is resolved through <see cref="ToolPermissionProfileResolver"/> —
     /// not built as an inline literal — so this path consults the same override registry
@@ -520,7 +532,11 @@ public sealed class McpConnectionManager : IAsyncDisposable
                 PermissionProfile = permissionProfile,
                 Command = definition.Command,
                 ArgumentList = definition.Args,
-                EnvironmentVariables = definition.Env.Count > 0 ? definition.Env : null
+                EnvironmentVariables = definition.Env.Count > 0 ? definition.Env : null,
+                ContainerImage = _appConfig.CurrentValue.AI.BundleExecution.StdioMcpServers.ContainerImage is { Length: > 0 } image
+                    ? image
+                    : null,
+                WorkspaceSeedDirectory = definition.SandboxSeedDirectory
             };
 
             var result = await sessionFactory.StartSessionAsync(request, cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -8,10 +8,13 @@ using Application.AI.Common.Services.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
 using Domain.Common.Config;
+using Domain.Common.Config.AI.BundleExecution;
 using Domain.Common.Config.AI.MCP;
+using Domain.Common.Helpers;
 using Infrastructure.AI.Egress;
 using Infrastructure.AI.Identity;
 using Infrastructure.AI.MCP.Egress;
+using Infrastructure.AI.Skills;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -66,6 +69,15 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _connectionLocks = new();
     private bool _disposed;
+
+    /// <summary>
+    /// Live bundle-owned sandboxed stdio sessions across the whole host, bounded by
+    /// <see cref="BundleStdioMcpServersConfig.MaxConcurrentSessions"/> — see the security-review
+    /// finding recorded on that property. Incremented before <see cref="ISandboxSessionFactory.StartSessionAsync"/>
+    /// is ever called; decremented either immediately on a failed start or via
+    /// <see cref="ScopedSandboxSession"/>'s disposal callback once a session actually ends.
+    /// </summary>
+    private int _liveSandboxedStdioSessions;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="McpConnectionManager"/> class.
@@ -510,6 +522,20 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private async Task<Result<ISandboxSession>> StartSandboxedStdioSessionAsync(
         string serverName, McpServerDefinition definition, CancellationToken cancellationToken)
     {
+        // Claimed before anything else — cheapest possible check, and it must bracket every failure
+        // path below (a resolver throwing, the containment check rejecting, the factory itself
+        // failing), not just the success path, or a slot leaks. ownershipTransferred below (already
+        // tracking whether the DI scope's lifetime transferred to the returned session) transfers
+        // this slot's ownership at the exact same point, so one flag does double duty rather than
+        // needing a second.
+        var maxConcurrentSessions = _appConfig.CurrentValue.AI.BundleExecution.StdioMcpServers.MaxConcurrentSessions;
+        if (Interlocked.Increment(ref _liveSandboxedStdioSessions) > maxConcurrentSessions)
+        {
+            Interlocked.Decrement(ref _liveSandboxedStdioSessions);
+            return Result<ISandboxSession>.Fail(
+                $"Host-wide bundle stdio sandbox session cap ({maxConcurrentSessions}) reached; refusing to start another.");
+        }
+
         var scope = _scopeFactory.CreateAsyncScope();
         var ownershipTransferred = false;
         try
@@ -524,6 +550,18 @@ public sealed class McpConnectionManager : IAsyncDisposable
                 MinimumIsolation = (SandboxIsolationLevel)Math.Max(
                     (int)resolvedProfile.MinimumIsolation, (int)SandboxIsolationLevel.Container)
             };
+
+            if (definition.SandboxSeedDirectory is { } seedDirectory && !IsWithinConfiguredStagingRoot(seedDirectory))
+            {
+                // A structural containment check, not just a convention: today's ONLY writer of
+                // SandboxSeedDirectory (BundleStagingService) only ever sets it to the bundle's own
+                // staged root, so this never fires in production. It exists so a future caller of
+                // this field cannot turn "seed a sandbox workspace" into "copy an arbitrary host
+                // directory into an untrusted, bundle-launched container" without this check also
+                // having to be deliberately bypassed, not merely never written in the first place.
+                return Result<ISandboxSession>.Fail(
+                    "Sandbox workspace seed directory is outside the configured bundle staging root — refusing to seed.");
+            }
 
             var request = new SandboxSessionRequest
             {
@@ -543,16 +581,36 @@ public sealed class McpConnectionManager : IAsyncDisposable
             if (!result.IsSuccess)
                 return result;
 
-            // From here on, ScopedSandboxSession owns the scope's lifetime — its own DisposeAsync
-            // releases it once the session ends.
+            // From here on, ScopedSandboxSession owns BOTH the scope's lifetime and this session's
+            // claimed concurrency slot — its own DisposeAsync releases both once the session ends.
             ownershipTransferred = true;
-            return Result<ISandboxSession>.Success(new ScopedSandboxSession(result.Value!, scope));
+            return Result<ISandboxSession>.Success(new ScopedSandboxSession(
+                result.Value!, scope, onDisposed: () => Interlocked.Decrement(ref _liveSandboxedStdioSessions)));
         }
         finally
         {
             if (!ownershipTransferred)
+            {
+                Interlocked.Decrement(ref _liveSandboxedStdioSessions);
                 await scope.DisposeAsync();
+            }
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="seedDirectory"/> resolves under the SAME bundle staging root
+    /// <c>BundleStagingService.ResolveStagingRoot</c> uses — the only tree a sandbox workspace may
+    /// ever be seeded from. Deliberately re-derives that resolution here rather than trusting the
+    /// caller: see the containment-check remarks at this method's one call site.
+    /// </summary>
+    private bool IsWithinConfiguredStagingRoot(string seedDirectory)
+    {
+        var bundleExecution = _appConfig.CurrentValue.AI.BundleExecution;
+        var stagingRoot = string.IsNullOrWhiteSpace(bundleExecution.TempRoot)
+            ? SkillContentRoots.BundleStaging(_appConfig.CurrentValue)
+            : SkillContentRoots.Resolve(bundleExecution.TempRoot);
+
+        return PathScope.IsSameOrUnderNormalized(PathScope.Normalize(seedDirectory), PathScope.Normalize(stagingRoot));
     }
 
     private HttpClientTransport CreateHttpTransport(string serverName, McpServerDefinition definition, bool isBundleOwned)

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/ScopedSandboxSession.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/ScopedSandboxSession.cs
@@ -16,7 +16,7 @@ namespace Infrastructure.AI.MCP.Services;
 /// the first genuine scope-outlives-its-creating-method case in this codebase, not a copy of an
 /// existing one. Every member below is a pure delegation except <see cref="DisposeAsync"/>.
 /// </summary>
-public sealed class ScopedSandboxSession(ISandboxSession inner, AsyncServiceScope scope, Action? onDisposed = null) : ISandboxSession
+public sealed class ScopedSandboxSession(ISandboxSession inner, AsyncServiceScope scope) : ISandboxSession
 {
     /// <inheritdoc />
     public Stream StandardInput => inner.StandardInput;
@@ -30,30 +30,16 @@ public sealed class ScopedSandboxSession(ISandboxSession inner, AsyncServiceScop
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        // Nested try/finally, not a plain sequence: if the inner session's own teardown throws, the
+        // try/finally, not a plain sequence: if the inner session's own teardown throws, the
         // scope must still be released — otherwise a single bad disposal leaks the DI scope (and
-        // every scoped disposable it resolved) for the lifetime of the singleton that held it. The
-        // outer finally runs regardless of either inner failure — see onDisposed's own remarks for
-        // why it must fire even when teardown itself throws.
+        // every scoped disposable it resolved) for the lifetime of the singleton that held it.
         try
         {
-            try
-            {
-                await inner.DisposeAsync();
-            }
-            finally
-            {
-                await scope.DisposeAsync();
-            }
+            await inner.DisposeAsync();
         }
         finally
         {
-            // Releases a slot the caller reserved BEFORE this session was ever handed back to it
-            // (see McpConnectionManager.StartSandboxedStdioSessionAsync's host-wide concurrency
-            // cap) — must fire even when the disposal above throws, or a session whose own
-            // teardown failed would permanently pin its slot for the rest of the host process's
-            // life, eventually starving every other bundle of the sandbox capability entirely.
-            onDisposed?.Invoke();
+            await scope.DisposeAsync();
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/ScopedSandboxSession.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/ScopedSandboxSession.cs
@@ -16,7 +16,7 @@ namespace Infrastructure.AI.MCP.Services;
 /// the first genuine scope-outlives-its-creating-method case in this codebase, not a copy of an
 /// existing one. Every member below is a pure delegation except <see cref="DisposeAsync"/>.
 /// </summary>
-public sealed class ScopedSandboxSession(ISandboxSession inner, AsyncServiceScope scope) : ISandboxSession
+public sealed class ScopedSandboxSession(ISandboxSession inner, AsyncServiceScope scope, Action? onDisposed = null) : ISandboxSession
 {
     /// <inheritdoc />
     public Stream StandardInput => inner.StandardInput;
@@ -30,16 +30,30 @@ public sealed class ScopedSandboxSession(ISandboxSession inner, AsyncServiceScop
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        // try/finally, not a plain sequence: if the inner session's own teardown throws, the
+        // Nested try/finally, not a plain sequence: if the inner session's own teardown throws, the
         // scope must still be released — otherwise a single bad disposal leaks the DI scope (and
-        // every scoped disposable it resolved) for the lifetime of the singleton that held it.
+        // every scoped disposable it resolved) for the lifetime of the singleton that held it. The
+        // outer finally runs regardless of either inner failure — see onDisposed's own remarks for
+        // why it must fire even when teardown itself throws.
         try
         {
-            await inner.DisposeAsync();
+            try
+            {
+                await inner.DisposeAsync();
+            }
+            finally
+            {
+                await scope.DisposeAsync();
+            }
         }
         finally
         {
-            await scope.DisposeAsync();
+            // Releases a slot the caller reserved BEFORE this session was ever handed back to it
+            // (see McpConnectionManager.StartSandboxedStdioSessionAsync's host-wide concurrency
+            // cap) — must fire even when the disposal above throws, or a session whose own
+            // teardown failed would permanently pin its slot for the rest of the host process's
+            // life, eventually starving every other bundle of the sandbox capability entirely.
+            onDisposed?.Invoke();
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/SlotReleasingSandboxSession.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/SlotReleasingSandboxSession.cs
@@ -1,0 +1,58 @@
+using Application.AI.Common.Interfaces.Sandbox;
+
+namespace Infrastructure.AI.MCP.Services;
+
+/// <summary>
+/// Decorates an <see cref="ISandboxSession"/> so that disposing it also releases a caller-held
+/// concurrency slot — <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c>'s host-wide cap on
+/// live bundle-owned sandboxed sessions.
+/// </summary>
+/// <remarks>
+/// A separate decorator, composed with <see cref="ScopedSandboxSession"/> rather than folded into it
+/// (an earlier version threaded an <c>onDisposed</c> callback through <c>ScopedSandboxSession</c>'s own
+/// constructor instead — a /simplify altitude finding caught it as smuggling a second, unrelated
+/// disposal responsibility into a type whose own doc comment promises "every member is a pure
+/// delegation except <c>DisposeAsync</c>", which itself was scoped to exactly one job: releasing the
+/// DI scope. Composition keeps each decorator responsible for exactly one lifetime.
+/// </remarks>
+public sealed class SlotReleasingSandboxSession(ISandboxSession inner, Action releaseSlot) : ISandboxSession
+{
+    /// <summary>
+    /// Guards <see cref="DisposeAsync"/> against running twice on the same instance — two callers
+    /// racing to tear down the same session (e.g. an explicit close overlapping host shutdown
+    /// enumeration) must decrement the host-wide concurrency counter exactly once, or the second,
+    /// redundant decrement would silently admit one more concurrent session than
+    /// <c>MaxConcurrentSessions</c> permits for as long as the host runs — the opposite failure
+    /// mode from a leaked slot, but just as real: found by /code-review (#371).
+    /// </summary>
+    private int _disposed;
+
+    /// <inheritdoc />
+    public Stream StandardInput => inner.StandardInput;
+
+    /// <inheritdoc />
+    public Stream StandardOutput => inner.StandardOutput;
+
+    /// <inheritdoc />
+    public Task Completion => inner.Completion;
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        // finally, not a plain sequence: the slot must be released even if the inner session's own
+        // teardown throws — otherwise a session whose disposal failed would permanently pin its slot
+        // for the rest of the host process's life, eventually starving every other bundle of the
+        // sandbox capability entirely.
+        try
+        {
+            await inner.DisposeAsync();
+        }
+        finally
+        {
+            releaseSlot();
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.StdioMcp.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.StdioMcp.cs
@@ -48,7 +48,7 @@ public sealed partial class BundleStagingService
     /// the server's name later — so <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c> can seed
     /// the server's sandbox workspace with the bundle's own files.
     /// <para>
-    /// The seed is always <paramref name="bundleDir"/> — the WHOLE bundle's staged root, not the
+    /// The seed is always <see cref="ServerRegistrationContext.BundleDir"/> — the WHOLE bundle's staged root, not the
     /// specific plugin manifest that declared this server — even when the declaration lives in a
     /// nested <c>plugins/&lt;name&gt;/mcp.json</c>. This was a deliberate choice, not an omission: the
     /// server may legitimately need sibling content elsewhere in the bundle. The consequence a bundle
@@ -59,34 +59,32 @@ public sealed partial class BundleStagingService
     /// </para>
     /// </summary>
     private bool TryRegisterStdioServer(
-        string bundleId, string namespacedName, JsonProperty serverProp, McpServerDefinition definition,
-        string bundleDir, BundleStdioMcpServersConfig stdioConfig, bool sandboxEnabled, ref int stdioServerCount)
+        ServerRegistrationContext context, string namespacedName, JsonProperty serverProp, McpServerDefinition definition,
+        int stdioServerCount)
     {
         if (!McpServerDefinitionBuilder.IsExplicitType(serverProp.Value, McpServerType.Stdio))
         {
-            LogStdioRejected(bundleId, serverProp.Name);
+            LogStdioRejected(context.BundleId, serverProp.Name);
             return false;
         }
+
+        var stdioConfig = context.BundleExecution.StdioMcpServers;
 
         // Short-circuiting || means the FIRST failing check logs and stops evaluation — the same
         // "log the first reason" ordering the inline checks this replaced had, just delegated one
         // guard per method instead of five inline blocks in one body.
-        if (!IsStdioCapabilityEnabled(bundleId, serverProp.Name, stdioConfig)
-            || !HasConfiguredContainerImage(bundleId, serverProp.Name, stdioConfig)
-            || !IsSandboxSubsystemEnabled(bundleId, serverProp.Name, sandboxEnabled)
-            || !HasNonEmptyCommand(bundleId, serverProp.Name, definition)
-            || !IsWithinPerBundleStdioServerCap(bundleId, serverProp.Name, stdioServerCount, stdioConfig))
+        if (!IsStdioCapabilityEnabled(context.BundleId, serverProp.Name, stdioConfig)
+            || !HasConfiguredContainerImage(context.BundleId, serverProp.Name, stdioConfig)
+            || !IsSandboxSubsystemEnabled(context.BundleId, serverProp.Name, context.SandboxEnabled)
+            || !HasNonEmptyCommand(context.BundleId, serverProp.Name, definition)
+            || !IsWithinPerBundleStdioServerCap(context.BundleId, serverProp.Name, stdioServerCount, stdioConfig))
         {
             return false;
         }
 
-        definition.SandboxSeedDirectory = bundleDir;
+        definition.SandboxSeedDirectory = context.BundleDir;
 
-        if (!TryAddOwnedServer(bundleId, namespacedName, serverProp.Name, definition))
-            return false;
-
-        stdioServerCount++;
-        return true;
+        return TryAddOwnedServer(context.BundleId, namespacedName, serverProp.Name, definition);
     }
 
     private bool IsStdioCapabilityEnabled(string bundleId, string serverName, BundleStdioMcpServersConfig stdioConfig)

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.StdioMcp.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.StdioMcp.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common.Config.AI.BundleExecution;
+using Domain.Common.Config.AI.MCP;
+using Infrastructure.AI.Plugins;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Bundles;
+
+/// <summary>
+/// The bundle-owned <c>stdio</c> (local-command, sandboxed) MCP server registration gate (#371) —
+/// split from <c>BundleStagingService.cs</c> per this repo's partial-class convention once the main
+/// file grew past its line budget absorbing this capability alongside the pre-existing remote
+/// (http/sse) one from #370. <see cref="TryAddOwnedServer"/> and the server-name safety check the
+/// remote path also uses stay in the main file — only what is exclusively stdio-specific moved here.
+/// </summary>
+public sealed partial class BundleStagingService
+{
+    /// <summary>
+    /// Registers a bundle-owned <c>stdio</c> (local-command) MCP server — reachable only when every one
+    /// of these holds, checked in order so the log line always names the FIRST reason a caller could fix:
+    /// <list type="number">
+    /// <item><description>The manifest declares <c>"type": "stdio"</c> <strong>explicitly</strong>. A
+    /// server that merely defaulted to stdio (absent or unrecognized <c>type</c> —
+    /// <see cref="McpServerDefinitionBuilder"/>'s <c>ParseType</c> maps both to
+    /// <see cref="McpServerType.Stdio"/>) is rejected via <see cref="LogStdioRejected"/> exactly as
+    /// before this capability existed — a bundle author who typos a remote transport must not silently
+    /// land on a sandboxed process launch instead.</description></item>
+    /// <item><description><see cref="BundleStdioMcpServersConfig.Enabled"/> is on — a separate opt-in
+    /// from <see cref="BundleExecutionConfig.AllowBundleDeclaredMcpServers"/>, which governs remote
+    /// servers only.</description></item>
+    /// <item><description>An operator has configured <see cref="BundleStdioMcpServersConfig.ContainerImage"/>
+    /// — otherwise every bundle stdio server would run in the harness's own default (.NET runtime) image,
+    /// which cannot run most MCP servers, so registering one would be pointless.</description></item>
+    /// <item><description>The sandbox subsystem itself is enabled
+    /// (<c>AppConfig.AI.SandboxCapabilities.Enabled</c>) — both session factories refuse to start when
+    /// it is off; checking here means staging never registers something that can never run.</description></item>
+    /// <item><description>The manifest declares a non-empty <c>command</c> —
+    /// <see cref="McpServerDefinitionBuilder"/> does not itself enforce this for stdio the way it enforces
+    /// a URL for remote servers.</description></item>
+    /// <item><description>The bundle has not already reached
+    /// <see cref="BundleStdioMcpServersConfig.MaxServersPerBundle"/> — each registered stdio server
+    /// becomes a long-lived sandbox container for the life of the bundle's staged handle.</description></item>
+    /// </list>
+    /// On success, tags <see cref="McpServerDefinition.SandboxSeedDirectory"/> with the bundle's staged
+    /// root directory <strong>before</strong> <see cref="IBundleOwnedMcpServerRegistry.TryAdd"/> — tagged
+    /// at the moment of creation, per this repo's provenance-tracking pattern, rather than re-derived from
+    /// the server's name later — so <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c> can seed
+    /// the server's sandbox workspace with the bundle's own files.
+    /// <para>
+    /// The seed is always <paramref name="bundleDir"/> — the WHOLE bundle's staged root, not the
+    /// specific plugin manifest that declared this server — even when the declaration lives in a
+    /// nested <c>plugins/&lt;name&gt;/mcp.json</c>. This was a deliberate choice, not an omission: the
+    /// server may legitimately need sibling content elsewhere in the bundle. The consequence a bundle
+    /// author must know: the container's working directory is the bundle root, so <c>command</c>/
+    /// <c>args</c> declared in a nested manifest must reference their own file(s) with a path relative
+    /// to the bundle root (e.g. <c>plugins/my-plugin/server.js</c>), not relative to the manifest's own
+    /// directory.
+    /// </para>
+    /// </summary>
+    private bool TryRegisterStdioServer(
+        string bundleId, string namespacedName, JsonProperty serverProp, McpServerDefinition definition,
+        string bundleDir, BundleStdioMcpServersConfig stdioConfig, bool sandboxEnabled, ref int stdioServerCount)
+    {
+        if (!McpServerDefinitionBuilder.IsExplicitType(serverProp.Value, McpServerType.Stdio))
+        {
+            LogStdioRejected(bundleId, serverProp.Name);
+            return false;
+        }
+
+        // Short-circuiting || means the FIRST failing check logs and stops evaluation — the same
+        // "log the first reason" ordering the inline checks this replaced had, just delegated one
+        // guard per method instead of five inline blocks in one body.
+        if (!IsStdioCapabilityEnabled(bundleId, serverProp.Name, stdioConfig)
+            || !HasConfiguredContainerImage(bundleId, serverProp.Name, stdioConfig)
+            || !IsSandboxSubsystemEnabled(bundleId, serverProp.Name, sandboxEnabled)
+            || !HasNonEmptyCommand(bundleId, serverProp.Name, definition)
+            || !IsWithinPerBundleStdioServerCap(bundleId, serverProp.Name, stdioServerCount, stdioConfig))
+        {
+            return false;
+        }
+
+        definition.SandboxSeedDirectory = bundleDir;
+
+        if (!TryAddOwnedServer(bundleId, namespacedName, serverProp.Name, definition))
+            return false;
+
+        stdioServerCount++;
+        return true;
+    }
+
+    private bool IsStdioCapabilityEnabled(string bundleId, string serverName, BundleStdioMcpServersConfig stdioConfig)
+    {
+        if (stdioConfig.Enabled)
+            return true;
+
+        _logger.LogInformation(
+            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but " +
+            "AppConfig:AI:BundleExecution:StdioMcpServers:Enabled is disabled — rejected, not registered. " +
+            "Set it to true to enable sandboxed bundle-owned stdio MCP servers.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool HasConfiguredContainerImage(string bundleId, string serverName, BundleStdioMcpServersConfig stdioConfig)
+    {
+        if (!string.IsNullOrEmpty(stdioConfig.ContainerImage))
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but no " +
+            "AppConfig:AI:BundleExecution:StdioMcpServers:ContainerImage is configured — rejected, not " +
+            "registered. The capability stays inert until an operator sets a runtime image.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool IsSandboxSubsystemEnabled(string bundleId, string serverName, bool sandboxEnabled)
+    {
+        if (sandboxEnabled)
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but the " +
+            "sandbox subsystem (AppConfig:AI:SandboxCapabilities:Enabled) is disabled — rejected, not registered.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool HasNonEmptyCommand(string bundleId, string serverName, McpServerDefinition definition)
+    {
+        if (!string.IsNullOrWhiteSpace(definition.Command))
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio transport with no command — " +
+            "rejected, not registered.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool IsWithinPerBundleStdioServerCap(
+        string bundleId, string serverName, int stdioServerCount, BundleStdioMcpServersConfig stdioConfig)
+    {
+        if (stdioServerCount < stdioConfig.MaxServersPerBundle)
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' exceeds the per-bundle stdio server cap of " +
+            "{MaxServersPerBundle} — rejected, not registered.",
+            bundleId, serverName, stdioConfig.MaxServersPerBundle);
+        return false;
+    }
+
+    // A bundle is untrusted, uploader-supplied content. A server whose manifest never explicitly declared
+    // "type": "stdio" — an absent or unrecognized value, which McpServerDefinitionBuilder.ParseType
+    // defaults to Stdio too — is rejected rather than treated as an intentional local-command request: a
+    // bundle author who typos a remote transport must not silently land on a sandboxed process launch.
+    // An EXPLICIT stdio declaration is handled by TryRegisterStdioServer instead, not here (#371).
+    private void LogStdioRejected(string bundleId, string serverName)
+    {
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) transport " +
+            "without an explicit 'type': 'stdio' declaration — rejected, not registered. The transport " +
+            "either defaulted to stdio because 'type' was missing or unrecognized (only 'http'/'sse'/'stdio' " +
+            "are recognized), which this host never treats as an intentional stdio request.",
+            bundleId, serverName);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -430,6 +430,10 @@ public sealed class BundleStagingService : IBundleStagingService
     {
         var manifests = new List<PluginManifest>();
         var mcpServerNames = new List<string>();
+        // Threaded by ref through every RegisterBundleMcpServers call for this bundle (root manifest
+        // plus every nested plugin manifest) so the per-bundle stdio server cap is enforced across all
+        // of a bundle's manifests, not reset per manifest.
+        var stdioServerCount = 0;
 
         try
         {
@@ -437,7 +441,7 @@ public sealed class BundleStagingService : IBundleStagingService
             if (rootManifest is not null)
             {
                 manifests.Add(rootManifest);
-                RegisterBundleMcpServers(bundleDir, bundleId, rootManifest, mcpServerNames);
+                RegisterBundleMcpServers(bundleDir, bundleId, rootManifest, mcpServerNames, bundleDir, ref stdioServerCount);
             }
 
             var pluginsRoot = Path.Combine(bundleDir, "plugins");
@@ -449,7 +453,7 @@ public sealed class BundleStagingService : IBundleStagingService
                     if (manifest is not null)
                     {
                         manifests.Add(manifest);
-                        RegisterBundleMcpServers(pluginDir, bundleId, manifest, mcpServerNames);
+                        RegisterBundleMcpServers(pluginDir, bundleId, manifest, mcpServerNames, bundleDir, ref stdioServerCount);
                     }
                 }
             }
@@ -479,21 +483,28 @@ public sealed class BundleStagingService : IBundleStagingService
     /// or missing <c>mcp.json</c> is skipped and logged, never fails staging.
     /// </summary>
     private void RegisterBundleMcpServers(
-        string manifestBaseDir, string bundleId, PluginManifest manifest, List<string> mcpServerNames)
+        string manifestBaseDir, string bundleId, PluginManifest manifest, List<string> mcpServerNames,
+        string bundleDir, ref int stdioServerCount)
     {
         if (string.IsNullOrEmpty(manifest.McpServers))
             return;
 
-        // A bundle is untrusted, externally-authored input. Honouring its own declared MCP servers means
-        // the host makes outbound connections a caller's CapabilityEnvelope never authorized — off by
-        // default until an operator opts in. The manifest is never even opened when off, so a disabled
-        // host pays no parsing cost for a capability it doesn't have.
-        if (!_appConfig.CurrentValue.AI.BundleExecution.AllowBundleDeclaredMcpServers)
+        // A bundle is untrusted, externally-authored input, and each transport is its own capability with
+        // its own opt-in (AllowBundleDeclaredMcpServers for remote, StdioMcpServers.Enabled for sandboxed
+        // local) — see BundleStdioMcpServersConfig's remarks for why the two are deliberately separate.
+        // The manifest is parsed only when AT LEAST ONE is on; a host with neither enabled never opens
+        // mcp.json, so it pays no parsing cost for a capability it doesn't have. When exactly one is on,
+        // parsing still proceeds so the OTHER transport's server can register — the per-server checks in
+        // TryBuildAndRegisterOneServer/TryRegisterStdioServer are what actually enforce which capability a
+        // given declared server needs.
+        var bundleExecution = _appConfig.CurrentValue.AI.BundleExecution;
+        if (!bundleExecution.AllowBundleDeclaredMcpServers && !bundleExecution.StdioMcpServers.Enabled)
         {
             _logger.LogInformation(
-                "Bundle {BundleId}: declares MCP servers but AllowBundleDeclaredMcpServers is disabled — " +
-                "skipping, none registered. Set AppConfig:AI:BundleExecution:AllowBundleDeclaredMcpServers " +
-                "= true to enable this capability.",
+                "Bundle {BundleId}: declares MCP servers but neither AllowBundleDeclaredMcpServers nor " +
+                "StdioMcpServers:Enabled is on — skipping, none registered. Set " +
+                "AppConfig:AI:BundleExecution:AllowBundleDeclaredMcpServers and/or " +
+                "AppConfig:AI:BundleExecution:StdioMcpServers:Enabled to enable this capability.",
                 bundleId);
             return;
         }
@@ -510,18 +521,26 @@ public sealed class BundleStagingService : IBundleStagingService
         foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
         {
             var namespacedName = $"{bundleId}:{serverProp.Name}";
-            if (TryBuildAndRegisterOneServer(bundleId, namespacedName, serverProp, allowlist))
+            if (TryBuildAndRegisterOneServer(bundleId, namespacedName, serverProp, allowlist, bundleDir, ref stdioServerCount))
                 mcpServerNames.Add(namespacedName);
         }
     }
 
     /// <summary>
-    /// Builds one manifest-declared server and registers it under <paramref name="namespacedName"/>,
-    /// rejecting a stdio (local-command) transport, a disallowed destination, and a duplicate name — see
-    /// <see cref="RegisterBundleMcpServers"/>. Returns whether registration succeeded.
+    /// Builds one manifest-declared server and registers it under <paramref name="namespacedName"/> —
+    /// remote (http/sse) through its own capability check, then the allowlist + duplicate-name checks
+    /// unchanged since #370, local (stdio) through <see cref="TryRegisterStdioServer"/>'s
+    /// sandboxed-registration gate (#371). Returns whether registration succeeded.
     /// </summary>
+    /// <remarks>
+    /// The caller (<see cref="RegisterBundleMcpServers"/>) opens a manifest once EITHER capability is on,
+    /// so a remote server's own <see cref="BundleExecutionConfig.AllowBundleDeclaredMcpServers"/> check
+    /// has to live HERE, per-server — it cannot rely on the caller's gate alone, since that gate now also
+    /// admits a manifest whose only enabled capability is <see cref="BundleStdioMcpServersConfig.Enabled"/>.
+    /// </remarks>
     private bool TryBuildAndRegisterOneServer(
-        string bundleId, string namespacedName, JsonProperty serverProp, IReadOnlyList<EgressAllowlistEntry> allowlist)
+        string bundleId, string namespacedName, JsonProperty serverProp, IReadOnlyList<EgressAllowlistEntry> allowlist,
+        string bundleDir, ref int stdioServerCount)
     {
         var buildResult = McpServerDefinitionBuilder.Build(
             // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
@@ -537,8 +556,14 @@ public sealed class BundleStagingService : IBundleStagingService
         var definition = buildResult.Value!;
 
         if (!definition.IsRemoteServer)
+            return TryRegisterStdioServer(bundleId, namespacedName, serverProp, definition, bundleDir, ref stdioServerCount);
+
+        if (!_appConfig.CurrentValue.AI.BundleExecution.AllowBundleDeclaredMcpServers)
         {
-            LogStdioRejected(bundleId, serverProp.Name);
+            _logger.LogInformation(
+                "Bundle {BundleId}: MCP server '{ServerName}' declares a remote transport, but " +
+                "AllowBundleDeclaredMcpServers is disabled — rejected, not registered.",
+                bundleId, serverProp.Name);
             return false;
         }
 
@@ -555,24 +580,164 @@ public sealed class BundleStagingService : IBundleStagingService
         return false;
     }
 
-    // A bundle is untrusted, uploader-supplied content. A stdio server's Command/Args/Env come
-    // straight from the bundle's own manifest, and connecting to it launches that command as a
-    // real host process (via McpConnectionManager -> StdioClientTransport) — arbitrary command
-    // execution on the harness host, gated only by upload permission. Host-installed plugins
-    // (PluginLoader) are a different trust tier and are unaffected: only this bundle path rejects
-    // Stdio. Tracked follow-up to run a bundle's stdio server inside the existing process/Docker
-    // sandbox instead of rejecting it outright: #371.
+    /// <summary>
+    /// Registers a bundle-owned <c>stdio</c> (local-command) MCP server — reachable only when every one
+    /// of these holds, checked in order so the log line always names the FIRST reason a caller could fix:
+    /// <list type="number">
+    /// <item><description>The manifest declares <c>"type": "stdio"</c> <strong>explicitly</strong>. A
+    /// server that merely defaulted to stdio (absent or unrecognized <c>type</c> —
+    /// <see cref="McpServerDefinitionBuilder"/>'s <c>ParseType</c> maps both to
+    /// <see cref="McpServerType.Stdio"/>) is rejected via <see cref="LogStdioRejected"/> exactly as
+    /// before this capability existed — a bundle author who typos a remote transport must not silently
+    /// land on a sandboxed process launch instead.</description></item>
+    /// <item><description><see cref="BundleStdioMcpServersConfig.Enabled"/> is on — a separate opt-in
+    /// from <see cref="BundleExecutionConfig.AllowBundleDeclaredMcpServers"/>, which governs remote
+    /// servers only.</description></item>
+    /// <item><description>An operator has configured <see cref="BundleStdioMcpServersConfig.ContainerImage"/>
+    /// — otherwise every bundle stdio server would run in the harness's own default (.NET runtime) image,
+    /// which cannot run most MCP servers, so registering one would be pointless.</description></item>
+    /// <item><description>The sandbox subsystem itself is enabled
+    /// (<c>AppConfig.AI.SandboxCapabilities.Enabled</c>) — both session factories refuse to start when
+    /// it is off; checking here means staging never registers something that can never run.</description></item>
+    /// <item><description>The manifest declares a non-empty <c>command</c> —
+    /// <see cref="McpServerDefinitionBuilder"/> does not itself enforce this for stdio the way it enforces
+    /// a URL for remote servers.</description></item>
+    /// <item><description>The bundle has not already reached
+    /// <see cref="BundleStdioMcpServersConfig.MaxServersPerBundle"/> — each registered stdio server
+    /// becomes a long-lived sandbox container for the life of the bundle's staged handle.</description></item>
+    /// </list>
+    /// On success, tags <see cref="McpServerDefinition.SandboxSeedDirectory"/> with the bundle's staged
+    /// root directory <strong>before</strong> <see cref="IBundleOwnedMcpServerRegistry.TryAdd"/> — tagged
+    /// at the moment of creation, per this repo's provenance-tracking pattern, rather than re-derived from
+    /// the server's name later — so <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c> can seed
+    /// the server's sandbox workspace with the bundle's own files.
+    /// </summary>
+    private bool TryRegisterStdioServer(
+        string bundleId, string namespacedName, JsonProperty serverProp, McpServerDefinition definition,
+        string bundleDir, ref int stdioServerCount)
+    {
+        if (!IsExplicitStdioDeclaration(serverProp.Value))
+        {
+            LogStdioRejected(bundleId, serverProp.Name);
+            return false;
+        }
+
+        var stdioConfig = _appConfig.CurrentValue.AI.BundleExecution.StdioMcpServers;
+
+        // Short-circuiting || means the FIRST failing check logs and stops evaluation — the same
+        // "log the first reason" ordering the inline checks this replaced had, just delegated one
+        // guard per method instead of five inline blocks in one body.
+        if (!IsStdioCapabilityEnabled(bundleId, serverProp.Name, stdioConfig)
+            || !HasConfiguredContainerImage(bundleId, serverProp.Name, stdioConfig)
+            || !IsSandboxSubsystemEnabled(bundleId, serverProp.Name)
+            || !HasNonEmptyCommand(bundleId, serverProp.Name, definition)
+            || !IsWithinPerBundleStdioServerCap(bundleId, serverProp.Name, stdioServerCount, stdioConfig))
+        {
+            return false;
+        }
+
+        definition.SandboxSeedDirectory = bundleDir;
+
+        if (_bundleOwnedMcpServers.TryAdd(namespacedName, definition))
+        {
+            stdioServerCount++;
+            return true;
+        }
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: duplicate MCP server name '{ServerName}' declared across " +
+            "more than one plugin manifest; keeping the first",
+            bundleId, serverProp.Name);
+        return false;
+    }
+
+    private bool IsStdioCapabilityEnabled(string bundleId, string serverName, BundleStdioMcpServersConfig stdioConfig)
+    {
+        if (stdioConfig.Enabled)
+            return true;
+
+        _logger.LogInformation(
+            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but " +
+            "AppConfig:AI:BundleExecution:StdioMcpServers:Enabled is disabled — rejected, not registered. " +
+            "Set it to true to enable sandboxed bundle-owned stdio MCP servers.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool HasConfiguredContainerImage(string bundleId, string serverName, BundleStdioMcpServersConfig stdioConfig)
+    {
+        if (!string.IsNullOrEmpty(stdioConfig.ContainerImage))
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but no " +
+            "AppConfig:AI:BundleExecution:StdioMcpServers:ContainerImage is configured — rejected, not " +
+            "registered. The capability stays inert until an operator sets a runtime image.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool IsSandboxSubsystemEnabled(string bundleId, string serverName)
+    {
+        if (_appConfig.CurrentValue.AI.SandboxCapabilities.Enabled)
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but the " +
+            "sandbox subsystem (AppConfig:Sandbox:Enabled) is disabled — rejected, not registered.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool HasNonEmptyCommand(string bundleId, string serverName, McpServerDefinition definition)
+    {
+        if (!string.IsNullOrWhiteSpace(definition.Command))
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio transport with no command — " +
+            "rejected, not registered.",
+            bundleId, serverName);
+        return false;
+    }
+
+    private bool IsWithinPerBundleStdioServerCap(
+        string bundleId, string serverName, int stdioServerCount, BundleStdioMcpServersConfig stdioConfig)
+    {
+        if (stdioServerCount < stdioConfig.MaxServersPerBundle)
+            return true;
+
+        _logger.LogWarning(
+            "Bundle {BundleId}: MCP server '{ServerName}' exceeds the per-bundle stdio server cap of " +
+            "{MaxServersPerBundle} — rejected, not registered.",
+            bundleId, serverName, stdioConfig.MaxServersPerBundle);
+        return false;
+    }
+
+    /// <summary>
+    /// Whether the manifest declares <c>"type": "stdio"</c> as an explicit JSON string — mirrors
+    /// <see cref="McpServerDefinitionBuilder"/>'s own <c>ParseType</c> matching exactly (property name
+    /// <c>type</c>, value compared case-insensitively) so the two can never independently drift on what
+    /// counts as an explicit declaration.
+    /// </summary>
+    private static bool IsExplicitStdioDeclaration(JsonElement serverElement) =>
+        serverElement.ValueKind == JsonValueKind.Object
+        && serverElement.TryGetProperty("type", out var typeElement)
+        && typeElement.ValueKind == JsonValueKind.String
+        && string.Equals(typeElement.GetString(), "stdio", StringComparison.OrdinalIgnoreCase);
+
+    // A bundle is untrusted, uploader-supplied content. A server whose manifest never explicitly declared
+    // "type": "stdio" — an absent or unrecognized value, which McpServerDefinitionBuilder.ParseType
+    // defaults to Stdio too — is rejected rather than treated as an intentional local-command request: a
+    // bundle author who typos a remote transport must not silently land on a sandboxed process launch.
+    // An EXPLICIT stdio declaration is handled by TryRegisterStdioServer instead, not here (#371).
     private void LogStdioRejected(string bundleId, string serverName)
     {
-        // "resolved to", not "declares": McpServerDefinitionBuilder.ParseType defaults an ABSENT or
-        // UNRECOGNIZED 'type' value to Stdio too (only "http"/"sse" are matched), so a bundle author
-        // who misspells a real remote transport lands here as well — this message must stay accurate
-        // for both cases, not assert an explicit stdio declaration that may not exist.
         _logger.LogWarning(
-            "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) " +
-            "transport, which is not permitted for bundle-owned servers — rejected, not registered. " +
-            "The transport was either explicitly declared, or defaulted to stdio because 'type' was " +
-            "missing or unrecognized (only 'http'/'sse' are supported).",
+            "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) transport " +
+            "without an explicit 'type': 'stdio' declaration — rejected, not registered. The transport " +
+            "either defaulted to stdio because 'type' was missing or unrecognized (only 'http'/'sse'/'stdio' " +
+            "are recognized), which this host never treats as an intentional stdio request.",
             bundleId, serverName);
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -545,6 +545,18 @@ public sealed class BundleStagingService : IBundleStagingService
         string bundleId, string namespacedName, JsonProperty serverProp, IReadOnlyList<EgressAllowlistEntry> allowlist,
         string bundleDir, BundleExecutionConfig bundleExecution, bool sandboxEnabled, ref int stdioServerCount)
     {
+        if (!IsSafeServerNameIdentifier(serverProp.Name))
+        {
+            // Deliberately does not echo the offending name: it is exactly the untrusted value this
+            // check exists to keep out of a plain-text log sink (control characters / newlines could
+            // otherwise forge log lines), and this diff makes it load-bearing in a second place —
+            // the sandbox ToolName used for the egress preflight key and the attestation record.
+            _logger.LogWarning(
+                "Bundle {BundleId}: rejected an MCP server whose declared name is not a safe identifier.",
+                bundleId);
+            return false;
+        }
+
         var buildResult = McpServerDefinitionBuilder.Build(
             // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
             serverProp.Value, NoDeclarationEnv, $"[Bundle: {bundleId}]", serverProp.Name);
@@ -693,7 +705,7 @@ public sealed class BundleStagingService : IBundleStagingService
 
         _logger.LogWarning(
             "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but the " +
-            "sandbox subsystem (AppConfig:Sandbox:Enabled) is disabled — rejected, not registered.",
+            "sandbox subsystem (AppConfig:AI:SandboxCapabilities:Enabled) is disabled — rejected, not registered.",
             bundleId, serverName);
         return false;
     }
@@ -709,6 +721,17 @@ public sealed class BundleStagingService : IBundleStagingService
             bundleId, serverName);
         return false;
     }
+
+    /// <summary>
+    /// Whether a manifest-declared server name is safe to use as a structured-log field, a sandbox
+    /// <c>ToolName</c> (the egress preflight key and the attestation record — both new consumers this
+    /// PR adds), and a namespaced registry key segment. Bounded ASCII identifier characters only —
+    /// no control characters or newlines that could forge a plain-text log line, no length unbounded
+    /// by anything upstream.
+    /// </summary>
+    private static bool IsSafeServerNameIdentifier(string serverName) =>
+        serverName.Length is > 0 and <= 128
+        && serverName.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_' or '.');
 
     private bool IsWithinPerBundleStdioServerCap(
         string bundleId, string serverName, int stdioServerCount, BundleStdioMcpServersConfig stdioConfig)

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -430,9 +430,11 @@ public sealed partial class BundleStagingService : IBundleStagingService
     {
         var manifests = new List<PluginManifest>();
         var mcpServerNames = new List<string>();
-        // Threaded by ref through every RegisterBundleMcpServers call for this bundle (root manifest
-        // plus every nested plugin manifest) so the per-bundle stdio server cap is enforced across all
-        // of a bundle's manifests, not reset per manifest.
+        // Threaded through every RegisterBundleMcpServers call for this bundle (root manifest plus
+        // every nested plugin manifest) via its return value — not a ref parameter, so neither that
+        // method nor the ones it calls need to distinguish "not yet mutated" from "mutated to the
+        // same value" — so the per-bundle stdio server cap is enforced across all of a bundle's
+        // manifests, not reset per manifest.
         var stdioServerCount = 0;
 
         try
@@ -441,7 +443,7 @@ public sealed partial class BundleStagingService : IBundleStagingService
             if (rootManifest is not null)
             {
                 manifests.Add(rootManifest);
-                RegisterBundleMcpServers(bundleDir, bundleId, rootManifest, mcpServerNames, bundleDir, ref stdioServerCount);
+                stdioServerCount = RegisterBundleMcpServers(bundleDir, bundleId, rootManifest, mcpServerNames, bundleDir, stdioServerCount);
             }
 
             var pluginsRoot = Path.Combine(bundleDir, "plugins");
@@ -453,7 +455,7 @@ public sealed partial class BundleStagingService : IBundleStagingService
                     if (manifest is not null)
                     {
                         manifests.Add(manifest);
-                        RegisterBundleMcpServers(pluginDir, bundleId, manifest, mcpServerNames, bundleDir, ref stdioServerCount);
+                        stdioServerCount = RegisterBundleMcpServers(pluginDir, bundleId, manifest, mcpServerNames, bundleDir, stdioServerCount);
                     }
                 }
             }
@@ -482,12 +484,18 @@ public sealed partial class BundleStagingService : IBundleStagingService
     /// never collide — while a manifest's <c>Name</c> is free text and not guaranteed unique. A malformed
     /// or missing <c>mcp.json</c> is skipped and logged, never fails staging.
     /// </summary>
-    private void RegisterBundleMcpServers(
+    /// <returns>
+    /// The stdio server count after processing this manifest — <paramref name="stdioServerCount"/>
+    /// unchanged when the manifest declares no MCP servers or neither capability is enabled, otherwise
+    /// incremented once per server this manifest registered as stdio. The caller threads this back in
+    /// as the next call's <paramref name="stdioServerCount"/> — see <see cref="ParsePluginManifests"/>.
+    /// </returns>
+    private int RegisterBundleMcpServers(
         string manifestBaseDir, string bundleId, PluginManifest manifest, List<string> mcpServerNames,
-        string bundleDir, ref int stdioServerCount)
+        string bundleDir, int stdioServerCount)
     {
         if (string.IsNullOrEmpty(manifest.McpServers))
-            return;
+            return stdioServerCount;
 
         // A bundle is untrusted, externally-authored input, and each transport is its own capability with
         // its own opt-in (AllowBundleDeclaredMcpServers for remote, StdioMcpServers.Enabled for sandboxed
@@ -506,28 +514,53 @@ public sealed partial class BundleStagingService : IBundleStagingService
                 "AppConfig:AI:BundleExecution:AllowBundleDeclaredMcpServers and/or " +
                 "AppConfig:AI:BundleExecution:StdioMcpServers:Enabled to enable this capability.",
                 bundleId);
-            return;
+            return stdioServerCount;
         }
 
         using var block = Infrastructure.AI.Plugins.McpManifestReader.ReadMcpServersBlock(
             manifestBaseDir, manifest.McpServers, $"Bundle {bundleId}", _logger);
         if (block is null)
-            return;
+            return stdioServerCount;
 
-        // Loop-invariants: every server this manifest declares is checked against the SAME harness-wide
-        // allowlist and the SAME sandbox-enabled flag, so both are read from config once here rather than
-        // re-derived (an extra IOptionsMonitor<AppConfig>.CurrentValue dictionary read) on every iteration.
-        var allowlist = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
-        var sandboxEnabled = _appConfig.CurrentValue.AI.SandboxCapabilities.Enabled;
+        // Loop-invariant across every server this manifest declares — the same harness-wide allowlist,
+        // sandbox-enabled flag, bundle id/dir, and execution config apply to all of them, so they're
+        // read from config once here (rather than re-derived per iteration) and bundled into one
+        // context value instead of threading five separate parameters through both registration methods.
+        var context = new ServerRegistrationContext(
+            bundleId, bundleDir, bundleExecution,
+            SandboxEnabled: _appConfig.CurrentValue.AI.SandboxCapabilities.Enabled,
+            Allowlist: EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist));
 
         foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
         {
             var namespacedName = $"{bundleId}:{serverProp.Name}";
-            if (TryBuildAndRegisterOneServer(
-                    bundleId, namespacedName, serverProp, allowlist, bundleDir, bundleExecution, sandboxEnabled, ref stdioServerCount))
+            var (registered, wasStdio) = TryBuildAndRegisterOneServer(context, namespacedName, serverProp, stdioServerCount);
+            if (registered)
+            {
                 mcpServerNames.Add(namespacedName);
+                // Only a server that both took the stdio branch AND actually registered counts
+                // against the per-bundle cap — a rejected stdio attempt (wrong capability off, no
+                // command, cap already reached, etc.) must not itself consume a cap slot.
+                if (wasStdio)
+                    stdioServerCount++;
+            }
         }
+
+        return stdioServerCount;
     }
+
+    /// <summary>
+    /// The per-manifest-loop-invariant values every server registration check needs — bundled here so
+    /// <see cref="TryBuildAndRegisterOneServer"/> and <see cref="TryRegisterStdioServer"/> each take one
+    /// parameter for "the bundle and its config" instead of four separate ones repeated across both
+    /// signatures. A /simplify finding on #371's original 8-positional-parameter shape.
+    /// </summary>
+    private readonly record struct ServerRegistrationContext(
+        string BundleId,
+        string BundleDir,
+        BundleExecutionConfig BundleExecution,
+        bool SandboxEnabled,
+        IReadOnlyList<EgressAllowlistEntry> Allowlist);
 
     /// <summary>
     /// Builds one manifest-declared server and registers it under <paramref name="namespacedName"/> —
@@ -541,9 +574,15 @@ public sealed partial class BundleStagingService : IBundleStagingService
     /// has to live HERE, per-server — it cannot rely on the caller's gate alone, since that gate now also
     /// admits a manifest whose only enabled capability is <see cref="BundleStdioMcpServersConfig.Enabled"/>.
     /// </remarks>
-    private bool TryBuildAndRegisterOneServer(
-        string bundleId, string namespacedName, JsonProperty serverProp, IReadOnlyList<EgressAllowlistEntry> allowlist,
-        string bundleDir, BundleExecutionConfig bundleExecution, bool sandboxEnabled, ref int stdioServerCount)
+    /// <returns>
+    /// <c>Registered</c>: whether the server was added to the registry. <c>WasStdio</c>: whether this
+    /// declaration took the stdio branch at all — true even when a stdio-specific guard inside
+    /// <see cref="TryRegisterStdioServer"/> rejected it, false for every remote-branch outcome. The
+    /// caller (<see cref="RegisterBundleMcpServers"/>) increments its per-bundle stdio count only when
+    /// BOTH are true — a rejected stdio attempt must not itself consume a cap slot.
+    /// </returns>
+    private (bool Registered, bool WasStdio) TryBuildAndRegisterOneServer(
+        ServerRegistrationContext context, string namespacedName, JsonProperty serverProp, int stdioServerCount)
     {
         if (!IsSafeServerNameIdentifier(serverProp.Name))
         {
@@ -553,43 +592,42 @@ public sealed partial class BundleStagingService : IBundleStagingService
             // the sandbox ToolName used for the egress preflight key and the attestation record.
             _logger.LogWarning(
                 "Bundle {BundleId}: rejected an MCP server whose declared name is not a safe identifier.",
-                bundleId);
-            return false;
+                context.BundleId);
+            return (false, false);
         }
 
         var buildResult = McpServerDefinitionBuilder.Build(
             // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
-            serverProp.Value, NoDeclarationEnv, $"[Bundle: {bundleId}]", serverProp.Name);
+            serverProp.Value, NoDeclarationEnv, $"[Bundle: {context.BundleId}]", serverProp.Name);
         if (!buildResult.IsSuccess)
         {
             _logger.LogWarning(
                 "Bundle {BundleId}: failed to build MCP server definition for '{ServerName}', skipping: {Errors}",
-                bundleId, serverProp.Name, string.Join("; ", buildResult.Errors));
-            return false;
+                context.BundleId, serverProp.Name, string.Join("; ", buildResult.Errors));
+            return (false, false);
         }
 
         var definition = buildResult.Value!;
 
         if (!definition.IsRemoteServer)
         {
-            return TryRegisterStdioServer(
-                bundleId, namespacedName, serverProp, definition, bundleDir, bundleExecution.StdioMcpServers, sandboxEnabled,
-                ref stdioServerCount);
+            var registered = TryRegisterStdioServer(context, namespacedName, serverProp, definition, stdioServerCount);
+            return (registered, true);
         }
 
-        if (!bundleExecution.AllowBundleDeclaredMcpServers)
+        if (!context.BundleExecution.AllowBundleDeclaredMcpServers)
         {
             _logger.LogInformation(
                 "Bundle {BundleId}: MCP server '{ServerName}' declares a remote transport, but " +
                 "AllowBundleDeclaredMcpServers is disabled — rejected, not registered.",
-                bundleId, serverProp.Name);
-            return false;
+                context.BundleId, serverProp.Name);
+            return (false, false);
         }
 
-        if (!IsUrlAllowlisted(bundleId, serverProp.Name, definition.Url, allowlist))
-            return false;
+        if (!IsUrlAllowlisted(context.BundleId, serverProp.Name, definition.Url, context.Allowlist))
+            return (false, false);
 
-        return TryAddOwnedServer(bundleId, namespacedName, serverProp.Name, definition);
+        return (TryAddOwnedServer(context.BundleId, namespacedName, serverProp.Name, definition), false);
     }
 
     /// <summary>
@@ -616,6 +654,16 @@ public sealed partial class BundleStagingService : IBundleStagingService
     /// no control characters or newlines that could forge a plain-text log line, no length unbounded
     /// by anything upstream.
     /// </summary>
+    /// <remarks>
+    /// Deliberately NOT <c>IPlanRunExecutor.IsWellFormedAgentId</c>,
+    /// though the two check the same shape (bounded length, ASCII-letter-or-digit-plus-separators):
+    /// that charset permits <c>:</c>, which is exactly the delimiter <c>namespacedName</c> below uses
+    /// to join <paramref name="serverName"/>'s bundle-scoped enclosing identifier to it — a server
+    /// name that itself contained <c>:</c> would let a bundle author forge a colliding namespaced
+    /// key. A future tightening of one identifier-safety rule (e.g. disallowing a leading
+    /// <c>.</c>) should be considered for the other too, but the charsets themselves may not
+    /// converge for this reason.
+    /// </remarks>
     private static bool IsSafeServerNameIdentifier(string serverName) =>
         serverName.Length is > 0 and <= 128
         && serverName.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_' or '.');

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -514,14 +514,17 @@ public sealed class BundleStagingService : IBundleStagingService
         if (block is null)
             return;
 
-        // Loop-invariant: every server this manifest declares is checked against the SAME harness-wide
-        // allowlist, so it is mapped from config once here rather than re-derived on every iteration.
+        // Loop-invariants: every server this manifest declares is checked against the SAME harness-wide
+        // allowlist and the SAME sandbox-enabled flag, so both are read from config once here rather than
+        // re-derived (an extra IOptionsMonitor<AppConfig>.CurrentValue dictionary read) on every iteration.
         var allowlist = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
+        var sandboxEnabled = _appConfig.CurrentValue.AI.SandboxCapabilities.Enabled;
 
         foreach (var serverProp in block.Value.ServersElement.EnumerateObject())
         {
             var namespacedName = $"{bundleId}:{serverProp.Name}";
-            if (TryBuildAndRegisterOneServer(bundleId, namespacedName, serverProp, allowlist, bundleDir, ref stdioServerCount))
+            if (TryBuildAndRegisterOneServer(
+                    bundleId, namespacedName, serverProp, allowlist, bundleDir, bundleExecution, sandboxEnabled, ref stdioServerCount))
                 mcpServerNames.Add(namespacedName);
         }
     }
@@ -540,7 +543,7 @@ public sealed class BundleStagingService : IBundleStagingService
     /// </remarks>
     private bool TryBuildAndRegisterOneServer(
         string bundleId, string namespacedName, JsonProperty serverProp, IReadOnlyList<EgressAllowlistEntry> allowlist,
-        string bundleDir, ref int stdioServerCount)
+        string bundleDir, BundleExecutionConfig bundleExecution, bool sandboxEnabled, ref int stdioServerCount)
     {
         var buildResult = McpServerDefinitionBuilder.Build(
             // A bundle (unlike a host-installed plugin) has no declaration-level env overrides.
@@ -556,9 +559,13 @@ public sealed class BundleStagingService : IBundleStagingService
         var definition = buildResult.Value!;
 
         if (!definition.IsRemoteServer)
-            return TryRegisterStdioServer(bundleId, namespacedName, serverProp, definition, bundleDir, ref stdioServerCount);
+        {
+            return TryRegisterStdioServer(
+                bundleId, namespacedName, serverProp, definition, bundleDir, bundleExecution.StdioMcpServers, sandboxEnabled,
+                ref stdioServerCount);
+        }
 
-        if (!_appConfig.CurrentValue.AI.BundleExecution.AllowBundleDeclaredMcpServers)
+        if (!bundleExecution.AllowBundleDeclaredMcpServers)
         {
             _logger.LogInformation(
                 "Bundle {BundleId}: MCP server '{ServerName}' declares a remote transport, but " +
@@ -570,14 +577,7 @@ public sealed class BundleStagingService : IBundleStagingService
         if (!IsUrlAllowlisted(bundleId, serverProp.Name, definition.Url, allowlist))
             return false;
 
-        if (_bundleOwnedMcpServers.TryAdd(namespacedName, definition))
-            return true;
-
-        _logger.LogWarning(
-            "Bundle {BundleId}: duplicate MCP server name '{ServerName}' declared across " +
-            "more than one plugin manifest; keeping the first",
-            bundleId, serverProp.Name);
-        return false;
+        return TryAddOwnedServer(bundleId, namespacedName, serverProp.Name, definition);
     }
 
     /// <summary>
@@ -614,7 +614,7 @@ public sealed class BundleStagingService : IBundleStagingService
     /// </summary>
     private bool TryRegisterStdioServer(
         string bundleId, string namespacedName, JsonProperty serverProp, McpServerDefinition definition,
-        string bundleDir, ref int stdioServerCount)
+        string bundleDir, BundleStdioMcpServersConfig stdioConfig, bool sandboxEnabled, ref int stdioServerCount)
     {
         if (!IsExplicitStdioDeclaration(serverProp.Value))
         {
@@ -622,14 +622,12 @@ public sealed class BundleStagingService : IBundleStagingService
             return false;
         }
 
-        var stdioConfig = _appConfig.CurrentValue.AI.BundleExecution.StdioMcpServers;
-
         // Short-circuiting || means the FIRST failing check logs and stops evaluation — the same
         // "log the first reason" ordering the inline checks this replaced had, just delegated one
         // guard per method instead of five inline blocks in one body.
         if (!IsStdioCapabilityEnabled(bundleId, serverProp.Name, stdioConfig)
             || !HasConfiguredContainerImage(bundleId, serverProp.Name, stdioConfig)
-            || !IsSandboxSubsystemEnabled(bundleId, serverProp.Name)
+            || !IsSandboxSubsystemEnabled(bundleId, serverProp.Name, sandboxEnabled)
             || !HasNonEmptyCommand(bundleId, serverProp.Name, definition)
             || !IsWithinPerBundleStdioServerCap(bundleId, serverProp.Name, stdioServerCount, stdioConfig))
         {
@@ -638,16 +636,27 @@ public sealed class BundleStagingService : IBundleStagingService
 
         definition.SandboxSeedDirectory = bundleDir;
 
+        if (!TryAddOwnedServer(bundleId, namespacedName, serverProp.Name, definition))
+            return false;
+
+        stdioServerCount++;
+        return true;
+    }
+
+    /// <summary>
+    /// Shared tail of both registration paths (remote and stdio): registers into
+    /// <see cref="_bundleOwnedMcpServers"/> under <paramref name="namespacedName"/>, or logs and
+    /// rejects a duplicate declared across more than one plugin manifest.
+    /// </summary>
+    private bool TryAddOwnedServer(string bundleId, string namespacedName, string serverName, McpServerDefinition definition)
+    {
         if (_bundleOwnedMcpServers.TryAdd(namespacedName, definition))
-        {
-            stdioServerCount++;
             return true;
-        }
 
         _logger.LogWarning(
             "Bundle {BundleId}: duplicate MCP server name '{ServerName}' declared across " +
             "more than one plugin manifest; keeping the first",
-            bundleId, serverProp.Name);
+            bundleId, serverName);
         return false;
     }
 
@@ -677,9 +686,9 @@ public sealed class BundleStagingService : IBundleStagingService
         return false;
     }
 
-    private bool IsSandboxSubsystemEnabled(string bundleId, string serverName)
+    private bool IsSandboxSubsystemEnabled(string bundleId, string serverName, bool sandboxEnabled)
     {
-        if (_appConfig.CurrentValue.AI.SandboxCapabilities.Enabled)
+        if (sandboxEnabled)
             return true;
 
         _logger.LogWarning(

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.cs
@@ -32,7 +32,7 @@ namespace Infrastructure.AI.Bundles;
 /// failure deletes the partial extraction before returning. The service never surfaces archive content
 /// in a failure reason — reasons describe the guard, not the payload.
 /// </remarks>
-public sealed class BundleStagingService : IBundleStagingService
+public sealed partial class BundleStagingService : IBundleStagingService
 {
     private const int CopyBufferSize = 81920;
 
@@ -593,69 +593,6 @@ public sealed class BundleStagingService : IBundleStagingService
     }
 
     /// <summary>
-    /// Registers a bundle-owned <c>stdio</c> (local-command) MCP server — reachable only when every one
-    /// of these holds, checked in order so the log line always names the FIRST reason a caller could fix:
-    /// <list type="number">
-    /// <item><description>The manifest declares <c>"type": "stdio"</c> <strong>explicitly</strong>. A
-    /// server that merely defaulted to stdio (absent or unrecognized <c>type</c> —
-    /// <see cref="McpServerDefinitionBuilder"/>'s <c>ParseType</c> maps both to
-    /// <see cref="McpServerType.Stdio"/>) is rejected via <see cref="LogStdioRejected"/> exactly as
-    /// before this capability existed — a bundle author who typos a remote transport must not silently
-    /// land on a sandboxed process launch instead.</description></item>
-    /// <item><description><see cref="BundleStdioMcpServersConfig.Enabled"/> is on — a separate opt-in
-    /// from <see cref="BundleExecutionConfig.AllowBundleDeclaredMcpServers"/>, which governs remote
-    /// servers only.</description></item>
-    /// <item><description>An operator has configured <see cref="BundleStdioMcpServersConfig.ContainerImage"/>
-    /// — otherwise every bundle stdio server would run in the harness's own default (.NET runtime) image,
-    /// which cannot run most MCP servers, so registering one would be pointless.</description></item>
-    /// <item><description>The sandbox subsystem itself is enabled
-    /// (<c>AppConfig.AI.SandboxCapabilities.Enabled</c>) — both session factories refuse to start when
-    /// it is off; checking here means staging never registers something that can never run.</description></item>
-    /// <item><description>The manifest declares a non-empty <c>command</c> —
-    /// <see cref="McpServerDefinitionBuilder"/> does not itself enforce this for stdio the way it enforces
-    /// a URL for remote servers.</description></item>
-    /// <item><description>The bundle has not already reached
-    /// <see cref="BundleStdioMcpServersConfig.MaxServersPerBundle"/> — each registered stdio server
-    /// becomes a long-lived sandbox container for the life of the bundle's staged handle.</description></item>
-    /// </list>
-    /// On success, tags <see cref="McpServerDefinition.SandboxSeedDirectory"/> with the bundle's staged
-    /// root directory <strong>before</strong> <see cref="IBundleOwnedMcpServerRegistry.TryAdd"/> — tagged
-    /// at the moment of creation, per this repo's provenance-tracking pattern, rather than re-derived from
-    /// the server's name later — so <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c> can seed
-    /// the server's sandbox workspace with the bundle's own files.
-    /// </summary>
-    private bool TryRegisterStdioServer(
-        string bundleId, string namespacedName, JsonProperty serverProp, McpServerDefinition definition,
-        string bundleDir, BundleStdioMcpServersConfig stdioConfig, bool sandboxEnabled, ref int stdioServerCount)
-    {
-        if (!IsExplicitStdioDeclaration(serverProp.Value))
-        {
-            LogStdioRejected(bundleId, serverProp.Name);
-            return false;
-        }
-
-        // Short-circuiting || means the FIRST failing check logs and stops evaluation — the same
-        // "log the first reason" ordering the inline checks this replaced had, just delegated one
-        // guard per method instead of five inline blocks in one body.
-        if (!IsStdioCapabilityEnabled(bundleId, serverProp.Name, stdioConfig)
-            || !HasConfiguredContainerImage(bundleId, serverProp.Name, stdioConfig)
-            || !IsSandboxSubsystemEnabled(bundleId, serverProp.Name, sandboxEnabled)
-            || !HasNonEmptyCommand(bundleId, serverProp.Name, definition)
-            || !IsWithinPerBundleStdioServerCap(bundleId, serverProp.Name, stdioServerCount, stdioConfig))
-        {
-            return false;
-        }
-
-        definition.SandboxSeedDirectory = bundleDir;
-
-        if (!TryAddOwnedServer(bundleId, namespacedName, serverProp.Name, definition))
-            return false;
-
-        stdioServerCount++;
-        return true;
-    }
-
-    /// <summary>
     /// Shared tail of both registration paths (remote and stdio): registers into
     /// <see cref="_bundleOwnedMcpServers"/> under <paramref name="namespacedName"/>, or logs and
     /// rejects a duplicate declared across more than one plugin manifest.
@@ -672,56 +609,6 @@ public sealed class BundleStagingService : IBundleStagingService
         return false;
     }
 
-    private bool IsStdioCapabilityEnabled(string bundleId, string serverName, BundleStdioMcpServersConfig stdioConfig)
-    {
-        if (stdioConfig.Enabled)
-            return true;
-
-        _logger.LogInformation(
-            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but " +
-            "AppConfig:AI:BundleExecution:StdioMcpServers:Enabled is disabled — rejected, not registered. " +
-            "Set it to true to enable sandboxed bundle-owned stdio MCP servers.",
-            bundleId, serverName);
-        return false;
-    }
-
-    private bool HasConfiguredContainerImage(string bundleId, string serverName, BundleStdioMcpServersConfig stdioConfig)
-    {
-        if (!string.IsNullOrEmpty(stdioConfig.ContainerImage))
-            return true;
-
-        _logger.LogWarning(
-            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but no " +
-            "AppConfig:AI:BundleExecution:StdioMcpServers:ContainerImage is configured — rejected, not " +
-            "registered. The capability stays inert until an operator sets a runtime image.",
-            bundleId, serverName);
-        return false;
-    }
-
-    private bool IsSandboxSubsystemEnabled(string bundleId, string serverName, bool sandboxEnabled)
-    {
-        if (sandboxEnabled)
-            return true;
-
-        _logger.LogWarning(
-            "Bundle {BundleId}: MCP server '{ServerName}' explicitly declares a stdio transport, but the " +
-            "sandbox subsystem (AppConfig:AI:SandboxCapabilities:Enabled) is disabled — rejected, not registered.",
-            bundleId, serverName);
-        return false;
-    }
-
-    private bool HasNonEmptyCommand(string bundleId, string serverName, McpServerDefinition definition)
-    {
-        if (!string.IsNullOrWhiteSpace(definition.Command))
-            return true;
-
-        _logger.LogWarning(
-            "Bundle {BundleId}: MCP server '{ServerName}' declares a stdio transport with no command — " +
-            "rejected, not registered.",
-            bundleId, serverName);
-        return false;
-    }
-
     /// <summary>
     /// Whether a manifest-declared server name is safe to use as a structured-log field, a sandbox
     /// <c>ToolName</c> (the egress preflight key and the attestation record — both new consumers this
@@ -732,46 +619,6 @@ public sealed class BundleStagingService : IBundleStagingService
     private static bool IsSafeServerNameIdentifier(string serverName) =>
         serverName.Length is > 0 and <= 128
         && serverName.All(c => char.IsAsciiLetterOrDigit(c) || c is '-' or '_' or '.');
-
-    private bool IsWithinPerBundleStdioServerCap(
-        string bundleId, string serverName, int stdioServerCount, BundleStdioMcpServersConfig stdioConfig)
-    {
-        if (stdioServerCount < stdioConfig.MaxServersPerBundle)
-            return true;
-
-        _logger.LogWarning(
-            "Bundle {BundleId}: MCP server '{ServerName}' exceeds the per-bundle stdio server cap of " +
-            "{MaxServersPerBundle} — rejected, not registered.",
-            bundleId, serverName, stdioConfig.MaxServersPerBundle);
-        return false;
-    }
-
-    /// <summary>
-    /// Whether the manifest declares <c>"type": "stdio"</c> as an explicit JSON string — mirrors
-    /// <see cref="McpServerDefinitionBuilder"/>'s own <c>ParseType</c> matching exactly (property name
-    /// <c>type</c>, value compared case-insensitively) so the two can never independently drift on what
-    /// counts as an explicit declaration.
-    /// </summary>
-    private static bool IsExplicitStdioDeclaration(JsonElement serverElement) =>
-        serverElement.ValueKind == JsonValueKind.Object
-        && serverElement.TryGetProperty("type", out var typeElement)
-        && typeElement.ValueKind == JsonValueKind.String
-        && string.Equals(typeElement.GetString(), "stdio", StringComparison.OrdinalIgnoreCase);
-
-    // A bundle is untrusted, uploader-supplied content. A server whose manifest never explicitly declared
-    // "type": "stdio" — an absent or unrecognized value, which McpServerDefinitionBuilder.ParseType
-    // defaults to Stdio too — is rejected rather than treated as an intentional local-command request: a
-    // bundle author who typos a remote transport must not silently land on a sandboxed process launch.
-    // An EXPLICIT stdio declaration is handled by TryRegisterStdioServer instead, not here (#371).
-    private void LogStdioRejected(string bundleId, string serverName)
-    {
-        _logger.LogWarning(
-            "Bundle {BundleId}: MCP server '{ServerName}' resolved to a stdio (local-command) transport " +
-            "without an explicit 'type': 'stdio' declaration — rejected, not registered. The transport " +
-            "either defaulted to stdio because 'type' was missing or unrecognized (only 'http'/'sse'/'stdio' " +
-            "are recognized), which this host never treats as an intentional stdio request.",
-            bundleId, serverName);
-    }
 
     /// <summary>
     /// Registration-time pre-check against the SAME harness-wide allowlist a bundle-owned server's live

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Domain.Common;
 using Domain.Common.Config.AI.MCP;
 using Domain.Common.Extensions;
+using Domain.Common.Helpers;
 
 namespace Infrastructure.AI.Plugins;
 
@@ -132,42 +133,27 @@ public static class McpServerDefinitionBuilder
     /// (see <c>BundleStagingService.LogStdioRejected</c>).
     /// </summary>
     private static Result<McpServerType> ParseType(JsonElement serverElement, string serverName) =>
-        ReadOptionalString(serverElement, "type", serverName).Map(raw => ParseTypeValue(raw));
-
-    /// <summary>Maps a raw, already-extracted <c>type</c> string the way <see cref="ParseType"/> does — the ONE mapping rule.</summary>
-    private static McpServerType ParseTypeValue(string? raw) => raw?.ToLowerInvariant() switch
-    {
-        "http" => McpServerType.Http,
-        "sse" => McpServerType.Sse,
-        _ => McpServerType.Stdio
-    };
+        ReadOptionalString(serverElement, "type", serverName).Map(ParseTypeValue);
 
     /// <summary>
-    /// The manifest string <see cref="ParseTypeValue"/> recognizes for <paramref name="type"/> —
-    /// deliberately NOT the inverse of the whole switch (its default arm maps every unrecognized string
-    /// to <see cref="McpServerType.Stdio"/> too, which is exactly the ambiguity
-    /// <see cref="IsExplicitType"/> exists to resolve; "recognized" and "defaulted-to" must stay
-    /// distinguishable, not merged into one lookup).
+    /// Maps a raw, already-extracted <c>type</c> string the way <see cref="ParseType"/> does — the ONE
+    /// mapping rule, via <see cref="EnumNameHelper.TryParseName{TEnum}"/> (#296/#312: the shared,
+    /// case-insensitive, numeric-form-rejecting enum-by-name parser every layer that reads a wire/config
+    /// enum value is expected to use, rather than a hand-rolled switch a second reader could drift from).
     /// </summary>
-    private static string? RecognizedTypeLiteral(McpServerType type) => type switch
-    {
-        McpServerType.Http => "http",
-        McpServerType.Sse => "sse",
-        McpServerType.Stdio => "stdio",
-        _ => null
-    };
+    private static McpServerType ParseTypeValue(string? raw) =>
+        EnumNameHelper.TryParseName<McpServerType>(raw, out var parsed) ? parsed : McpServerType.Stdio;
 
     /// <summary>
-    /// Whether a manifest declares <c>"type"</c> as the exact recognized string for
-    /// <paramref name="type"/> — distinct from <see cref="ParseType"/>'s own default-to-stdio behavior
-    /// for an absent or unrecognized value. <c>BundleStagingService.TryRegisterStdioServer</c> needs
-    /// exactly this distinction for <see cref="McpServerType.Stdio"/> specifically: a bundle author's
-    /// typo'd remote transport (<c>"type": "htp"</c>) must not silently land on a sandboxed process
-    /// launch just because unrecognized values default to the same enum value an explicit
-    /// <c>"stdio"</c> would. Shares <see cref="RecognizedTypeLiteral"/> with <see cref="ParseTypeValue"/>
-    /// rather than a second, independently-written comparison, so the two mapping rules cannot drift —
-    /// a caller that instead re-implemented "read type, compare case-insensitively" would have no
-    /// build-time signal if this class's own recognized aliases ever changed.
+    /// Whether a manifest declares <c>"type"</c> as the exact, recognized name of <paramref name="type"/>
+    /// — distinct from <see cref="ParseType"/>'s own default-to-stdio behavior for an absent or
+    /// unrecognized value. <c>BundleStagingService.TryRegisterStdioServer</c> needs exactly this
+    /// distinction for <see cref="McpServerType.Stdio"/> specifically: a bundle author's typo'd remote
+    /// transport (<c>"type": "htp"</c>) must not silently land on a sandboxed process launch just because
+    /// unrecognized values default to the same enum value an explicit <c>"stdio"</c> would.
+    /// <see cref="EnumNameHelper.TryParseName{TEnum}"/> already refuses anything that isn't a genuinely
+    /// defined member — no separate "recognized literal" lookup table is needed to keep "recognized" and
+    /// "defaulted-to" distinguishable; a failed parse simply cannot equal <paramref name="type"/>.
     /// </summary>
     /// <remarks>
     /// Callers of this method are expected to have already called <see cref="Build"/> successfully on
@@ -178,7 +164,8 @@ public static class McpServerDefinitionBuilder
     public static bool IsExplicitType(JsonElement serverElement, McpServerType type) =>
         serverElement.TryGetProperty("type", out var value)
         && value.ValueKind == JsonValueKind.String
-        && string.Equals(value.GetString()?.ToLowerInvariant(), RecognizedTypeLiteral(type), StringComparison.Ordinal);
+        && EnumNameHelper.TryParseName<McpServerType>(value.GetString(), out var parsed)
+        && parsed == type;
 
     /// <summary>
     /// Reads an optional string property. Absent is success with a <see langword="null"/> value —

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/McpServerDefinitionBuilder.cs
@@ -132,12 +132,53 @@ public static class McpServerDefinitionBuilder
     /// (see <c>BundleStagingService.LogStdioRejected</c>).
     /// </summary>
     private static Result<McpServerType> ParseType(JsonElement serverElement, string serverName) =>
-        ReadOptionalString(serverElement, "type", serverName).Map(raw => raw?.ToLowerInvariant() switch
-        {
-            "http" => McpServerType.Http,
-            "sse" => McpServerType.Sse,
-            _ => McpServerType.Stdio
-        });
+        ReadOptionalString(serverElement, "type", serverName).Map(raw => ParseTypeValue(raw));
+
+    /// <summary>Maps a raw, already-extracted <c>type</c> string the way <see cref="ParseType"/> does — the ONE mapping rule.</summary>
+    private static McpServerType ParseTypeValue(string? raw) => raw?.ToLowerInvariant() switch
+    {
+        "http" => McpServerType.Http,
+        "sse" => McpServerType.Sse,
+        _ => McpServerType.Stdio
+    };
+
+    /// <summary>
+    /// The manifest string <see cref="ParseTypeValue"/> recognizes for <paramref name="type"/> —
+    /// deliberately NOT the inverse of the whole switch (its default arm maps every unrecognized string
+    /// to <see cref="McpServerType.Stdio"/> too, which is exactly the ambiguity
+    /// <see cref="IsExplicitType"/> exists to resolve; "recognized" and "defaulted-to" must stay
+    /// distinguishable, not merged into one lookup).
+    /// </summary>
+    private static string? RecognizedTypeLiteral(McpServerType type) => type switch
+    {
+        McpServerType.Http => "http",
+        McpServerType.Sse => "sse",
+        McpServerType.Stdio => "stdio",
+        _ => null
+    };
+
+    /// <summary>
+    /// Whether a manifest declares <c>"type"</c> as the exact recognized string for
+    /// <paramref name="type"/> — distinct from <see cref="ParseType"/>'s own default-to-stdio behavior
+    /// for an absent or unrecognized value. <c>BundleStagingService.TryRegisterStdioServer</c> needs
+    /// exactly this distinction for <see cref="McpServerType.Stdio"/> specifically: a bundle author's
+    /// typo'd remote transport (<c>"type": "htp"</c>) must not silently land on a sandboxed process
+    /// launch just because unrecognized values default to the same enum value an explicit
+    /// <c>"stdio"</c> would. Shares <see cref="RecognizedTypeLiteral"/> with <see cref="ParseTypeValue"/>
+    /// rather than a second, independently-written comparison, so the two mapping rules cannot drift —
+    /// a caller that instead re-implemented "read type, compare case-insensitively" would have no
+    /// build-time signal if this class's own recognized aliases ever changed.
+    /// </summary>
+    /// <remarks>
+    /// Callers of this method are expected to have already called <see cref="Build"/> successfully on
+    /// the same <paramref name="serverElement"/> — this method does not itself validate that <c>type</c>
+    /// has a string shape (an absent/wrong-shaped property both resolve to <c>false</c> here, harmlessly),
+    /// because <see cref="Build"/> already rejects that shape before any caller could reach this check.
+    /// </remarks>
+    public static bool IsExplicitType(JsonElement serverElement, McpServerType type) =>
+        serverElement.TryGetProperty("type", out var value)
+        && value.ValueKind == JsonValueKind.String
+        && string.Equals(value.GetString()?.ToLowerInvariant(), RecognizedTypeLiteral(type), StringComparison.Ordinal);
 
     /// <summary>
     /// Reads an optional string property. Absent is success with a <see langword="null"/> value —

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerContainerLaunchPreparer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerContainerLaunchPreparer.cs
@@ -80,13 +80,25 @@ public sealed class DockerContainerLaunchPreparer(
         dockerClient.Containers.WaitContainerAsync(containerId, ct);
 
     /// <summary>
-    /// Resolves the container image for a tool: a per-tool <c>ContainerImage</c> override from
-    /// <see cref="SandboxExecutionOptions.ToolOverrides"/> when one is configured (validated
-    /// against <see cref="ContainerSandboxOptions.AllowedImagePrefixes"/>), otherwise the
-    /// configured default image.
+    /// Resolves the container image to run: <paramref name="requestImage"/> when the caller
+    /// specified one (e.g. <see cref="Domain.AI.Sandbox.SandboxSessionRequest.ContainerImage"/> —
+    /// used for a bundle-owned stdio MCP server, whose registered name contains a fresh GUID per
+    /// staging and so can never match a <paramref name="toolName"/>-keyed
+    /// <see cref="SandboxExecutionOptions.ToolOverrides"/> entry), else a per-tool
+    /// <c>ContainerImage</c> override from <see cref="SandboxExecutionOptions.ToolOverrides"/> when
+    /// one is configured, else the configured default image. Every non-default image — caller-
+    /// specified or tool-override — is validated against
+    /// <see cref="ContainerSandboxOptions.AllowedImagePrefixes"/>: a caller can choose among images
+    /// the operator has already permitted, never escape that allowlist.
     /// </summary>
-    public string ResolveImage(string toolName)
+    public string ResolveImage(string toolName, string? requestImage = null)
     {
+        if (!string.IsNullOrEmpty(requestImage))
+        {
+            ValidateImageAllowed(requestImage);
+            return requestImage;
+        }
+
         var currentOptions = options.CurrentValue;
 
         if (currentOptions.ToolOverrides.TryGetValue(toolName, out var toolOverride)
@@ -163,7 +175,8 @@ public sealed class DockerContainerLaunchPreparer(
         string workspaceDir,
         string image,
         bool interactive = false,
-        IReadOnlyDictionary<string, string>? environmentVariables = null)
+        IReadOnlyDictionary<string, string>? environmentVariables = null,
+        string? workingDirectory = null)
     {
         var hasNetworkAccess = permissionProfile.RequiredCapabilities.HasFlag(ToolCapability.NetworkAccess);
 
@@ -179,6 +192,7 @@ public sealed class DockerContainerLaunchPreparer(
         {
             Image = image,
             Cmd = cmd,
+            WorkingDir = workingDirectory,
             Env = environmentVariables is { Count: > 0 }
                 ? environmentVariables.Select(kvp => $"{kvp.Key}={kvp.Value}").ToList()
                 : null,
@@ -202,6 +216,13 @@ public sealed class DockerContainerLaunchPreparer(
                 Binds = [permissionProfile.RequiredCapabilities.HasFlag(ToolCapability.FileWrite)
                     ? $"{workspaceDir}:/workspace:rw"
                     : $"{workspaceDir}:/workspace:ro"],
+                // ReadonlyRootfs plus a possibly read-only /workspace bind leaves NO writable path
+                // anywhere in the container by default. Most real programs (npm/pip caches, lock
+                // files, a temp file mid-write) touch /tmp unconditionally regardless of whether
+                // ToolCapability.FileWrite was granted, so this tmpfs is unconditional too — sized
+                // off the same ResourceLimits.DiskQuotaBytes the workspace bind is implicitly bounded
+                // by, capped by the tmpfs's own noexec/nosuid mount options.
+                Tmpfs = new Dictionary<string, string> { ["/tmp"] = $"rw,noexec,nosuid,size={limits.DiskQuotaBytes}" },
                 PidsLimit = limits.MaxSubprocesses,
                 SecurityOpt = ["no-new-privileges:true"],
                 CapDrop = ["ALL"]
@@ -210,6 +231,16 @@ public sealed class DockerContainerLaunchPreparer(
     }
 
     /// <summary>Creates a fresh, restrictively-permissioned temp directory bind-mounted into the container as <c>/workspace</c>.</summary>
+    /// <remarks>
+    /// Owner-only (0700) by default, matching every consumer before #371. A caller that seeds this
+    /// workspace with content the container's own fixed unprivileged UID must read (see
+    /// <see cref="SandboxWorkspace.SeedFrom"/>) must widen it explicitly, scoped to exactly that case,
+    /// via <see cref="SandboxWorkspace.SetContainerAccessiblePermissions"/> — NOT here, unconditionally,
+    /// for every Docker-tier workspace regardless of whether it holds seeded content. /code-review
+    /// caught an earlier version of this method doing exactly that: it would have made every ordinary
+    /// (non-bundle) Docker-tier workspace on the host readable by any local OS account, not just the
+    /// container's own UID, to fix a problem that only exists for a seeded one.
+    /// </remarks>
     public string CreateWorkspace()
     {
         var workspaceDir = Path.Combine(Path.GetTempPath(), $"docker-sandbox-{Guid.NewGuid():N}");

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerContainerLaunchPreparer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerContainerLaunchPreparer.cs
@@ -216,12 +216,17 @@ public sealed class DockerContainerLaunchPreparer(
                 Binds = [permissionProfile.RequiredCapabilities.HasFlag(ToolCapability.FileWrite)
                     ? $"{workspaceDir}:/workspace:rw"
                     : $"{workspaceDir}:/workspace:ro"],
-                // ReadonlyRootfs plus a possibly read-only /workspace bind leaves NO writable path
-                // anywhere in the container by default. Most real programs (npm/pip caches, lock
+                // ReadonlyRootfs plus a possibly read-only /workspace bind would otherwise leave NO
+                // writable path anywhere in the container. Most real programs (npm/pip caches, lock
                 // files, a temp file mid-write) touch /tmp unconditionally regardless of whether
                 // ToolCapability.FileWrite was granted, so this tmpfs is unconditional too — sized
                 // off the same ResourceLimits.DiskQuotaBytes the workspace bind is implicitly bounded
-                // by, capped by the tmpfs's own noexec/nosuid mount options.
+                // by, capped by the tmpfs's own noexec/nosuid mount options. Security-review note:
+                // this means ToolCapability.FileWrite governs writes to the /workspace bind
+                // specifically, not "can this container write anything at all" — every Docker-tier
+                // container, regardless of that capability, gets 100 MB of ephemeral, non-executable,
+                // per-container scratch space that is destroyed with the container and never shared
+                // with the host or another container.
                 Tmpfs = new Dictionary<string, string> { ["/tmp"] = $"rw,noexec,nosuid,size={limits.DiskQuotaBytes}" },
                 PidsLimit = limits.MaxSubprocesses,
                 SecurityOpt = ["no-new-privileges:true"],
@@ -230,10 +235,28 @@ public sealed class DockerContainerLaunchPreparer(
         };
     }
 
+    /// <summary>
+    /// Shared parent directory every Docker-tier workspace nests under, one level below
+    /// <see cref="Path.GetTempPath"/> (which is typically world-listable, e.g. mode 1777 on Linux).
+    /// </summary>
+    /// <remarks>
+    /// A seeded workspace's own directory is deliberately other-readable so the container's fixed
+    /// unprivileged UID can traverse it (see <see cref="SandboxWorkspace.SetContainerAccessiblePermissions"/>),
+    /// but that says nothing about whether another local account can find its unguessable GUID name in
+    /// the first place. This parent is other-EXECUTABLE (traverse) but not other-READABLE (list), so a
+    /// local account without the exact GUID cannot enumerate live bundle-owned workspace names — only
+    /// walk into one it already knows.
+    /// </remarks>
+    private const string WorkspaceParentDirName = "agentic-harness-sandbox";
+
     /// <summary>Creates a fresh, restrictively-permissioned temp directory bind-mounted into the container as <c>/workspace</c>.</summary>
     public string CreateWorkspace()
     {
-        var workspaceDir = Path.Combine(Path.GetTempPath(), $"docker-sandbox-{Guid.NewGuid():N}");
+        var parent = Path.Combine(Path.GetTempPath(), WorkspaceParentDirName);
+        Directory.CreateDirectory(parent);
+        SandboxWorkspace.SetTraverseOnlyPermissions(parent);
+
+        var workspaceDir = Path.Combine(parent, $"docker-sandbox-{Guid.NewGuid():N}");
         Directory.CreateDirectory(workspaceDir);
         SandboxWorkspace.SetRestrictivePermissions(workspaceDir);
         return workspaceDir;

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerContainerLaunchPreparer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerContainerLaunchPreparer.cs
@@ -231,22 +231,35 @@ public sealed class DockerContainerLaunchPreparer(
     }
 
     /// <summary>Creates a fresh, restrictively-permissioned temp directory bind-mounted into the container as <c>/workspace</c>.</summary>
-    /// <remarks>
-    /// Owner-only (0700) by default, matching every consumer before #371. A caller that seeds this
-    /// workspace with content the container's own fixed unprivileged UID must read (see
-    /// <see cref="SandboxWorkspace.SeedFrom"/>) must widen it explicitly, scoped to exactly that case,
-    /// via <see cref="SandboxWorkspace.SetContainerAccessiblePermissions"/> — NOT here, unconditionally,
-    /// for every Docker-tier workspace regardless of whether it holds seeded content. /code-review
-    /// caught an earlier version of this method doing exactly that: it would have made every ordinary
-    /// (non-bundle) Docker-tier workspace on the host readable by any local OS account, not just the
-    /// container's own UID, to fix a problem that only exists for a seeded one.
-    /// </remarks>
     public string CreateWorkspace()
     {
         var workspaceDir = Path.Combine(Path.GetTempPath(), $"docker-sandbox-{Guid.NewGuid():N}");
         Directory.CreateDirectory(workspaceDir);
         SandboxWorkspace.SetRestrictivePermissions(workspaceDir);
         return workspaceDir;
+    }
+
+    /// <summary>
+    /// Seeds an already-created <paramref name="workspaceDir"/> from <paramref name="seedDirectory"/>
+    /// and widens its permissions so the container's own fixed unprivileged UID can read what was
+    /// just seeded into it.
+    /// </summary>
+    /// <remarks>
+    /// Owned here — one call, through the same class that already owns <see cref="CreateWorkspace"/>
+    /// and <see cref="CleanupWorkspace"/> — rather than left as a two-step "seed, then widen, in that
+    /// exact order" ritual for each call site to reimplement correctly. A prior version of #371 did
+    /// leave it as a bare two-line sequence at the one call site that needed it; caught in review as
+    /// a structural risk (an easy order-of-operations mistake for a future second call site to make),
+    /// not a concrete bug in the one call site that existed. The widening must stay scoped to exactly
+    /// a workspace this method actually seeded — never applied unconditionally to every Docker-tier
+    /// workspace regardless of whether it holds seeded content, which a still-earlier version did and
+    /// /code-review caught as broader host-filesystem exposure than the problem it solved (see
+    /// <see cref="SandboxWorkspace.SetContainerAccessiblePermissions"/>'s own remarks).
+    /// </remarks>
+    public void SeedWorkspace(string workspaceDir, string seedDirectory)
+    {
+        SandboxWorkspace.SeedFrom(seedDirectory, workspaceDir);
+        SandboxWorkspace.SetContainerAccessiblePermissions(workspaceDir);
     }
 
     /// <summary>Best-effort recursive delete of a workspace created by <see cref="CreateWorkspace"/>. Never throws.</summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxSessionFactory.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxSessionFactory.cs
@@ -94,24 +94,31 @@ public sealed class DockerSandboxSessionFactory(
         string? containerId = null;
         DockerSandboxSession? session = null;
         MultiplexedStream? attachStream = null;
+        // Populated once ResolveImage runs below; stays null for a failure ahead of that point, so
+        // the attestation signer's own fallback to request.ContainerImage still applies to those.
+        string? resolvedImage = null;
 
         try
         {
-            // Seeded before the container is created, so the bind mount below picks up the
-            // content in the same pass Docker already makes to read the workspace directory —
-            // no separate "write into a running container" step needed. SeedWorkspace is the
-            // preparer's own single call for this — not two direct SandboxWorkspace calls at
-            // this site — so ownership of "how a Docker-tier workspace gets initialized" stays
-            // with the one class already responsible for CreateWorkspace/CleanupWorkspace.
-            if (request.WorkspaceSeedDirectory is { } seedDirectory)
-                launchPreparer.SeedWorkspace(workspaceDir, seedDirectory);
-
-            var image = launchPreparer.ResolveImage(request.ToolName, request.ContainerImage);
-            await launchPreparer.EnsureImageAvailableAsync(image, ct);
+            // Seeding (blocking disk I/O, potentially a whole bundle's worth of files) and the
+            // image pull (Docker daemon I/O) have no data dependency on each other — both must
+            // finish before the container starts, but neither needs the other's result first, so
+            // they run concurrently rather than paying their sum. Same shape as the egress-check +
+            // Docker-ping pairing above in StartSessionAsync. SeedWorkspace itself stays the
+            // preparer's own single call — not two direct SandboxWorkspace calls at this site — so
+            // ownership of "how a Docker-tier workspace gets initialized" stays with the one class
+            // already responsible for CreateWorkspace/CleanupWorkspace; Task.Run only moves WHEN
+            // that call happens, not who owns it.
+            resolvedImage = launchPreparer.ResolveImage(request.ToolName, request.ContainerImage);
+            var seedTask = request.WorkspaceSeedDirectory is { } seedDirectory
+                ? Task.Run(() => launchPreparer.SeedWorkspace(workspaceDir, seedDirectory), ct)
+                : Task.CompletedTask;
+            var imagePullTask = launchPreparer.EnsureImageAvailableAsync(resolvedImage, ct);
+            await Task.WhenAll(seedTask, imagePullTask);
 
             var containerParams = launchPreparer.BuildContainerParams(
                 request.Command ?? request.ToolName, request.ArgumentList, request.Limits, request.PermissionProfile,
-                workspaceDir, image, interactive: true, environmentVariables: request.EnvironmentVariables,
+                workspaceDir, resolvedImage, interactive: true, environmentVariables: request.EnvironmentVariables,
                 workingDirectory: request.WorkspaceSeedDirectory is not null ? "/workspace" : null);
             var createResponse = await dockerClient.Containers.CreateContainerAsync(containerParams, ct);
             containerId = createResponse.ID;
@@ -139,7 +146,7 @@ public sealed class DockerSandboxSessionFactory(
             // session is the more consequential event. Deliberately not passed ct — see
             // SignStartAsync's own remarks for why signing this specific event must not be
             // abandonable by the caller's token.
-            await attestationSigner.SignStartAsync(request, egressDigest);
+            await attestationSigner.SignStartAsync(request, egressDigest, resolvedImage);
 
             return Result<ISandboxSession>.Success(session);
         }
@@ -171,7 +178,7 @@ public sealed class DockerSandboxSessionFactory(
             // harder to diagnose for no security benefit.
             await TearDownPartialStartAsync(session, attachStream, containerId, workspaceDir);
 
-            await attestationSigner.SignFailureAsync(request, ex.Message, egressDigest, ct);
+            await attestationSigner.SignFailureAsync(request, ex.Message, egressDigest, ct, resolvedImage);
             return Result<ISandboxSession>.Fail(ex.Message);
         }
         catch (Exception ex)
@@ -183,7 +190,7 @@ public sealed class DockerSandboxSessionFactory(
             await TearDownPartialStartAsync(session, attachStream, containerId, workspaceDir);
 
             sessionLogger.LogWarning(ex, "Docker sandbox session failed to start for tool {ToolName}", request.ToolName);
-            await attestationSigner.SignFailureAsync(request, $"Docker error: {ex.Message}", egressDigest, ct);
+            await attestationSigner.SignFailureAsync(request, $"Docker error: {ex.Message}", egressDigest, ct, resolvedImage);
             return Result<ISandboxSession>.Fail(DockerErrorFailureCode);
         }
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxSessionFactory.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxSessionFactory.cs
@@ -97,12 +97,26 @@ public sealed class DockerSandboxSessionFactory(
 
         try
         {
-            var image = launchPreparer.ResolveImage(request.ToolName);
+            // Seeded before the container is created, so the bind mount below picks up the
+            // content in the same pass Docker already makes to read the workspace directory —
+            // no separate "write into a running container" step needed. The workspace root's
+            // permissions are widened ONLY here, in the seeded branch — not unconditionally in
+            // CreateWorkspace for every Docker-tier session (an earlier version did that;
+            // /code-review caught it as broader exposure than the problem it solved). Every
+            // OTHER Docker-tier consumer keeps the tighter owner-only default.
+            if (request.WorkspaceSeedDirectory is { } seedDirectory)
+            {
+                SandboxWorkspace.SeedFrom(seedDirectory, workspaceDir);
+                SandboxWorkspace.SetContainerAccessiblePermissions(workspaceDir);
+            }
+
+            var image = launchPreparer.ResolveImage(request.ToolName, request.ContainerImage);
             await launchPreparer.EnsureImageAvailableAsync(image, ct);
 
             var containerParams = launchPreparer.BuildContainerParams(
                 request.Command ?? request.ToolName, request.ArgumentList, request.Limits, request.PermissionProfile,
-                workspaceDir, image, interactive: true, environmentVariables: request.EnvironmentVariables);
+                workspaceDir, image, interactive: true, environmentVariables: request.EnvironmentVariables,
+                workingDirectory: request.WorkspaceSeedDirectory is not null ? "/workspace" : null);
             var createResponse = await dockerClient.Containers.CreateContainerAsync(containerParams, ct);
             containerId = createResponse.ID;
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxSessionFactory.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxSessionFactory.cs
@@ -99,16 +99,12 @@ public sealed class DockerSandboxSessionFactory(
         {
             // Seeded before the container is created, so the bind mount below picks up the
             // content in the same pass Docker already makes to read the workspace directory —
-            // no separate "write into a running container" step needed. The workspace root's
-            // permissions are widened ONLY here, in the seeded branch — not unconditionally in
-            // CreateWorkspace for every Docker-tier session (an earlier version did that;
-            // /code-review caught it as broader exposure than the problem it solved). Every
-            // OTHER Docker-tier consumer keeps the tighter owner-only default.
+            // no separate "write into a running container" step needed. SeedWorkspace is the
+            // preparer's own single call for this — not two direct SandboxWorkspace calls at
+            // this site — so ownership of "how a Docker-tier workspace gets initialized" stays
+            // with the one class already responsible for CreateWorkspace/CleanupWorkspace.
             if (request.WorkspaceSeedDirectory is { } seedDirectory)
-            {
-                SandboxWorkspace.SeedFrom(seedDirectory, workspaceDir);
-                SandboxWorkspace.SetContainerAccessiblePermissions(workspaceDir);
-            }
+                launchPreparer.SeedWorkspace(workspaceDir, seedDirectory);
 
             var image = launchPreparer.ResolveImage(request.ToolName, request.ContainerImage);
             await launchPreparer.EnsureImageAvailableAsync(image, ct);

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxSessionFactory.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/ProcessSandboxSessionFactory.cs
@@ -62,6 +62,19 @@ public sealed class ProcessSandboxSessionFactory(
             return await attestationSigner.RejectAsync(request, reason, ct);
         }
 
+        // Workspace seeding exists to give caller-supplied content (e.g. a bundle's staged files)
+        // to the sandbox — content this backend's "not a containment boundary" caveat (see this
+        // class's own remarks) makes unsafe to expose to a process running as the harness's own
+        // OS user. A future caller that rewires this factory into a path it isn't reachable from
+        // today must not silently downgrade seeded content to this tier — it must fail loudly here
+        // instead.
+        if (request.WorkspaceSeedDirectory is not null)
+        {
+            const string reason = "Workspace seeding requires container isolation and is not supported " +
+                "on the process sandbox tier, which is not a containment boundary.";
+            return await attestationSigner.RejectAsync(request, reason, ct);
+        }
+
         var egress = await egressPreflightRunner.EvaluateAsync(request.ToolName, request.EgressPrecheckTargets, ct);
         if (egress.IsDenied)
             return await attestationSigner.RejectAsync(request, egress.ErrorMessage!, ct, egress.Digest);

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxSessionAttestationSigner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxSessionAttestationSigner.cs
@@ -79,12 +79,23 @@ public sealed class SandboxSessionAttestationSigner(IAttestationService attestat
     /// but values are not — a value may itself be a secret, and should not be persisted verbatim
     /// into an audit record.
     /// </summary>
+    /// <remarks>
+    /// <c>image</c> and <c>seeded</c> (#371) are both new inputs that materially determine what
+    /// actually ran a container without changing <c>command</c>/<c>args</c>/<c>envNames</c> at all
+    /// — two sessions with identical logged command/args/env-names but a different runtime image,
+    /// or one seeded with a bundle's own files and one started empty, would otherwise produce
+    /// byte-identical attested input. <c>seeded</c> is recorded as a bool, not the raw
+    /// <see cref="SandboxSessionRequest.WorkspaceSeedDirectory"/> path, so no host path lands in
+    /// the audit store — consistent with the env-values-excluded posture above.
+    /// </remarks>
     private static string DescribeSessionInput(SandboxSessionRequest request) => JsonSerializer.Serialize(new
     {
         command = request.Command ?? request.ToolName,
         args = request.ArgumentList ?? [],
         envNames = request.EnvironmentVariables?.Keys.Order().ToArray() ?? [],
         isolation = request.PermissionProfile.MinimumIsolation.ToString(),
-        capabilities = request.PermissionProfile.RequiredCapabilities.ToString()
+        capabilities = request.PermissionProfile.RequiredCapabilities.ToString(),
+        image = request.ContainerImage,
+        seeded = request.WorkspaceSeedDirectory is not null
     });
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxSessionAttestationSigner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxSessionAttestationSigner.cs
@@ -26,18 +26,24 @@ public sealed class SandboxSessionAttestationSigner(IAttestationService attestat
 
     /// <summary>Signs a failure attestation for <paramref name="reason"/> and wraps it as a failure <see cref="Result{T}"/>.</summary>
     public async Task<Result<ISandboxSession>> RejectAsync(
-        SandboxSessionRequest request, string reason, CancellationToken ct, string? egressDigest = null)
+        SandboxSessionRequest request, string reason, CancellationToken ct, string? egressDigest = null, string? resolvedImage = null)
     {
-        await SignFailureAsync(request, reason, egressDigest, ct);
+        await SignFailureAsync(request, reason, egressDigest, ct, resolvedImage);
         return Result<ISandboxSession>.Fail(reason);
     }
 
-    /// <summary>Signs a failure attestation only, for a caller that builds its own <see cref="Result{T}"/> (e.g. to preserve exception context).</summary>
+    /// <summary>
+    /// Signs a failure attestation only, for a caller that builds its own <see cref="Result{T}"/>
+    /// (e.g. to preserve exception context). <paramref name="resolvedImage"/> is the image
+    /// <c>DockerContainerLaunchPreparer.ResolveImage</c> actually picked, when a caller has already
+    /// reached that step by the time of failure — see <see cref="DescribeSessionInput"/>'s remarks
+    /// for why this must win over <see cref="SandboxSessionRequest.ContainerImage"/>.
+    /// </summary>
     public Task SignFailureAsync(
-        SandboxSessionRequest request, string failureReason, string? egressDigest, CancellationToken ct) =>
+        SandboxSessionRequest request, string failureReason, string? egressDigest, CancellationToken ct, string? resolvedImage = null) =>
         attestationService.SignAsync(
             Domain.AI.Attestation.AttestationRequest.Failure(
-                request.ToolName, DescribeSessionInput(request), failureReason, egressDigest: egressDigest),
+                request.ToolName, DescribeSessionInput(request, resolvedImage), failureReason, egressDigest: egressDigest),
             ct);
 
     /// <summary>
@@ -58,14 +64,14 @@ public sealed class SandboxSessionAttestationSigner(IAttestationService attestat
     /// caller's token — the same reasoning <c>DockerContainerLaunchPreparer.RemoveContainerSafeAsync</c>
     /// already applies to a different post-hoc cleanup call.
     /// </remarks>
-    public async Task SignStartAsync(SandboxSessionRequest request, string? egressDigest)
+    public async Task SignStartAsync(SandboxSessionRequest request, string? egressDigest, string? resolvedImage = null)
     {
         // Must await inside this scope, not just return the Task, or `using` would dispose the
         // CancellationTokenSource — and disarm its timeout — before the write actually completes.
         using var cts = new CancellationTokenSource(StartAttestationWriteTimeout);
         await attestationService.SignAsync(
             Domain.AI.Attestation.AttestationRequest.Success(
-                request.ToolName, DescribeSessionInput(request), output: "session-started", egressDigest),
+                request.ToolName, DescribeSessionInput(request, resolvedImage), output: "session-started", egressDigest),
             cts.Token);
     }
 
@@ -87,15 +93,27 @@ public sealed class SandboxSessionAttestationSigner(IAttestationService attestat
     /// byte-identical attested input. <c>seeded</c> is recorded as a bool, not the raw
     /// <see cref="SandboxSessionRequest.WorkspaceSeedDirectory"/> path, so no host path lands in
     /// the audit store — consistent with the env-values-excluded posture above.
+    /// <para>
+    /// <paramref name="resolvedImage"/>, not <see cref="SandboxSessionRequest.ContainerImage"/>,
+    /// is what <c>image</c> records whenever a caller has one to give — a first-party tool never
+    /// populates <see cref="SandboxSessionRequest.ContainerImage"/> (its image comes from
+    /// <c>DockerContainerLaunchPreparer.ResolveImage</c>'s own <c>SandboxExecutionOptions.ToolOverrides</c>
+    /// lookup, not a request-level override), so reading the raw request field alone would attest
+    /// <c>image: null</c> for every first-party session regardless of which image genuinely ran —
+    /// an operator could repoint a tool's override to a different image between two runs and the
+    /// attested input would be silently identical either way. Callers that have not yet reached
+    /// image resolution when a failure occurs (e.g. a pre-flight rejection) correctly omit this
+    /// argument; <c>DescribeSessionInput</c> then falls back to whatever the request itself carried.
+    /// </para>
     /// </remarks>
-    private static string DescribeSessionInput(SandboxSessionRequest request) => JsonSerializer.Serialize(new
+    private static string DescribeSessionInput(SandboxSessionRequest request, string? resolvedImage = null) => JsonSerializer.Serialize(new
     {
         command = request.Command ?? request.ToolName,
         args = request.ArgumentList ?? [],
         envNames = request.EnvironmentVariables?.Keys.Order().ToArray() ?? [],
         isolation = request.PermissionProfile.MinimumIsolation.ToString(),
         capabilities = request.PermissionProfile.RequiredCapabilities.ToString(),
-        image = request.ContainerImage,
+        image = resolvedImage ?? request.ContainerImage,
         seeded = request.WorkspaceSeedDirectory is not null
     });
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxWorkspace.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxWorkspace.cs
@@ -119,10 +119,11 @@ internal static class SandboxWorkspace
 
     /// <summary>
     /// Copies files and subdirectories one level at a time, skipping any entry that is itself a
-    /// symlink/junction (<see cref="FileSystemInfo.LinkTarget"/> non-null) rather than following
-    /// it — a symlink inside an untrusted source directory could otherwise point outside the
-    /// source tree entirely (e.g. to a host path the caller has no business exposing to the
-    /// sandbox), and this copy has no way to distinguish an intended relative link from that.
+    /// symlink/junction (<see cref="FileSystemInfo.Attributes"/> carries <see cref="FileAttributes.ReparsePoint"/>)
+    /// rather than following it — a symlink inside an untrusted source directory could otherwise
+    /// point outside the source tree entirely (e.g. to a host path the caller has no business
+    /// exposing to the sandbox), and this copy has no way to distinguish an intended relative link
+    /// from that.
     /// </summary>
     /// <remarks>
     /// Every copied entry gets its permissions set explicitly (other-readable, dirs also
@@ -132,6 +133,16 @@ internal static class SandboxWorkspace
     /// <see cref="SetContainerAccessiblePermissions"/>), so relying on an ambient umask default
     /// (which may be as restrictive as 0077 on a hardened host) would make the seed silently
     /// unreadable on exactly the hosts most likely to run this feature.
+    /// <para>
+    /// Uses a single <see cref="DirectoryInfo.EnumerateFileSystemInfos()"/> scan per level rather
+    /// than separate <c>EnumerateDirectories</c>/<c>EnumerateFiles</c> passes plus a fresh
+    /// <c>DirectoryInfo</c>/<c>FileInfo</c> per entry just to read <c>LinkTarget</c> — that shape
+    /// walked the same native directory listing twice and issued an extra stat/readlink syscall for
+    /// every entry, symlink or not. <see cref="FileSystemInfo.Attributes"/> is already populated from
+    /// the same scan that produced the entry, so both the dir-vs-file test and the symlink test are
+    /// free here. Cost scales with bundle content size (nested plugin directories, vendored
+    /// dependencies), so this isn't negligible for larger bundles.
+    /// </para>
     /// </remarks>
     /// <exception cref="InvalidOperationException">The source tree nests deeper than <see cref="MaxSeedDepth"/>.</exception>
     private static void CopyDirectory(string sourceDir, string destinationDir, int depth)
@@ -142,26 +153,25 @@ internal static class SandboxWorkspace
                 $"Seed source exceeds the maximum directory depth of {MaxSeedDepth}; refusing to copy.");
         }
 
-        foreach (var dir in Directory.EnumerateDirectories(sourceDir))
+        foreach (var entry in new DirectoryInfo(sourceDir).EnumerateFileSystemInfos())
         {
-            if (new DirectoryInfo(dir).LinkTarget is not null)
+            if (entry.Attributes.HasFlag(FileAttributes.ReparsePoint))
                 continue;
 
-            var destSubDir = Path.Combine(destinationDir, Path.GetFileName(dir));
-            Directory.CreateDirectory(destSubDir);
-            SetContainerAccessiblePermissions(destSubDir);
-            CopyDirectory(dir, destSubDir, depth + 1);
-        }
-
-        foreach (var file in Directory.EnumerateFiles(sourceDir))
-        {
-            if (new FileInfo(file).LinkTarget is not null)
-                continue;
-
-            var destFile = Path.Combine(destinationDir, Path.GetFileName(file));
-            File.Copy(file, destFile, overwrite: true);
-            if (!OperatingSystem.IsWindows())
-                File.SetUnixFileMode(destFile, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.OtherRead);
+            if (entry.Attributes.HasFlag(FileAttributes.Directory))
+            {
+                var destSubDir = Path.Combine(destinationDir, entry.Name);
+                Directory.CreateDirectory(destSubDir);
+                SetContainerAccessiblePermissions(destSubDir);
+                CopyDirectory(entry.FullName, destSubDir, depth + 1);
+            }
+            else
+            {
+                var destFile = Path.Combine(destinationDir, entry.Name);
+                File.Copy(entry.FullName, destFile, overwrite: true);
+                if (!OperatingSystem.IsWindows())
+                    File.SetUnixFileMode(destFile, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.OtherRead);
+            }
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxWorkspace.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxWorkspace.cs
@@ -18,6 +18,42 @@ internal static class SandboxWorkspace
             File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
+    /// <summary>
+    /// Owner-only PLUS other-readable-and-traversable — widens a Docker-tier workspace beyond
+    /// <see cref="SetRestrictivePermissions"/>'s owner-only 0700, ONLY for a session that seeds the
+    /// workspace with content the container's own UID must be able to read (see
+    /// <see cref="DockerSandboxSessionFactory.StartSessionAsync"/>'s seeded branch — the only call
+    /// site). Every other Docker-tier workspace stays at 0700.
+    /// </summary>
+    /// <remarks>
+    /// A container's process runs as a fixed, unprivileged UID (65534 — see
+    /// <see cref="DockerContainerLaunchPreparer.BuildContainerParams"/>'s <c>User</c> field) that is
+    /// never the harness host process's own UID, and Docker does not remap UIDs across a bind mount
+    /// by default. Bare 0700 (owner-only) therefore denies the container ANY access to its own
+    /// bind-mounted workspace — directory traversal fails before the container process can even stat
+    /// a file inside it. This is a pre-existing gap in every Docker-tier workspace, not specific to a
+    /// seeded one, but this method must NOT be called unconditionally for every Docker-tier session to
+    /// close it: doing so would widen host directory permissions — readable by ANY local OS account,
+    /// not just the container's own fixed UID — for every ordinary (non-bundle) Docker-tier workspace
+    /// too, a strictly larger exposure than the seeded case this method exists to fix. (An earlier
+    /// version of this change did exactly that; caught by /code-review.) The Process tier is
+    /// unaffected and must keep <see cref="SetRestrictivePermissions"/> unchanged: that tier's process
+    /// runs as the SAME host user, so 0700 is both sufficient and correct there — the workspace
+    /// boundary there is the only isolation that tier has.
+    /// <para>
+    /// Not group-writable and not other-writable: this only grants what a read-only (or, once a
+    /// bundle-owned session is ever granted <c>ToolCapability.FileWrite</c>, read-write-by-the-
+    /// container-UID-via-the-bind-mount, not via host filesystem permissions) session needs.
+    /// </para>
+    /// </remarks>
+    internal static void SetContainerAccessiblePermissions(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+    }
+
     /// <summary>Best-effort recursive delete of a workspace directory. Never throws.</summary>
     internal static void Cleanup(string path, ILogger logger, string backendName)
     {
@@ -29,6 +65,70 @@ internal static class SandboxWorkspace
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to clean up {Backend} sandbox workspace {Path}", backendName, path);
+        }
+    }
+
+    /// <summary>
+    /// Recursively copies the contents of <paramref name="source"/> into an already-created
+    /// <paramref name="destination"/> workspace directory — used to seed a sandbox session with
+    /// caller-provided content (e.g. a bundle's staged files) that the fresh, empty workspace
+    /// <see cref="DockerContainerLaunchPreparer.CreateWorkspace"/> creates has no visibility of on
+    /// its own. A copy, not a link or bind of <paramref name="source"/> itself, deliberately: the
+    /// caller may delete <paramref name="source"/> on a lifecycle independent of this session (see
+    /// <see cref="Domain.AI.Sandbox.SandboxSessionRequest.WorkspaceSeedDirectory"/>'s remarks), so
+    /// nothing about the running session may depend on it continuing to exist.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="source"/> is not an absolute path.</exception>
+    /// <exception cref="DirectoryNotFoundException"><paramref name="source"/> does not exist.</exception>
+    internal static void SeedFrom(string source, string destination)
+    {
+        if (!Path.IsPathRooted(source))
+            throw new ArgumentException($"Seed source '{source}' must be an absolute path.", nameof(source));
+
+        if (!Directory.Exists(source))
+            throw new DirectoryNotFoundException($"Seed source directory '{source}' does not exist.");
+
+        CopyDirectory(source, destination);
+    }
+
+    /// <summary>
+    /// Copies files and subdirectories one level at a time, skipping any entry that is itself a
+    /// symlink/junction (<see cref="FileSystemInfo.LinkTarget"/> non-null) rather than following
+    /// it — a symlink inside an untrusted source directory could otherwise point outside the
+    /// source tree entirely (e.g. to a host path the caller has no business exposing to the
+    /// sandbox), and this copy has no way to distinguish an intended relative link from that.
+    /// </summary>
+    /// <remarks>
+    /// Every copied entry gets its permissions set explicitly (other-readable, dirs also
+    /// other-executable/traversable) rather than left at whatever the host process's umask
+    /// happens to produce — the destination is a Docker-tier workspace a container reads as a
+    /// fixed, unprivileged UID that never matches the copying process's own UID (see
+    /// <see cref="SetContainerAccessiblePermissions"/>), so relying on an ambient umask default
+    /// (which may be as restrictive as 0077 on a hardened host) would make the seed silently
+    /// unreadable on exactly the hosts most likely to run this feature.
+    /// </remarks>
+    private static void CopyDirectory(string sourceDir, string destinationDir)
+    {
+        foreach (var dir in Directory.EnumerateDirectories(sourceDir))
+        {
+            if (new DirectoryInfo(dir).LinkTarget is not null)
+                continue;
+
+            var destSubDir = Path.Combine(destinationDir, Path.GetFileName(dir));
+            Directory.CreateDirectory(destSubDir);
+            SetContainerAccessiblePermissions(destSubDir);
+            CopyDirectory(dir, destSubDir);
+        }
+
+        foreach (var file in Directory.EnumerateFiles(sourceDir))
+        {
+            if (new FileInfo(file).LinkTarget is not null)
+                continue;
+
+            var destFile = Path.Combine(destinationDir, Path.GetFileName(file));
+            File.Copy(file, destFile, overwrite: true);
+            if (!OperatingSystem.IsWindows())
+                File.SetUnixFileMode(destFile, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.OtherRead);
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxWorkspace.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/SandboxWorkspace.cs
@@ -19,6 +19,20 @@ internal static class SandboxWorkspace
     }
 
     /// <summary>
+    /// Owner full access, other-EXECUTE (traverse) but not other-READ (list) — for a shared parent
+    /// directory that individually-permissioned children live under. Lets a caller who already knows
+    /// a specific child's name walk into it (required for the container's fixed unprivileged UID to
+    /// resolve the bind-mount path down to a seeded, other-readable workspace), without letting an
+    /// unrelated local account enumerate which workspace names currently exist.
+    /// </summary>
+    internal static void SetTraverseOnlyPermissions(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute | UnixFileMode.OtherExecute);
+    }
+
+    /// <summary>
     /// Owner-only PLUS other-readable-and-traversable — widens a Docker-tier workspace beyond
     /// <see cref="SetRestrictivePermissions"/>'s owner-only 0700, ONLY for a session that seeds the
     /// workspace with content the container's own UID must be able to read (see
@@ -88,8 +102,20 @@ internal static class SandboxWorkspace
         if (!Directory.Exists(source))
             throw new DirectoryNotFoundException($"Seed source directory '{source}' does not exist.");
 
-        CopyDirectory(source, destination);
+        CopyDirectory(source, destination, depth: 0);
     }
+
+    /// <summary>
+    /// Deepest directory nesting <see cref="CopyDirectory"/> will descend before refusing to continue.
+    /// Extraction's own <c>MaxEntryCount</c> guard (default 2000) permits a path nested up to ~2000
+    /// levels deep within a single-path-length budget, and this is the only RECURSIVE walk anywhere in
+    /// the staging/seeding pipeline over attacker-shaped content — extraction itself is a flat loop, and
+    /// symlink validation uses the iterative <c>EnumerateFileSystemEntries(AllDirectories)</c>. Recursing
+    /// thousands of frames risks <see cref="StackOverflowException"/>, which .NET cannot catch and which
+    /// kills the entire host process — a bounded, catchable <see cref="InvalidOperationException"/> well
+    /// before that point is the only sane failure mode for a directory tree no legitimate bundle needs.
+    /// </summary>
+    private const int MaxSeedDepth = 64;
 
     /// <summary>
     /// Copies files and subdirectories one level at a time, skipping any entry that is itself a
@@ -107,8 +133,15 @@ internal static class SandboxWorkspace
     /// (which may be as restrictive as 0077 on a hardened host) would make the seed silently
     /// unreadable on exactly the hosts most likely to run this feature.
     /// </remarks>
-    private static void CopyDirectory(string sourceDir, string destinationDir)
+    /// <exception cref="InvalidOperationException">The source tree nests deeper than <see cref="MaxSeedDepth"/>.</exception>
+    private static void CopyDirectory(string sourceDir, string destinationDir, int depth)
     {
+        if (depth > MaxSeedDepth)
+        {
+            throw new InvalidOperationException(
+                $"Seed source exceeds the maximum directory depth of {MaxSeedDepth}; refusing to copy.");
+        }
+
         foreach (var dir in Directory.EnumerateDirectories(sourceDir))
         {
             if (new DirectoryInfo(dir).LinkTarget is not null)
@@ -117,7 +150,7 @@ internal static class SandboxWorkspace
             var destSubDir = Path.Combine(destinationDir, Path.GetFileName(dir));
             Directory.CreateDirectory(destSubDir);
             SetContainerAccessiblePermissions(destSubDir);
-            CopyDirectory(dir, destSubDir);
+            CopyDirectory(dir, destSubDir, depth + 1);
         }
 
         foreach (var file in Directory.EnumerateFiles(sourceDir))

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillContentRoots.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillContentRoots.cs
@@ -32,7 +32,7 @@ namespace Infrastructure.AI.Skills;
 /// there would make discovery depend on how the host was launched.
 /// </para>
 /// </remarks>
-internal static class SkillContentRoots
+public static class SkillContentRoots
 {
     /// <summary>
     /// The default staging location for expanded bundles when none is configured.

--- a/src/Content/Presentation/Presentation.ExecutionApi/appsettings.json
+++ b/src/Content/Presentation/Presentation.ExecutionApi/appsettings.json
@@ -68,6 +68,11 @@
       "BundleExecution": {
         "Enabled": true,
         "AllowBundleDeclaredMcpServers": false,
+        "StdioMcpServers": {
+          "Enabled": false,
+          "ContainerImage": "",
+          "MaxServersPerBundle": 2
+        },
         "Auth": {
         }
       },

--- a/src/Content/Tests/Application.Core.Tests/Validation/BundleExecutionConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/BundleExecutionConfigValidatorTests.cs
@@ -140,6 +140,79 @@ public class BundleExecutionConfigValidatorTests
     }
 
     [Fact]
+    public async Task Validate_ZeroMaxServersPerBundle_HasError()
+    {
+        var config = new BundleExecutionConfig
+        {
+            StdioMcpServers = new BundleStdioMcpServersConfig { MaxServersPerBundle = 0 },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "StdioMcpServers.MaxServersPerBundle");
+    }
+
+    [Fact]
+    public async Task Validate_ZeroMaxConcurrentSessions_HasError()
+    {
+        var config = new BundleExecutionConfig
+        {
+            StdioMcpServers = new BundleStdioMcpServersConfig { MaxConcurrentSessions = 0 },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "StdioMcpServers.MaxConcurrentSessions");
+    }
+
+    [Fact]
+    public async Task Validate_WhitespaceOnlyContainerImage_HasError()
+    {
+        var config = new BundleExecutionConfig
+        {
+            StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = "   " },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "StdioMcpServers.ContainerImage");
+    }
+
+    [Fact]
+    public async Task Validate_ContainerImageWithLeadingOrTrailingWhitespace_HasError()
+    {
+        // /code-review finding: the original rule checked image.Trim().Length > 0 but never rejected
+        // (or trimmed) a value that merely HAD padding — "mcr.microsoft.com/node:20 " passed validation
+        // while reaching Docker's image-reference parser unsanitized, with nothing downstream trimming it.
+        var config = new BundleExecutionConfig
+        {
+            StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = "mcr.microsoft.com/node:20 " },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "StdioMcpServers.ContainerImage");
+    }
+
+    [Fact]
+    public async Task Validate_EmptyContainerImage_NoError()
+    {
+        // Empty is the valid "capability stays inert" default — must not be conflated with whitespace-only.
+        var config = new BundleExecutionConfig
+        {
+            StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = string.Empty },
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue(string.Join("; ", result.Errors.Select(e => e.ErrorMessage)));
+    }
+
+    [Fact]
     public async Task Validate_DisabledConfigWithBadValue_StillFails()
     {
         // Rules are unconditional: switching the subsystem off does not license a non-positive TTL.

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
@@ -7,6 +7,7 @@ using Application.AI.Common.Services.Sandbox;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Egress;
 using Domain.AI.Identity;
+using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Sandbox;
 using Infrastructure.AI.Bundles;
@@ -108,6 +109,12 @@ internal static class McpConnectionManagerBundleEgressSupport
         // in this minimal provider, so the empty key set correctly resolves every server name to
         // the same None/None base the production registration would give an unrecognised name.
         services.AddOptions<SandboxConfig>();
+        // McpConnectionManager also resolves IOptionsMonitor<AppConfig> eagerly at construction (the
+        // sandboxed-stdio path's container image comes from AppConfig.AI.BundleExecution.StdioMcpServers).
+        // Default-bound AppConfig — ContainerImage empty, capability off — matches production's own
+        // fail-inert-until-configured posture, so a test that does not opt in never accidentally reaches
+        // a real sandbox path via this shared provider.
+        services.AddOptions<AppConfig>();
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>(StringComparer.Ordinal)));
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
             sp.GetRequiredService<FirstPartyToolLookup>(), sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>()));

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -3,6 +3,9 @@ using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.BundleExecution;
 using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
@@ -137,6 +140,74 @@ public sealed class McpConnectionManagerSandboxedStdioTests
     }
 
     [Fact]
+    public async Task GetClientAsync_BundleOwnedStdioServer_PassesSeedDirectoryAndConfiguredImageToTheSessionRequest()
+    {
+        // #371: the two facts that make a sandboxed stdio session actually able to run the bundle's own
+        // server — the seed directory tagged onto the definition at registration, and the operator's
+        // configured image (never a per-tool ToolOverrides image, since a bundle's GUID-namespaced name
+        // could never match one) — must both reach the sandbox session request.
+        const string seedDirectory = @"C:\staged\bundle-abc123";
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Stdio,
+            Command = "node",
+            StartupTimeoutSeconds = 1,
+            SandboxSeedDirectory = seedDirectory,
+        });
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new BundleExecutionConfig
+                {
+                    StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = "mcr.microsoft.com/node:20" },
+                },
+            },
+        };
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, _fakeSessionFactory);
+            // Registered after BuildRootServices' own IOptionsMonitor<AppConfig> — last registration
+            // wins for a non-keyed singleton, so this overrides the default (empty) AppConfig.
+            services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
+        });
+        var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+
+        await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
+
+        _fakeSessionFactory.LastRequest.Should().NotBeNull();
+        _fakeSessionFactory.LastRequest!.WorkspaceSeedDirectory.Should().Be(seedDirectory);
+        _fakeSessionFactory.LastRequest.ContainerImage.Should().Be("mcr.microsoft.com/node:20");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedStdioServer_NoConfiguredImage_LeavesRequestImageNull()
+    {
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Stdio,
+            Command = "node",
+            StartupTimeoutSeconds = 1,
+        });
+        // BuildRootServices' default AppConfig has an empty (unconfigured) StdioMcpServers.ContainerImage.
+        var sut = CreateManager(new McpServersConfig(), bundleOwned);
+
+        await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
+
+        _fakeSessionFactory.LastRequest.Should().NotBeNull();
+        _fakeSessionFactory.LastRequest!.ContainerImage.Should().BeNull(
+            "an unconfigured image must fall through to the session factory's own default resolution, " +
+            "not an empty string that would fail Docker's image reference parsing");
+    }
+
+    [Fact]
     public async Task GetClientAsync_HostConfiguredStdioServer_NeverReachesTheSandbox()
     {
         // The trust-tier boundary #371 must not blur: a host-installed plugin's stdio server keeps
@@ -161,6 +232,19 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         await act.Should().ThrowAsync<McpConnectionException>();
         _fakeSessionFactory.WasCalled.Should().BeFalse(
             "a host-configured server is a different trust tier and must never route through the sandbox");
+    }
+
+    private sealed class StaticAppConfigMonitor(AppConfig value) : IOptionsMonitor<AppConfig>
+    {
+        public AppConfig CurrentValue => value;
+        public AppConfig Get(string? name) => value;
+        public IDisposable OnChange(Action<AppConfig, string?> listener) => NullDisposable.Instance;
+
+        private sealed class NullDisposable : IDisposable
+        {
+            public static readonly NullDisposable Instance = new();
+            public void Dispose() { }
+        }
     }
 
     private sealed class StaticSandboxConfigMonitor(SandboxConfig value) : IOptionsMonitor<SandboxConfig>

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -146,6 +146,10 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         // server — the seed directory tagged onto the definition at registration, and the operator's
         // configured image (never a per-tool ToolOverrides image, since a bundle's GUID-namespaced name
         // could never match one) — must both reach the sandbox session request.
+        // Under BundleExecution.TempRoot below — StartSandboxedStdioSessionAsync's containment check
+        // (#371, a code-review/security-review finding) refuses a seed directory outside the
+        // configured staging root, so this test's own seed path must actually resolve under it.
+        const string stagingRoot = @"C:\staged";
         const string seedDirectory = @"C:\staged\bundle-abc123";
         var bundleOwned = new BundleOwnedMcpServerRegistry();
         bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
@@ -163,6 +167,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             {
                 BundleExecution = new BundleExecutionConfig
                 {
+                    TempRoot = stagingRoot,
                     StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = "mcr.microsoft.com/node:20" },
                 },
             },
@@ -183,6 +188,106 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         _fakeSessionFactory.LastRequest.Should().NotBeNull();
         _fakeSessionFactory.LastRequest!.WorkspaceSeedDirectory.Should().Be(seedDirectory);
         _fakeSessionFactory.LastRequest.ContainerImage.Should().Be("mcr.microsoft.com/node:20");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_ConcurrentSandboxedStdioSessions_RefusesBeyondTheHostWideCap()
+    {
+        // Security-review finding: MaxServersPerBundle bounds one bundle's own container count, but
+        // nothing bounded how many bundles could be concurrently staged — an authenticated caller
+        // could otherwise pin an unbounded number of containers by staging enough bundles. This test
+        // holds one session "in flight" (its factory call never completes until released) to prove a
+        // SECOND concurrent attempt is refused while the cap (deliberately set to 1) is exhausted,
+        // without needing a real session to ever succeed.
+        var blockingFactory = new BlockingSandboxSessionFactory();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true, Type = McpServerType.Stdio, Command = "node", StartupTimeoutSeconds = 1,
+        });
+        bundleOwned.TryAdd("b2:local-tool", new McpServerDefinition
+        {
+            Enabled = true, Type = McpServerType.Stdio, Command = "node", StartupTimeoutSeconds = 1,
+        });
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new BundleExecutionConfig
+                {
+                    StdioMcpServers = new BundleStdioMcpServersConfig
+                    {
+                        ContainerImage = "mcr.microsoft.com/node:20",
+                        MaxConcurrentSessions = 1,
+                    },
+                },
+            },
+        };
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, blockingFactory);
+            services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
+        });
+        var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+
+        var firstCallTask = sut.GetClientAsync("b1:local-tool");
+        await blockingFactory.EntrySignaled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var act = () => sut.GetClientAsync("b2:local-tool");
+
+        var exception = await act.Should().ThrowAsync<McpConnectionException>();
+        exception.Which.Message.Should().Contain("Host-wide bundle stdio sandbox session cap");
+
+        blockingFactory.Release.SetResult();
+        await Assert.ThrowsAsync<McpConnectionException>(() => firstCallTask);
+    }
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedStdioServer_SeedDirectoryOutsideStagingRoot_RefusesWithoutStartingASession()
+    {
+        // Security-review finding: SandboxSeedDirectory is provenance-tagged by BundleStagingService
+        // today, but the field itself is just a public string with no structural guarantee. This test
+        // proves the containment check is real, not just documented convention — a seed directory
+        // that resolves outside the configured staging root must never reach the sandbox session
+        // factory at all.
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Stdio,
+            Command = "node",
+            StartupTimeoutSeconds = 1,
+            SandboxSeedDirectory = @"C:\definitely-not-the-staging-root\evil",
+        });
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new BundleExecutionConfig
+                {
+                    TempRoot = @"C:\staged",
+                    StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = "mcr.microsoft.com/node:20" },
+                },
+            },
+        };
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, _fakeSessionFactory);
+            services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
+        });
+        var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+
+        var act = () => sut.GetClientAsync("b1:local-tool");
+
+        var exception = await act.Should().ThrowAsync<McpConnectionException>();
+        exception.Which.Message.Should().Contain("outside the configured bundle staging root");
+        _fakeSessionFactory.WasCalled.Should().BeFalse(
+            "an out-of-bounds seed directory must be refused before the sandbox session factory is ever called");
     }
 
     [Fact]
@@ -257,6 +362,24 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         {
             public static readonly NullDisposable Instance = new();
             public void Dispose() { }
+        }
+    }
+
+    /// <summary>
+    /// A session factory whose <see cref="StartSessionAsync"/> does not complete until the test
+    /// explicitly releases it — lets a test hold a "slot" open to prove the host-wide concurrency cap
+    /// rejects a second concurrent attempt while it's exhausted, without needing a real session.
+    /// </summary>
+    private sealed class BlockingSandboxSessionFactory : ISandboxSessionFactory
+    {
+        public TaskCompletionSource EntrySignaled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<Result<ISandboxSession>> StartSessionAsync(SandboxSessionRequest request, CancellationToken ct)
+        {
+            EntrySignaled.TrySetResult();
+            await Release.Task;
+            return Result<ISandboxSession>.Fail("fake factory: not starting a real session");
         }
     }
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -245,6 +245,51 @@ public sealed class McpConnectionManagerSandboxedStdioTests
     }
 
     [Fact]
+    public async Task GetClientAsync_ScopeFactoryThrowsDuringSessionStart_DoesNotLeakTheConcurrencySlot()
+    {
+        // /code-review finding (#371): the concurrency slot was claimed via Interlocked.Increment
+        // BEFORE _scopeFactory.CreateAsyncScope() — which sat outside the method's try/finally —
+        // so a throw during scope creation (e.g. an already-disposed root provider during host
+        // shutdown) permanently pinned that slot for the rest of the process's life. Proven here by
+        // a SECOND attempt after the first throws: if the slot leaked, it fails with "Host-wide
+        // bundle stdio sandbox session cap"; if released correctly, it fails at scope creation
+        // again instead, exactly like the first attempt.
+        var throwingScopeFactory = new ThrowingServiceScopeFactory();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true, Type = McpServerType.Stdio, Command = "node", StartupTimeoutSeconds = 1,
+        });
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new BundleExecutionConfig
+                {
+                    StdioMcpServers = new BundleStdioMcpServersConfig
+                    {
+                        ContainerImage = "mcr.microsoft.com/node:20",
+                        MaxConcurrentSessions = 1,
+                    },
+                },
+            },
+        };
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
+        });
+        var sut = new McpConnectionManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned,
+            throwingScopeFactory, McpConnectionManagerBundleEgressSupport.Args.AmbientScope, rootServices);
+
+        await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
+        var secondException = await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
+
+        secondException.Message.Should().NotContain("Host-wide bundle stdio sandbox session cap");
+    }
+
+    [Fact]
     public async Task GetClientAsync_BundleOwnedStdioServer_SeedDirectoryOutsideStagingRoot_RefusesWithoutStartingASession()
     {
         // Security-review finding: SandboxSeedDirectory is provenance-tagged by BundleStagingService
@@ -381,6 +426,13 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             await Release.Task;
             return Result<ISandboxSession>.Fail("fake factory: not starting a real session");
         }
+    }
+
+    /// <summary>Its <see cref="CreateScope"/> always throws — stands in for an already-disposed root provider during host shutdown.</summary>
+    private sealed class ThrowingServiceScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope() =>
+            throw new InvalidOperationException("test: scope factory intentionally throws");
     }
 
     private sealed class FakeSandboxSessionFactory : ISandboxSessionFactory

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -149,8 +149,14 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         // Under BundleExecution.TempRoot below — StartSandboxedStdioSessionAsync's containment check
         // (#371, a code-review/security-review finding) refuses a seed directory outside the
         // configured staging root, so this test's own seed path must actually resolve under it.
-        const string stagingRoot = @"C:\staged";
-        const string seedDirectory = @"C:\staged\bundle-abc123";
+        // Built via Path.Combine (never a hardcoded "C:\..." literal): a Windows-style absolute path
+        // is not rooted at all on Linux, so PathScope.IsSameOrUnder's Path.GetFullPath-based
+        // normalization would treat the whole literal as one opaque path segment relative to the
+        // working directory — the seed would never resolve as "under" the staging root there, and
+        // this positive-containment test would fail in Linux CI while passing on a Windows dev
+        // machine. Caught when this exact thing happened on this PR's first CI run.
+        var stagingRoot = Path.Combine(Path.GetTempPath(), "staged");
+        var seedDirectory = Path.Combine(stagingRoot, "bundle-abc123");
         var bundleOwned = new BundleOwnedMcpServerRegistry();
         bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
         {
@@ -296,7 +302,9 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         // today, but the field itself is just a public string with no structural guarantee. This test
         // proves the containment check is real, not just documented convention — a seed directory
         // that resolves outside the configured staging root must never reach the sandbox session
-        // factory at all.
+        // factory at all. Sibling of (never nested under) the staging root, both built via
+        // Path.Combine so the "outside" relationship holds on any OS — see the positive-containment
+        // test above for why a hardcoded "C:\..." literal doesn't portably mean what it looks like.
         var bundleOwned = new BundleOwnedMcpServerRegistry();
         bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
         {
@@ -304,7 +312,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             Type = McpServerType.Stdio,
             Command = "node",
             StartupTimeoutSeconds = 1,
-            SandboxSeedDirectory = @"C:\definitely-not-the-staging-root\evil",
+            SandboxSeedDirectory = Path.Combine(Path.GetTempPath(), "definitely-not-the-staging-root", "evil"),
         });
 
         var appConfig = new AppConfig
@@ -313,7 +321,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             {
                 BundleExecution = new BundleExecutionConfig
                 {
-                    TempRoot = @"C:\staged",
+                    TempRoot = Path.Combine(Path.GetTempPath(), "staged"),
                     StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = "mcr.microsoft.com/node:20" },
                 },
             },

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/SlotReleasingSandboxSessionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/SlotReleasingSandboxSessionTests.cs
@@ -1,0 +1,76 @@
+using Application.AI.Common.Interfaces.Sandbox;
+using FluentAssertions;
+using Infrastructure.AI.MCP.Services;
+using Xunit;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// Coverage for <see cref="SlotReleasingSandboxSession"/>'s disposal contract — specifically the
+/// idempotency guard a fresh /code-review pass on #371 found missing: two overlapping disposers of
+/// the same session must not double-decrement the host-wide concurrency counter it releases, or the
+/// cap silently admits more concurrent sessions than <c>MaxConcurrentSessions</c> permits.
+/// </summary>
+public sealed class SlotReleasingSandboxSessionTests
+{
+    [Fact]
+    public async Task DisposeAsync_CalledOnce_ReleasesTheSlotExactlyOnce()
+    {
+        var inner = new FakeSandboxSession();
+        var releaseCount = 0;
+        var sut = new SlotReleasingSandboxSession(inner, () => releaseCount++);
+
+        await sut.DisposeAsync();
+
+        releaseCount.Should().Be(1);
+        inner.DisposeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CalledTwice_ReleasesTheSlotOnlyOnce()
+    {
+        // The exact regression this test locks in: without the idempotency guard, a second
+        // DisposeAsync call would decrement the concurrency counter a second time, silently
+        // widening the effective cap for the rest of the host process's life.
+        var inner = new FakeSandboxSession();
+        var releaseCount = 0;
+        var sut = new SlotReleasingSandboxSession(inner, () => releaseCount++);
+
+        await sut.DisposeAsync();
+        await sut.DisposeAsync();
+
+        releaseCount.Should().Be(1);
+        inner.DisposeCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_InnerDisposalThrows_StillReleasesTheSlot()
+    {
+        var inner = new FakeSandboxSession { ThrowOnDispose = true };
+        var releaseCount = 0;
+        var sut = new SlotReleasingSandboxSession(inner, () => releaseCount++);
+
+        var act = async () => await sut.DisposeAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        releaseCount.Should().Be(1);
+    }
+
+    private sealed class FakeSandboxSession : ISandboxSession
+    {
+        public bool ThrowOnDispose { get; init; }
+        public int DisposeCount { get; private set; }
+
+        public Stream StandardInput => Stream.Null;
+        public Stream StandardOutput => Stream.Null;
+        public Task Completion => Task.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ThrowOnDispose
+                ? ValueTask.FromException(new InvalidOperationException("fake inner disposal failure"))
+                : ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -325,6 +325,32 @@ public sealed class BundleStagingServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task StageAsync_RejectedStdioAttemptFollowedByValidOne_ValidOneStillRegisters()
+    {
+        // A stdio server rejected for a reason OTHER than the cap (here: empty command) must not
+        // itself consume a cap slot — only a server that actually registers may count against
+        // MaxServersPerBundle. With the cap set to 1, if a rejected attempt wrongly counted, this
+        // bundle's genuinely valid second server would be refused too, even though zero servers
+        // are actually registered yet.
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: rejected-then-valid-bundle\nname: Rejected Then Valid Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { " +
+                "\"first\": { \"type\": \"stdio\" }, " +
+                "\"second\": { \"type\": \"stdio\", \"command\": \"npx\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig(maxServersPerBundle: 1);
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        var namespacedName = $"{result.Value!.BundleId}:second";
+        result.Value!.McpServerNames.Should().ContainSingle().Which.Should().Be(namespacedName,
+            "the first server's empty-command rejection must not consume the per-bundle cap slot " +
+            "the second, valid server needs");
+    }
+
+    [Fact]
     public async Task StageAsync_BundleWithHttpMcpServer_RegistersHttpDefinitionWithUrl()
     {
         using var zip = ZipOf(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -7,6 +7,7 @@ using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.BundleExecution;
 using Domain.Common.Config.AI.MCP;
+using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
 using Infrastructure.AI.Agents;
 using Infrastructure.AI.Bundles;
@@ -161,11 +162,13 @@ public sealed class BundleStagingServiceTests : IDisposable
     // --- Bundle-owned MCP servers (issue #368) -------------------------------------------------------
 
     [Fact]
-    public async Task StageAsync_BundleWithStdioMcpServer_IsRejectedNotRegistered()
+    public async Task StageAsync_BundleWithDefaultedStdioMcpServer_IsRejectedNotRegistered()
     {
-        // A bundle is untrusted, uploader-supplied content. Registering its self-declared `command` as a
-        // live stdio server would let any bundle author run an arbitrary process on the harness host —
-        // staging must reject it, not register it under a namespaced key.
+        // No "type" property, so McpServerDefinitionBuilder.ParseType DEFAULTS this to stdio — the
+        // gate treats a defaulted stdio resolution differently from an EXPLICIT "type": "stdio"
+        // declaration (see StageAsync_ExplicitStdioServer_RegistersWhenEnabled below): only an explicit
+        // declaration can ever reach the sandboxed-registration path, so this must still be rejected via
+        // LogStdioRejected even with every stdio capability flag turned on.
         using var zip = ZipOf(
             ("AGENT.md", "---\nid: mcp-bundle\nname: MCP Bundle\n---\nx"),
             ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
@@ -174,16 +177,151 @@ public sealed class BundleStagingServiceTests : IDisposable
         var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
         // AllowBundleDeclaredMcpServers must be ON here — otherwise the flag-off guard short-circuits
         // RegisterBundleMcpServers before mcp.json is even parsed, and this test would pass for that
-        // reason instead of exercising the stdio-transport rejection it names and documents.
-        var appConfig = AllowlistedAppConfig();
+        // reason instead of exercising the stdio-transport rejection it names and documents. StdioMcpServers
+        // is also fully enabled with a configured image, to prove the rejection is about the MISSING
+        // explicit declaration, not about either capability being off.
+        var appConfig = StdioEnabledAppConfig();
         var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
 
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         var bundle = result.Value!;
         var namespacedName = $"{bundle.BundleId}:echo";
 
-        bundle.McpServerNames.Should().BeEmpty("a stdio server must be rejected, not registered");
+        bundle.McpServerNames.Should().BeEmpty("a defaulted (non-explicit) stdio server must be rejected, not registered");
         bundleOwnedMcpServers.TryGetValue(namespacedName, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StageAsync_ExplicitStdioServer_RegistersWhenEnabled()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: stdio-bundle\nname: Stdio Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"type\": \"stdio\", \"command\": \"npx\", \"args\": [\"echo-mcp\"] } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig();
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        var bundle = result.Value!;
+        var namespacedName = $"{bundle.BundleId}:echo";
+
+        bundle.McpServerNames.Should().ContainSingle().Which.Should().Be(namespacedName);
+        bundleOwnedMcpServers.TryGetValue(namespacedName, out var definition).Should().BeTrue();
+        definition!.Type.Should().Be(McpServerType.Stdio);
+        definition.Command.Should().Be("npx");
+        definition.SandboxSeedDirectory.Should().Be(bundle.StagedRootDirectory,
+            "the sandbox session needs the bundle's own staged files to seed the container workspace");
+    }
+
+    [Fact]
+    public async Task StageAsync_ExplicitStdioServer_RejectedWhenStdioFlagOff()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: stdio-off-bundle\nname: Stdio Off Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"type\": \"stdio\", \"command\": \"npx\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        // AllowBundleDeclaredMcpServers must be ON here so RegisterBundleMcpServers' own top-level gate
+        // (either capability admits the manifest) doesn't short-circuit before mcp.json is ever parsed —
+        // otherwise this test would pass for that reason instead of exercising StdioMcpServers.Enabled's
+        // OWN check inside TryRegisterStdioServer, which is what it names and documents.
+        var appConfig = StdioEnabledAppConfig(stdioServersEnabled: false);
+        appConfig.AI.BundleExecution.AllowBundleDeclaredMcpServers = true;
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().BeEmpty("the stdio capability is off by default even for an explicit declaration");
+    }
+
+    [Fact]
+    public async Task StageAsync_ExplicitStdioServer_RejectedWhenNoContainerImageConfigured()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: no-image-bundle\nname: No Image Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"type\": \"stdio\", \"command\": \"npx\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig(containerImage: string.Empty);
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().BeEmpty(
+            "an unconfigured container image means the capability is inert even when the flag is on");
+    }
+
+    [Fact]
+    public async Task StageAsync_ExplicitStdioServer_RejectedWhenSandboxDisabled()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: sandbox-off-bundle\nname: Sandbox Off Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"type\": \"stdio\", \"command\": \"npx\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig(sandboxEnabled: false);
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().BeEmpty(
+            "registering a server that could never start would be pointless");
+    }
+
+    [Fact]
+    public async Task StageAsync_StdioServerWithEmptyCommand_Rejected()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: empty-command-bundle\nname: Empty Command Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"type\": \"stdio\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig();
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().BeEmpty(
+            "McpServerDefinitionBuilder does not itself require a command for stdio; this gate must");
+    }
+
+    [Fact]
+    public async Task StageAsync_UnrecognizedTypeValue_StillRejected()
+    {
+        // A typo'd remote-transport name ("htp") must not silently land on a sandboxed process launch —
+        // only an explicit, exact "stdio" counts as an intentional local-command declaration.
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: typo-bundle\nname: Typo Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"echo\": { \"type\": \"htp\", \"command\": \"npx\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig();
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().BeEmpty("an unrecognized type value must never be treated as an explicit stdio request");
+    }
+
+    [Fact]
+    public async Task StageAsync_StdioServersBeyondCap_Rejected()
+    {
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: capped-bundle\nname: Capped Bundle\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { " +
+                "\"first\": { \"type\": \"stdio\", \"command\": \"npx\" }, " +
+                "\"second\": { \"type\": \"stdio\", \"command\": \"npx\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig(maxServersPerBundle: 1);
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().ContainSingle(
+            "the per-bundle cap of 1 must admit the first declared server and reject the second");
     }
 
     [Fact]
@@ -229,6 +367,33 @@ public sealed class BundleStagingServiceTests : IDisposable
             "an unparsable URL must be rejected at registration time, not silently registered");
         var namespacedName = $"{result.Value.BundleId}:remote";
         bundleOwnedMcpServers.TryGetValue(namespacedName, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task StageAsync_RemoteServer_RejectedWhenOnlyStdioFlagOn()
+    {
+        // Regression: RegisterBundleMcpServers' own top-level gate now opens mcp.json when EITHER
+        // AllowBundleDeclaredMcpServers OR StdioMcpServers.Enabled is on (#371, so a bundle declaring
+        // only a stdio server doesn't need the remote flag). TryBuildAndRegisterOneServer's remote
+        // branch must therefore carry its OWN AllowBundleDeclaredMcpServers check — without it, opting
+        // into stdio alone would silently also open the door to remote servers.
+        using var zip = ZipOf(
+            ("AGENT.md", "---\nid: remote-via-stdio-flag-bundle\nname: X\n---\nx"),
+            ("plugin.json", "{ \"name\": \"root\", \"version\": \"1.0.0\", \"mcpServers\": \"./mcp.json\" }"),
+            ("mcp.json", "{ \"mcpServers\": { \"remote\": { \"type\": \"http\", \"url\": \"https://tools.example.com/mcp\" } } }"));
+
+        var bundleOwnedMcpServers = new BundleOwnedMcpServerRegistry();
+        var appConfig = StdioEnabledAppConfig();
+        appConfig.AI.Egress = new EgressConfig
+        {
+            DefaultAllowlist = [new EgressAllowlistConfigEntry { Host = "tools.example.com", Schemes = ["https"], Ports = [443] }],
+        };
+        var result = await CreateService(appConfig, bundleOwnedMcpServers).StageAsync(zip);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        result.Value!.McpServerNames.Should().BeEmpty(
+            "AllowBundleDeclaredMcpServers stayed off in this config — a remote server must not register " +
+            "just because the unrelated stdio capability happened to be on");
     }
 
     [Fact]
@@ -498,6 +663,36 @@ public sealed class BundleStagingServiceTests : IDisposable
                     })
                     .ToList(),
             },
+        },
+    };
+
+    /// <summary>
+    /// An <see cref="AppConfig"/> fully opted into bundle-owned <strong>stdio</strong> MCP servers:
+    /// <see cref="BundleStdioMcpServersConfig.Enabled"/> on, a container image configured, and
+    /// (via the class default) the sandbox subsystem enabled — the three preconditions
+    /// <c>TryRegisterStdioServer</c> checks beyond the explicit-declaration and non-empty-command gates
+    /// that live in the manifest content itself. Each parameter defaults to the "capability fully on"
+    /// value so a test only needs to override the ONE precondition it means to violate.
+    /// </summary>
+    private AppConfig StdioEnabledAppConfig(
+        bool stdioServersEnabled = true,
+        string containerImage = "mcr.microsoft.com/dotnet/runtime:10.0",
+        int maxServersPerBundle = 2,
+        bool sandboxEnabled = true) => new()
+    {
+        AI = new AIConfig
+        {
+            BundleExecution = new BundleExecutionConfig
+            {
+                TempRoot = _stagingRoot,
+                StdioMcpServers = new BundleStdioMcpServersConfig
+                {
+                    Enabled = stdioServersEnabled,
+                    ContainerImage = containerImage,
+                    MaxServersPerBundle = maxServersPerBundle,
+                },
+            },
+            SandboxCapabilities = new SandboxConfig { Enabled = sandboxEnabled },
         },
     };
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/BundleMcpEgressAttributionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/BundleMcpEgressAttributionTests.cs
@@ -143,6 +143,10 @@ public sealed class BundleMcpEgressAttributionTests
             // handler itself from DI" remarks on ResolveBundleEgressClient) — not from a registration of
             // EgressPolicyDelegatingHandler itself, which would be resolved-but-never-invoked here.
             .AddSingleton<ILogger<EgressPolicyDelegatingHandler>>(NullLogger<EgressPolicyDelegatingHandler>.Instance)
+            // McpConnectionManager also resolves IOptionsMonitor<AppConfig> eagerly at construction (the
+            // sandboxed-stdio path's container image comes from AppConfig.AI.BundleExecution.StdioMcpServers)
+            // — irrelevant to these bundle-owned HTTP/SSE tests, but required for construction to succeed.
+            .AddSingleton<Microsoft.Extensions.Options.IOptionsMonitor<AppConfig>>(new TestConfig.StaticOptionsMonitor<AppConfig>(new AppConfig()))
             .BuildServiceProvider();
 
         var antiSsrfFactory = new AntiSsrfHandlerFactory(new TestConfig.StaticOptionsMonitor<AppConfig>(new AppConfig()));

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/McpSsrfProtectionTests.cs
@@ -68,6 +68,10 @@ public sealed class McpSsrfProtectionTests
         var rootServices = new ServiceCollection()
             .AddSingleton<IEgressAuditWriter>(new InMemoryEgressAuditWriter())
             .AddSingleton<ILogger<EgressPolicyDelegatingHandler>>(NullLogger<EgressPolicyDelegatingHandler>.Instance)
+            // McpConnectionManager also resolves IOptionsMonitor<AppConfig> eagerly at construction (the
+            // sandboxed-stdio path's container image comes from AppConfig.AI.BundleExecution.StdioMcpServers)
+            // — irrelevant to this host-configured-server test, but required for construction to succeed.
+            .AddSingleton<Microsoft.Extensions.Options.IOptionsMonitor<AppConfig>>(new TestConfig.StaticOptionsMonitor<AppConfig>(cfg))
             .BuildServiceProvider();
 
         return new McpConnectionManager(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/McpServerDefinitionBuilderTests.cs
@@ -164,4 +164,48 @@ public sealed class McpServerDefinitionBuilderTests
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         result.Value!.Type.Should().Be(McpServerType.Stdio);
     }
+
+    // --- IsExplicitType (#371, /code-review finding: shared with ParseType so a bundle-owned
+    // registration gate that needs "explicit vs. defaulted" cannot independently drift on the rule) ---
+
+    [Theory]
+    [InlineData("stdio")]
+    [InlineData("STDIO")]
+    [InlineData("StDiO")]
+    public void IsExplicitType_ExplicitStdioStringAnyCase_ReturnsTrue(string typeValue)
+    {
+        var element = Parse($$"""{ "type": "{{typeValue}}", "command": "npx" }""");
+
+        McpServerDefinitionBuilder.IsExplicitType(element, McpServerType.Stdio).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsExplicitType_AbsentTypeProperty_ReturnsFalseForStdio()
+    {
+        // The whole point of this method: an ABSENT type defaults to Stdio via ParseType, but that is
+        // not an explicit declaration — the two must never be conflated.
+        var element = Parse("""{ "command": "npx" }""");
+
+        McpServerDefinitionBuilder.IsExplicitType(element, McpServerType.Stdio).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExplicitType_UnrecognizedTypeString_ReturnsFalseForStdio()
+    {
+        // The exact regression this method fixes: an unrecognized string ALSO defaults to Stdio via
+        // ParseType's mapping rule, but a typo'd remote transport must not be treated as an explicit
+        // stdio declaration just because they resolve to the same enum value.
+        var element = Parse("""{ "type": "htp", "command": "npx" }""");
+
+        McpServerDefinitionBuilder.IsExplicitType(element, McpServerType.Stdio).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExplicitType_ExplicitHttpType_ReturnsFalseForStdioAndTrueForHttp()
+    {
+        var element = Parse("""{ "type": "http", "url": "https://example.com/mcp" }""");
+
+        McpServerDefinitionBuilder.IsExplicitType(element, McpServerType.Stdio).Should().BeFalse();
+        McpServerDefinitionBuilder.IsExplicitType(element, McpServerType.Http).Should().BeTrue();
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerContainerLaunchPreparerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerContainerLaunchPreparerTests.cs
@@ -1,0 +1,72 @@
+using Application.AI.Common.Models.Sandbox;
+using Docker.DotNet;
+using FluentAssertions;
+using Infrastructure.AI.Sandbox;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Sandbox;
+
+/// <summary>
+/// Focused coverage for <see cref="DockerContainerLaunchPreparer.ResolveImage"/>'s request-supplied
+/// image overload — #371's registration gate needs a bundle-owned session to pick its own runtime
+/// image (no per-tool <c>ToolOverrides</c> entry can ever match a bundle's GUID-namespaced name), and
+/// that new precedence must not weaken the existing operator image allowlist.
+/// </summary>
+public class DockerContainerLaunchPreparerTests
+{
+    private readonly Mock<IOptionsMonitor<SandboxExecutionOptions>> _options = new();
+    private readonly DockerContainerLaunchPreparer _sut;
+
+    public DockerContainerLaunchPreparerTests()
+    {
+        _options.Setup(x => x.CurrentValue).Returns(new SandboxExecutionOptions());
+        _sut = new DockerContainerLaunchPreparer(
+            Mock.Of<IDockerClient>(), _options.Object, Mock.Of<ILogger<DockerContainerLaunchPreparer>>());
+    }
+
+    [Fact]
+    public void ResolveImage_RequestImageOutsideAllowedPrefixes_Throws()
+    {
+        // The default allowlist is mcr.microsoft.com/ only — a caller-specified image cannot use this
+        // parameter to escape the operator's registry allowlist, only to pick among permitted images.
+        var act = () => _sut.ResolveImage("bundle-owned-tool", "docker.io/attacker/malicious:latest");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not in allowed registry list*");
+    }
+
+    [Fact]
+    public void ResolveImage_RequestImageWithinAllowedPrefixes_ReturnsIt()
+    {
+        var image = _sut.ResolveImage("bundle-owned-tool", "mcr.microsoft.com/dotnet/sdk:10.0");
+
+        image.Should().Be("mcr.microsoft.com/dotnet/sdk:10.0");
+    }
+
+    [Fact]
+    public void ResolveImage_RequestImageTakesPrecedenceOverToolOverride()
+    {
+        _options.Setup(x => x.CurrentValue).Returns(new SandboxExecutionOptions
+        {
+            ToolOverrides = new Dictionary<string, ToolSandboxOverride>
+            {
+                ["bundle-owned-tool"] = new() { ContainerImage = "mcr.microsoft.com/dotnet/aspnet:10.0" },
+            },
+        });
+
+        var image = _sut.ResolveImage("bundle-owned-tool", "mcr.microsoft.com/dotnet/sdk:10.0");
+
+        image.Should().Be("mcr.microsoft.com/dotnet/sdk:10.0",
+            "an explicit request image is the caller's own instruction for THIS session and must win");
+    }
+
+    [Fact]
+    public void ResolveImage_NoRequestImage_FallsBackToToolOverrideThenDefault()
+    {
+        var image = _sut.ResolveImage("unconfigured-tool");
+
+        image.Should().Be("mcr.microsoft.com/dotnet/runtime:10.0", "unchanged pre-#371 fallback behavior");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using Application.AI.Common.Interfaces.Attestation;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Models.Sandbox;
@@ -375,6 +376,38 @@ public class DockerSandboxSessionFactoryTests
         result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
         await using var session = result.Value!;
         _capturedParams!.Image.Should().Be("mcr.microsoft.com/dotnet/sdk:10.0");
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_NoRequestContainerImage_AttestsTheResolvedImageNotNull()
+    {
+        // /code-review finding (#371): DescribeSessionInput used to log request.ContainerImage
+        // directly, which is null for every first-party session (none of them populate that
+        // field — their image comes from ResolveImage's own ToolOverrides/default lookup, same
+        // as here). Two sessions on genuinely different resolved images would attest identical
+        // (null) input either way. The attested "image" must match what the container actually
+        // ran, not the raw per-request override.
+        SetUpAttachStream(BuildFrames(("stdout", "")));
+        AttestationRequest? signed = null;
+        _attestation
+            .Setup(x => x.SignAsync(It.Is<AttestationRequest>(r => !r.IsFailure), It.IsAny<CancellationToken>()))
+            .Callback<AttestationRequest, CancellationToken>((r, _) => signed = r)
+            .ReturnsAsync((AttestationRequest r, CancellationToken _) => new ToolExecutionAttestation
+            {
+                ToolName = r.ToolName, InputHash = "test-hash", Timestamp = DateTimeOffset.UtcNow,
+                Signature = "test-sig", KeyVersion = "v1", IsFailureAttestation = false
+            });
+
+        var result = await _sut.StartSessionAsync(CreateRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        await using var session = result.Value!;
+        signed.Should().NotBeNull();
+        var attestedImage = JsonDocument.Parse(signed!.Input).RootElement.GetProperty("image").GetString();
+        attestedImage.Should().Be(_capturedParams!.Image,
+            "the attested image must be what ResolveImage actually picked, not the (always-null, for a " +
+            "first-party session) request-level override");
+        attestedImage.Should().NotBeNullOrEmpty();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
@@ -255,6 +255,117 @@ public class DockerSandboxSessionFactoryTests
     }
 
     [Fact]
+    public async Task StartSessionAsync_WorkspaceSeedDirectory_SeedsContainerWorkspaceAndSetsWorkingDir()
+    {
+        // #371: the bundle's own staged files must actually be present in the container's workspace for
+        // its stdio MCP server to have anything to run — this is the wiring that turns the registration
+        // gate into a working feature rather than a container that starts and immediately fails.
+        SetUpAttachStream(BuildFrames(("stdout", "")));
+        var seedSource = Path.Combine(Path.GetTempPath(), $"seed-source-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(seedSource);
+        File.WriteAllText(Path.Combine(seedSource, "server.js"), "console.log('hi');");
+        try
+        {
+            var request = CreateRequest() with { WorkspaceSeedDirectory = seedSource };
+
+            var result = await _sut.StartSessionAsync(request, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+            await using var session = result.Value!;
+            _capturedParams.Should().NotBeNull();
+            _capturedParams!.WorkingDir.Should().Be("/workspace");
+            // Bind format is "{workspaceDir}:/workspace:{ro|rw}" — split on the known ":/workspace:"
+            // separator rather than the last ':' in the string, since a Windows host path itself
+            // contains a drive-letter colon (e.g. "C:\...\docker-sandbox-xxx").
+            var bind = _capturedParams.HostConfig!.Binds!.Should().ContainSingle().Subject;
+            var hostWorkspaceDir = bind[..bind.IndexOf(":/workspace:", StringComparison.Ordinal)];
+            File.Exists(Path.Combine(hostWorkspaceDir, "server.js")).Should().BeTrue(
+                "the seed source's files must have been copied into the container's actual bind-mounted workspace");
+        }
+        finally
+        {
+            Directory.Delete(seedSource, recursive: true);
+        }
+    }
+
+    [SkippableFact]
+    public async Task StartSessionAsync_WorkspaceSeedDirectory_WidensPermissionsOnlyForTheSeededWorkspace()
+    {
+        // Regression for a /code-review finding: an earlier version widened EVERY Docker-tier
+        // workspace's permissions unconditionally in CreateWorkspace, not just a seeded one — readable
+        // by any local OS account on the host, not only the container's own fixed UID. The widening
+        // must be scoped to exactly the seeded case.
+        Skip.If(OperatingSystem.IsWindows(), "Unix file-mode bits have no meaning on Windows.");
+        SetUpAttachStream(BuildFrames(("stdout", "")));
+        var seedSource = Path.Combine(Path.GetTempPath(), $"seed-source-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(seedSource);
+        try
+        {
+            var request = CreateRequest() with { WorkspaceSeedDirectory = seedSource };
+
+            var result = await _sut.StartSessionAsync(request, CancellationToken.None);
+
+            result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+            await using var session = result.Value!;
+            var bind = _capturedParams!.HostConfig!.Binds!.Should().ContainSingle().Subject;
+            var hostWorkspaceDir = bind[..bind.IndexOf(":/workspace:", StringComparison.Ordinal)];
+            var mode = File.GetUnixFileMode(hostWorkspaceDir);
+            mode.Should().HaveFlag(UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
+                "the container's own fixed UID must be able to traverse a workspace that was seeded with content it needs to read");
+        }
+        finally
+        {
+            Directory.Delete(seedSource, recursive: true);
+        }
+    }
+
+    [SkippableFact]
+    public async Task StartSessionAsync_NoWorkspaceSeedDirectory_KeepsWorkspaceOwnerOnly()
+    {
+        // The other half of the same regression: an UNSEEDED session's workspace must stay at the
+        // tighter owner-only default — the widening in the test above must not have become the new
+        // baseline for every Docker-tier session.
+        Skip.If(OperatingSystem.IsWindows(), "Unix file-mode bits have no meaning on Windows.");
+        SetUpAttachStream(BuildFrames(("stdout", "")));
+
+        var result = await _sut.StartSessionAsync(CreateRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        await using var session = result.Value!;
+        var bind = _capturedParams!.HostConfig!.Binds!.Should().ContainSingle().Subject;
+        var hostWorkspaceDir = bind[..bind.IndexOf(":/workspace:", StringComparison.Ordinal)];
+        var mode = File.GetUnixFileMode(hostWorkspaceDir);
+        mode.Should().NotHaveFlag(UnixFileMode.OtherRead,
+            "an ordinary (non-bundle) Docker-tier workspace must not be widened just because the seeded case exists elsewhere");
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_NoWorkspaceSeedDirectory_LeavesWorkingDirUnset()
+    {
+        SetUpAttachStream(BuildFrames(("stdout", "")));
+
+        var result = await _sut.StartSessionAsync(CreateRequest(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        await using var session = result.Value!;
+        _capturedParams!.WorkingDir.Should().BeNullOrEmpty(
+            "unseeded sessions (the one-shot executor's own callers, and every pre-#371 session) must keep the prior unset behavior");
+    }
+
+    [Fact]
+    public async Task StartSessionAsync_RequestContainerImage_IsUsedInsteadOfDefault()
+    {
+        SetUpAttachStream(BuildFrames(("stdout", "")));
+        var request = CreateRequest() with { ContainerImage = "mcr.microsoft.com/dotnet/sdk:10.0" };
+
+        var result = await _sut.StartSessionAsync(request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(string.Join("; ", result.Errors));
+        await using var session = result.Value!;
+        _capturedParams!.Image.Should().Be("mcr.microsoft.com/dotnet/sdk:10.0");
+    }
+
+    [Fact]
     public async Task StartSessionAsync_NullCommand_FallsBackToToolName()
     {
         SetUpAttachStream(BuildFrames(("stdout", "")));

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
@@ -309,9 +309,15 @@ public class DockerSandboxSessionFactoryTests
             await using var session = result.Value!;
             var bind = _capturedParams!.HostConfig!.Binds!.Should().ContainSingle().Subject;
             var hostWorkspaceDir = bind[..bind.IndexOf(":/workspace:", StringComparison.Ordinal)];
-            var mode = File.GetUnixFileMode(hostWorkspaceDir);
-            mode.Should().HaveFlag(UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
-                "the container's own fixed UID must be able to traverse a workspace that was seeded with content it needs to read");
+            // Skip.If above already makes this unreachable on Windows at runtime; the extra static
+            // guard is for the CA1416 platform-compatibility analyzer, which recognizes
+            // OperatingSystem.IsWindows() if-guards but not xunit's SkippableFact runtime skip.
+            if (!OperatingSystem.IsWindows())
+            {
+                var mode = File.GetUnixFileMode(hostWorkspaceDir);
+                mode.Should().HaveFlag(UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
+                    "the container's own fixed UID must be able to traverse a workspace that was seeded with content it needs to read");
+            }
         }
         finally
         {
@@ -334,9 +340,15 @@ public class DockerSandboxSessionFactoryTests
         await using var session = result.Value!;
         var bind = _capturedParams!.HostConfig!.Binds!.Should().ContainSingle().Subject;
         var hostWorkspaceDir = bind[..bind.IndexOf(":/workspace:", StringComparison.Ordinal)];
-        var mode = File.GetUnixFileMode(hostWorkspaceDir);
-        mode.Should().NotHaveFlag(UnixFileMode.OtherRead,
-            "an ordinary (non-bundle) Docker-tier workspace must not be widened just because the seeded case exists elsewhere");
+        // Skip.If above already makes this unreachable on Windows at runtime; the extra static guard
+        // is for the CA1416 platform-compatibility analyzer, which recognizes OperatingSystem.IsWindows()
+        // if-guards but not xunit's SkippableFact runtime skip.
+        if (!OperatingSystem.IsWindows())
+        {
+            var mode = File.GetUnixFileMode(hostWorkspaceDir);
+            mode.Should().NotHaveFlag(UnixFileMode.OtherRead,
+                "an ordinary (non-bundle) Docker-tier workspace must not be widened just because the seeded case exists elsewhere");
+        }
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxSessionFactoryTests.cs
@@ -141,6 +141,20 @@ public class ProcessSandboxSessionFactoryTests
     }
 
     [Fact]
+    public async Task StartSessionAsync_WorkspaceSeedRequested_RejectedBeforeSpawning()
+    {
+        // #371: this tier is not a containment boundary, so a request carrying caller-supplied content
+        // to seed the workspace (e.g. a bundle's staged files) must be refused outright — never silently
+        // downgraded from the Container tier that seeding actually requires.
+        var request = CreateRequest() with { WorkspaceSeedDirectory = Path.GetTempPath() };
+
+        var result = await _sut.StartSessionAsync(request, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().ContainSingle(e => e.Contains("container isolation", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task StartSessionAsync_CommandNotAllowlisted_FailsWithoutSpawning()
     {
         var request = CreateRequest() with

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxWorkspaceSeedFromTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxWorkspaceSeedFromTests.cs
@@ -99,12 +99,18 @@ public class SandboxWorkspaceSeedFromTests : IDisposable
 
         SandboxWorkspace.SeedFrom(source, destination);
 
-        var fileMode = File.GetUnixFileMode(Path.Combine(destination, "server.js"));
-        fileMode.Should().HaveFlag(UnixFileMode.OtherRead,
-            "a container process running as a different UID must be able to read the seeded file");
+        // Skip.If above already makes this unreachable on Windows at runtime; the extra static guard
+        // is for the CA1416 platform-compatibility analyzer, which recognizes OperatingSystem.IsWindows()
+        // if-guards but not xunit's SkippableFact runtime skip.
+        if (!OperatingSystem.IsWindows())
+        {
+            var fileMode = File.GetUnixFileMode(Path.Combine(destination, "server.js"));
+            fileMode.Should().HaveFlag(UnixFileMode.OtherRead,
+                "a container process running as a different UID must be able to read the seeded file");
 
-        var dirMode = File.GetUnixFileMode(Path.Combine(destination, "nested"));
-        dirMode.Should().HaveFlag(UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
-            "a container process running as a different UID must be able to traverse into the seeded directory");
+            var dirMode = File.GetUnixFileMode(Path.Combine(destination, "nested"));
+            dirMode.Should().HaveFlag(UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
+                "a container process running as a different UID must be able to traverse into the seeded directory");
+        }
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxWorkspaceSeedFromTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxWorkspaceSeedFromTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using Infrastructure.AI.Sandbox;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Sandbox;
+
+/// <summary>
+/// Coverage for <see cref="SandboxWorkspace.SeedFrom"/> — #371's copy (never link/mount) of a
+/// caller-supplied directory (e.g. a bundle's staged files) into a fresh sandbox workspace.
+/// </summary>
+public class SandboxWorkspaceSeedFromTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"seed-from-tests-{Guid.NewGuid():N}");
+
+    public SandboxWorkspaceSeedFromTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public void SeedFrom_RelativeSource_Throws()
+    {
+        var destination = Path.Combine(_root, "dest");
+        Directory.CreateDirectory(destination);
+
+        var act = () => SandboxWorkspace.SeedFrom("relative/path", destination);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*absolute*");
+    }
+
+    [Fact]
+    public void SeedFrom_MissingSource_Throws()
+    {
+        var destination = Path.Combine(_root, "dest");
+        Directory.CreateDirectory(destination);
+        var missingSource = Path.Combine(_root, "does-not-exist");
+
+        var act = () => SandboxWorkspace.SeedFrom(missingSource, destination);
+
+        act.Should().Throw<DirectoryNotFoundException>();
+    }
+
+    [Fact]
+    public void SeedFrom_FilesAndNestedDirectories_AreCopiedToDestination()
+    {
+        var source = Path.Combine(_root, "source");
+        Directory.CreateDirectory(Path.Combine(source, "nested"));
+        File.WriteAllText(Path.Combine(source, "server.js"), "console.log('hi');");
+        File.WriteAllText(Path.Combine(source, "nested", "data.json"), "{}");
+        var destination = Path.Combine(_root, "dest");
+        Directory.CreateDirectory(destination);
+
+        SandboxWorkspace.SeedFrom(source, destination);
+
+        File.Exists(Path.Combine(destination, "server.js")).Should().BeTrue();
+        File.Exists(Path.Combine(destination, "nested", "data.json")).Should().BeTrue();
+        File.ReadAllText(Path.Combine(destination, "server.js")).Should().Be("console.log('hi');");
+    }
+
+    [Fact]
+    public void SeedFrom_SourceDeletedAfterSeeding_DestinationContentSurvives()
+    {
+        // The whole reason this is a copy contract, not a bind/link: the caller may delete the source
+        // (e.g. a bundle's staging directory on handle eviction) on a lifecycle independent of the
+        // sandbox session. Proves the copy has no residual dependency on the source once it returns.
+        var source = Path.Combine(_root, "source");
+        Directory.CreateDirectory(source);
+        File.WriteAllText(Path.Combine(source, "server.js"), "console.log('hi');");
+        var destination = Path.Combine(_root, "dest");
+        Directory.CreateDirectory(destination);
+
+        SandboxWorkspace.SeedFrom(source, destination);
+        Directory.Delete(source, recursive: true);
+
+        File.Exists(Path.Combine(destination, "server.js")).Should().BeTrue();
+    }
+
+    [SkippableFact]
+    public void SeedFrom_CopiedFilesAndDirectories_AreReadableByOtherUidsOnUnix()
+    {
+        // The bug an adversarial review caught that nothing else in this repo could: the container
+        // reads its bind-mounted /workspace as a fixed unprivileged UID (65534) that never matches
+        // the host process copying files into it. A copied file/dir left at umask-default permissions
+        // is invisible to that UID — the container process cannot even traverse the directory, let
+        // alone read the seeded server's own script. "Other" bits must be set explicitly, not left to
+        // the host's ambient umask (which may be 0077 on a hardened host, silently breaking this on
+        // exactly the deployments most likely to run it).
+        Skip.If(OperatingSystem.IsWindows(), "Unix file-mode bits have no meaning on Windows.");
+
+        var source = Path.Combine(_root, "source");
+        Directory.CreateDirectory(Path.Combine(source, "nested"));
+        File.WriteAllText(Path.Combine(source, "server.js"), "console.log('hi');");
+        File.WriteAllText(Path.Combine(source, "nested", "data.json"), "{}");
+        var destination = Path.Combine(_root, "dest");
+        Directory.CreateDirectory(destination);
+
+        SandboxWorkspace.SeedFrom(source, destination);
+
+        var fileMode = File.GetUnixFileMode(Path.Combine(destination, "server.js"));
+        fileMode.Should().HaveFlag(UnixFileMode.OtherRead,
+            "a container process running as a different UID must be able to read the seeded file");
+
+        var dirMode = File.GetUnixFileMode(Path.Combine(destination, "nested"));
+        dirMode.Should().HaveFlag(UnixFileMode.OtherRead | UnixFileMode.OtherExecute,
+            "a container process running as a different UID must be able to traverse into the seeded directory");
+    }
+}


### PR DESCRIPTION
## Summary

PR3 of #371's 4-PR plan. PR1+PR2 (#409, merged) landed the sandbox session
plumbing (`ISandboxSession`/`ISandboxSessionFactory`, Docker + Process
backends, `SandboxedStdioClientTransport`). This PR is the registration gate
**plus** what it takes to make a sandboxed bundle-owned stdio MCP server
actually run end-to-end, not just register:

- **Registration gate** — `BundleStagingService` now routes an explicit
  `"type": "stdio"` bundle declaration through the sandbox instead of
  rejecting it outright, gated behind a new, separate opt-in
  (`AppConfig:AI:BundleExecution:StdioMcpServers`) from the existing
  remote-server capability.
- **Workspace seeding** — the sandbox workspace is seeded by copy (never
  bind/link) from the bundle's staged directory, so the container sees the
  bundle's own files. Copy, not mount, because the staging directory's
  lifecycle is independent of a live session's.
- **Container imaging** — an operator-configured runtime image
  (`StdioMcpServers.ContainerImage`), still validated against the existing
  `AllowedImagePrefixes` allowlist — a bundle can never escape it.
- **Fail-closed on the Process tier** — `ProcessSandboxSessionFactory`
  rejects any request carrying a workspace seed directory; that tier is not
  a containment boundary.
- **Host-wide concurrency cap** — `MaxConcurrentSessions` bounds how many
  bundle-owned sandbox containers can run at once across all bundles (a
  security-review finding: the per-bundle cap alone didn't bound this).

## Review history

Four rounds of `/code-review` + `/simplify` + a dedicated `security-reviewer`
pass (this is sandbox/RCE-adjacent code), each fix mutation-tested (guard
removed/inverted → confirmed the test fails → guard restored):

1. Initial implementation + first `/code-review`/`/simplify` pass.
2. Security review: host-wide session cap, seed-path containment check,
   attestation gaps.
3. Second `/code-review`/`/simplify` pass: `BundleStagingService.cs` split
   into a partial (`.StdioMcp.cs`) to stay under the repo's 800-line file
   cap, validator whitespace bug, duplicate JSON type-parsing logic unified
   via `EnumNameHelper.TryParseName`.
4. Final pass (this commit): attestation image-forgery gap (the attested
   `image` field logged the always-null request override instead of the
   actually-resolved image), a concurrency-slot leak if `CreateAsyncScope()`
   itself throws, a missing disposal-idempotency guard that could
   double-decrement the concurrency cap, and a `ref int`/8-parameter
   signature cleanup in the registration gate. Workspace seeding and the
   image pull now run concurrently (`Task.WhenAll`) instead of sequentially.

## Known limits (stated plainly, not oversights)

- **No network** for a bundle-owned stdio server — capability resolves to
  `None`, so `NetworkMode = "none"`. A bundle's stdio server must be
  self-contained; bridging one would bypass the egress attribution the
  HTTP/SSE bundle path enforces.
- **Operator must supply a runtime image.** The harness's own default (.NET)
  image runs nothing else — the capability stays inert until configured.
- **A failed session start isn't cached** — each tool call retries a
  container start. Acceptable for now; a follow-up issue is warranted if it
  proves noisy in practice.
- **Container lifetime** follows `HandleTtl` (default 30 min) / eviction —
  operators should size hosts accordingly.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 errors.
- [x] `dotnet test` on every touched project — all green (Docker-dependent
      suites elsewhere in the solution — KnowledgeGraph Neo4j/Postgres,
      AgentHub Prometheus/Testcontainers — fail locally because Docker isn't
      running on this machine; confirmed pre-existing and unrelated to this
      diff, none of those projects were touched).
- [x] Every new guard mutation-tested (temporarily broken, confirmed the
      corresponding test fails, restored).
- [x] `mcp__gitnexus__detect_changes` against `main` — scope coherent, all
      changed symbols map to the sandbox stdio pipeline and its tests.
- [x] `/code-review`, `/simplify`, and `security-reviewer` receipts recorded
      for the final commit per `.claude/rules/review-cadence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW