### PR TITLE
fix: let WorkspaceCommandRunner own the full scope lifecycle (#426)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceCommandRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceCommandRunner.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Services.Sandbox;
 using Domain.AI.Models;
 using Domain.AI.Sandbox;
 using Domain.AI.Workspace;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Tools.Workspace;
@@ -43,41 +44,36 @@ public static class WorkspaceCommandRunner
     /// (<c>WorkspaceRunTestsTool</c>/<c>WorkspaceRunLintTool</c>) reads the command to run from it
     /// before calling here.
     /// </param>
-    /// <param name="scopedServices">
-    /// The per-execution DI scope's provider, used to resolve the keyed-scoped
-    /// <see cref="ISandboxExecutor"/> for the effective isolation tier — resolved here, after the
-    /// profile, rather than passed in already-resolved (#405 follow-up, a security-review finding on
-    /// the original fix): the executor must be selected for the tier the operator's
-    /// <c>MinimumIsolation</c> override actually resolves to, not a tier fixed before that override
-    /// was consulted. Selecting the executor from a caller-fixed tier while the profile silently
-    /// carries a different, elevated one is the same "one field, two meanings" defect class #405
-    /// exists to close, reproduced on the isolation axis instead of the capability axis.
+    /// <param name="scopeFactory">
+    /// The caller's <see cref="IServiceScopeFactory"/>. This method opens one fresh scope per run — so
+    /// the caller's own singleton tool never captures scope-bound state — and resolves both the
+    /// <see cref="ToolPermissionProfileResolver"/> and the keyed-scoped <see cref="ISandboxExecutor"/>
+    /// for the effective isolation tier from it, entirely inside the try/catch below (#426: the two
+    /// callers used to create this scope and resolve the resolver themselves, outside any try/catch,
+    /// mirroring the exact gap #421 fixed for <c>IacSandboxRunner</c>/<c>TerraformGenerator</c>/
+    /// <c>BicepGenerator</c> — a DI-resolution or executor-lookup failure threw uncaught out of
+    /// <c>ITool.ExecuteAsync</c>). The executor is resolved after the profile (#405 follow-up, a
+    /// security-review finding mirroring the identical fix in <c>IacSandboxRunner</c>): it must be
+    /// selected for the tier the operator's <c>MinimumIsolation</c> override actually resolves to, not
+    /// a tier fixed before that override was consulted.
     /// </param>
     /// <param name="defaultIsolationLevel">
     /// The tool's own minimum isolation requirement, independent of any operator override — the floor
     /// this run never drops below even absent a <c>MinimumIsolation</c> override.
     /// </param>
     /// <param name="toolName">Tool name for diagnostic attribution in the sandbox request, and the
-    /// keyed-DI name <paramref name="permissionResolver"/> looks up an operator's per-tool override
-    /// under.</param>
+    /// keyed-DI name the resolved <see cref="ToolPermissionProfileResolver"/> looks up an operator's
+    /// per-tool override under.</param>
     /// <param name="requiredCapabilities">
     /// The sandbox capabilities this run needs — supplied by the caller (e.g.
     /// <c>WorkspaceRunTestsTool.RequiredSandboxCapabilities</c>) rather than hardcoded here, so there
     /// is one place that states what a <c>run_tests</c>/<c>run_lint</c> call may do, not two (#387).
     /// </param>
-    /// <param name="permissionResolver">
-    /// Resolves the operator's <c>ToolOverrideConfig</c> for <paramref name="toolName"/> — this runner
-    /// used to build its permission profile inline, so a per-tool <c>DeniedCapabilities</c> or
-    /// <c>MinimumIsolation</c> override never reached it (#405). Via
-    /// <see cref="ToolPermissionProfileResolver.ResolveForUngovernedDispatch"/>, which also refuses
-    /// outright when the override intersects <paramref name="requiredCapabilities"/>, matching the
-    /// governed-call semantics <c>CapabilityEnforcer</c> guarantees rather than silently narrowing
-    /// what gets provisioned.
-    /// </param>
     /// <param name="logger">
-    /// The caller's own logger, used to record a governance refusal before dispatch — the sibling
-    /// <c>IacSandboxRunner.MapDispatchFailure</c> logs this same event on the <c>iac_plan</c>/<c>iac_scan</c>
-    /// dispatch path; this runner's equivalent refusal used to return silently.
+    /// The caller's own logger — used both to record a governance refusal before dispatch and to log a
+    /// sandbox-level exception here directly rather than in each caller's own try/catch. The sibling
+    /// <c>IacSandboxRunner.RunAsync</c> logs the equivalent event on the <c>iac_plan</c>/<c>iac_scan</c>
+    /// dispatch path.
     /// </param>
     /// <param name="timeout">Optional wall-clock timeout for the command. Defaults to 5 minutes — tests can be slow.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
@@ -85,20 +81,18 @@ public static class WorkspaceCommandRunner
     public static async Task<ToolResult> RunAsync(
         string commandLine,
         WorkspaceContext workspace,
-        IServiceProvider scopedServices,
+        IServiceScopeFactory scopeFactory,
         SandboxIsolationLevel defaultIsolationLevel,
         string toolName,
         ToolCapability requiredCapabilities,
-        ToolPermissionProfileResolver permissionResolver,
         ILogger logger,
         TimeSpan? timeout = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(commandLine);
         ArgumentNullException.ThrowIfNull(workspace);
-        ArgumentNullException.ThrowIfNull(scopedServices);
+        ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentException.ThrowIfNullOrWhiteSpace(toolName);
-        ArgumentNullException.ThrowIfNull(permissionResolver);
         ArgumentNullException.ThrowIfNull(logger);
 
         var tokens = commandLine.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
@@ -108,11 +102,49 @@ public static class WorkspaceCommandRunner
         var program = tokens[0];
         var arguments = tokens.Length > 1 ? tokens[1..] : Array.Empty<string>();
 
+        try
+        {
+            // Scope creation, ToolPermissionProfileResolver resolution, dispatch resolution, and
+            // execution all live inside this one try/catch (#426) — mirrors IacSandboxRunner.RunAsync's
+            // final shape after #421's three successive widenings.
+            await using var scope = scopeFactory.CreateAsyncScope();
+            var permissionResolver = scope.ServiceProvider.GetRequiredService<ToolPermissionProfileResolver>();
+
+            return await DispatchAsync(
+                program, arguments, workspace, scope.ServiceProvider, defaultIsolationLevel,
+                toolName, requiredCapabilities, permissionResolver, logger, timeout, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "{ToolName} sandbox run failed for {WorkingCopyPath}.", toolName, workspace.WorkingCopyPath);
+            return ToolResult.Fail($"Sandbox execution failed: {ex.GetType().Name}.");
+        }
+    }
+
+    private static async Task<ToolResult> DispatchAsync(
+        string program,
+        string[] arguments,
+        WorkspaceContext workspace,
+        IServiceProvider scopedServices,
+        SandboxIsolationLevel defaultIsolationLevel,
+        string toolName,
+        ToolCapability requiredCapabilities,
+        ToolPermissionProfileResolver permissionResolver,
+        ILogger logger,
+        TimeSpan? timeout,
+        CancellationToken cancellationToken)
+    {
         // Profile and executor resolved together — the ordering invariant (executor only after the
-        // profile, at its resolved tier) is now structural inside ResolveExecutorForUngovernedDispatch
+        // profile, at its resolved tier) is structural inside ResolveExecutorForUngovernedDispatch
         // rather than reproduced here, a /simplify finding: this runner and IacSandboxRunner had
-        // independently copy-pasted the same resolve-then-select sequence, with only a comment at each
-        // site — not a shared implementation — protecting the ordering the stale-tier bug depended on.
+        // independently copy-pasted the same resolve-then-select sequence, with only a comment at
+        // each site — not a shared implementation — protecting the ordering the stale-tier bug
+        // depended on.
         var dispatchResult = permissionResolver.ResolveExecutorForUngovernedDispatch(
             toolName, requiredCapabilities, [program], scopedServices, defaultIsolationLevel);
         if (!dispatchResult.IsSuccess)
@@ -137,19 +169,7 @@ public static class WorkspaceCommandRunner
             Timeout = timeout ?? TimeSpan.FromMinutes(5)
         };
 
-        SandboxExecutionResult sandboxResult;
-        try
-        {
-            sandboxResult = await executor.ExecuteAsync(request, cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            return ToolResult.Fail($"Sandbox execution failed: {ex.GetType().Name}.");
-        }
+        var sandboxResult = await executor.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
 
         var summary =
             $"exit={sandboxResult.ExitCode?.ToString() ?? "n/a"} success={sandboxResult.Success}\n" +

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunLintTool.cs
@@ -110,20 +110,17 @@ public sealed class WorkspaceRunLintTool : ITool
         if (!workspace.HasLintCommand)
             return ToolResult.Fail("Workspace has no LintCommand configured.");
 
-        // The executor is SCOPED — resolve it from a fresh scope per execution
-        // so this singleton tool never captures scope-bound state. Resolved inside RunAsync, after
-        // the profile, so an operator's MinimumIsolation override actually selects the executor.
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var permissionResolver = scope.ServiceProvider.GetRequiredService<ToolPermissionProfileResolver>();
-
+        // Scope creation, resolver resolution, executor resolution, and execution all live inside
+        // WorkspaceCommandRunner.RunAsync's own try/catch now (#426) — this singleton tool no longer
+        // creates the scope itself, so a DI-resolution failure can no longer throw uncaught out of
+        // ExecuteAsync before RunAsync's exception handling is even reached.
         return await WorkspaceCommandRunner.RunAsync(
             workspace.LintCommand,
             workspace,
-            scope.ServiceProvider,
+            _scopeFactory,
             _isolationLevel,
             ToolName,
             RequiredSandboxCapabilities,
-            permissionResolver,
             _logger,
             timeout: null,
             cancellationToken);

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceRunTestsTool.cs
@@ -111,20 +111,17 @@ public sealed class WorkspaceRunTestsTool : ITool
         if (!workspace.HasTestCommand)
             return ToolResult.Fail("Workspace has no TestCommand configured.");
 
-        // The executor is SCOPED — resolve it from a fresh scope per execution
-        // so this singleton tool never captures scope-bound state. Resolved inside RunAsync, after
-        // the profile, so an operator's MinimumIsolation override actually selects the executor.
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var permissionResolver = scope.ServiceProvider.GetRequiredService<ToolPermissionProfileResolver>();
-
+        // Scope creation, resolver resolution, executor resolution, and execution all live inside
+        // WorkspaceCommandRunner.RunAsync's own try/catch now (#426) — this singleton tool no longer
+        // creates the scope itself, so a DI-resolution failure can no longer throw uncaught out of
+        // ExecuteAsync before RunAsync's exception handling is even reached.
         return await WorkspaceCommandRunner.RunAsync(
             workspace.TestCommand,
             workspace,
-            scope.ServiceProvider,
+            _scopeFactory,
             _isolationLevel,
             ToolName,
             RequiredSandboxCapabilities,
-            permissionResolver,
             _logger,
             timeout: null,
             cancellationToken);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacSandboxRunnerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacSandboxRunnerSolutionReviewFixTests.cs
@@ -7,6 +7,7 @@ using Domain.Common;
 using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
 using Infrastructure.AI.Iac;
+using Infrastructure.AI.Tests.Support;
 using Infrastructure.AI.Tools.Iac;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -56,20 +57,6 @@ public sealed class IacSandboxRunnerSolutionReviewFixTests
             if (overrideToolName is not null && overrideConfig is not null)
                 c.ToolOverrides[overrideToolName] = overrideConfig;
         });
-        services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
-        services.AddSingleton<ToolPermissionProfileResolver>();
-        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
-    }
-
-    /// <summary>
-    /// As <see cref="ScopeFactory"/>, but with no keyed <see cref="ISandboxExecutor"/> registered for
-    /// any tier — models a template consumer whose DI wiring doesn't cover every isolation tier an
-    /// operator override can select.
-    /// </summary>
-    private static IServiceScopeFactory ScopeFactoryWithoutExecutors()
-    {
-        var services = new ServiceCollection();
-        services.AddOptions<SandboxConfig>();
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
         services.AddSingleton<ToolPermissionProfileResolver>();
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
@@ -250,7 +237,7 @@ public sealed class IacSandboxRunnerSolutionReviewFixTests
             arguments: ["plan"],
             moduleDirectory: ModuleDir,
             registryAllowlist: [],
-            scopeFactory: ScopeFactoryWithoutExecutors(),
+            scopeFactory: TestScopeFactory.WithoutExecutors(),
             defaultIsolationLevel: SandboxIsolationLevel.Process,
             toolName: "iac_plan",
             requiredCapabilities: IacPlanTool.RequiredSandboxCapabilities,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
@@ -72,4 +72,20 @@ internal static class TestScopeFactory
 
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }
+
+    /// <summary>
+    /// Scope factory with no keyed <see cref="ISandboxExecutor"/> registered for any tier — models a
+    /// template consumer whose DI wiring doesn't cover every isolation tier an operator override can
+    /// select, so a <c>WorkspaceCommandRunner</c>/<c>IacSandboxRunner</c> dispatch resolving that tier
+    /// must fail gracefully rather than throw. Shared by the Workspace and Iac test suites, which used
+    /// to each keep a byte-for-byte private copy of this same builder (#426 code-review finding).
+    /// </summary>
+    public static IServiceScopeFactory WithoutExecutors()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions<SandboxConfig>();
+        services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
+        services.AddSingleton<ToolPermissionProfileResolver>();
+        return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceRunCommandsToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceRunCommandsToolTests.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Infrastructure.AI.Tests.Support;
 using Infrastructure.AI.Tests.Tools.Workspace.Support;
 using Infrastructure.AI.Tools.Workspace;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -176,6 +177,44 @@ public sealed class WorkspaceRunCommandsToolTests
         result.Success.Should().BeFalse();
         result.Error.Should().Contain("workspace context is active");
         sandbox.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunTests_NoExecutorRegisteredForResolvedIsolationTier_ReturnsFailureInsteadOfThrowing()
+    {
+        // #426 (mirrors #421's IacSandboxRunner fix): WorkspaceCommandRunner.RunAsync's try/catch must
+        // cover ResolveExecutorForUngovernedDispatch's own executor lookup, not just
+        // executor.ExecuteAsync — an operator's MinimumIsolation override can select a tier a template
+        // consumer never registered a keyed ISandboxExecutor for at all.
+        using var fx = new WorkspaceTestFixture(testCommand: "dotnet test");
+        var sut = new WorkspaceRunTestsTool(
+            fx.Accessor, TestScopeFactory.WithoutExecutors(), NullLogger<WorkspaceRunTestsTool>.Instance);
+
+        var result = await sut.ExecuteAsync("run", new Dictionary<string, object?>());
+
+        result.Success.Should().BeFalse(
+            "an unconfigured executor is a sandbox-level error — it must not throw out of ExecuteAsync uncaught");
+    }
+
+    [Fact]
+    public async Task RunTests_ScopeFactoryHasNoPermissionResolverRegistered_ReturnsFailureInsteadOfThrowing()
+    {
+        // #426 (mirrors #421's IacSandboxRunner fix): scope creation and ToolPermissionProfileResolver
+        // resolution used to happen in the caller, outside RunAsync's try/catch entirely, so a
+        // DI-resolution failure there threw uncaught out of ITool.ExecuteAsync. RunAsync now creates
+        // the scope and resolves the resolver itself, inside the same try/catch as dispatch/execution.
+        using var fx = new WorkspaceTestFixture(testCommand: "dotnet test");
+        var servicesWithNoResolver = new ServiceCollection().BuildServiceProvider();
+        var sut = new WorkspaceRunTestsTool(
+            fx.Accessor,
+            servicesWithNoResolver.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<WorkspaceRunTestsTool>.Instance);
+
+        var result = await sut.ExecuteAsync("run", new Dictionary<string, object?>());
+
+        result.Success.Should().BeFalse(
+            "a DI-resolution failure for ToolPermissionProfileResolver is a sandbox-level error — it " +
+            "must not throw out of ExecuteAsync uncaught");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fixes #426: `WorkspaceCommandRunner.RunAsync` used to receive an already-resolved `IServiceProvider`/`ToolPermissionProfileResolver` from its two callers (`WorkspaceRunTestsTool`, `WorkspaceRunLintTool`), which created their own DI scope outside any try/catch — a DI-resolution or executor-lookup failure threw uncaught out of `ITool.ExecuteAsync`. Mirrors the identical fix already shipped for the sibling `IacSandboxRunner` in #421/#427.
- `RunAsync` now takes an `IServiceScopeFactory` and owns scope creation, resolver resolution, dispatch resolution, and execution inside its own try/catch, split into `RunAsync` + a private `DispatchAsync` to stay under the repo's 50-line function convention (a `/code-review` finding on this same PR).
- `/simplify` (4 parallel angles) found one duplicate test helper — `ScopeFactoryWithoutExecutors` existed as a byte-for-byte private copy in both the Iac and Workspace test suites — consolidated into `TestScopeFactory.WithoutExecutors()`.
- Filed #428 as a follow-up for the same defect shape found one dispatch mechanism over (`WorkspaceWriteFileTool`/`DocumentIngestTool`, MediatR dispatch instead of sandbox dispatch) — deliberately not bundled into this PR.

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] Two new regression tests (no-executor-registered, no-resolver-registered) added and mutation-tested — both independently confirmed to fail when the try/catch boundary is reverted to the pre-fix shape
- [x] `Infrastructure.AI.Tests.dll` full suite: 3239/3239 passed (0 failures) after the fix
- [x] `/code-review` and `/simplify` both run; findings applied
- [x] Full-solution test suite: only pre-existing, Docker-dependent failures elsewhere (Prometheus/Neo4j/Postgres testcontainer fixtures — Docker not running locally), unrelated to this diff

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW