### PR TITLE
fix: sync the actually-selected isolation tier into the dispatched profile (#420)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -93,6 +93,19 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
 
         var profile = await _capabilityEnforcer.ResolveProfileAsync(config.ToolName, ct);
         var isolationLevel = DetermineIsolation(config, profile, step);
+        // DetermineIsolation only ever elevates (config.IsolationLevelOverride, or a
+        // Supervised/Restricted step forcing Container) — never lowers — so isolationLevel is always
+        // >= profile.MinimumIsolation. The embedded profile must reflect the tier actually selected,
+        // not just the tool's own declared floor: SandboxSessionAttestationSigner signs both
+        // `isolation` and `capabilitiesEnforcedBy` from PermissionProfile.MinimumIsolation on every
+        // successful run, and DockerSandboxExecutor.HandleDockerUnavailableAsync reads the same field
+        // to decide whether a Docker outage is a hard, attested refusal or a soft fallback hint (#420).
+        // Without this sync, an autonomy-elevated step's stale, un-elevated profile mislabels the
+        // signed attestation on success and can misroute the outage branch on failure — the same
+        // "sync the actually-selected tier into the profile before embedding it" pattern
+        // McpConnectionManager already follows for its own sandbox-session dispatch.
+        if (isolationLevel != profile.MinimumIsolation)
+            profile = profile with { MinimumIsolation = isolationLevel };
 
         var (sandboxResult, sandboxFailure) = await RunSandboxAsync(
             config, step, profile, isolationLevel, arguments, admission, sw, ct);

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -93,19 +93,7 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
 
         var profile = await _capabilityEnforcer.ResolveProfileAsync(config.ToolName, ct);
         var isolationLevel = DetermineIsolation(config, profile, step);
-        // DetermineIsolation only ever elevates (config.IsolationLevelOverride, or a
-        // Supervised/Restricted step forcing Container) — never lowers — so isolationLevel is always
-        // >= profile.MinimumIsolation. The embedded profile must reflect the tier actually selected,
-        // not just the tool's own declared floor: SandboxSessionAttestationSigner signs both
-        // `isolation` and `capabilitiesEnforcedBy` from PermissionProfile.MinimumIsolation on every
-        // successful run, and DockerSandboxExecutor.HandleDockerUnavailableAsync reads the same field
-        // to decide whether a Docker outage is a hard, attested refusal or a soft fallback hint (#420).
-        // Without this sync, an autonomy-elevated step's stale, un-elevated profile mislabels the
-        // signed attestation on success and can misroute the outage branch on failure — the same
-        // "sync the actually-selected tier into the profile before embedding it" pattern
-        // McpConnectionManager already follows for its own sandbox-session dispatch.
-        if (isolationLevel != profile.MinimumIsolation)
-            profile = profile with { MinimumIsolation = isolationLevel };
+        profile = SyncProfileIsolation(profile, isolationLevel);
 
         var (sandboxResult, sandboxFailure) = await RunSandboxAsync(
             config, step, profile, isolationLevel, arguments, admission, sw, ct);
@@ -342,6 +330,31 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         });
     }
 
+
+    /// <summary>
+    /// Rebuilds <paramref name="profile"/> so its own <see cref="ToolPermissionProfile.MinimumIsolation"/>
+    /// matches <paramref name="isolationLevel"/> — the tier <see cref="DetermineIsolation"/> actually
+    /// selected, which can be elevated above the profile's declared floor by
+    /// <c>config.IsolationLevelOverride</c> or a <c>Supervised</c>/<c>Restricted</c> step (#420).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="DetermineIsolation"/> only ever raises the level, never lowers it, so
+    /// <paramref name="isolationLevel"/> is always ≥ <paramref name="profile"/>'s own
+    /// <see cref="ToolPermissionProfile.MinimumIsolation"/> — the equality check below only guards
+    /// against an unnecessary record rebuild, not against ever lowering the floor.
+    /// <see cref="Infrastructure.AI.Sandbox.DockerSandboxExecutor.HandleDockerUnavailableAsync"/> reads
+    /// this embedded field to decide whether a Docker outage is a hard, attested refusal or a soft,
+    /// unattested fallback hint — an un-elevated profile can misroute an autonomy-elevated step into
+    /// the unattested branch. <c>McpConnectionManager</c>'s own sandbox-session dispatch
+    /// (<c>resolvedProfile with { MinimumIsolation = Math.Max(...) }</c>) and
+    /// <c>ToolPermissionProfileResolver.ResolveForUngovernedDispatch</c> already follow this same
+    /// sync-before-embed pattern independently — see #433 for consolidating all three into one helper.
+    /// </remarks>
+    private static ToolPermissionProfile SyncProfileIsolation(
+        ToolPermissionProfile profile, SandboxIsolationLevel isolationLevel) =>
+        isolationLevel == profile.MinimumIsolation
+            ? profile
+            : profile with { MinimumIsolation = isolationLevel };
 
     private static SandboxIsolationLevel DetermineIsolation(
         ToolUseConfig config,

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
@@ -208,12 +208,13 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             };
         }
 
-        // Defensive-only as of #420: this class is registered exclusively under the Container keyed-DI
-        // slot, and every first-party caller (ToolUseStepExecutor, IacSandboxRunner,
-        // WorkspaceCommandRunner) now syncs an elevated tier into PermissionProfile.MinimumIsolation
-        // before embedding it — so a request that reached this executor always has isRequired true
-        // above. This branch stays as a guard against a future caller that resolves the Container
-        // executor without that sync, not because any current path can reach it.
+        // Unreachable from any first-party caller as of #420: this class is registered exclusively
+        // under the Container keyed-DI slot, so isRequired above is re-deriving from a caller-supplied
+        // field a fact the DI key already proves structurally — every first-party caller now also
+        // syncs an elevated tier into PermissionProfile.MinimumIsolation before embedding it, so
+        // isRequired is always true in practice. #434 tracks removing this branch (and its identical
+        // twin in DockerSandboxSessionFactory) rather than continuing to trust a caller-controlled
+        // field for something the DI key already guarantees.
         _logger.LogWarning("Docker unavailable for tool {ToolName}. Caller may fall back to process isolation", request.ToolName);
 
         return new SandboxExecutionResult

--- a/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Sandbox/DockerSandboxExecutor.cs
@@ -208,6 +208,12 @@ public sealed class DockerSandboxExecutor : ISandboxExecutor
             };
         }
 
+        // Defensive-only as of #420: this class is registered exclusively under the Container keyed-DI
+        // slot, and every first-party caller (ToolUseStepExecutor, IacSandboxRunner,
+        // WorkspaceCommandRunner) now syncs an elevated tier into PermissionProfile.MinimumIsolation
+        // before embedding it — so a request that reached this executor always has isRequired true
+        // above. This branch stays as a guard against a future caller that resolves the Container
+        // executor without that sync, not because any current path can reach it.
         _logger.LogWarning("Docker unavailable for tool {ToolName}. Caller may fall back to process isolation", request.ToolName);
 
         return new SandboxExecutionResult

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
@@ -29,6 +29,7 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
     private readonly Mock<ICompositeResponseSanitizer> _responseSanitizer = new();
     private readonly Mock<IPlanProgressNotifier> _notifier = new();
     private readonly Mock<ISandboxExecutor> _processExecutor = new();
+    private readonly Mock<ISandboxExecutor> _containerExecutor = new();
     private readonly PlanExecutionContext _context = new() { CurrentPlanId = new PlanId(Guid.NewGuid()) };
     private readonly ToolUseStepExecutor _sut;
 
@@ -47,7 +48,7 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
         // the gap the fix protects against.
         var services = new ServiceCollection();
         services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, _processExecutor.Object);
-        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, new Mock<ISandboxExecutor>().Object);
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, _containerExecutor.Object);
         var sp = services.BuildServiceProvider();
 
         _sut = new ToolUseStepExecutor(
@@ -115,20 +116,6 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
         // DockerSandboxExecutor.HandleDockerUnavailableAsync reads the same field to decide whether a
         // Docker outage is a hard, attested refusal or a soft fallback hint — both misread a stale,
         // un-elevated profile.
-        var containerExecutor = new Mock<ISandboxExecutor>();
-        var services = new ServiceCollection();
-        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, _processExecutor.Object);
-        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, containerExecutor.Object);
-        var sut = new ToolUseStepExecutor(
-            _capabilityEnforcer.Object,
-            PermissiveAdmission.Pipeline(),
-            services.BuildServiceProvider(),
-            _attestationService.Object,
-            _responseSanitizer.Object,
-            _notifier.Object,
-            _context,
-            NullLogger<ToolUseStepExecutor>.Instance);
-
         _capabilityEnforcer.Setup(c => c.ResolveProfileAsync("shell_tool", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ToolPermissionProfile
             {
@@ -137,7 +124,7 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
             });
 
         SandboxExecutionRequest? dispatchedRequest = null;
-        containerExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+        _containerExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
             .Callback<SandboxExecutionRequest, CancellationToken>((req, _) => dispatchedRequest = req)
             .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
 
@@ -151,10 +138,10 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
             RequiredAutonomyLevel = AutonomyLevel.Supervised
         };
 
-        var result = await sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         Assert.Equal(StepExecutionStatus.Completed, result.Status);
-        containerExecutor.Verify(
+        _containerExecutor.Verify(
             s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Once,
             "the elevated tier must select the Container executor, not the tool's own Process floor");
         Assert.NotNull(dispatchedRequest);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
@@ -103,4 +103,96 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
         _processExecutor.Verify(
             s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_SupervisedStepElevatesAboveProfileFloor_EmbedsTheElevatedTierInTheDispatchedRequest()
+    {
+        // #420: DetermineIsolation elevates isolation for a Supervised/Restricted step even when the
+        // tool's own profile only declares Process — but the elevated tier must also reach the
+        // *embedded* PermissionProfile.MinimumIsolation on the dispatched request, not just select
+        // the right keyed executor. SandboxSessionAttestationSigner signs both `isolation` and
+        // `capabilitiesEnforcedBy` from that embedded field on every successful run, and
+        // DockerSandboxExecutor.HandleDockerUnavailableAsync reads the same field to decide whether a
+        // Docker outage is a hard, attested refusal or a soft fallback hint — both misread a stale,
+        // un-elevated profile.
+        var containerExecutor = new Mock<ISandboxExecutor>();
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, _processExecutor.Object);
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, containerExecutor.Object);
+        var sut = new ToolUseStepExecutor(
+            _capabilityEnforcer.Object,
+            PermissiveAdmission.Pipeline(),
+            services.BuildServiceProvider(),
+            _attestationService.Object,
+            _responseSanitizer.Object,
+            _notifier.Object,
+            _context,
+            NullLogger<ToolUseStepExecutor>.Instance);
+
+        _capabilityEnforcer.Setup(c => c.ResolveProfileAsync("shell_tool", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ToolPermissionProfile
+            {
+                RequiredCapabilities = ToolCapability.Subprocess,
+                MinimumIsolation = SandboxIsolationLevel.Process
+            });
+
+        SandboxExecutionRequest? dispatchedRequest = null;
+        containerExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SandboxExecutionRequest, CancellationToken>((req, _) => dispatchedRequest = req)
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
+
+        var step = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "supervised-step",
+            Type = StepType.ToolUse,
+            Configuration = new ToolUseConfig { ToolName = "shell_tool" },
+            RetryPolicy = new RetryPolicy(),
+            RequiredAutonomyLevel = AutonomyLevel.Supervised
+        };
+
+        var result = await sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        containerExecutor.Verify(
+            s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Once,
+            "the elevated tier must select the Container executor, not the tool's own Process floor");
+        Assert.NotNull(dispatchedRequest);
+        Assert.Equal(SandboxIsolationLevel.Container, dispatchedRequest!.PermissionProfile.MinimumIsolation);
+        Assert.Equal(ToolCapability.Subprocess, dispatchedRequest.PermissionProfile.RequiredCapabilities);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoElevationNeeded_ProfileMinimumIsolationUnchanged()
+    {
+        // The other half of #420's guarantee: when DetermineIsolation doesn't elevate (no autonomy
+        // requirement, no override), the profile embedded in the request must be the exact instance
+        // resolved by the capability enforcer -- not a needlessly rebuilt copy.
+        _capabilityEnforcer.Setup(c => c.ResolveProfileAsync("read_only_tool", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ToolPermissionProfile
+            {
+                RequiredCapabilities = ToolCapability.FileRead,
+                MinimumIsolation = SandboxIsolationLevel.Process
+            });
+
+        SandboxExecutionRequest? dispatchedRequest = null;
+        _processExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SandboxExecutionRequest, CancellationToken>((req, _) => dispatchedRequest = req)
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
+
+        var step = new PlanStep
+        {
+            Id = new PlanStepId(Guid.NewGuid()),
+            Name = "read-only-step-2",
+            Type = StepType.ToolUse,
+            Configuration = new ToolUseConfig { ToolName = "read_only_tool" },
+            RetryPolicy = new RetryPolicy()
+        };
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        Assert.NotNull(dispatchedRequest);
+        Assert.Equal(SandboxIsolationLevel.Process, dispatchedRequest!.PermissionProfile.MinimumIsolation);
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorSolutionReviewFixTests.cs
@@ -167,13 +167,17 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
     {
         // The other half of #420's guarantee: when DetermineIsolation doesn't elevate (no autonomy
         // requirement, no override), the profile embedded in the request must be the exact instance
-        // resolved by the capability enforcer -- not a needlessly rebuilt copy.
+        // resolved by the capability enforcer -- not a needlessly rebuilt copy. Asserted by reference
+        // identity, not just value equality: ToolPermissionProfile is a record, so `with` would
+        // produce a value-equal but distinct instance even when unconditionally rebuilding -- a value
+        // check alone can't tell that apart from the guarded, no-op case this test exists to prove.
+        var resolvedProfile = new ToolPermissionProfile
+        {
+            RequiredCapabilities = ToolCapability.FileRead,
+            MinimumIsolation = SandboxIsolationLevel.Process
+        };
         _capabilityEnforcer.Setup(c => c.ResolveProfileAsync("read_only_tool", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ToolPermissionProfile
-            {
-                RequiredCapabilities = ToolCapability.FileRead,
-                MinimumIsolation = SandboxIsolationLevel.Process
-            });
+            .ReturnsAsync(resolvedProfile);
 
         SandboxExecutionRequest? dispatchedRequest = null;
         _processExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
@@ -193,6 +197,6 @@ public sealed class ToolUseStepExecutorSolutionReviewFixTests
 
         Assert.Equal(StepExecutionStatus.Completed, result.Status);
         Assert.NotNull(dispatchedRequest);
-        Assert.Equal(SandboxIsolationLevel.Process, dispatchedRequest!.PermissionProfile.MinimumIsolation);
+        Assert.Same(resolvedProfile, dispatchedRequest!.PermissionProfile);
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #420: `ToolUseStepExecutor.ExecuteAsync` resolves a tool's `PermissionProfile` once, then `DetermineIsolation` computes the tier actually selected — which can be elevated above the profile's own `MinimumIsolation` by `config.IsolationLevelOverride` or a `Supervised`/`Restricted` step forcing `Container`. That elevated tier picks the right keyed `ISandboxExecutor`, but the profile embedded in the dispatched `SandboxExecutionRequest` was the original, un-elevated one — so `DockerSandboxExecutor.HandleDockerUnavailableAsync` could misroute an autonomy-elevated step into an unattested "soft fallback" response on a Docker outage, instead of a hard, attested refusal (the issue's originally-reported symptom).
- Confirmed `McpConnectionManager`'s own sandbox-session dispatch already follows this exact "sync the elevated tier into the profile before embedding it" pattern — `ToolUseStepExecutor` was the one place that computed the elevated tier without writing it back.
- `/code-review` caught a real defect in my own fix comment: it claimed `SandboxSessionAttestationSigner` reads the embedded profile on every successful run — verified false, that class signs a different request type on a different dispatch path. Rewrote the comment around the actual, verified consequence, and extracted a `SyncProfileIsolation` helper (which also brought `ExecuteAsync` back under the 50-line convention).
- `/simplify` (4 parallel angles): applied a test-fixture cleanup (shared executor mock instead of a parallel per-test instance). The altitude pass made a strong case that a now-dead branch in `DockerSandboxExecutor` should be *removed*, not just commented — filed as follow-up #434 rather than expanding this PR, since it's a behavior change touching a file (`DockerSandboxSessionFactory.cs`) entirely outside this diff. Also filed #433 for the cross-file duplication of the sync-before-embed pattern (now 3 independent implementations).

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] Two new regression tests: an autonomy-elevated step's dispatched request now carries the elevated tier (mutation-tested — reverted the sync, confirmed this test failed, restored); a non-elevated step's dispatched request carries the *exact same* profile instance (`Assert.Same`), proving the fix doesn't needlessly rebuild
- [x] `Infrastructure.AI.Tests`: 3241/3241 passed
- [x] `/code-review` and `/simplify` both run; findings applied or filed as scoped follow-ups (#433, #434)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW