### PR TITLE
fix: close the uncaught-exception gap in write_file/document_ingest (#428)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -87,7 +87,9 @@ public static partial class DependencyInjection
         // Takes the scope factory (not IMediator): the mediator pipeline resolves
         // scoped services, so the singleton tool dispatches inside a fresh scope.
         services.AddKeyedSingleton<ITool>(DocumentIngestTool.ToolName, (sp, _) =>
-            new DocumentIngestTool(sp.GetRequiredService<IServiceScopeFactory>()));
+            new DocumentIngestTool(
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<ILogger<DocumentIngestTool>>()));
 
         // Echo tools — deterministic tools for E2E testing pipeline verification
         services.AddKeyedSingleton<ITool>(EchoLookupTool.ToolName, (_, _) => new EchoLookupTool());

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -148,41 +148,29 @@ public sealed class DocumentIngestTool : ITool
             CollectionName = collection
         };
 
-        try
-        {
-            // Scope creation, IMediator resolution, and dispatch all live inside this one try/catch
-            // (#428) — mirrors WorkspaceCommandRunner.RunAsync/IacSandboxRunner.RunAsync's shape.
-            // The MediatR pipeline resolves scoped services (IAgentExecutionContext et al.), which a
-            // singleton must never pull from the root, so the dispatch still runs inside a fresh scope.
-            // Scoped separately from the caller's UriFormatException/ArgumentException handling above
-            // — those guard parameter validation, not dispatch, and must keep their own messages.
-            await using var scope = _scopeFactory.CreateAsyncScope();
-            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-
-            var result = await mediator.Send(command, cancellationToken);
-
-            if (!result.Success)
-                return ToolResult.Fail($"Ingestion failed: {result.Error}");
-
-            var response = new
+        // Scoped separately from the caller's UriFormatException/ArgumentException handling above —
+        // those guard parameter validation, not dispatch, and must keep their own messages.
+        return await MediatorDispatchRunner.RunAsync(
+            _scopeFactory,
+            async (mediator, ct) =>
             {
-                jobId = result.JobId,
-                chunksProduced = result.ChunksProduced,
-                tokensEmbedded = result.TokensEmbedded,
-                durationMs = result.Duration.TotalMilliseconds
-            };
+                var result = await mediator.Send(command, ct);
+                if (!result.Success)
+                    return ToolResult.Fail($"Ingestion failed: {result.Error}");
 
-            return ToolResult.Ok(JsonSerializer.Serialize(response, JsonOptions));
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "document_ingest dispatch failed for {DocumentUri}.", uri);
-            return ToolResult.Fail($"Ingestion failed: {ex.GetType().Name}.");
-        }
+                var response = new
+                {
+                    jobId = result.JobId,
+                    chunksProduced = result.ChunksProduced,
+                    tokensEmbedded = result.TokensEmbedded,
+                    durationMs = result.Duration.TotalMilliseconds
+                };
+                return ToolResult.Ok(JsonSerializer.Serialize(response, JsonOptions));
+            },
+            _logger,
+            ToolName,
+            failureContext: uri.ToString(),
+            cancellationToken);
     }
 
     private static string GetRequiredString(IReadOnlyDictionary<string, object?> parameters, string key)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -169,10 +169,14 @@ public sealed class DocumentIngestTool : ITool
             },
             _logger,
             ToolName,
-            // GetLeftPart(UriPartial.Path) drops the query string — a document URI can legitimately be
-            // a SAS-signed blob URL (?sv=...&sig=...), and this failure path is reached on exactly the
-            // input this tool is expected to reject, so the credential must never land in an error log.
-            failureContext: uri.GetLeftPart(UriPartial.Path),
+            // Scheme+Host+Port+Path only — a document URI can legitimately be a SAS-signed blob URL
+            // (?sv=...&sig=...) or carry basic-auth userinfo (https://user:pass@host/...), and this
+            // failure path is reached on exactly the input this tool is expected to reject, so no
+            // credential-bearing component may land in an error log. GetLeftPart(UriPartial.Path)
+            // alone is NOT sufficient: it drops the query but keeps userinfo verbatim.
+            failureContext: uri.GetComponents(
+                UriComponents.Scheme | UriComponents.Host | UriComponents.Port | UriComponents.Path,
+                UriFormat.UriEscaped),
             cancellationToken);
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -7,6 +7,7 @@ using Domain.AI.Models;
 using Domain.AI.Sandbox;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Tools;
 
@@ -20,7 +21,9 @@ namespace Infrastructure.AI.Tools;
 /// Register via keyed DI:
 /// <code>
 /// services.AddKeyedSingleton&lt;ITool&gt;("document_ingest", (sp, _) =&gt;
-///     new DocumentIngestTool(sp.GetRequiredService&lt;IServiceScopeFactory&gt;()));
+///     new DocumentIngestTool(
+///         sp.GetRequiredService&lt;IServiceScopeFactory&gt;(),
+///         sp.GetRequiredService&lt;ILogger&lt;DocumentIngestTool&gt;&gt;()));
 /// </code>
 /// </para>
 /// <para>
@@ -44,15 +47,23 @@ public sealed class DocumentIngestTool : ITool
     private static readonly IReadOnlyList<string> Operations = ["ingest"];
 
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<DocumentIngestTool> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DocumentIngestTool"/> class.
     /// </summary>
     /// <param name="scopeFactory">Scope factory used to resolve <see cref="IMediator"/> per ingestion dispatch.</param>
-    public DocumentIngestTool(IServiceScopeFactory scopeFactory)
+    /// <param name="logger">
+    /// Logs a scope-creation or dispatch failure before it is mapped to a failed
+    /// <see cref="ToolResult"/> (#428) — the same shape <c>WorkspaceCommandRunner.RunAsync</c> and
+    /// <c>IacSandboxRunner.RunAsync</c> already log on their own dispatch paths.
+    /// </param>
+    public DocumentIngestTool(IServiceScopeFactory scopeFactory, ILogger<DocumentIngestTool> logger)
     {
         ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(logger);
         _scopeFactory = scopeFactory;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -137,25 +148,41 @@ public sealed class DocumentIngestTool : ITool
             CollectionName = collection
         };
 
-        // Dispatch inside a fresh scope: the MediatR pipeline resolves scoped services
-        // (IAgentExecutionContext et al.), which a singleton must never pull from the root.
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-
-        var result = await mediator.Send(command, cancellationToken);
-
-        if (!result.Success)
-            return ToolResult.Fail($"Ingestion failed: {result.Error}");
-
-        var response = new
+        try
         {
-            jobId = result.JobId,
-            chunksProduced = result.ChunksProduced,
-            tokensEmbedded = result.TokensEmbedded,
-            durationMs = result.Duration.TotalMilliseconds
-        };
+            // Scope creation, IMediator resolution, and dispatch all live inside this one try/catch
+            // (#428) — mirrors WorkspaceCommandRunner.RunAsync/IacSandboxRunner.RunAsync's shape.
+            // The MediatR pipeline resolves scoped services (IAgentExecutionContext et al.), which a
+            // singleton must never pull from the root, so the dispatch still runs inside a fresh scope.
+            // Scoped separately from the caller's UriFormatException/ArgumentException handling above
+            // — those guard parameter validation, not dispatch, and must keep their own messages.
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
 
-        return ToolResult.Ok(JsonSerializer.Serialize(response, JsonOptions));
+            var result = await mediator.Send(command, cancellationToken);
+
+            if (!result.Success)
+                return ToolResult.Fail($"Ingestion failed: {result.Error}");
+
+            var response = new
+            {
+                jobId = result.JobId,
+                chunksProduced = result.ChunksProduced,
+                tokensEmbedded = result.TokensEmbedded,
+                durationMs = result.Duration.TotalMilliseconds
+            };
+
+            return ToolResult.Ok(JsonSerializer.Serialize(response, JsonOptions));
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "document_ingest dispatch failed for {DocumentUri}.", uri);
+            return ToolResult.Fail($"Ingestion failed: {ex.GetType().Name}.");
+        }
     }
 
     private static string GetRequiredString(IReadOnlyDictionary<string, object?> parameters, string key)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -169,7 +169,10 @@ public sealed class DocumentIngestTool : ITool
             },
             _logger,
             ToolName,
-            failureContext: uri.ToString(),
+            // GetLeftPart(UriPartial.Path) drops the query string — a document URI can legitimately be
+            // a SAS-signed blob URL (?sv=...&sig=...), and this failure path is reached on exactly the
+            // input this tool is expected to reject, so the credential must never land in an error log.
+            failureContext: uri.GetLeftPart(UriPartial.Path),
             cancellationToken);
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
@@ -54,8 +54,12 @@ internal static class MediatorDispatchRunner
             var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
             return await dispatch(mediator, cancellationToken).ConfigureAwait(false);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Only rethrow when it's genuinely the caller's own token — an internal timeout unrelated
+            // to the caller (e.g. HttpClient's own timeout mid-fetch) also throws OperationCanceledException
+            // but must be mapped to a failure below, not escape ExecuteAsync uncaught (#428's own gap,
+            // mirroring the caller-token guard RestrictedSearchTool.cs already uses for the same reason).
             throw;
         }
         catch (Exception ex)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
@@ -52,15 +52,21 @@ internal static class MediatorDispatchRunner
         string failureContext,
         CancellationToken cancellationToken)
     {
-        // Scope creation lives outside the try/finally pair below so an already-obtained successful
+        // `scope` stays nullable and unassigned until CreateAsyncScope() itself succeeds, so a
+        // creation failure (e.g. an already-disposed root provider during shutdown) is caught by the
+        // same catch blocks below instead of escaping uncaught — closing the one gap #428 left open,
+        // per correctness-review on PR #442. The catch blocks each check for null before disposing, so
+        // a creation failure never attempts to dispose a scope that was never created. Disposal itself
+        // still happens outside the try, in DisposeScopeAsync, so an already-obtained successful
         // `result` is never discarded: disposing the scope AFTER the dispatch has committed its write
-        // can itself throw, and if that were inside the same try/catch that maps dispatch failures,
-        // a genuinely successful ChangeProposal submission or ingest would be reported to the model as
+        // can itself throw, and if that were inside the same try/catch that maps dispatch failures, a
+        // genuinely successful ChangeProposal submission or ingest would be reported to the model as
         // "dispatch failed" — inviting a retry of work that already landed.
-        var scope = scopeFactory.CreateAsyncScope();
+        AsyncServiceScope? scope = null;
         try
         {
-            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            scope = scopeFactory.CreateAsyncScope();
+            var mediator = scope.Value.ServiceProvider.GetRequiredService<IMediator>();
             var result = await dispatch(mediator, cancellationToken).ConfigureAwait(false);
             await DisposeScopeAsync(scope, logger, toolName).ConfigureAwait(false);
             return result;
@@ -83,15 +89,20 @@ internal static class MediatorDispatchRunner
     }
 
     /// <summary>
-    /// Disposes <paramref name="scope"/>, logging (not throwing) if disposal itself fails. A disposal
-    /// failure is a resource-cleanup problem worth surfacing in logs, but must never overwrite a
-    /// dispatch outcome — success or failure — that was already determined before disposal ran.
+    /// Disposes <paramref name="scope"/> if it was ever created, logging (not throwing) if disposal
+    /// itself fails. A disposal failure is a resource-cleanup problem worth surfacing in logs, but
+    /// must never overwrite a dispatch outcome — success or failure — that was already determined
+    /// before disposal ran. A <see langword="null"/> scope (creation itself failed) is a no-op: there
+    /// is nothing to dispose.
     /// </summary>
-    private static async Task DisposeScopeAsync(AsyncServiceScope scope, ILogger logger, string toolName)
+    private static async Task DisposeScopeAsync(AsyncServiceScope? scope, ILogger logger, string toolName)
     {
+        if (scope is null)
+            return;
+
         try
         {
-            await scope.DisposeAsync().ConfigureAwait(false);
+            await scope.Value.DisposeAsync().ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
@@ -33,7 +33,11 @@ internal static class MediatorDispatchRunner
     /// <param name="dispatch">Builds the command and sends it via the scoped <see cref="IMediator"/>.</param>
     /// <param name="logger">Logs a scope-creation, resolution, or dispatch failure before it is mapped.</param>
     /// <param name="toolName">Tool name for the log template and the failure message prefix.</param>
-    /// <param name="failureContext">Free-form context (e.g. a path or URI) included in the log entry.</param>
+    /// <param name="failureContext">
+    /// Free-form context (e.g. a path or URI) included in the log entry <strong>verbatim</strong> —
+    /// callers own scrubbing anything credential-bearing (query strings, userinfo) out of this value
+    /// before passing it; this method does not inspect or redact it.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
     /// <paramref name="dispatch"/>'s result, or a failed <see cref="ToolResult"/> whose message is
@@ -48,11 +52,18 @@ internal static class MediatorDispatchRunner
         string failureContext,
         CancellationToken cancellationToken)
     {
+        // Scope creation lives outside the try/finally pair below so an already-obtained successful
+        // `result` is never discarded: disposing the scope AFTER the dispatch has committed its write
+        // can itself throw, and if that were inside the same try/catch that maps dispatch failures,
+        // a genuinely successful ChangeProposal submission or ingest would be reported to the model as
+        // "dispatch failed" — inviting a retry of work that already landed.
+        var scope = scopeFactory.CreateAsyncScope();
         try
         {
-            await using var scope = scopeFactory.CreateAsyncScope();
             var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-            return await dispatch(mediator, cancellationToken).ConfigureAwait(false);
+            var result = await dispatch(mediator, cancellationToken).ConfigureAwait(false);
+            await DisposeScopeAsync(scope, logger, toolName).ConfigureAwait(false);
+            return result;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -60,12 +71,31 @@ internal static class MediatorDispatchRunner
             // to the caller (e.g. HttpClient's own timeout mid-fetch) also throws OperationCanceledException
             // but must be mapped to a failure below, not escape ExecuteAsync uncaught (#428's own gap,
             // mirroring the caller-token guard RestrictedSearchTool.cs already uses for the same reason).
+            await DisposeScopeAsync(scope, logger, toolName).ConfigureAwait(false);
             throw;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "{ToolName} dispatch failed for {FailureContext}.", toolName, failureContext);
+            await DisposeScopeAsync(scope, logger, toolName).ConfigureAwait(false);
             return ToolResult.Fail($"{toolName} dispatch failed: {ex.GetType().Name}.");
+        }
+    }
+
+    /// <summary>
+    /// Disposes <paramref name="scope"/>, logging (not throwing) if disposal itself fails. A disposal
+    /// failure is a resource-cleanup problem worth surfacing in logs, but must never overwrite a
+    /// dispatch outcome — success or failure — that was already determined before disposal ran.
+    /// </summary>
+    private static async Task DisposeScopeAsync(AsyncServiceScope scope, ILogger logger, string toolName)
+    {
+        try
+        {
+            await scope.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "{ToolName} DI scope disposal failed after dispatch completed.", toolName);
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/MediatorDispatchRunner.cs
@@ -1,0 +1,67 @@
+using Domain.AI.Models;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Shared dispatch wrapper for <c>ITool</c> implementations that submit a MediatR command from a
+/// fresh DI scope (as opposed to <c>WorkspaceCommandRunner</c>/<c>IacSandboxRunner</c>, which
+/// dispatch to a keyed-scoped <c>ISandboxExecutor</c> instead). Resolves <see cref="IMediator"/>
+/// from a new scope, runs the caller's dispatch delegate, and maps any exception to a failed
+/// <see cref="ToolResult"/> instead of letting it escape <c>ITool.ExecuteAsync</c> uncaught.
+/// </summary>
+/// <remarks>
+/// Extracted from <c>WorkspaceWriteFileTool</c> and <c>DocumentIngestTool</c> (#428): both tools
+/// independently duplicated this exact scope-creation/resolve/dispatch/catch shape after fixing the
+/// uncaught-exception gap #421 (<c>IacSandboxRunner</c>) and #426 (<c>WorkspaceCommandRunner</c>)
+/// already closed on the sandbox-dispatch path — the same "fix one instance, stop" defect shape
+/// CLAUDE.md's own Common Mistakes section records for that history.
+/// </remarks>
+internal static class MediatorDispatchRunner
+{
+    /// <summary>
+    /// Runs <paramref name="dispatch"/> against an <see cref="IMediator"/> resolved from a fresh scope.
+    /// </summary>
+    /// <param name="scopeFactory">
+    /// The caller's <see cref="IServiceScopeFactory"/>. A fresh scope is created per call so the
+    /// caller's own singleton tool never captures scope-bound state, and so the MediatR pipeline can
+    /// resolve scoped services (e.g. <c>IAgentExecutionContext</c>) that a root-bound mediator would
+    /// reject as a captive dependency.
+    /// </param>
+    /// <param name="dispatch">Builds the command and sends it via the scoped <see cref="IMediator"/>.</param>
+    /// <param name="logger">Logs a scope-creation, resolution, or dispatch failure before it is mapped.</param>
+    /// <param name="toolName">Tool name for the log template and the failure message prefix.</param>
+    /// <param name="failureContext">Free-form context (e.g. a path or URI) included in the log entry.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// <paramref name="dispatch"/>'s result, or a failed <see cref="ToolResult"/> whose message is
+    /// scrubbed to the exception's type name — never <c>ex.Message</c>, which can carry raw exception
+    /// text (connection strings, stack detail) that must not reach the model or an audit log verbatim.
+    /// </returns>
+    public static async Task<ToolResult> RunAsync(
+        IServiceScopeFactory scopeFactory,
+        Func<IMediator, CancellationToken, Task<ToolResult>> dispatch,
+        ILogger logger,
+        string toolName,
+        string failureContext,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var scope = scopeFactory.CreateAsyncScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            return await dispatch(mediator, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "{ToolName} dispatch failed for {FailureContext}.", toolName, failureContext);
+            return ToolResult.Fail($"{toolName} dispatch failed: {ex.GetType().Name}.");
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/DependencyInjection.WorkspaceTools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/DependencyInjection.WorkspaceTools.cs
@@ -67,7 +67,8 @@ public static class WorkspaceDependencyInjection
         services.AddKeyedSingleton<ITool>(WorkspaceWriteFileTool.ToolName, (sp, _) =>
             new WorkspaceWriteFileTool(
                 sp.GetRequiredService<IWorkspaceContextAccessor>(),
-                sp.GetRequiredService<IServiceScopeFactory>()));
+                sp.GetRequiredService<IServiceScopeFactory>(),
+                sp.GetRequiredService<ILogger<WorkspaceWriteFileTool>>()));
 
         services.AddKeyedSingleton<ITool>(WorkspaceRunTestsTool.ToolName, (sp, _) =>
             new WorkspaceRunTestsTool(

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
@@ -9,6 +9,7 @@ using Domain.AI.Sandbox;
 using Domain.AI.SkillTraining;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Tools.Workspace;
 
@@ -43,6 +44,7 @@ public sealed class WorkspaceWriteFileTool : ITool
 
     private readonly IWorkspaceContextAccessor _workspace;
     private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<WorkspaceWriteFileTool> _logger;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="WorkspaceWriteFileTool"/> class.
@@ -52,12 +54,22 @@ public sealed class WorkspaceWriteFileTool : ITool
     /// The tool is a keyed SINGLETON, but a mediator dispatch constructs pipeline behaviors that
     /// ctor-inject the SCOPED <c>IAgentExecutionContext</c>, so the dispatch must run inside a
     /// created scope rather than against a root-bound mediator.</param>
-    public WorkspaceWriteFileTool(IWorkspaceContextAccessor workspace, IServiceScopeFactory scopeFactory)
+    /// <param name="logger">
+    /// Logs a scope-creation or dispatch failure before it is mapped to a failed
+    /// <see cref="ToolResult"/> (#428) — the same shape <see cref="WorkspaceCommandRunner.RunAsync"/>
+    /// and <c>IacSandboxRunner.RunAsync</c> already log on their own dispatch paths.
+    /// </param>
+    public WorkspaceWriteFileTool(
+        IWorkspaceContextAccessor workspace,
+        IServiceScopeFactory scopeFactory,
+        ILogger<WorkspaceWriteFileTool> logger)
     {
         ArgumentNullException.ThrowIfNull(workspace);
         ArgumentNullException.ThrowIfNull(scopeFactory);
+        ArgumentNullException.ThrowIfNull(logger);
         _workspace = workspace;
         _scopeFactory = scopeFactory;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -166,23 +178,37 @@ public sealed class WorkspaceWriteFileTool : ITool
             IsStateChange = true
         };
 
-        // Dispatch inside a fresh scope: the MediatR pipeline resolves scoped services
-        // (IAgentExecutionContext et al.), which a singleton must never pull from the root.
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-
-        var result = await mediator.Send(command, cancellationToken);
-        if (!result.IsSuccess)
+        try
         {
-            var reason = result.Errors.Count > 0
-                ? string.Join("; ", result.Errors)
-                : "unknown error";
-            return ToolResult.Fail($"ChangeProposal submission failed: {reason}");
-        }
+            // Scope creation, IMediator resolution, and dispatch all live inside this one try/catch
+            // (#428) — mirrors WorkspaceCommandRunner.RunAsync/IacSandboxRunner.RunAsync's shape.
+            // The MediatR pipeline resolves scoped services (IAgentExecutionContext et al.), which a
+            // singleton must never pull from the root, so the dispatch still runs inside a fresh scope.
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
 
-        var proposal = result.Value!;
-        return ToolResult.Ok(
-            $"ChangeProposal submitted: id={proposal.Id} status={proposal.Status} target={proposal.Target.DisplayName} path={relativePath}");
+            var result = await mediator.Send(command, cancellationToken);
+            if (!result.IsSuccess)
+            {
+                var reason = result.Errors.Count > 0
+                    ? string.Join("; ", result.Errors)
+                    : "unknown error";
+                return ToolResult.Fail($"ChangeProposal submission failed: {reason}");
+            }
+
+            var proposal = result.Value!;
+            return ToolResult.Ok(
+                $"ChangeProposal submitted: id={proposal.Id} status={proposal.Status} target={proposal.Target.DisplayName} path={relativePath}");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "write_file dispatch failed for {RelativePath}.", relativePath);
+            return ToolResult.Fail($"ChangeProposal submission failed: {ex.GetType().Name}.");
+        }
     }
 
     private static BlastRadius ParseBlastRadius(IReadOnlyDictionary<string, object?> parameters)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
@@ -7,6 +7,7 @@ using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
 using Domain.AI.Sandbox;
 using Domain.AI.SkillTraining;
+using Domain.AI.Workspace;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -55,9 +56,8 @@ public sealed class WorkspaceWriteFileTool : ITool
     /// ctor-inject the SCOPED <c>IAgentExecutionContext</c>, so the dispatch must run inside a
     /// created scope rather than against a root-bound mediator.</param>
     /// <param name="logger">
-    /// Logs a scope-creation or dispatch failure before it is mapped to a failed
-    /// <see cref="ToolResult"/> (#428) — the same shape <see cref="WorkspaceCommandRunner.RunAsync"/>
-    /// and <c>IacSandboxRunner.RunAsync</c> already log on their own dispatch paths.
+    /// Passed to <see cref="MediatorDispatchRunner"/>, which logs a scope-creation or dispatch
+    /// failure before mapping it to a failed <see cref="ToolResult"/> (#428).
     /// </param>
     public WorkspaceWriteFileTool(
         IWorkspaceContextAccessor workspace,
@@ -132,24 +132,65 @@ public sealed class WorkspaceWriteFileTool : ITool
         if (!parameters.TryGetValue("summary", out var summaryValue) || summaryValue is not string summary || string.IsNullOrWhiteSpace(summary))
             return ToolResult.Fail("Required parameter 'summary' is missing or empty. Summaries surface in approval prompts and audit.");
 
-        // Resolve+validate the path. The proposal records the *relative* form so the
-        // applier can re-resolve against whatever working copy it operates on — the
-        // sandbox-injected absolute path is not portable across machines/replays.
-        string relativePath;
+        var (relativePath, pathFailure) = ResolveRelativePath(workspace, path);
+        if (pathFailure is not null)
+            return pathFailure;
+
+        var command = BuildCommand(workspace, relativePath!, content, summary, parameters);
+
+        return await MediatorDispatchRunner.RunAsync(
+            _scopeFactory,
+            async (mediator, ct) =>
+            {
+                var result = await mediator.Send(command, ct);
+                if (!result.IsSuccess)
+                {
+                    var reason = result.Errors.Count > 0
+                        ? string.Join("; ", result.Errors)
+                        : "unknown error";
+                    return ToolResult.Fail($"ChangeProposal submission failed: {reason}");
+                }
+
+                var proposal = result.Value!;
+                return ToolResult.Ok(
+                    $"ChangeProposal submitted: id={proposal.Id} status={proposal.Status} target={proposal.Target.DisplayName} path={relativePath}");
+            },
+            _logger,
+            ToolName,
+            failureContext: relativePath,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Resolves+validates <paramref name="path"/> against <paramref name="workspace"/>. The proposal
+    /// records the *relative* form so the applier can re-resolve against whatever working copy it
+    /// operates on — the sandbox-injected absolute path is not portable across machines/replays.
+    /// </summary>
+    private static (string? RelativePath, ToolResult? Failure) ResolveRelativePath(
+        WorkspaceContext workspace, string path)
+    {
         try
         {
             var fullPath = WorkspacePathResolver.Resolve(workspace, path);
-            relativePath = WorkspacePathResolver.ToRelative(workspace, fullPath);
+            return (WorkspacePathResolver.ToRelative(workspace, fullPath), null);
         }
         catch (UnauthorizedAccessException)
         {
-            return ToolResult.Fail("Access denied: path is outside the workspace.");
+            return (null, ToolResult.Fail("Access denied: path is outside the workspace."));
         }
         catch (ArgumentException)
         {
-            return ToolResult.Fail("Invalid path.");
+            return (null, ToolResult.Fail("Invalid path."));
         }
+    }
 
+    private static SubmitChangeProposalCommand BuildCommand(
+        WorkspaceContext workspace,
+        string relativePath,
+        string content,
+        string summary,
+        IReadOnlyDictionary<string, object?> parameters)
+    {
         var target = new GitRepoTarget(
             workspace.RepoUrl,
             workspace.Branch,
@@ -168,7 +209,7 @@ public sealed class WorkspaceWriteFileTool : ITool
             ? sks
             : null;
 
-        var command = new SubmitChangeProposalCommand
+        return new SubmitChangeProposalCommand
         {
             Target = target,
             Diff = [edit],
@@ -177,38 +218,6 @@ public sealed class WorkspaceWriteFileTool : ITool
             SkillKey = skillKey,
             IsStateChange = true
         };
-
-        try
-        {
-            // Scope creation, IMediator resolution, and dispatch all live inside this one try/catch
-            // (#428) — mirrors WorkspaceCommandRunner.RunAsync/IacSandboxRunner.RunAsync's shape.
-            // The MediatR pipeline resolves scoped services (IAgentExecutionContext et al.), which a
-            // singleton must never pull from the root, so the dispatch still runs inside a fresh scope.
-            await using var scope = _scopeFactory.CreateAsyncScope();
-            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-
-            var result = await mediator.Send(command, cancellationToken);
-            if (!result.IsSuccess)
-            {
-                var reason = result.Errors.Count > 0
-                    ? string.Join("; ", result.Errors)
-                    : "unknown error";
-                return ToolResult.Fail($"ChangeProposal submission failed: {reason}");
-            }
-
-            var proposal = result.Value!;
-            return ToolResult.Ok(
-                $"ChangeProposal submitted: id={proposal.Id} status={proposal.Status} target={proposal.Target.DisplayName} path={relativePath}");
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "write_file dispatch failed for {RelativePath}.", relativePath);
-            return ToolResult.Fail($"ChangeProposal submission failed: {ex.GetType().Name}.");
-        }
     }
 
     private static BlastRadius ParseBlastRadius(IReadOnlyDictionary<string, object?> parameters)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceWriteFileTool.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.CQRS.Changes.SubmitChangeProposal;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Workspace;
+using Domain.Common;
 using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.Common.Config.AI.Governance;
@@ -132,11 +133,12 @@ public sealed class WorkspaceWriteFileTool : ITool
         if (!parameters.TryGetValue("summary", out var summaryValue) || summaryValue is not string summary || string.IsNullOrWhiteSpace(summary))
             return ToolResult.Fail("Required parameter 'summary' is missing or empty. Summaries surface in approval prompts and audit.");
 
-        var (relativePath, pathFailure) = ResolveRelativePath(workspace, path);
-        if (pathFailure is not null)
-            return pathFailure;
+        var pathResult = ResolveRelativePath(workspace, path);
+        if (!pathResult.IsSuccess)
+            return ToolResult.Fail(pathResult.Errors.Count > 0 ? pathResult.Errors[0] : "Invalid path.");
 
-        var command = BuildCommand(workspace, relativePath!, content, summary, parameters);
+        var relativePath = pathResult.Value!;
+        var command = BuildCommand(workspace, relativePath, content, summary, parameters);
 
         return await MediatorDispatchRunner.RunAsync(
             _scopeFactory,
@@ -166,21 +168,20 @@ public sealed class WorkspaceWriteFileTool : ITool
     /// records the *relative* form so the applier can re-resolve against whatever working copy it
     /// operates on — the sandbox-injected absolute path is not portable across machines/replays.
     /// </summary>
-    private static (string? RelativePath, ToolResult? Failure) ResolveRelativePath(
-        WorkspaceContext workspace, string path)
+    private static Result<string> ResolveRelativePath(WorkspaceContext workspace, string path)
     {
         try
         {
             var fullPath = WorkspacePathResolver.Resolve(workspace, path);
-            return (WorkspacePathResolver.ToRelative(workspace, fullPath), null);
+            return Result<string>.Success(WorkspacePathResolver.ToRelative(workspace, fullPath));
         }
         catch (UnauthorizedAccessException)
         {
-            return (null, ToolResult.Fail("Access denied: path is outside the workspace."));
+            return Result<string>.Fail("Access denied: path is outside the workspace.");
         }
         catch (ArgumentException)
         {
-            return (null, ToolResult.Fail("Invalid path."));
+            return Result<string>.Fail("Invalid path.");
         }
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Governance.Tests/Policies/DefaultPolicyCapabilityAlignmentTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Governance.Tests/Policies/DefaultPolicyCapabilityAlignmentTests.cs
@@ -6,6 +6,7 @@ using Infrastructure.AI.Tools.Iac;
 using Infrastructure.AI.Tools.Workspace;
 using Infrastructure.AI.Tools;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Tests.Common;
@@ -50,7 +51,8 @@ public sealed class DefaultPolicyCapabilityAlignmentTests
             Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>())).RequiredCapabilities,
         [WorkspaceWriteFileTool.ToolName] = new WorkspaceWriteFileTool(
             Mock.Of<Application.AI.Common.Interfaces.Workspace.IWorkspaceContextAccessor>(),
-            Mock.Of<IServiceScopeFactory>()).RequiredCapabilities,
+            Mock.Of<IServiceScopeFactory>(),
+            Mock.Of<ILogger<WorkspaceWriteFileTool>>()).RequiredCapabilities,
         [FileSystemTool.ToolName] = new FileSystemTool(
             Mock.Of<IFileSystemService>()).RequiredCapabilities,
         [WorkspaceReadFileTool.ToolName] = new WorkspaceReadFileTool(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Support/ThrowingMediator.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Support/ThrowingMediator.cs
@@ -1,0 +1,36 @@
+using MediatR;
+
+namespace Infrastructure.AI.Tests.Support;
+
+/// <summary>
+/// Minimal <see cref="IMediator"/> whose <c>Send</c> always throws — models a downstream MediatR
+/// pipeline failure (e.g. a handler-level dependency outage) for tools that must map a dispatch
+/// exception to a failed <c>ToolResult</c> rather than let it escape <c>ITool.ExecuteAsync</c>
+/// uncaught (#428). Previously duplicated byte-for-byte in <c>WorkspaceWriteFileToolTests</c> and
+/// <c>DocumentIngestToolTests</c>.
+/// </summary>
+internal sealed class ThrowingMediator : IMediator
+{
+    public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException("Simulated MediatR pipeline failure.");
+
+    public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+        where TRequest : IRequest
+        => throw new NotSupportedException();
+
+    public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException();
+
+    public Task Publish(object notification, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+        where TNotification : INotification
+        => Task.CompletedTask;
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/DocumentIngestToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/DocumentIngestToolTests.cs
@@ -113,34 +113,4 @@ public sealed class DocumentIngestToolTests
             where TNotification : INotification
             => Task.CompletedTask;
     }
-
-    /// <summary>
-    /// Minimal <see cref="IMediator"/> whose <c>Send</c> always throws — models a downstream
-    /// pipeline failure for <see cref="Ingest_MediatorThrows_ReturnsFailureInsteadOfThrowing"/>.
-    /// </summary>
-    private sealed class ThrowingMediator : IMediator
-    {
-        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
-            => throw new InvalidOperationException("Simulated MediatR pipeline failure.");
-
-        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
-            where TRequest : IRequest
-            => throw new NotSupportedException();
-
-        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public Task Publish(object notification, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
-
-        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
-            where TNotification : INotification
-            => Task.CompletedTask;
-    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/DocumentIngestToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/DocumentIngestToolTests.cs
@@ -1,0 +1,146 @@
+using Application.Core.CQRS.RAG.IngestDocument;
+using FluentAssertions;
+using Infrastructure.AI.Tests.Support;
+using Infrastructure.AI.Tools;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Unit tests for <see cref="DocumentIngestTool"/>'s exception handling around its MediatR dispatch
+/// (#428, mirroring #421's <c>IacSandboxRunner</c> fix and #426's <c>WorkspaceCommandRunner</c> fix):
+/// scope creation and <see cref="IMediator"/> resolution/dispatch must never throw uncaught out of
+/// <see cref="DocumentIngestTool.ExecuteAsync"/>.
+/// </summary>
+public sealed class DocumentIngestToolTests
+{
+    [Fact]
+    public async Task Ingest_ScopeFactoryHasNoMediatorRegistered_ReturnsFailureInsteadOfThrowing()
+    {
+        var servicesWithNoMediator = new ServiceCollection().BuildServiceProvider();
+        var sut = new DocumentIngestTool(
+            servicesWithNoMediator.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<DocumentIngestTool>.Instance);
+
+        var result = await sut.ExecuteAsync(
+            "ingest",
+            new Dictionary<string, object?> { ["uri"] = "file:///tmp/doc.md" });
+
+        result.Success.Should().BeFalse(
+            "a DI-resolution failure for IMediator is a sandbox-level error — it must not throw out of ExecuteAsync uncaught");
+    }
+
+    [Fact]
+    public async Task Ingest_MediatorThrows_ReturnsFailureInsteadOfThrowing()
+    {
+        var mediator = new ThrowingMediator();
+        var sut = new DocumentIngestTool(TestScopeFactory.For(mediator), NullLogger<DocumentIngestTool>.Instance);
+
+        var result = await sut.ExecuteAsync(
+            "ingest",
+            new Dictionary<string, object?> { ["uri"] = "file:///tmp/doc.md" });
+
+        result.Success.Should().BeFalse(
+            "an exception from the MediatR pipeline must be caught and mapped to a failed ToolResult, not thrown out of ExecuteAsync");
+    }
+
+    [Fact]
+    public async Task Ingest_MediatorReturnsSuccess_SurfacesJobDetails()
+    {
+        var mediator = new RecordingMediator(new IngestDocumentResult
+        {
+            JobId = "job-1",
+            ChunksProduced = 3,
+            TokensEmbedded = 120,
+            Duration = TimeSpan.FromSeconds(2),
+            Success = true
+        });
+        var sut = new DocumentIngestTool(TestScopeFactory.For(mediator), NullLogger<DocumentIngestTool>.Instance);
+
+        var result = await sut.ExecuteAsync(
+            "ingest",
+            new Dictionary<string, object?> { ["uri"] = "file:///tmp/doc.md" });
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Contain("job-1");
+        mediator.DispatchedCommands.Should().ContainSingle()
+            .Which.DocumentUri.Should().Be(new Uri("file:///tmp/doc.md"));
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IMediator"/> that records dispatched <see cref="IngestDocumentCommand"/>
+    /// instances and returns a preconfigured <see cref="IngestDocumentResult"/>.
+    /// </summary>
+    private sealed class RecordingMediator : IMediator
+    {
+        private readonly IngestDocumentResult _response;
+
+        public RecordingMediator(IngestDocumentResult response) => _response = response;
+
+        public List<IngestDocumentCommand> DispatchedCommands { get; } = new();
+
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+        {
+            if (request is IngestDocumentCommand command)
+            {
+                DispatchedCommands.Add(command);
+                return Task.FromResult((TResponse)(object)_response);
+            }
+
+            throw new NotSupportedException($"RecordingMediator does not handle {request.GetType().Name}.");
+        }
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Publish(object notification, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+            => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IMediator"/> whose <c>Send</c> always throws — models a downstream
+    /// pipeline failure for <see cref="Ingest_MediatorThrows_ReturnsFailureInsteadOfThrowing"/>.
+    /// </summary>
+    private sealed class ThrowingMediator : IMediator
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Simulated MediatR pipeline failure.");
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Publish(object notification, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+            => Task.CompletedTask;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/DocumentIngestToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/DocumentIngestToolTests.cs
@@ -1,5 +1,6 @@
 using Application.Core.CQRS.RAG.IngestDocument;
 using FluentAssertions;
+using Infrastructure.AI.Tests.Resilience;
 using Infrastructure.AI.Tests.Support;
 using Infrastructure.AI.Tools;
 using MediatR;
@@ -45,6 +46,33 @@ public sealed class DocumentIngestToolTests
 
         result.Success.Should().BeFalse(
             "an exception from the MediatR pipeline must be caught and mapped to a failed ToolResult, not thrown out of ExecuteAsync");
+    }
+
+    [Theory]
+    [InlineData(
+        "https://acct.blob.core.windows.net/c/d.md?sv=2024&sig=SUPERSECRETSIG",
+        "SUPERSECRETSIG")]
+    [InlineData(
+        "https://svc:P4ssw0rd@internal.example/doc.md",
+        "P4ssw0rd")]
+    public async Task Ingest_DispatchFails_NeverLogsCredentialBearingUriComponents(
+        string credentialBearingUri, string credential)
+    {
+        // security-review MEDIUM on PR #442: GetLeftPart(UriPartial.Path) drops the query string
+        // (closing the SAS-token case) but keeps userinfo verbatim (https://user:pass@host/...) --
+        // both must be scrubbed before this failure path's URI reaches an error log.
+        var mediator = new ThrowingMediator();
+        var logger = new RecordingLogger<DocumentIngestTool>();
+        var sut = new DocumentIngestTool(TestScopeFactory.For(mediator), logger);
+
+        var result = await sut.ExecuteAsync(
+            "ingest",
+            new Dictionary<string, object?> { ["uri"] = credentialBearingUri });
+
+        result.Success.Should().BeFalse();
+        logger.Entries.Should().NotBeEmpty();
+        logger.Entries.Should().OnlyContain(e => !e.Message.Contains(credential),
+            $"the credential '{credential}' from '{credentialBearingUri}' must never reach a log entry");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/MediatorDispatchRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/MediatorDispatchRunnerTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Tools;
+
+/// <summary>
+/// Unit tests for <see cref="MediatorDispatchRunner"/> — the shared dispatch wrapper extracted from
+/// <c>WorkspaceWriteFileTool</c> and <c>DocumentIngestTool</c> (#428).
+/// </summary>
+public sealed class MediatorDispatchRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_DispatchThrowsOperationCanceledException_CallerTokenNotCancelled_MapsToFailure()
+    {
+        // #428 correctness-review follow-up: an OperationCanceledException from an internal timeout
+        // unrelated to the caller's own token (e.g. HttpClient's own timeout mid-fetch) must still be
+        // mapped to a failed ToolResult, not rethrown — rethrowing unconditionally reopens the exact
+        // uncaught-exception gap #428 exists to close.
+        var services = new ServiceCollection().AddScoped(_ => (IMediator)new ThrowingOceMediator());
+        using var provider = services.BuildServiceProvider();
+
+        var result = await MediatorDispatchRunner.RunAsync(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            async (mediator, ct) => { await mediator.Send(new Ping(), ct); return null!; },
+            NullLogger.Instance,
+            "test_tool",
+            failureContext: "n/a",
+            cancellationToken: CancellationToken.None);
+
+        result.Success.Should().BeFalse(
+            "an OperationCanceledException unrelated to the caller's own token must be mapped to a " +
+            "failure, not rethrown");
+    }
+
+    [Fact]
+    public async Task RunAsync_CallerCancelsOwnToken_Rethrows()
+    {
+        var services = new ServiceCollection().AddScoped(_ => (IMediator)new ThrowingOceMediator());
+        using var provider = services.BuildServiceProvider();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var act = () => MediatorDispatchRunner.RunAsync(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            async (mediator, ct) => { await mediator.Send(new Ping(), ct); return null!; },
+            NullLogger.Instance,
+            "test_tool",
+            failureContext: "n/a",
+            cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "the caller's own cancellation must still propagate, not be swallowed into a ToolResult.Fail");
+    }
+
+    private sealed record Ping : IRequest<Unit>;
+
+    private sealed class ThrowingOceMediator : IMediator
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new OperationCanceledException("Simulated internal timeout, unrelated to the caller's token.");
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Publish(object notification, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+            => Task.CompletedTask;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/MediatorDispatchRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/MediatorDispatchRunnerTests.cs
@@ -1,3 +1,4 @@
+using Domain.AI.Models;
 using FluentAssertions;
 using Infrastructure.AI.Tools;
 using MediatR;
@@ -56,7 +57,78 @@ public sealed class MediatorDispatchRunnerTests
             "the caller's own cancellation must still propagate, not be swallowed into a ToolResult.Fail");
     }
 
+    [Fact]
+    public async Task RunAsync_DispatchSucceeds_ScopeDisposalThrows_StillReturnsTheSuccessfulResult()
+    {
+        // correctness-review follow-up on PR #442: disposing the scope AFTER a successful dispatch
+        // must not overwrite that success with a failure if disposal itself throws -- otherwise a
+        // committed write (e.g. a submitted ChangeProposal) gets reported to the model as a dispatch
+        // failure, inviting a pointless retry of work that already landed.
+        var innerProvider = new ServiceCollection()
+            .AddScoped(_ => (IMediator)new SucceedingMediator())
+            .BuildServiceProvider();
+        var scopeFactory = new ThrowingDisposalScopeFactory(innerProvider);
+
+        var result = await MediatorDispatchRunner.RunAsync(
+            scopeFactory,
+            async (mediator, ct) => { await mediator.Send(new Ping(), ct); return ToolResult.Ok("done"); },
+            NullLogger.Instance,
+            "test_tool",
+            failureContext: "n/a",
+            cancellationToken: CancellationToken.None);
+
+        result.Success.Should().BeTrue(
+            "a scope-disposal failure occurring after a successful dispatch must not overwrite the " +
+            "already-obtained successful result");
+    }
+
     private sealed record Ping : IRequest<Unit>;
+
+    private sealed class SucceedingMediator : IMediator
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => Task.FromResult((TResponse)(object)Unit.Value);
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Publish(object notification, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+            => Task.CompletedTask;
+    }
+
+    /// <summary>An <see cref="IServiceScopeFactory"/> whose every scope throws on disposal.</summary>
+    private sealed class ThrowingDisposalScopeFactory : IServiceScopeFactory
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public ThrowingDisposalScopeFactory(IServiceProvider serviceProvider) => _serviceProvider = serviceProvider;
+
+        public IServiceScope CreateScope() => new ThrowingDisposalScope(_serviceProvider);
+
+        private sealed class ThrowingDisposalScope(IServiceProvider serviceProvider) : IServiceScope, IAsyncDisposable
+        {
+            public IServiceProvider ServiceProvider { get; } = serviceProvider;
+
+            public void Dispose() => throw new InvalidOperationException("Simulated scope disposal failure.");
+
+            public ValueTask DisposeAsync() =>
+                ValueTask.FromException(new InvalidOperationException("Simulated scope disposal failure."));
+        }
+    }
 
     private sealed class ThrowingOceMediator : IMediator
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/MediatorDispatchRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/MediatorDispatchRunnerTests.cs
@@ -82,7 +82,35 @@ public sealed class MediatorDispatchRunnerTests
             "already-obtained successful result");
     }
 
+    [Fact]
+    public async Task RunAsync_ScopeCreationThrows_ReturnsFailureInsteadOfThrowing()
+    {
+        // correctness-review follow-up on PR #442: this method's own doc comment claims a
+        // "scope-creation ... failure" is logged and mapped, but scope creation originally sat
+        // outside the try/catch entirely -- an already-disposed root provider during host shutdown
+        // (or any other CreateAsyncScope() failure) escaped ExecuteAsync uncaught, reopening the
+        // exact gap #428 exists to close.
+        var scopeFactory = new ThrowingCreationScopeFactory();
+
+        var result = await MediatorDispatchRunner.RunAsync(
+            scopeFactory,
+            async (mediator, ct) => { await mediator.Send(new Ping(), ct); return ToolResult.Ok("unreachable"); },
+            NullLogger.Instance,
+            "test_tool",
+            failureContext: "n/a",
+            cancellationToken: CancellationToken.None);
+
+        result.Success.Should().BeFalse(
+            "a scope-creation failure is a sandbox-level error — it must not throw out of RunAsync uncaught");
+    }
+
     private sealed record Ping : IRequest<Unit>;
+
+    /// <summary>An <see cref="IServiceScopeFactory"/> whose <see cref="CreateScope"/> always throws.</summary>
+    private sealed class ThrowingCreationScopeFactory : IServiceScopeFactory
+    {
+        public IServiceScope CreateScope() => throw new InvalidOperationException("Simulated scope creation failure.");
+    }
 
     private sealed class SucceedingMediator : IMediator
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceWriteFileToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceWriteFileToolTests.cs
@@ -310,35 +310,4 @@ public sealed class WorkspaceWriteFileToolTests
             where TNotification : INotification
             => Task.CompletedTask;
     }
-
-    /// <summary>
-    /// Minimal <see cref="IMediator"/> whose <c>Send</c> always throws — models a downstream
-    /// pipeline failure (e.g. a handler-level dependency outage) for
-    /// <see cref="Write_MediatorThrows_ReturnsFailureInsteadOfThrowing"/> (#428).
-    /// </summary>
-    private sealed class ThrowingMediator : IMediator
-    {
-        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
-            => throw new InvalidOperationException("Simulated MediatR pipeline failure.");
-
-        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
-            where TRequest : IRequest
-            => throw new NotSupportedException();
-
-        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public Task Publish(object notification, CancellationToken cancellationToken = default)
-            => Task.CompletedTask;
-
-        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
-            where TNotification : INotification
-            => Task.CompletedTask;
-    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceWriteFileToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceWriteFileToolTests.cs
@@ -7,6 +7,8 @@ using Infrastructure.AI.Tests.Support;
 using Infrastructure.AI.Tests.Tools.Workspace.Support;
 using Infrastructure.AI.Tools.Workspace;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using EditOp = Domain.AI.SkillTraining.EditOp;
 
@@ -26,7 +28,8 @@ public sealed class WorkspaceWriteFileToolTests
         using var fx = new WorkspaceTestFixture();
         var existingPath = fx.WriteFile("foo.txt", "original-content");
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -60,7 +63,8 @@ public sealed class WorkspaceWriteFileToolTests
     {
         using var fx = new WorkspaceTestFixture();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -82,7 +86,8 @@ public sealed class WorkspaceWriteFileToolTests
     {
         var bareAccessor = new WorkspaceContextAccessor();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(bareAccessor, TestScopeFactory.For(mediator));
+        var sut = new WorkspaceWriteFileTool(
+            bareAccessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -102,7 +107,8 @@ public sealed class WorkspaceWriteFileToolTests
     {
         using var fx = new WorkspaceTestFixture();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -124,7 +130,8 @@ public sealed class WorkspaceWriteFileToolTests
         using var fx = new WorkspaceTestFixture();
         var failureResult = Result<ChangeProposal>.Fail(["validation failed: target unsupported"]);
         var mediator = new RecordingMediator(failureResult);
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
 
         var result = await sut.ExecuteAsync(
             "submit",
@@ -144,7 +151,8 @@ public sealed class WorkspaceWriteFileToolTests
     {
         using var fx = new WorkspaceTestFixture();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
 
         await sut.ExecuteAsync(
             "submit",
@@ -175,7 +183,8 @@ public sealed class WorkspaceWriteFileToolTests
         // can reject.
         using var fx = new WorkspaceTestFixture();
         var mediator = new RecordingMediator(SuccessProposal());
-        var sut = new WorkspaceWriteFileTool(fx.Accessor, TestScopeFactory.For(mediator));
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
 
         await sut.ExecuteAsync(
             "submit",
@@ -189,6 +198,57 @@ public sealed class WorkspaceWriteFileToolTests
 
         mediator.DispatchedSubmits.Should().ContainSingle()
             .Which.BlastRadius.Should().Be(BlastRadius.Low);
+    }
+
+    [Fact]
+    public async Task Write_ScopeFactoryHasNoMediatorRegistered_ReturnsFailureInsteadOfThrowing()
+    {
+        // #428 (mirrors #421/#426's IacSandboxRunner/WorkspaceCommandRunner fix): scope creation and
+        // IMediator resolution used to happen outside ExecuteAsync's try/catch entirely, so a
+        // DI-resolution failure threw uncaught out of ITool.ExecuteAsync. ExecuteAsync now creates the
+        // scope and resolves IMediator itself, inside the same try/catch as dispatch.
+        using var fx = new WorkspaceTestFixture();
+        var servicesWithNoMediator = new ServiceCollection().BuildServiceProvider();
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor,
+            servicesWithNoMediator.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<WorkspaceWriteFileTool>.Instance);
+
+        var result = await sut.ExecuteAsync(
+            "submit",
+            new Dictionary<string, object?>
+            {
+                ["path"] = "ok.txt",
+                ["content"] = "data",
+                ["summary"] = "summary"
+            });
+
+        result.Success.Should().BeFalse(
+            "a DI-resolution failure for IMediator is a sandbox-level error — it must not throw out of ExecuteAsync uncaught");
+    }
+
+    [Fact]
+    public async Task Write_MediatorThrows_ReturnsFailureInsteadOfThrowing()
+    {
+        // #428: an exception from the MediatR pipeline itself (e.g. a downstream dependency failure
+        // inside the SubmitChangeProposalCommand handler chain) must be caught and mapped to a failed
+        // ToolResult, not propagate out of ExecuteAsync uncaught.
+        using var fx = new WorkspaceTestFixture();
+        var mediator = new ThrowingMediator();
+        var sut = new WorkspaceWriteFileTool(
+            fx.Accessor, TestScopeFactory.For(mediator), NullLogger<WorkspaceWriteFileTool>.Instance);
+
+        var result = await sut.ExecuteAsync(
+            "submit",
+            new Dictionary<string, object?>
+            {
+                ["path"] = "ok.txt",
+                ["content"] = "data",
+                ["summary"] = "summary"
+            });
+
+        result.Success.Should().BeFalse(
+            "an exception from the MediatR pipeline must be caught and mapped to a failed ToolResult, not thrown out of ExecuteAsync");
     }
 
     private static Result<ChangeProposal> SuccessProposal()
@@ -229,6 +289,37 @@ public sealed class WorkspaceWriteFileToolTests
             throw new NotSupportedException(
                 $"RecordingMediator does not handle {request.GetType().Name}.");
         }
+
+        public Task<object?> Send(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Send<TRequest>(TRequest request, CancellationToken cancellationToken = default)
+            where TRequest : IRequest
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<TResponse> CreateStream<TResponse>(IStreamRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public IAsyncEnumerable<object?> CreateStream(object request, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException();
+
+        public Task Publish(object notification, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+
+        public Task Publish<TNotification>(TNotification notification, CancellationToken cancellationToken = default)
+            where TNotification : INotification
+            => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Minimal <see cref="IMediator"/> whose <c>Send</c> always throws — models a downstream
+    /// pipeline failure (e.g. a handler-level dependency outage) for
+    /// <see cref="Write_MediatorThrows_ReturnsFailureInsteadOfThrowing"/> (#428).
+    /// </summary>
+    private sealed class ThrowingMediator : IMediator
+    {
+        public Task<TResponse> Send<TResponse>(IRequest<TResponse> request, CancellationToken cancellationToken = default)
+            => throw new InvalidOperationException("Simulated MediatR pipeline failure.");
 
         public Task<object?> Send(object request, CancellationToken cancellationToken = default)
             => throw new NotSupportedException();


### PR DESCRIPTION
## Summary

`WorkspaceWriteFileTool` and `DocumentIngestTool` created a DI scope and resolved/dispatched through `IMediator` outside any try/catch (or inside one typed too narrowly to catch a DI-resolution failure). Any exception from scope creation, `IMediator` resolution, or the dispatch itself escaped `ExecuteAsync` uncaught -- the same defect shape #421 (`IacSandboxRunner`) and #426 (`WorkspaceCommandRunner`) already fixed on the sandbox-dispatch path, present unfixed on these two MediatR-dispatch tools in the same directory.

- Widens both tools' exception handling to the four-part shape the two fixed references settled on: argument guards stay outside the try; scope creation + resolution + dispatch all live inside one try; `OperationCanceledException` rethrows; any other exception logs and maps to a scrubbed `ToolResult.Fail`.
- Both tools gain a logger dependency to support this -- updates their DI registrations and ~9 existing test call sites.
- A full sweep of all 21 `ITool` implementations under `Infrastructure.AI` found exactly these two remaining occurrences plus the already-fixed `WorkspaceCommandRunner` -- this closes the `#421 -> #426 -> #428` chain.

## Review

A `/code-review` pass found 5 issues:
- **2 confirmed real but pre-existing, not fixed here.** `GovernedAIFunction` reports a caught tool-dispatch crash as `Succeeded` in the escalation audit trail, because it can only detect failure via a thrown exception and `AIToolConverter` flattens `ToolResult.Fail` into a plain string return. Verified against source: `GovernedAIFunction.cs` already documents this exact imprecision as an explicitly out-of-scope known limitation, and the identical tradeoff already shipped for `WorkspaceCommandRunner`/`IacSandboxRunner` in #421/#426. This PR extends an already-accepted pattern rather than introducing a new one. Filed as #441 -- fixing it properly requires a converter-wide change affecting every `ITool`, well beyond this PR's scope.
- **3 fixed.** The scope/dispatch/catch block was duplicated near-verbatim between the two tools with no shared helper -- extracted `MediatorDispatchRunner`, mirroring `WorkspaceCommandRunner`'s existing consolidation of the equivalent sandbox-dispatch pattern. `WorkspaceWriteFileTool.ExecuteAsync` had grown past the repo's 50-line guideline -- split into `ResolveRelativePath`/`BuildCommand` helpers. A byte-identical `ThrowingMediator` test double was duplicated across both test files -- moved to `Infrastructure.AI.Tests/Support`, alongside the existing `TestScopeFactory`.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` -- 0 errors
- [x] `Infrastructure.AI.Tests` (`WorkspaceWriteFileToolTests`, `DocumentIngestToolTests`, `WorkspaceRunCommandsToolTests`) -- 25/25
- [x] `Infrastructure.AI.Governance.Tests` (`DefaultPolicyCapabilityAlignmentTests`) -- 6/6
- [x] Every new regression test mutation-tested twice: once against the original per-tool fix, again against the extracted shared `MediatorDispatchRunner` -- both confirmed to fail with the exact pre-fix uncaught-exception stack trace when the fix is reverted

Closes #428

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW