### PR TITLE
fix: audit-log ungoverned-dispatch refusals to the governance trail (#419)

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -22,6 +22,7 @@ using Application.AI.Common.Services.Sandbox;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
 using Application.Common.Interfaces.Telemetry;
+using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Sandbox;
 using FluentValidation;
 using MediatR;
@@ -136,10 +137,12 @@ public static class DependencyInjection
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
             sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>(),
             sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>(),
-            // Optional (#419): a composition root that never calls AddGovernance still constructs
-            // this widely-used singleton — it just gets no durable audit trail for an ungoverned-
-            // dispatch refusal. See the constructor's own remarks.
-            sp.GetService<IGovernanceAuditService>()));
+            // Both optional (#419): a composition root that never calls AddGovernance still
+            // constructs this widely-used singleton — it just gets no durable audit trail for an
+            // ungoverned-dispatch refusal, and (absent an EnableAudit toggle to read) defaults to
+            // the historically-correct "audit on" behavior. See the constructor's own remarks.
+            sp.GetService<IGovernanceAuditService>(),
+            sp.GetService<IOptionsMonitor<GovernanceConfig>>()));
         services.AddScoped<ICapabilityEnforcer, CapabilityEnforcer>();
 
         // Scoped agent execution context — carries agent identity through the pipeline

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Tools;
@@ -134,7 +135,11 @@ public static class DependencyInjection
         services.AddOptions<SandboxConfig>();
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
             sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>(),
-            sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>()));
+            sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>(),
+            // Optional (#419): a composition root that never calls AddGovernance still constructs
+            // this widely-used singleton — it just gets no durable audit trail for an ungoverned-
+            // dispatch refusal. See the constructor's own remarks.
+            sp.GetService<IGovernanceAuditService>()));
         services.AddScoped<ICapabilityEnforcer, CapabilityEnforcer>();
 
         // Scoped agent execution context — carries agent identity through the pipeline

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -5,6 +5,7 @@ using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Governance;
 using Domain.Common;
+using Domain.Common.Config.AI;
 using Domain.Common.Helpers;
 using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Sandbox;
@@ -32,6 +33,7 @@ public sealed class ToolPermissionProfileResolver
     private readonly FirstPartyToolLookup _firstPartyLookup;
     private readonly IOptionsMonitor<SandboxConfig> _config;
     private readonly IGovernanceAuditService? _auditService;
+    private readonly IOptionsMonitor<GovernanceConfig>? _governanceConfig;
 
     /// <summary>Initializes a new instance of the <see cref="ToolPermissionProfileResolver"/> class.</summary>
     /// <param name="firstPartyLookup">
@@ -49,10 +51,21 @@ public sealed class ToolPermissionProfileResolver
     /// than required, so a composition root that never calls <c>AddGovernance</c> still constructs
     /// this widely-used singleton; it just gets no durable audit trail for this path.
     /// </param>
+    /// <param name="governanceConfig">
+    /// Gates <paramref name="auditService"/>'s <c>.Log(...)</c> calls on <c>GovernanceConfig.EnableAudit</c>
+    /// (#419 code-review finding) — every other audit call site in the codebase honors this same
+    /// toggle (<c>ToolInvocationGovernor</c>, <c>PromptInjectionBehavior</c>), so an operator who sets
+    /// it <see langword="false"/> must not keep seeing writes to <c>governance.jsonl</c> from this
+    /// path alone. Optional for the same reason <paramref name="auditService"/> is: when absent,
+    /// <see cref="GovernanceConfig.EnableAudit"/>'s own default (<see langword="true"/>) applies, so a
+    /// composition root that doesn't wire this still gets the historically-correct "audit on" behavior
+    /// rather than silently losing the trail.
+    /// </param>
     public ToolPermissionProfileResolver(
         FirstPartyToolLookup firstPartyLookup,
         IOptionsMonitor<SandboxConfig> config,
-        IGovernanceAuditService? auditService = null)
+        IGovernanceAuditService? auditService = null,
+        IOptionsMonitor<GovernanceConfig>? governanceConfig = null)
     {
         ArgumentNullException.ThrowIfNull(firstPartyLookup);
         ArgumentNullException.ThrowIfNull(config);
@@ -60,6 +73,7 @@ public sealed class ToolPermissionProfileResolver
         _firstPartyLookup = firstPartyLookup;
         _config = config;
         _auditService = auditService;
+        _governanceConfig = governanceConfig;
     }
 
     /// <summary>
@@ -200,7 +214,7 @@ public sealed class ToolPermissionProfileResolver
             var underDeclared = firstPartyTool.RequiredCapabilities & ~requiredCapabilities;
             if (underDeclared != ToolCapability.None)
             {
-                _auditService?.Log(agentId ?? "unknown", toolName, ToolDecisionOutcome.Denied.ToString());
+                LogRefusal(agentId, toolName);
                 return Result<ToolPermissionProfile>.Forbidden(
                     $"Tool '{toolName}' was dispatched with capabilities narrower than its own " +
                     $"registered declaration: missing {underDeclared}.");
@@ -213,7 +227,7 @@ public sealed class ToolPermissionProfileResolver
         var denied = requiredCapabilities & deniedCaps;
         if (denied != ToolCapability.None)
         {
-            _auditService?.Log(agentId ?? "unknown", toolName, ToolDecisionOutcome.Denied.ToString());
+            LogRefusal(agentId, toolName);
             return Result<ToolPermissionProfile>.Forbidden(
                 $"Tool '{toolName}' requires capabilities denied by operator override: {denied}");
         }
@@ -226,6 +240,24 @@ public sealed class ToolPermissionProfileResolver
             MinimumIsolation = (SandboxIsolationLevel)Math.Max(
                 (int)defaultIsolationLevel, (int)overrideIsolation)
         });
+    }
+
+    /// <summary>
+    /// Writes a refusal to the durable audit trail — gated on <see cref="GovernanceConfig.EnableAudit"/>
+    /// (#419 code-review finding), matching every other <see cref="IGovernanceAuditService"/> call site
+    /// in the codebase (<c>ToolInvocationGovernor</c>, <c>PromptInjectionBehavior</c>). An operator who
+    /// sets that flag <see langword="false"/> expects every tamper-evident write to stop, not just the
+    /// governed ones — a single unconditional call site here would silently break that contract.
+    /// </summary>
+    private void LogRefusal(string? agentId, string toolName)
+    {
+        if (_auditService is null)
+            return;
+
+        if (_governanceConfig is not null && !_governanceConfig.CurrentValue.EnableAudit)
+            return;
+
+        _auditService.Log(agentId ?? "unknown", toolName, ToolDecisionOutcome.Denied.ToString());
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -1,6 +1,9 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
+using Domain.AI.Governance;
 using Domain.Common;
 using Domain.Common.Helpers;
 using Domain.AI.Sandbox;
@@ -28,6 +31,7 @@ public sealed class ToolPermissionProfileResolver
 {
     private readonly FirstPartyToolLookup _firstPartyLookup;
     private readonly IOptionsMonitor<SandboxConfig> _config;
+    private readonly IGovernanceAuditService? _auditService;
 
     /// <summary>Initializes a new instance of the <see cref="ToolPermissionProfileResolver"/> class.</summary>
     /// <param name="firstPartyLookup">
@@ -35,15 +39,27 @@ public sealed class ToolPermissionProfileResolver
     /// keyed DI outside its bounded key set is unsafe.
     /// </param>
     /// <param name="config">Sandbox configuration with per-tool overrides.</param>
+    /// <param name="auditService">
+    /// Optional durable audit sink for a refusal on the ungoverned-dispatch path (#419) — every
+    /// governed refusal already reaches <c>governance.jsonl</c> via <c>CapabilityEnforcer</c>/
+    /// <c>ToolInvocationGovernor</c>'s use of the same interface; a refusal from
+    /// <see cref="ResolveForUngovernedDispatch"/> previously reached neither that trail nor an app
+    /// log (the app-log gap was closed separately, per-caller, in #421/#426). Resolved optionally —
+    /// mirroring <c>ProvenanceMemoryWriteGate</c>'s <c>IGovernanceAuditService?</c> convention — rather
+    /// than required, so a composition root that never calls <c>AddGovernance</c> still constructs
+    /// this widely-used singleton; it just gets no durable audit trail for this path.
+    /// </param>
     public ToolPermissionProfileResolver(
         FirstPartyToolLookup firstPartyLookup,
-        IOptionsMonitor<SandboxConfig> config)
+        IOptionsMonitor<SandboxConfig> config,
+        IGovernanceAuditService? auditService = null)
     {
         ArgumentNullException.ThrowIfNull(firstPartyLookup);
         ArgumentNullException.ThrowIfNull(config);
 
         _firstPartyLookup = firstPartyLookup;
         _config = config;
+        _auditService = auditService;
     }
 
     /// <summary>
@@ -161,11 +177,17 @@ public sealed class ToolPermissionProfileResolver
     /// already reflects it.
     /// </para>
     /// </remarks>
+    /// <param name="agentId">
+    /// The dispatching agent's identifier, recorded on a refusal's audit entry (#419) — <c>null</c>
+    /// when the caller has no agent identity to supply (e.g. direct unit-test calls), in which case
+    /// the audit entry records <c>"unknown"</c> rather than omitting the entry.
+    /// </param>
     public Result<ToolPermissionProfile> ResolveForUngovernedDispatch(
         string toolName,
         ToolCapability requiredCapabilities,
         IReadOnlyList<string> allowedPrograms,
-        SandboxIsolationLevel defaultIsolationLevel = SandboxIsolationLevel.Process)
+        SandboxIsolationLevel defaultIsolationLevel = SandboxIsolationLevel.Process,
+        string? agentId = null)
     {
         // Single FirstPartyToolLookup.Resolve call, reused for the under-declaration check below and
         // as ResolveOverride's isolation floor — this used to call Resolve(toolName) (itself a lookup,
@@ -178,6 +200,7 @@ public sealed class ToolPermissionProfileResolver
             var underDeclared = firstPartyTool.RequiredCapabilities & ~requiredCapabilities;
             if (underDeclared != ToolCapability.None)
             {
+                _auditService?.Log(agentId ?? "unknown", toolName, ToolDecisionOutcome.Denied.ToString());
                 return Result<ToolPermissionProfile>.Forbidden(
                     $"Tool '{toolName}' was dispatched with capabilities narrower than its own " +
                     $"registered declaration: missing {underDeclared}.");
@@ -190,6 +213,7 @@ public sealed class ToolPermissionProfileResolver
         var denied = requiredCapabilities & deniedCaps;
         if (denied != ToolCapability.None)
         {
+            _auditService?.Log(agentId ?? "unknown", toolName, ToolDecisionOutcome.Denied.ToString());
             return Result<ToolPermissionProfile>.Forbidden(
                 $"Tool '{toolName}' requires capabilities denied by operator override: {denied}");
         }
@@ -235,8 +259,14 @@ public sealed class ToolPermissionProfileResolver
     {
         ArgumentNullException.ThrowIfNull(scopedServices);
 
+        // IAgentExecutionContext is scoped (never captured on this singleton's own constructor —
+        // that would be a captive dependency pinning every call to whichever scope first resolved
+        // this singleton) so it is read from the caller's per-execution scope here, at the one place
+        // this dispatch path already receives one, and forwarded down for the audit entry (#419).
+        var agentId = scopedServices.GetService<IAgentExecutionContext>()?.AgentId;
+
         var profileResult = ResolveForUngovernedDispatch(
-            toolName, requiredCapabilities, allowedPrograms, defaultIsolationLevel);
+            toolName, requiredCapabilities, allowedPrograms, defaultIsolationLevel, agentId);
         if (!profileResult.IsSuccess)
             return Result<(ToolPermissionProfile, ISandboxExecutor)>.Forbidden(
                 string.Join("; ", profileResult.Errors));

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
@@ -1,6 +1,9 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Sandbox;
 using Application.AI.Common.Services.Tools;
+using Domain.AI.Governance;
 using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
@@ -25,6 +28,14 @@ public sealed class ToolPermissionProfileResolverTests
         SandboxConfig? config = null,
         params (string Name, ITool Tool)[] tools)
     {
+        return BuildResolver(config, auditService: null, tools);
+    }
+
+    private static ToolPermissionProfileResolver BuildResolver(
+        SandboxConfig? config,
+        IGovernanceAuditService? auditService,
+        params (string Name, ITool Tool)[] tools)
+    {
         var services = new ServiceCollection();
         foreach (var (name, tool) in tools)
             services.AddKeyedSingleton<ITool>(name, (_, _) => tool);
@@ -34,7 +45,7 @@ public sealed class ToolPermissionProfileResolverTests
 
         var lookup = new FirstPartyToolLookup(
             services.BuildServiceProvider(), new HashSet<string>(tools.Select(t => t.Name)));
-        return new ToolPermissionProfileResolver(lookup, configMock.Object);
+        return new ToolPermissionProfileResolver(lookup, configMock.Object, auditService);
     }
 
     private static ITool FileTool() => Mock.Of<ITool>(t =>
@@ -453,6 +464,144 @@ public sealed class ToolPermissionProfileResolverTests
             "mcp_tool", ToolCapability.None, ["program"]);
 
         result.IsSuccess.Should().BeTrue();
+    }
+
+    // --- Governance audit trail on refusal (#419 — every governed refusal already reaches
+    // governance.jsonl via CapabilityEnforcer/ToolInvocationGovernor's use of the same
+    // IGovernanceAuditService; a refusal on this ungoverned-dispatch path previously reached
+    // neither that trail nor an app log (the app-log gap was closed separately in #421/#426)). ---
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_IntersectingDeny_LogsDenialToAuditTrail()
+    {
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
+            }
+        };
+        var resolver = BuildResolver(config, auditMock.Object);
+
+        resolver.ResolveForUngovernedDispatch(
+            "iac_plan", ToolCapability.FileRead | ToolCapability.NetworkAccess, ["terraform"],
+            agentId: "agent-42");
+
+        auditMock.Verify(a => a.Log("agent-42", "iac_plan", ToolDecisionOutcome.Denied.ToString()), Times.Once);
+    }
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_UnderDeclaration_LogsDenialToAuditTrail()
+    {
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var resolver = BuildResolver(null, auditMock.Object, ("full_tool", FullTool()));
+
+        resolver.ResolveForUngovernedDispatch(
+            "full_tool", ToolCapability.FileRead, ["program"], agentId: "agent-7");
+
+        auditMock.Verify(a => a.Log("agent-7", "full_tool", ToolDecisionOutcome.Denied.ToString()), Times.Once);
+    }
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_NoAgentIdSupplied_LogsUnknownRatherThanOmittingTheEntry()
+    {
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
+            }
+        };
+        var resolver = BuildResolver(config, auditMock.Object);
+
+        resolver.ResolveForUngovernedDispatch(
+            "iac_plan", ToolCapability.NetworkAccess, ["terraform"]);
+
+        auditMock.Verify(a => a.Log("unknown", "iac_plan", ToolDecisionOutcome.Denied.ToString()), Times.Once);
+    }
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_Succeeds_NeverLogsToTheAuditTrail()
+    {
+        // A successful dispatch is not a governance decision — only a refusal is. Proves the audit
+        // call is refusal-gated, not fired unconditionally on every call.
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var resolver = BuildResolver(null, auditMock.Object);
+
+        resolver.ResolveForUngovernedDispatch(
+            "unregistered_tool", ToolCapability.FileRead, ["dotnet"]);
+
+        auditMock.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_NoAuditServiceConfigured_RefusalStillWorksWithoutThrowing()
+    {
+        // The optional-dependency contract (#419): a composition root that never wires
+        // IGovernanceAuditService must still get a working resolver, just with no durable audit
+        // trail for this path — mirrors ProvenanceMemoryWriteGate's IGovernanceAuditService? convention.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
+            }
+        };
+        var resolver = BuildResolver(config, auditService: null);
+
+        var act = () => resolver.ResolveForUngovernedDispatch(
+            "iac_plan", ToolCapability.NetworkAccess, ["terraform"]);
+
+        act.Should().NotThrow();
+        act().IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResolveExecutorForUngovernedDispatch_RefusalOnResolvedTier_ForwardsAgentIdFromScopedExecutionContext()
+    {
+        // The one production wiring point for agentId (#419): IAgentExecutionContext is scoped, so it
+        // is read from the caller's own per-execution scope — never captured on this singleton's
+        // constructor — and forwarded down to ResolveForUngovernedDispatch's audit call.
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
+            }
+        };
+        var resolver = BuildResolver(config, auditMock.Object);
+        var executionContext = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "scoped-agent-99");
+        var scopedServices = new ServiceCollection()
+            .AddSingleton(executionContext)
+            .BuildServiceProvider();
+
+        resolver.ResolveExecutorForUngovernedDispatch(
+            "iac_plan", ToolCapability.NetworkAccess, ["terraform"], scopedServices);
+
+        auditMock.Verify(a => a.Log("scoped-agent-99", "iac_plan", ToolDecisionOutcome.Denied.ToString()), Times.Once);
+    }
+
+    [Fact]
+    public void ResolveExecutorForUngovernedDispatch_RefusalWithNoExecutionContextInScope_LogsUnknown()
+    {
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
+            }
+        };
+        var resolver = BuildResolver(config, auditMock.Object);
+        var scopedServices = new ServiceCollection().BuildServiceProvider();
+
+        resolver.ResolveExecutorForUngovernedDispatch(
+            "iac_plan", ToolCapability.NetworkAccess, ["terraform"], scopedServices);
+
+        auditMock.Verify(a => a.Log("unknown", "iac_plan", ToolDecisionOutcome.Denied.ToString()), Times.Once);
     }
 
     // --- ResolveExecutorForUngovernedDispatch (a /simplify finding: WorkspaceCommandRunner and

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
@@ -29,21 +29,13 @@ public sealed class ToolPermissionProfileResolverTests
         SandboxConfig? config = null,
         params (string Name, ITool Tool)[] tools)
     {
-        return BuildResolver(config, auditService: null, tools);
+        return BuildResolver(config, auditService: null, tools: tools);
     }
 
     private static ToolPermissionProfileResolver BuildResolver(
         SandboxConfig? config,
         IGovernanceAuditService? auditService,
-        params (string Name, ITool Tool)[] tools)
-    {
-        return BuildResolver(config, auditService, governanceConfig: null, tools);
-    }
-
-    private static ToolPermissionProfileResolver BuildResolver(
-        SandboxConfig? config,
-        IGovernanceAuditService? auditService,
-        IOptionsMonitor<GovernanceConfig>? governanceConfig,
+        IOptionsMonitor<GovernanceConfig>? governanceConfig = null,
         params (string Name, ITool Tool)[] tools)
     {
         var services = new ServiceCollection();
@@ -505,7 +497,7 @@ public sealed class ToolPermissionProfileResolverTests
     public void ResolveForUngovernedDispatch_UnderDeclaration_LogsDenialToAuditTrail()
     {
         var auditMock = new Mock<IGovernanceAuditService>();
-        var resolver = BuildResolver(null, auditMock.Object, ("full_tool", FullTool()));
+        var resolver = BuildResolver(null, auditMock.Object, tools: ("full_tool", FullTool()));
 
         resolver.ResolveForUngovernedDispatch(
             "full_tool", ToolCapability.FileRead, ["program"], agentId: "agent-7");
@@ -568,15 +560,17 @@ public sealed class ToolPermissionProfileResolverTests
         act().IsSuccess.Should().BeFalse();
     }
 
-    [Fact]
-    public void ResolveForUngovernedDispatch_EnableAuditFalse_SuppressesTheAuditLogCall()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ResolveForUngovernedDispatch_HonorsEnableAuditFlag(bool enableAudit)
     {
         // #419 code-review finding: every other IGovernanceAuditService call site in the codebase
         // (ToolInvocationGovernor, PromptInjectionBehavior) honors GovernanceConfig.EnableAudit — an
         // operator who disables it must not keep seeing writes to governance.jsonl from this path alone.
         var auditMock = new Mock<IGovernanceAuditService>();
         var governanceConfigMock = new Mock<IOptionsMonitor<GovernanceConfig>>();
-        governanceConfigMock.Setup(m => m.CurrentValue).Returns(new GovernanceConfig { EnableAudit = false });
+        governanceConfigMock.Setup(m => m.CurrentValue).Returns(new GovernanceConfig { EnableAudit = enableAudit });
         var config = new SandboxConfig
         {
             ToolOverrides = new()
@@ -587,31 +581,12 @@ public sealed class ToolPermissionProfileResolverTests
         var resolver = BuildResolver(config, auditMock.Object, governanceConfigMock.Object);
 
         var result = resolver.ResolveForUngovernedDispatch(
-            "iac_plan", ToolCapability.NetworkAccess, ["terraform"]);
-
-        result.IsSuccess.Should().BeFalse("the refusal itself must still happen — only the audit write is gated");
-        auditMock.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-    }
-
-    [Fact]
-    public void ResolveForUngovernedDispatch_EnableAuditTrue_StillLogsToTheAuditTrail()
-    {
-        var auditMock = new Mock<IGovernanceAuditService>();
-        var governanceConfigMock = new Mock<IOptionsMonitor<GovernanceConfig>>();
-        governanceConfigMock.Setup(m => m.CurrentValue).Returns(new GovernanceConfig { EnableAudit = true });
-        var config = new SandboxConfig
-        {
-            ToolOverrides = new()
-            {
-                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
-            }
-        };
-        var resolver = BuildResolver(config, auditMock.Object, governanceConfigMock.Object);
-
-        resolver.ResolveForUngovernedDispatch(
             "iac_plan", ToolCapability.NetworkAccess, ["terraform"], agentId: "agent-1");
 
-        auditMock.Verify(a => a.Log("agent-1", "iac_plan", ToolDecisionOutcome.Denied.ToString()), Times.Once);
+        result.IsSuccess.Should().BeFalse("the refusal itself must still happen — only the audit write is gated");
+        auditMock.Verify(
+            a => a.Log("agent-1", "iac_plan", ToolDecisionOutcome.Denied.ToString()),
+            enableAudit ? Times.Once : Times.Never);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
@@ -5,6 +5,7 @@ using Application.AI.Common.Services.Sandbox;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Governance;
 using Domain.AI.Sandbox;
+using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,6 +37,15 @@ public sealed class ToolPermissionProfileResolverTests
         IGovernanceAuditService? auditService,
         params (string Name, ITool Tool)[] tools)
     {
+        return BuildResolver(config, auditService, governanceConfig: null, tools);
+    }
+
+    private static ToolPermissionProfileResolver BuildResolver(
+        SandboxConfig? config,
+        IGovernanceAuditService? auditService,
+        IOptionsMonitor<GovernanceConfig>? governanceConfig,
+        params (string Name, ITool Tool)[] tools)
+    {
         var services = new ServiceCollection();
         foreach (var (name, tool) in tools)
             services.AddKeyedSingleton<ITool>(name, (_, _) => tool);
@@ -45,7 +55,7 @@ public sealed class ToolPermissionProfileResolverTests
 
         var lookup = new FirstPartyToolLookup(
             services.BuildServiceProvider(), new HashSet<string>(tools.Select(t => t.Name)));
-        return new ToolPermissionProfileResolver(lookup, configMock.Object, auditService);
+        return new ToolPermissionProfileResolver(lookup, configMock.Object, auditService, governanceConfig);
     }
 
     private static ITool FileTool() => Mock.Of<ITool>(t =>
@@ -556,6 +566,52 @@ public sealed class ToolPermissionProfileResolverTests
 
         act.Should().NotThrow();
         act().IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_EnableAuditFalse_SuppressesTheAuditLogCall()
+    {
+        // #419 code-review finding: every other IGovernanceAuditService call site in the codebase
+        // (ToolInvocationGovernor, PromptInjectionBehavior) honors GovernanceConfig.EnableAudit — an
+        // operator who disables it must not keep seeing writes to governance.jsonl from this path alone.
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var governanceConfigMock = new Mock<IOptionsMonitor<GovernanceConfig>>();
+        governanceConfigMock.Setup(m => m.CurrentValue).Returns(new GovernanceConfig { EnableAudit = false });
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
+            }
+        };
+        var resolver = BuildResolver(config, auditMock.Object, governanceConfigMock.Object);
+
+        var result = resolver.ResolveForUngovernedDispatch(
+            "iac_plan", ToolCapability.NetworkAccess, ["terraform"]);
+
+        result.IsSuccess.Should().BeFalse("the refusal itself must still happen — only the audit write is gated");
+        auditMock.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_EnableAuditTrue_StillLogsToTheAuditTrail()
+    {
+        var auditMock = new Mock<IGovernanceAuditService>();
+        var governanceConfigMock = new Mock<IOptionsMonitor<GovernanceConfig>>();
+        governanceConfigMock.Setup(m => m.CurrentValue).Returns(new GovernanceConfig { EnableAudit = true });
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["iac_plan"] = new ToolOverrideConfig { DeniedCapabilities = ["NetworkAccess"] }
+            }
+        };
+        var resolver = BuildResolver(config, auditMock.Object, governanceConfigMock.Object);
+
+        resolver.ResolveForUngovernedDispatch(
+            "iac_plan", ToolCapability.NetworkAccess, ["terraform"], agentId: "agent-1");
+
+        auditMock.Verify(a => a.Log("agent-1", "iac_plan", ToolDecisionOutcome.Denied.ToString()), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fixes #419: `ToolPermissionProfileResolver.ResolveForUngovernedDispatch` is the refusal path for `WorkspaceCommandRunner`/`IacSandboxRunner` — the two dispatch paths that bypass `ICapabilityEnforcer`/`IToolInvocationGovernor` by design. Every governed refusal already reaches `governance.jsonl` via `CapabilityEnforcer`/`ToolInvocationGovernor`'s use of `IGovernanceAuditService`; a refusal on this ungoverned path reached neither that trail nor (until #421/#426) an app log.
- `ToolPermissionProfileResolver` now takes an optional `IGovernanceAuditService` (mirroring `ProvenanceMemoryWriteGate`'s established optional-dependency convention, since the resolver is a widely-used singleton) and logs both refusal branches — deny-intersection and under-declaration.
- Agent identity is read from the caller's own per-execution DI scope inside `ResolveExecutorForUngovernedDispatch` (`IAgentExecutionContext` is scoped, so it can never be captured on this singleton's own constructor) and forwarded down, defaulting to `"unknown"` rather than omitting the audit entry when unavailable.
- `/code-review` caught a real gap: the audit-log call didn't honor `GovernanceConfig.EnableAudit`, unlike every other audit call site in the codebase — fixed by gating on an optional `IOptionsMonitor<GovernanceConfig>`.
- `/simplify` (4 parallel angles) found and fixed two test-file cleanups (overload-chain collapse, duplicate-test-body merge into a `[Theory]`), and surfaced two out-of-scope findings filed as follow-ups: #430 (the audit-gate check is independently hand-rolled at 8 call sites codebase-wide) and #431 (`McpConnectionManager`'s sandboxed-session refusals have the same unaudited shape on a different control point).

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] New regression tests prove: both refusal branches log to the audit trail; agent id forwards correctly from the scoped `IAgentExecutionContext`; `"unknown"` is logged (not omitted) when no identity is available; a successful dispatch never logs; a missing audit service degrades gracefully without throwing; `EnableAudit=false` suppresses the write while the refusal itself still happens
- [x] Both the `EnableAudit` gate and the original audit-log call were mutation-tested — reverted each, confirmed the corresponding test failed, restored
- [x] `Application.AI.Common.Tests`: 2131/2131 passed
- [x] `/code-review` and `/simplify` both run; findings applied or filed as scoped follow-ups

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW