### PR TITLE
fix: validate eval MetricSpec parameter keys against each metric's declared set (#423)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IEvalMetric.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IEvalMetric.cs
@@ -21,8 +21,31 @@ namespace Application.AI.Common.Evaluation.Interfaces;
 /// </remarks>
 public interface IEvalMetric
 {
+    /// <summary>
+    /// Empty set shared by every metric that reads no <see cref="MetricSpec.Parameters"/> —
+    /// avoids each such metric allocating its own empty <see cref="HashSet{T}"/> instance.
+    /// </summary>
+    private static readonly IReadOnlySet<string> NoRecognizedParameters = new HashSet<string>();
+
     /// <summary>The stable string key by which this metric is referenced from cases (e.g. "exact_match").</summary>
     string Key { get; }
+
+    /// <summary>
+    /// The <see cref="MetricSpec.Parameters"/> keys this metric actually reads. Empty by default —
+    /// only a metric that reads case-author-supplied parameters needs to override this.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Application.AI.Common.Evaluation.MetricSpecExtensions"/>'s accessors are
+    /// deliberately fail-soft: a missing or unparseable parameter falls back to a default rather
+    /// than throwing, so a bad case must not take down an eval run. The cost is that a typo'd key
+    /// is architecturally indistinguishable from an absent one at score time — both hit the same
+    /// silent-default path (#423, first surfaced by #410's six silently-no-op'd eval cases). This
+    /// property exists so that distinction can be made at dataset-load time instead: a validation
+    /// pass can compare a case's declared <see cref="MetricSpec.Parameters"/> keys against the
+    /// resolved metric's own declared set and flag anything neither side recognizes, without
+    /// needing to inspect <see cref="ScoreAsync"/>'s behavior to find out what it actually reads.
+    /// </remarks>
+    IReadOnlySet<string> RecognizedParameterKeys => NoRecognizedParameters;
 
     /// <summary>
     /// Scores the given case's output.

--- a/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IEvalMetric.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IEvalMetric.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Application.AI.Common.Evaluation.Models;
 using Domain.AI.Evaluation;
 
@@ -21,12 +22,6 @@ namespace Application.AI.Common.Evaluation.Interfaces;
 /// </remarks>
 public interface IEvalMetric
 {
-    /// <summary>
-    /// Empty set shared by every metric that reads no <see cref="MetricSpec.Parameters"/> —
-    /// avoids each such metric allocating its own empty <see cref="HashSet{T}"/> instance.
-    /// </summary>
-    private static readonly IReadOnlySet<string> NoRecognizedParameters = new HashSet<string>();
-
     /// <summary>The stable string key by which this metric is referenced from cases (e.g. "exact_match").</summary>
     string Key { get; }
 
@@ -45,7 +40,7 @@ public interface IEvalMetric
     /// resolved metric's own declared set and flag anything neither side recognizes, without
     /// needing to inspect <see cref="ScoreAsync"/>'s behavior to find out what it actually reads.
     /// </remarks>
-    IReadOnlySet<string> RecognizedParameterKeys => NoRecognizedParameters;
+    IReadOnlySet<string> RecognizedParameterKeys => ImmutableHashSet<string>.Empty;
 
     /// <summary>
     /// Scores the given case's output.

--- a/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Governance/GovernanceBehaviorMetric.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Metrics/Governance/GovernanceBehaviorMetric.cs
@@ -50,6 +50,10 @@ public sealed class GovernanceBehaviorMetric : IEvalMetric
     public string Key => MetricKeyName;
 
     /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedParameterKeys { get; } =
+        new HashSet<string> { RequireEnforcementKey, ExpectEscalationKey };
+
+    /// <inheritdoc />
     public Task<MetricScore> ScoreAsync(
         EvalCase @case,
         AgentInvocationResult output,

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/ContainsAllMetric.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/ContainsAllMetric.cs
@@ -16,8 +16,15 @@ namespace Infrastructure.AI.Evaluation.Metrics;
 /// </remarks>
 public sealed class ContainsAllMetric : IEvalMetric
 {
+    private const string ValuesKey = "values";
+    private const string CaseSensitiveKey = "case_sensitive";
+
     /// <inheritdoc />
     public string Key => "contains_all";
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedParameterKeys { get; } =
+        new HashSet<string> { ValuesKey, CaseSensitiveKey };
 
     /// <inheritdoc />
     public Task<MetricScore> ScoreAsync(
@@ -28,7 +35,7 @@ public sealed class ContainsAllMetric : IEvalMetric
     {
         var sw = Stopwatch.StartNew();
 
-        if (!spec.Parameters.TryGetValue("values", out var valuesRaw) || string.IsNullOrWhiteSpace(valuesRaw))
+        if (!spec.Parameters.TryGetValue(ValuesKey, out var valuesRaw) || string.IsNullOrWhiteSpace(valuesRaw))
         {
             sw.Stop();
             return Task.FromResult(new MetricScore
@@ -41,7 +48,7 @@ public sealed class ContainsAllMetric : IEvalMetric
             });
         }
 
-        var caseSensitive = spec.Parameters.TryGetValue("case_sensitive", out var cs)
+        var caseSensitive = spec.Parameters.TryGetValue(CaseSensitiveKey, out var cs)
             && bool.TryParse(cs, out var parsed) && parsed;
 
         var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/DoesNotContainMetric.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/DoesNotContainMetric.cs
@@ -15,8 +15,15 @@ namespace Infrastructure.AI.Evaluation.Metrics;
 /// </remarks>
 public sealed class DoesNotContainMetric : IEvalMetric
 {
+    private const string ValuesKey = "values";
+    private const string CaseSensitiveKey = "case_sensitive";
+
     /// <inheritdoc />
     public string Key => "does_not_contain";
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedParameterKeys { get; } =
+        new HashSet<string> { ValuesKey, CaseSensitiveKey };
 
     /// <inheritdoc />
     public Task<MetricScore> ScoreAsync(
@@ -27,13 +34,13 @@ public sealed class DoesNotContainMetric : IEvalMetric
     {
         var sw = Stopwatch.StartNew();
 
-        if (!spec.Parameters.TryGetValue("values", out var valuesRaw) || string.IsNullOrWhiteSpace(valuesRaw))
+        if (!spec.Parameters.TryGetValue(ValuesKey, out var valuesRaw) || string.IsNullOrWhiteSpace(valuesRaw))
         {
             sw.Stop();
             return Task.FromResult(Warn(sw, "Missing required 'values' parameter (pipe-separated)."));
         }
 
-        var caseSensitive = spec.Parameters.TryGetValue("case_sensitive", out var cs)
+        var caseSensitive = spec.Parameters.TryGetValue(CaseSensitiveKey, out var cs)
             && bool.TryParse(cs, out var parsed) && parsed;
 
         var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/ExactMatchMetric.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/ExactMatchMetric.cs
@@ -16,8 +16,13 @@ namespace Infrastructure.AI.Evaluation.Metrics;
 /// </remarks>
 public sealed class ExactMatchMetric : IEvalMetric
 {
+    private const string CaseSensitiveKey = "case_sensitive";
+
     /// <inheritdoc />
     public string Key => "exact_match";
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedParameterKeys { get; } = new HashSet<string> { CaseSensitiveKey };
 
     /// <inheritdoc />
     public Task<MetricScore> ScoreAsync(
@@ -41,7 +46,7 @@ public sealed class ExactMatchMetric : IEvalMetric
             });
         }
 
-        var caseSensitive = !spec.Parameters.TryGetValue("case_sensitive", out var cs)
+        var caseSensitive = !spec.Parameters.TryGetValue(CaseSensitiveKey, out var cs)
             || !bool.TryParse(cs, out var parsed) || parsed;
 
         var comparison = caseSensitive

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/LlmJudgeMetric.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/LlmJudgeMetric.cs
@@ -63,6 +63,7 @@ public sealed class LlmJudgeMetric : IEvalMetric
         "you MUST quote the specific rubric requirement it violates verbatim in \"violated_clause\" — do not " +
         "paraphrase or invent a requirement that is not present in the rubric.";
 
+    private const string RubricKey = "rubric";
     private const string VerdictContractKey = "verdict_contract";
     private const string TrajectoryKey = "trajectory";
     private const string IncludeExpectedOutputKey = "include_expected_output";
@@ -86,6 +87,12 @@ public sealed class LlmJudgeMetric : IEvalMetric
     public string Key => "llm_judge";
 
     /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedParameterKeys { get; } = new HashSet<string>
+    {
+        RubricKey, VerdictContractKey, TrajectoryKey, IncludeExpectedOutputKey
+    };
+
+    /// <inheritdoc />
     public async Task<MetricScore> ScoreAsync(
         EvalCase @case,
         AgentInvocationResult output,
@@ -98,7 +105,7 @@ public sealed class LlmJudgeMetric : IEvalMetric
 
         var sw = Stopwatch.StartNew();
 
-        if (!spec.Parameters.TryGetValue("rubric", out var rubric) || string.IsNullOrWhiteSpace(rubric))
+        if (!spec.Parameters.TryGetValue(RubricKey, out var rubric) || string.IsNullOrWhiteSpace(rubric))
         {
             return Warn(sw, "llm_judge requires a 'rubric' parameter.");
         }

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/RegexMatchMetric.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Metrics/RegexMatchMetric.cs
@@ -20,8 +20,15 @@ public sealed class RegexMatchMetric : IEvalMetric
 {
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(1);
 
+    private const string PatternKey = "pattern";
+    private const string MustNotMatchKey = "must_not_match";
+
     /// <inheritdoc />
     public string Key => "regex_match";
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedParameterKeys { get; } =
+        new HashSet<string> { PatternKey, MustNotMatchKey };
 
     /// <inheritdoc />
     public Task<MetricScore> ScoreAsync(
@@ -32,7 +39,7 @@ public sealed class RegexMatchMetric : IEvalMetric
     {
         var sw = Stopwatch.StartNew();
 
-        if (!spec.Parameters.TryGetValue("pattern", out var pattern) || string.IsNullOrWhiteSpace(pattern))
+        if (!spec.Parameters.TryGetValue(PatternKey, out var pattern) || string.IsNullOrWhiteSpace(pattern))
         {
             sw.Stop();
             return Task.FromResult(Warn(sw, "Missing required 'pattern' parameter."));
@@ -60,7 +67,7 @@ public sealed class RegexMatchMetric : IEvalMetric
             return Task.FromResult(Warn(sw, "Regex evaluation timed out (possible catastrophic backtracking)."));
         }
 
-        var mustNotMatch = spec.GetBool("must_not_match", defaultValue: false);
+        var mustNotMatch = spec.GetBool(MustNotMatchKey, defaultValue: false);
         var passed = mustNotMatch ? !isMatch : isMatch;
         var verb = isMatch ? "matched" : "did not match";
         var qualifier = mustNotMatch ? "forbidden " : "";

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerTestComposition.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerTestComposition.cs
@@ -1,0 +1,37 @@
+using Domain.Common.Config;
+using Infrastructure.AI.Evaluation;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.Common.Extensions;
+
+namespace Presentation.EvalRunner.Tests.Composition;
+
+/// <summary>
+/// Builds the same service graph the real EvalRunner host composes (<c>Program.cs</c>: the shared
+/// solution root, then <see cref="DependencyInjection.AddEvaluationDependencies"/>), against an
+/// empty in-memory configuration.
+/// </summary>
+/// <remarks>
+/// Shared by every test in this folder that needs the real eval-framework service graph — this
+/// exact sequence used to be duplicated per test file (a /simplify finding).
+/// </remarks>
+internal static class EvalRunnerTestComposition
+{
+    /// <summary>Builds an unregistered <see cref="ServiceCollection"/> mirroring the EvalRunner host.</summary>
+    public static ServiceCollection BuildServices()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterConfigSections(configuration);
+        var appConfig = configuration.GetSection("AppConfig").Get<AppConfig>() ?? new AppConfig();
+        services.BuildGlobalSolutionServices(appConfig, includeHealthChecksUI: false);
+
+        // Mirror Program.cs: the eval host opts into the framework AFTER the shared root.
+        services.AddEvaluationDependencies();
+        return services;
+    }
+}

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerValidateOnBuildTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerValidateOnBuildTests.cs
@@ -1,10 +1,6 @@
 using Application.AI.Common.Evaluation.Interfaces;
-using Domain.Common.Config;
 using FluentAssertions;
-using Infrastructure.AI.Evaluation;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Presentation.Common.Extensions;
 using Xunit;
 
 namespace Presentation.EvalRunner.Tests.Composition;
@@ -19,27 +15,10 @@ namespace Presentation.EvalRunner.Tests.Composition;
 /// </summary>
 public sealed class EvalRunnerValidateOnBuildTests
 {
-    private static ServiceCollection BuildEvalRunnerServices()
-    {
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>())
-            .Build();
-
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.RegisterConfigSections(configuration);
-        var appConfig = configuration.GetSection("AppConfig").Get<AppConfig>() ?? new AppConfig();
-        services.BuildGlobalSolutionServices(appConfig, includeHealthChecksUI: false);
-
-        // Mirror Program.cs: the eval host opts into the framework AFTER the shared root.
-        services.AddEvaluationDependencies();
-        return services;
-    }
-
     [Fact]
     public void EvalRunnerComposition_BuildsWithValidateOnBuild()
     {
-        var services = BuildEvalRunnerServices();
+        var services = EvalRunnerTestComposition.BuildServices();
 
         var exception = Record.Exception(() =>
         {
@@ -56,7 +35,7 @@ public sealed class EvalRunnerValidateOnBuildTests
     [Fact]
     public void EvalRunnerComposition_ResolvesRealEvalRunner_NotTheNotConfiguredDefault()
     {
-        var services = BuildEvalRunnerServices();
+        var services = EvalRunnerTestComposition.BuildServices();
 
         // No validation flags needed here — this asserts resolution only; the sibling
         // BuildsWithValidateOnBuild test pins the validation policy for this same graph.

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
@@ -1,11 +1,8 @@
 using Application.AI.Common.Evaluation.Interfaces;
-using Domain.Common.Config;
 using FluentAssertions;
-using Infrastructure.AI.Evaluation;
 using Infrastructure.AI.Evaluation.Loaders;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Presentation.Common.Extensions;
+using Tests.Common;
 using Xunit;
 
 namespace Presentation.EvalRunner.Tests.Composition;
@@ -43,21 +40,11 @@ public sealed class MetricSpecParameterKeyValidationTests
 
     private static IReadOnlyDictionary<string, IEvalMetric> BuildMetricsByKey()
     {
-        // Mirrors EvalRunnerValidateOnBuildTests' composition exactly — the full shared root plus
-        // AddEvaluationDependencies is what actually constructs every metric (including the
+        // EvalRunnerTestComposition mirrors the real EvalRunner host exactly — the full shared root
+        // plus AddEvaluationDependencies is what actually constructs every metric (including the
         // LlmJudge/RAG ones with real constructor dependencies) against an empty in-memory config,
-        // proven to build cleanly under ValidateOnBuild by that sibling test.
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>())
-            .Build();
-
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.RegisterConfigSections(configuration);
-        var appConfig = configuration.GetSection("AppConfig").Get<AppConfig>() ?? new AppConfig();
-        services.BuildGlobalSolutionServices(appConfig, includeHealthChecksUI: false);
-        services.AddEvaluationDependencies();
-
+        // proven to build cleanly under ValidateOnBuild by the sibling EvalRunnerValidateOnBuildTests.
+        var services = EvalRunnerTestComposition.BuildServices();
         using var provider = services.BuildServiceProvider();
 
         var byKey = provider.GetServices<IEvalMetric>()
@@ -70,23 +57,20 @@ public sealed class MetricSpecParameterKeyValidationTests
 
     public static IEnumerable<object[]> DatasetFiles()
     {
-        var root = LocateEvalDatasetsDir();
-        if (root is null) yield break;
-
+        var root = RepoRoot.Combine("eval-datasets");
         foreach (var f in Directory.EnumerateFiles(root, "*.yaml", SearchOption.AllDirectories))
             yield return [f];
     }
 
     [Fact]
-    public void Eval_datasets_dir_is_locatable_and_has_expected_file_count()
+    public void Eval_datasets_dir_has_expected_file_count()
     {
         // Same hard-fail guard SeedDatasetSmokeTests uses: without this, the Theory below silently
-        // runs zero invocations on a host where path resolution breaks, hiding drift instead of
-        // catching it.
-        var root = LocateEvalDatasetsDir();
-        root.Should().NotBeNull("'eval-datasets' must be reachable by walking up from the test bin dir");
-
-        var count = Directory.EnumerateFiles(root!, "*.yaml", SearchOption.AllDirectories).Count();
+        // runs zero invocations if the datasets are ever deleted, hiding drift instead of catching
+        // it. RepoRoot.Combine itself throws (with a clear message) if the repo root can't be
+        // located at all, so there's no separate "is locatable" check needed here.
+        var count = Directory.EnumerateFiles(
+            RepoRoot.Combine("eval-datasets"), "*.yaml", SearchOption.AllDirectories).Count();
         count.Should().BeGreaterThanOrEqualTo(9, "at least the 8 seed datasets plus owasp-agentic-top-10.yaml");
     }
 
@@ -128,15 +112,4 @@ public sealed class MetricSpecParameterKeyValidationTests
             "instead of failing the build (#423)");
     }
 
-    private static string? LocateEvalDatasetsDir()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null)
-        {
-            var candidate = Path.Combine(dir.FullName, "eval-datasets");
-            if (Directory.Exists(candidate)) return candidate;
-            dir = dir.Parent;
-        }
-        return null;
-    }
 }

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
@@ -1,0 +1,142 @@
+using Application.AI.Common.Evaluation.Interfaces;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Evaluation;
+using Infrastructure.AI.Evaluation.Loaders;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Presentation.Common.Extensions;
+using Xunit;
+
+namespace Presentation.EvalRunner.Tests.Composition;
+
+/// <summary>
+/// Validates every <c>eval-datasets/**/*.yaml</c> case's <c>MetricSpec.Parameters</c> keys against
+/// the resolved metric's own declared <see cref="IEvalMetric.RecognizedParameterKeys"/> (#423).
+/// </summary>
+/// <remarks>
+/// <see cref="Application.AI.Common.Evaluation.MetricSpecExtensions"/>'s accessors are deliberately
+/// fail-soft — a typo'd parameter key is architecturally indistinguishable from an absent one at
+/// score time, both fall back to the same default. That is exactly how #410's six eval cases
+/// silently no-op'd or scored inverted for an unknown period, caught only when someone happened to
+/// read the metric source by hand during an unrelated PR review — <c>Verdict.Warn</c> does
+/// not gate CI (per its own doc comment), so nothing automated caught it. This test closes that gap
+/// at build time: every dataset's declared parameters are checked against the metric's own declared
+/// set before any case ever runs.
+/// </remarks>
+public sealed class MetricSpecParameterKeyValidationTests
+{
+    // The 10 OWASP metrics are registered keyed-only in Application.AI.Common's own
+    // DependencyInjection.cs — see that file's remarks on EvalRunner building its metric map from
+    // the non-keyed IEnumerable<IEvalMetric>, which keyed-only registrations are invisible to (a
+    // separate, pre-existing gap, filed as #436 rather than folded into this fix). Resolved here by
+    // key explicitly so this test's own coverage doesn't silently exclude them.
+    private static readonly string[] KeyedOnlyMetricKeys =
+    [
+        "owasp.asi01.goal_hijack", "owasp.asi02.tool_misuse", "owasp.asi03.privilege_abuse",
+        "owasp.asi04.supply_chain", "owasp.asi05.code_exec", "owasp.asi06.memory_poison",
+        "owasp.asi07.inter_agent", "owasp.asi08.cascading", "owasp.asi09.human_trust",
+        "owasp.asi10.rogue_agent"
+    ];
+
+    private static readonly Lazy<IReadOnlyDictionary<string, IEvalMetric>> MetricsByKey = new(BuildMetricsByKey);
+
+    private static IReadOnlyDictionary<string, IEvalMetric> BuildMetricsByKey()
+    {
+        // Mirrors EvalRunnerValidateOnBuildTests' composition exactly — the full shared root plus
+        // AddEvaluationDependencies is what actually constructs every metric (including the
+        // LlmJudge/RAG ones with real constructor dependencies) against an empty in-memory config,
+        // proven to build cleanly under ValidateOnBuild by that sibling test.
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.RegisterConfigSections(configuration);
+        var appConfig = configuration.GetSection("AppConfig").Get<AppConfig>() ?? new AppConfig();
+        services.BuildGlobalSolutionServices(appConfig, includeHealthChecksUI: false);
+        services.AddEvaluationDependencies();
+
+        using var provider = services.BuildServiceProvider();
+
+        var byKey = provider.GetServices<IEvalMetric>()
+            .ToDictionary(m => m.Key, StringComparer.OrdinalIgnoreCase);
+        foreach (var key in KeyedOnlyMetricKeys)
+            byKey[key] = provider.GetRequiredKeyedService<IEvalMetric>(key);
+
+        return byKey;
+    }
+
+    public static IEnumerable<object[]> DatasetFiles()
+    {
+        var root = LocateEvalDatasetsDir();
+        if (root is null) yield break;
+
+        foreach (var f in Directory.EnumerateFiles(root, "*.yaml", SearchOption.AllDirectories))
+            yield return [f];
+    }
+
+    [Fact]
+    public void Eval_datasets_dir_is_locatable_and_has_expected_file_count()
+    {
+        // Same hard-fail guard SeedDatasetSmokeTests uses: without this, the Theory below silently
+        // runs zero invocations on a host where path resolution breaks, hiding drift instead of
+        // catching it.
+        var root = LocateEvalDatasetsDir();
+        root.Should().NotBeNull("'eval-datasets' must be reachable by walking up from the test bin dir");
+
+        var count = Directory.EnumerateFiles(root!, "*.yaml", SearchOption.AllDirectories).Count();
+        count.Should().BeGreaterThanOrEqualTo(9, "at least the 8 seed datasets plus owasp-agentic-top-10.yaml");
+    }
+
+    [Theory]
+    [MemberData(nameof(DatasetFiles))]
+    public async Task Every_case_parameter_key_is_recognized_by_its_metric(string path)
+    {
+        var metricsByKey = MetricsByKey.Value;
+        var loader = new YamlEvalDatasetLoader();
+        var dataset = await loader.LoadAsync(path, CancellationToken.None);
+
+        var problems = new List<string>();
+        foreach (var @case in dataset.Cases)
+        {
+            foreach (var spec in @case.MetricSpecs)
+            {
+                if (!metricsByKey.TryGetValue(spec.MetricKey, out var metric))
+                {
+                    problems.Add($"case '{@case.Id}': no registered metric with key '{spec.MetricKey}'.");
+                    continue;
+                }
+
+                var unrecognized = spec.Parameters.Keys
+                    .Where(k => !metric.RecognizedParameterKeys.Contains(k))
+                    .ToList();
+                if (unrecognized.Count > 0)
+                {
+                    problems.Add(
+                        $"case '{@case.Id}', metric '{spec.MetricKey}': unrecognized parameter key(s) " +
+                        $"{string.Join(", ", unrecognized.Select(k => $"'{k}'"))} " +
+                        $"(recognized: {string.Join(", ", metric.RecognizedParameterKeys)})");
+                }
+            }
+        }
+
+        problems.Should().BeEmpty(
+            $"{Path.GetFileName(path)} has case(s) whose MetricSpec.Parameters key the resolved " +
+            "metric doesn't read — almost certainly a typo that would otherwise silently no-op " +
+            "instead of failing the build (#423)");
+    }
+
+    private static string? LocateEvalDatasetsDir()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "eval-datasets");
+            if (Directory.Exists(candidate)) return candidate;
+            dir = dir.Parent;
+        }
+        return null;
+    }
+}

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Presentation.EvalRunner.Tests.csproj
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Presentation.EvalRunner.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../Presentation/Presentation.EvalRunner/Presentation.EvalRunner.csproj" />
+    <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Fixes #423: `MetricSpecExtensions`' accessors are deliberately fail-soft — a missing or unparseable parameter falls back to a default rather than throwing, so a bad case parameter can't take down an eval run. The cost: a typo'd key is architecturally indistinguishable from an absent one at score time. #410 previously fixed 6 eval cases that silently no-op'd or scored inverted for an unknown period, caught only when someone read metric source by hand — `Verdict.Warn` doesn't gate CI, so nothing automated caught it.
- `IEvalMetric` gains a `RecognizedParameterKeys` property (default: empty, via a default interface member — 14 of 20 metrics that read no parameters need no change). The 6 metrics that do read parameters declare their recognized keys, referencing named constants their own `ScoreAsync` already reads from.
- A new test validates every `eval-datasets/**/*.yaml` case's declared parameters against the resolved metric's declared set, composing the same DI graph the real EvalRunner host uses.
- Mutation-tested twice: removing a recognized key (`rubric`) correctly failed 7 seed files; disabling a workaround for the 10 OWASP metrics' keyed-only DI registration correctly failed the OWASP dataset with "no registered metric" — confirming that workaround is load-bearing.
- `/code-review`: clean, no findings. `/simplify` (4 parallel angles): two converging findings applied — extracted a shared DI-composition helper (was duplicated with a sibling test) and replaced a hand-rolled directory-walk with the project's existing `RepoRoot` helper (which itself replaced 5 duplicate copies after one broke test discovery in git worktrees, #293) — plus a minor `ImmutableHashSet<string>.Empty` cleanup.
- Filed 3 follow-ups for things found along the way, none folded into this PR: #436 (the 10 OWASP metrics are registered keyed-only in DI, invisible to `EvalRunner`'s normal lookup — unrelated to #423, found while building this fix's test), #437 (`RecognizedParameterKeys` currently has zero runtime consumers — only the repo's own checked-in datasets are protected, not a template consumer's own dataset; plus a structurally identical gap in `EvalCase.InvocationOverrides`).

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] New test: `Application.AI.Common.Tests` 2131/2131, `Infrastructure.AI.Evaluation.Tests` 304/304, `Presentation.EvalRunner.Tests` 34/34 (11 new) — all passed
- [x] Mutation-tested the core check (removed a recognized key) and the OWASP DI workaround (disabled it) — both correctly caused test failures, then restored
- [x] `/code-review` and `/simplify` both run; findings applied or filed as scoped follow-ups (#436, #437)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW