### PR TITLE
fix: register OWASP eval metrics non-keyed for EvalRunner discovery (#436)

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -272,28 +272,25 @@ public static class DependencyInjection
         // until AppConfig:AI:HarmonicMemory:Mode is raised above Off.
         services.AddHarmonicMemoryDependencies();
 
-        // OWASP Agentic Top-10 eval metrics — keyed by metric key for IEvalRunner resolution
-        services
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi01GoalHijackMetric>("owasp.asi01.goal_hijack")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi02ToolMisuseMetric>("owasp.asi02.tool_misuse")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi03PrivilegeAbuseMetric>("owasp.asi03.privilege_abuse")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi04SupplyChainMetric>("owasp.asi04.supply_chain")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi05CodeExecMetric>("owasp.asi05.code_exec")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi06MemoryPoisonMetric>("owasp.asi06.memory_poison")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi07InterAgentMetric>("owasp.asi07.inter_agent")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi08CascadingMetric>("owasp.asi08.cascading")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi09HumanTrustMetric>("owasp.asi09.human_trust")
-            .AddKeyedSingleton<IEvalMetric, OwaspAsi10RogueAgentMetric>("owasp.asi10.rogue_agent");
+        // OWASP Agentic Top-10 eval metrics. AddEvalMetric registers each non-keyed (so
+        // EvalRunner's IEnumerable<IEvalMetric> lookup can actually find it) as well as keyed by
+        // its own IEvalMetric.Key (#436 — these were previously keyed-only, invisible to
+        // EvalRunner, and every case in eval-datasets/owasp-agentic-top-10.yaml silently scored
+        // 0.0/Warn instead of ever running).
+        services.AddEvalMetric<OwaspAsi01GoalHijackMetric>("owasp.asi01.goal_hijack");
+        services.AddEvalMetric<OwaspAsi02ToolMisuseMetric>("owasp.asi02.tool_misuse");
+        services.AddEvalMetric<OwaspAsi03PrivilegeAbuseMetric>("owasp.asi03.privilege_abuse");
+        services.AddEvalMetric<OwaspAsi04SupplyChainMetric>("owasp.asi04.supply_chain");
+        services.AddEvalMetric<OwaspAsi05CodeExecMetric>("owasp.asi05.code_exec");
+        services.AddEvalMetric<OwaspAsi06MemoryPoisonMetric>("owasp.asi06.memory_poison");
+        services.AddEvalMetric<OwaspAsi07InterAgentMetric>("owasp.asi07.inter_agent");
+        services.AddEvalMetric<OwaspAsi08CascadingMetric>("owasp.asi08.cascading");
+        services.AddEvalMetric<OwaspAsi09HumanTrustMetric>("owasp.asi09.human_trust");
+        services.AddEvalMetric<OwaspAsi10RogueAgentMetric>("owasp.asi10.rogue_agent");
 
         // Governance-behaviour eval metric — grades the real per-invocation GovernanceTrace
         // (approval-bypass / observe-only / missing-escalation), independently of task outcome.
-        // EvalRunner builds its metric map from the non-keyed IEnumerable<IEvalMetric> — and keyed
-        // registrations are invisible to IEnumerable<T> — so this MUST be registered non-keyed to be
-        // discoverable by MetricKey at run time. The keyed alias mirrors the canonical AddMetric pattern.
-        services.AddSingleton<GovernanceBehaviorMetric>();
-        services.AddSingleton<IEvalMetric>(sp => sp.GetRequiredService<GovernanceBehaviorMetric>());
-        services.AddKeyedSingleton<IEvalMetric>(
-            "governance.behavior", (sp, _) => sp.GetRequiredService<GovernanceBehaviorMetric>());
+        services.AddEvalMetric<GovernanceBehaviorMetric>("governance.behavior");
 
         return services;
     }

--- a/src/Content/Application/Application.AI.Common/Extensions/EvalMetricRegistrationExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/EvalMetricRegistrationExtensions.cs
@@ -1,0 +1,48 @@
+using Application.AI.Common.Evaluation.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.AI.Common.Extensions;
+
+/// <summary>
+/// The one correct way to register an <see cref="IEvalMetric"/>: as a concrete singleton, as a
+/// plain (non-keyed) <see cref="IEvalMetric"/>, and as a keyed <see cref="IEvalMetric"/> under the
+/// same string the metric's own <see cref="IEvalMetric.Key"/> returns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>Infrastructure.AI.Evaluation.Runners.EvalRunner</c> (Infrastructure layer) builds its
+/// metric lookup table exclusively from the non-keyed <c>IEnumerable&lt;IEvalMetric&gt;</c>
+/// constructor parameter — a keyed-only registration is invisible to that enumerable and silently
+/// resolves to <c>EvalRunner</c>'s "No registered metric with key '...'" branch, which reports a
+/// non-gating <c>Verdict.Warn</c> rather than failing. This helper is the single place that
+/// guarantees both registration shapes stay in sync (#436, following the exact gap #410 caused one
+/// layer down at the parameter-key level).
+/// </para>
+/// <para>
+/// Lives in the Application layer, not Infrastructure, because some <c>IEvalMetric</c>
+/// implementations (e.g. the OWASP Agentic Top-10 metrics) are themselves registered from
+/// <c>Application.AI.Common.DependencyInjection</c>, which cannot reference the Infrastructure
+/// project that used to own the only copy of this pattern.
+/// </para>
+/// </remarks>
+public static class EvalMetricRegistrationExtensions
+{
+    /// <summary>
+    /// Registers <typeparamref name="TMetric"/> as a concrete singleton, a plain
+    /// <see cref="IEvalMetric"/>, and a keyed <see cref="IEvalMetric"/> under <paramref name="key"/>.
+    /// </summary>
+    /// <param name="key">
+    /// Must equal the registered metric's own <see cref="IEvalMetric.Key"/> — the keyed alias exists
+    /// only so a caller who already knows the key can resolve one metric without walking the whole
+    /// <c>IEnumerable&lt;IEvalMetric&gt;</c>; the non-keyed registration is what actually makes the
+    /// metric runnable.
+    /// </param>
+    public static IServiceCollection AddEvalMetric<TMetric>(this IServiceCollection services, string key)
+        where TMetric : class, IEvalMetric
+    {
+        services.AddSingleton<TMetric>();
+        services.AddSingleton<IEvalMetric>(sp => sp.GetRequiredService<TMetric>());
+        services.AddKeyedSingleton<IEvalMetric>(key, (sp, _) => sp.GetRequiredService<TMetric>());
+        return services;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Extensions/EvalMetricRegistrationExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/EvalMetricRegistrationExtensions.cs
@@ -30,19 +30,38 @@ public static class EvalMetricRegistrationExtensions
     /// <summary>
     /// Registers <typeparamref name="TMetric"/> as a concrete singleton, a plain
     /// <see cref="IEvalMetric"/>, and a keyed <see cref="IEvalMetric"/> under <paramref name="key"/>.
+    /// Calling this twice for the same <typeparamref name="TMetric"/> (e.g. a consumer that composes
+    /// <c>AddEvaluationDependencies</c> more than once) is a no-op the second time, not a duplicate
+    /// registration — <c>EvalRunner</c>'s constructor builds its lookup with <c>ToDictionary</c>,
+    /// which throws on a duplicate key.
     /// </summary>
     /// <param name="key">
     /// Must equal the registered metric's own <see cref="IEvalMetric.Key"/> — the keyed alias exists
     /// only so a caller who already knows the key can resolve one metric without walking the whole
     /// <c>IEnumerable&lt;IEvalMetric&gt;</c>; the non-keyed registration is what actually makes the
-    /// metric runnable.
+    /// metric runnable. Enforced at first resolution: a mismatch throws
+    /// <see cref="InvalidOperationException"/> rather than silently registering an alias under a
+    /// string no <c>MetricSpec</c> will ever reference.
     /// </param>
     public static IServiceCollection AddEvalMetric<TMetric>(this IServiceCollection services, string key)
         where TMetric : class, IEvalMetric
     {
+        if (services.Any(d => d.ServiceType == typeof(TMetric)))
+            return services;
+
         services.AddSingleton<TMetric>();
         services.AddSingleton<IEvalMetric>(sp => sp.GetRequiredService<TMetric>());
-        services.AddKeyedSingleton<IEvalMetric>(key, (sp, _) => sp.GetRequiredService<TMetric>());
+        services.AddKeyedSingleton<IEvalMetric>(key, (sp, _) =>
+        {
+            var metric = sp.GetRequiredService<TMetric>();
+            if (metric.Key != key)
+            {
+                throw new InvalidOperationException(
+                    $"AddEvalMetric<{typeof(TMetric).Name}> was registered under key '{key}', but the " +
+                    $"metric's own Key is '{metric.Key}'. The keyed alias must match IEvalMetric.Key exactly.");
+            }
+            return metric;
+        });
         return services;
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Evaluation.Interfaces;
 using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Extensions;
 using Infrastructure.AI.Evaluation.Invokers;
 using Infrastructure.AI.Evaluation.Judges;
 using Infrastructure.AI.Evaluation.Loaders;
@@ -44,26 +45,26 @@ public static class DependencyInjection
         // Metrics — register both as the concrete IEvalMetric set and as keyed services
         // so future EvalRunner / handler can resolve a specific metric by Key without
         // walking the whole enumeration.
-        AddMetric<ExactMatchMetric>(services, "exact_match");
-        AddMetric<RegexMatchMetric>(services, "regex_match");
-        AddMetric<ContainsAllMetric>(services, "contains_all");
-        AddMetric<DoesNotContainMetric>(services, "does_not_contain");
-        AddMetric<IsValidJsonMetric>(services, "is_valid_json");
-        AddMetric<LlmJudgeMetric>(services, "llm_judge");
+        services.AddEvalMetric<ExactMatchMetric>("exact_match");
+        services.AddEvalMetric<RegexMatchMetric>("regex_match");
+        services.AddEvalMetric<ContainsAllMetric>("contains_all");
+        services.AddEvalMetric<DoesNotContainMetric>("does_not_contain");
+        services.AddEvalMetric<IsValidJsonMetric>("is_valid_json");
+        services.AddEvalMetric<LlmJudgeMetric>("llm_judge");
 
         // Routing-accuracy: compares a router's predicted label to the case's gold label.
         // Paired with RouterEvalInvoker (below) and the router probes registered by the RAG
         // and routing infrastructure projects.
-        AddMetric<RoutingAccuracyMetric>(services, "routing_accuracy");
+        services.AddEvalMetric<RoutingAccuracyMetric>("routing_accuracy");
 
         // RAG metric pack: faithfulness, context precision/recall, answer relevance/correctness.
         // All share ILlmJudge + IPromptRegistry (registry registered separately via
         // AddPromptRegistry — the eval framework consumes it, does not own it).
-        AddMetric<FaithfulnessMetric>(services, "faithfulness");
-        AddMetric<ContextPrecisionMetric>(services, "context_precision");
-        AddMetric<ContextRecallMetric>(services, "context_recall");
-        AddMetric<AnswerRelevanceMetric>(services, "answer_relevance");
-        AddMetric<AnswerCorrectnessMetric>(services, "answer_correctness");
+        services.AddEvalMetric<FaithfulnessMetric>("faithfulness");
+        services.AddEvalMetric<ContextPrecisionMetric>("context_precision");
+        services.AddEvalMetric<ContextRecallMetric>("context_recall");
+        services.AddEvalMetric<AnswerRelevanceMetric>("answer_relevance");
+        services.AddEvalMetric<AnswerCorrectnessMetric>("answer_correctness");
 
         // Reporters
         services.AddSingleton<IEvalReporter, JsonEvalReporter>();
@@ -106,13 +107,5 @@ public static class DependencyInjection
         }
 
         return services;
-    }
-
-    private static void AddMetric<TMetric>(IServiceCollection services, string key)
-        where TMetric : class, IEvalMetric
-    {
-        services.AddSingleton<TMetric>();
-        services.AddSingleton<IEvalMetric>(sp => sp.GetRequiredService<TMetric>());
-        services.AddKeyedSingleton<IEvalMetric>(key, (sp, _) => sp.GetRequiredService<TMetric>());
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/DependencyInjectionTests.cs
@@ -267,6 +267,24 @@ public class DependencyInjectionTests
     }
 
     [Fact]
+    public void AddApplicationAIDependencies_RegistersOwaspMetrics_InNonKeyedMetricSet()
+    {
+        // The 10 OWASP metrics were registered keyed-only until #436, invisible to the same
+        // IEnumerable<IEvalMetric> enumeration EvalRunner resolves from — every case in
+        // eval-datasets/owasp-agentic-top-10.yaml silently scored 0.0/Warn instead of running.
+        var provider = CreateServicesWithAIDependencies().BuildServiceProvider();
+
+        var keys = provider.GetServices<IEvalMetric>().Select(m => m.Key);
+
+        keys.Should().Contain([
+            "owasp.asi01.goal_hijack", "owasp.asi02.tool_misuse", "owasp.asi03.privilege_abuse",
+            "owasp.asi04.supply_chain", "owasp.asi05.code_exec", "owasp.asi06.memory_poison",
+            "owasp.asi07.inter_agent", "owasp.asi08.cascading", "owasp.asi09.human_trust",
+            "owasp.asi10.rogue_agent",
+        ]);
+    }
+
+    [Fact]
     public void AddApplicationAIDependencies_ReturnsServiceCollection_ForChaining()
     {
         var services = new ServiceCollection();

--- a/src/Content/Tests/Application.AI.Common.Tests/Extensions/EvalMetricRegistrationExtensionsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Extensions/EvalMetricRegistrationExtensionsTests.cs
@@ -1,0 +1,74 @@
+using Application.AI.Common.Evaluation.Interfaces;
+using Application.AI.Common.Evaluation.Models;
+using Application.AI.Common.Extensions;
+using Domain.AI.Evaluation;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Extensions;
+
+/// <summary>
+/// Guards the two invariants a correctness-review pass on #436 flagged as advisory but worth
+/// covering: calling <see cref="EvalMetricRegistrationExtensions.AddEvalMetric{TMetric}"/> twice
+/// must not crash a consumer that composes the eval framework more than once, and a keyed alias
+/// that drifts from the metric's own <see cref="IEvalMetric.Key"/> must fail loudly rather than
+/// silently registering under a string no <c>MetricSpec</c> will ever reference.
+/// </summary>
+public sealed class EvalMetricRegistrationExtensionsTests
+{
+    [Fact]
+    public void AddEvalMetric_CalledTwiceForTheSameMetric_DoesNotThrow()
+    {
+        var services = new ServiceCollection();
+
+        services.AddEvalMetric<FakeMetric>(FakeMetric.RegisteredKey);
+        var act = () => services.AddEvalMetric<FakeMetric>(FakeMetric.RegisteredKey);
+
+        act.Should().NotThrow(
+            "a consumer that calls AddEvaluationDependencies (or AddApplicationAIDependencies) more " +
+            "than once must not end up with a duplicate key that crashes EvalRunner's ToDictionary");
+
+        using var provider = services.BuildServiceProvider();
+        provider.GetServices<IEvalMetric>().Should().ContainSingle(m => m.Key == FakeMetric.RegisteredKey,
+            "the second call must be a no-op, not a second registration");
+    }
+
+    [Fact]
+    public void AddEvalMetric_KeyedAliasMatchesMetricsOwnKey_ResolvesWithoutError()
+    {
+        var services = new ServiceCollection();
+        services.AddEvalMetric<FakeMetric>(FakeMetric.RegisteredKey);
+        using var provider = services.BuildServiceProvider();
+
+        var resolved = provider.GetRequiredKeyedService<IEvalMetric>(FakeMetric.RegisteredKey);
+
+        resolved.Key.Should().Be(FakeMetric.RegisteredKey);
+    }
+
+    [Fact]
+    public void AddEvalMetric_KeyedAliasDoesNotMatchMetricsOwnKey_ThrowsOnResolution()
+    {
+        var services = new ServiceCollection();
+        services.AddEvalMetric<FakeMetric>("mismatched.key");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredKeyedService<IEvalMetric>("mismatched.key");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*mismatched.key*{FakeMetric.RegisteredKey}*",
+                "a drifted keyed alias must fail loudly at resolution, not silently register under a " +
+                "string no MetricSpec will ever reference");
+    }
+
+    private sealed class FakeMetric : IEvalMetric
+    {
+        public const string RegisteredKey = "fake.metric";
+
+        public string Key => RegisteredKey;
+
+        public Task<MetricScore> ScoreAsync(
+            EvalCase @case, AgentInvocationResult output, MetricSpec spec, CancellationToken cancellationToken) =>
+            throw new NotImplementedException("Never invoked — these tests only exercise DI registration.");
+    }
+}

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerMetricDiscoveryTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/EvalRunnerMetricDiscoveryTests.cs
@@ -1,0 +1,44 @@
+using Application.AI.Common.Evaluation.Interfaces;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Presentation.EvalRunner.Tests.Composition;
+
+/// <summary>
+/// Pins that every registered <see cref="IEvalMetric"/> — the 10 OWASP Agentic Top-10 metrics
+/// specifically — resolves through the plain, non-keyed <c>IEnumerable&lt;IEvalMetric&gt;</c>
+/// enumeration (#436).
+/// </summary>
+/// <remarks>
+/// <see cref="Infrastructure.AI.Evaluation.Runners.EvalRunner"/> builds its metric lookup table
+/// exclusively from that non-keyed enumeration (<c>EvalRunner.cs</c>). Before #436, the 10 OWASP
+/// metrics were registered keyed-only, so every case in
+/// <c>eval-datasets/owasp-agentic-top-10.yaml</c> silently resolved to EvalRunner's
+/// "No registered metric with key '...'" branch and scored a non-gating <c>Verdict.Warn</c>
+/// instead of ever actually running. This test fails loudly the same way if that regresses.
+/// </remarks>
+public sealed class EvalRunnerMetricDiscoveryTests
+{
+    private static readonly string[] OwaspMetricKeys =
+    [
+        "owasp.asi01.goal_hijack", "owasp.asi02.tool_misuse", "owasp.asi03.privilege_abuse",
+        "owasp.asi04.supply_chain", "owasp.asi05.code_exec", "owasp.asi06.memory_poison",
+        "owasp.asi07.inter_agent", "owasp.asi08.cascading", "owasp.asi09.human_trust",
+        "owasp.asi10.rogue_agent",
+    ];
+
+    [Fact]
+    public void NonKeyed_IEvalMetric_enumeration_includes_every_owasp_metric()
+    {
+        var services = EvalRunnerTestComposition.BuildServices();
+        using var provider = services.BuildServiceProvider();
+
+        var resolvedKeys = provider.GetServices<IEvalMetric>().Select(m => m.Key).ToList();
+
+        resolvedKeys.Should().Contain(OwaspMetricKeys,
+            "the 10 OWASP metrics must be discoverable via the same non-keyed IEnumerable<IEvalMetric> " +
+            "EvalRunner resolves its metric map from — a keyed-only registration is invisible to it " +
+            "and silently no-ops every case that references the metric (#436)");
+    }
+}

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
@@ -23,19 +23,6 @@ namespace Presentation.EvalRunner.Tests.Composition;
 /// </remarks>
 public sealed class MetricSpecParameterKeyValidationTests
 {
-    // The 10 OWASP metrics are registered keyed-only in Application.AI.Common's own
-    // DependencyInjection.cs — see that file's remarks on EvalRunner building its metric map from
-    // the non-keyed IEnumerable<IEvalMetric>, which keyed-only registrations are invisible to (a
-    // separate, pre-existing gap, filed as #436 rather than folded into this fix). Resolved here by
-    // key explicitly so this test's own coverage doesn't silently exclude them.
-    private static readonly string[] KeyedOnlyMetricKeys =
-    [
-        "owasp.asi01.goal_hijack", "owasp.asi02.tool_misuse", "owasp.asi03.privilege_abuse",
-        "owasp.asi04.supply_chain", "owasp.asi05.code_exec", "owasp.asi06.memory_poison",
-        "owasp.asi07.inter_agent", "owasp.asi08.cascading", "owasp.asi09.human_trust",
-        "owasp.asi10.rogue_agent"
-    ];
-
     private static readonly Lazy<IReadOnlyDictionary<string, IEvalMetric>> MetricsByKey = new(BuildMetricsByKey);
 
     private static IReadOnlyDictionary<string, IEvalMetric> BuildMetricsByKey()
@@ -44,15 +31,14 @@ public sealed class MetricSpecParameterKeyValidationTests
         // plus AddEvaluationDependencies is what actually constructs every metric (including the
         // LlmJudge/RAG ones with real constructor dependencies) against an empty in-memory config,
         // proven to build cleanly under ValidateOnBuild by the sibling EvalRunnerValidateOnBuildTests.
+        // Every registered IEvalMetric — including the 10 OWASP metrics, previously keyed-only and
+        // invisible here until #436 — resolves through this single non-keyed enumeration; that is
+        // exactly the guarantee EvalRunnerMetricDiscoveryTests pins directly.
         var services = EvalRunnerTestComposition.BuildServices();
         using var provider = services.BuildServiceProvider();
 
-        var byKey = provider.GetServices<IEvalMetric>()
+        return provider.GetServices<IEvalMetric>()
             .ToDictionary(m => m.Key, StringComparer.OrdinalIgnoreCase);
-        foreach (var key in KeyedOnlyMetricKeys)
-            byKey[key] = provider.GetRequiredKeyedService<IEvalMetric>(key);
-
-        return byKey;
     }
 
     public static IEnumerable<object[]> DatasetFiles()


### PR DESCRIPTION
## Summary

The 10 OWASP Agentic Top-10 eval metrics were registered keyed-only, invisible to `EvalRunner`'s non-keyed `IEnumerable<IEvalMetric>` lookup. Every case in `eval-datasets/owasp-agentic-top-10.yaml` silently resolved to `EvalRunner`'s "No registered metric with key '...'" branch and scored a non-gating `Verdict.Warn` instead of ever actually running -- the exact same silent-no-op shape #410 caused one layer down, at the parameter-key level.

- Extracts the correct three-registration shape (concrete singleton + non-keyed `IEvalMetric` + keyed alias) -- already proven correct by `GovernanceBehaviorMetric`'s existing registration, four lines below the broken block -- into a shared `AddEvalMetric<TMetric>` extension in `Application.AI.Common/Extensions/`.
- The canonical helper that did this correctly (`AddMetric<TMetric>`) was private and lived in `Infrastructure.AI.Evaluation`, which `Application.AI.Common` cannot reference (Application must not depend on Infrastructure). Lifting the helper up to Application, with Infrastructure's 12 existing metric registrations now calling it, resolves the layering conflict without a duplicate copy.
- Registers all 10 OWASP metrics + `GovernanceBehaviorMetric` through the new helper.
- Retires the now-dead `KeyedOnlyMetricKeys` workaround in `MetricSpecParameterKeyValidationTests` -- it existed only to patch around this exact gap.

**Pre-flight check done before touching anything:** `EvalRunner` builds its lookup with `ToDictionary`, which throws on a duplicate key. Verified all 10 OWASP metric classes' own `Key` properties match their DI registration keys exactly and collide with nothing else registered, so switching them to non-keyed can't turn a silent zero-score into a startup crash.

## Review

A `/code-review` pass caught one real issue: the new extension file was first placed in `Evaluation/` instead of `Extensions/`, violating this repo's documented DI-extension-file convention (`clean-architecture.md`) that two existing sibling files (`HarmonicMemoryDependencyInjection.cs`, `SkillTrainingDependencyInjection.cs`) already follow. Moved, namespace and using directives fixed, rebuilt and re-tested clean.

A `/simplify` pass (done inline given the diff's small size) found one using-directive ordering issue from the same move, fixed. No reuse, efficiency, or altitude issues.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` -- 0 errors
- [x] `Application.AI.Common.Tests` -- 83/83 (includes new `AddApplicationAIDependencies_RegistersOwaspMetrics_InNonKeyedMetricSet`)
- [x] `Presentation.EvalRunner.Tests` Composition suite -- 14/14 (includes new `EvalRunnerMetricDiscoveryTests`)
- [x] `Infrastructure.AI.Evaluation.Tests` -- 304/304 (full suite, unrelated to the change but exercises the shared helper's other 12 callers)
- [x] `Presentation.Common.Tests` composition/config/hosting -- 76/76 (full DI graph build)
- [x] `Presentation.ExecutionApi.Tests` evaluation-enablement -- 4/4
- [x] Both new regression tests mutation-tested: reverted one metric to keyed-only, confirmed the new test fails with the exact expected message, reverted back

Closes #436

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW