### PR TITLE
refactor: consolidate isolation-floor merging into one shared helper (#433)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -120,8 +120,7 @@ public sealed class ToolPermissionProfileResolver
             overrideConfig.MinimumIsolation, out var parsed)
             ? parsed
             : SandboxIsolationLevel.None;
-        var effectiveIsolation = (SandboxIsolationLevel)Math.Max(
-            (int)baseIsolation, (int)overrideIsolation);
+        var effectiveIsolation = baseIsolation.AtLeast(overrideIsolation);
 
         return (deniedCaps, effectiveIsolation);
     }
@@ -155,8 +154,8 @@ public sealed class ToolPermissionProfileResolver
     /// relative to that tool's own <see cref="ITool.RequiredCapabilities"/> — see the under-declaration
     /// remarks below. Otherwise the merged profile: the override's <c>DeniedCapabilities</c> carried
     /// through (for <see cref="ToolPermissionProfile.EffectiveCapabilities"/>), and isolation set to
-    /// <c>Math.Max(</c><paramref name="defaultIsolationLevel"/><c>, operatorOverride)</c> — never
-    /// downgraded below the caller's own floor even when no override is configured.
+    /// <paramref name="defaultIsolationLevel"/><c>.AtLeast(operatorOverride)</c> — never downgraded
+    /// below the caller's own floor even when no override is configured.
     /// </returns>
     /// <remarks>
     /// <para>
@@ -237,8 +236,7 @@ public sealed class ToolPermissionProfileResolver
             RequiredCapabilities = requiredCapabilities,
             DeniedCapabilities = deniedCaps,
             AllowedPrograms = allowedPrograms,
-            MinimumIsolation = (SandboxIsolationLevel)Math.Max(
-                (int)defaultIsolationLevel, (int)overrideIsolation)
+            MinimumIsolation = defaultIsolationLevel.AtLeast(overrideIsolation)
         });
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -178,7 +178,7 @@ public sealed class ToolPermissionProfileResolver
     /// regardless of what the caller actually required, so a consumer constructed with an elevated
     /// floor (the constructor parameter every first-party caller of this dispatch path exposes) got
     /// the right sandbox executor selected — the caller computes
-    /// <c>Math.Max(defaultIsolationLevel, profile.MinimumIsolation)</c> for that — but a profile whose
+    /// <c>defaultIsolationLevel.AtLeast(profile.MinimumIsolation)</c> for that — but a profile whose
     /// own <see cref="ToolPermissionProfile.MinimumIsolation"/> still read the un-elevated value.
     /// <c>SandboxSessionAttestationSigner</c>'s <c>capabilitiesEnforcedBy</c> field and
     /// <c>DockerSandboxExecutor</c>'s Docker-unavailable fallback gate both read that field, so a
@@ -186,8 +186,8 @@ public sealed class ToolPermissionProfileResolver
     /// decision both based on the wrong tier. Unreachable today — every shipped call site's floor
     /// defaults to <see cref="SandboxIsolationLevel.Process"/> — but latent for the first consumer
     /// that isn't. Now that this method receives the floor directly, the caller no longer needs its
-    /// own outer <c>Math.Max</c> against the returned profile — <see cref="ToolPermissionProfile.MinimumIsolation"/>
-    /// already reflects it.
+    /// own outer <see cref="SandboxIsolationLevelExtensions.AtLeast"/> call against the returned
+    /// profile — <see cref="ToolPermissionProfile.MinimumIsolation"/> already reflects it.
     /// </para>
     /// </remarks>
     /// <param name="agentId">

--- a/src/Content/Domain/Domain.AI/Sandbox/SandboxIsolationLevelExtensions.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/SandboxIsolationLevelExtensions.cs
@@ -17,6 +17,15 @@ public static class SandboxIsolationLevelExtensions
     /// <summary>
     /// Returns the stricter of this level and <paramref name="floor"/> — never a downgrade.
     /// </summary>
+    /// <remarks>
+    /// Relies on <see cref="SandboxIsolationLevel"/>'s declared numeric values being strictly
+    /// ascending in isolation strength — see that enum's own remarks. Every isolation-elevation call
+    /// site in the sandbox subsystem now funnels through this one method, so a future member added
+    /// out of strictness order (e.g. a weaker tier given a higher numeric value than
+    /// <see cref="SandboxIsolationLevel.Container"/>) would silently invert every floor merge at once.
+    /// <c>SandboxIsolationLevelExtensionsTests</c> pins the current three-member ordering; a new
+    /// member must extend that ordering, not merely satisfy it.
+    /// </remarks>
     public static SandboxIsolationLevel AtLeast(this SandboxIsolationLevel level, SandboxIsolationLevel floor) =>
         (SandboxIsolationLevel)Math.Max((int)level, (int)floor);
 

--- a/src/Content/Domain/Domain.AI/Sandbox/SandboxIsolationLevelExtensions.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/SandboxIsolationLevelExtensions.cs
@@ -1,0 +1,41 @@
+namespace Domain.AI.Sandbox;
+
+/// <summary>
+/// Helpers for raising a <see cref="SandboxIsolationLevel"/> to at least a given floor —
+/// the "never downgrade" merge every isolation-elevation call site in the sandbox subsystem needs.
+/// </summary>
+/// <remarks>
+/// Before #433, this shape — <c>(SandboxIsolationLevel)Math.Max((int)a, (int)b)</c> or an
+/// equivalent hand-rolled comparison — was independently reimplemented at four call sites across
+/// three files (<c>ToolUseStepExecutor.SyncProfileIsolation</c>, <c>McpConnectionManager</c>'s
+/// inline profile rebind, and <c>ToolPermissionProfileResolver</c>'s two isolation-merge branches).
+/// CLAUDE.md's own Common Mistakes section records this exact defect shape (a stale/un-synced
+/// isolation tier) recurring twice before this consolidation.
+/// </remarks>
+public static class SandboxIsolationLevelExtensions
+{
+    /// <summary>
+    /// Returns the stricter of this level and <paramref name="floor"/> — never a downgrade.
+    /// </summary>
+    public static SandboxIsolationLevel AtLeast(this SandboxIsolationLevel level, SandboxIsolationLevel floor) =>
+        (SandboxIsolationLevel)Math.Max((int)level, (int)floor);
+
+    /// <summary>
+    /// Returns <paramref name="profile"/> unchanged if its <see cref="ToolPermissionProfile.MinimumIsolation"/>
+    /// already meets <paramref name="floor"/>; otherwise a copy with <c>MinimumIsolation</c> raised to
+    /// <paramref name="floor"/>. Every other field is preserved as-is.
+    /// </summary>
+    /// <remarks>
+    /// Callers that embed the result in a sandbox execution request should raise the floor before
+    /// dispatch, not after: <c>DockerSandboxExecutor.HandleDockerUnavailableAsync</c> (Infrastructure
+    /// layer) reads a request's own <c>PermissionProfile.MinimumIsolation</c> to decide whether a
+    /// Docker outage is a hard, attested refusal or a soft, unattested fallback — an un-elevated
+    /// profile can misroute an autonomy-elevated call into the unattested branch (#420).
+    /// </remarks>
+    public static ToolPermissionProfile WithMinimumIsolationAtLeast(
+        this ToolPermissionProfile profile, SandboxIsolationLevel floor)
+    {
+        var raised = profile.MinimumIsolation.AtLeast(floor);
+        return raised == profile.MinimumIsolation ? profile : profile with { MinimumIsolation = raised };
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -507,8 +507,8 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// ANDing anything against a <c>None</c> requirement is still <c>None</c>, so a
     /// <c>DeniedCapabilities</c> override has no observable effect here regardless of what an
     /// operator writes. The isolation floor is then raised to
-    /// <see cref="SandboxIsolationLevel.Container"/> unconditionally via <c>Math.Max</c>, so a
-    /// <c>MinimumIsolation</c> override can never lower it either.</description></item>
+    /// <see cref="SandboxIsolationLevel.Container"/> unconditionally via <c>WithMinimumIsolationAtLeast</c>
+    /// (#433), so a <c>MinimumIsolation</c> override can never lower it either.</description></item>
     /// <item><description>A bundle-owned server name is <c>{bundleId}:{serverName}</c> —
     /// <c>bundleId</c> is a fresh GUID per staging (<c>BundleStagingService</c>) — so no operator
     /// can currently author a <c>ToolOverrides</c> key that matches one at all. The resolver call
@@ -555,11 +555,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
             var profileResolver = scope.Value.ServiceProvider.GetRequiredService<ToolPermissionProfileResolver>();
 
             var resolvedProfile = profileResolver.Resolve(serverName);
-            var permissionProfile = resolvedProfile with
-            {
-                MinimumIsolation = (SandboxIsolationLevel)Math.Max(
-                    (int)resolvedProfile.MinimumIsolation, (int)SandboxIsolationLevel.Container)
-            };
+            var permissionProfile = resolvedProfile.WithMinimumIsolationAtLeast(SandboxIsolationLevel.Container);
 
             if (definition.SandboxSeedDirectory is { } seedDirectory && !IsWithinConfiguredStagingRoot(seedDirectory))
             {

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -338,24 +338,18 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
     {
         var level = profile.MinimumIsolation;
 
-        if (config.IsolationLevelOverride.HasValue && config.IsolationLevelOverride.Value > level)
-            level = config.IsolationLevelOverride.Value;
+        if (config.IsolationLevelOverride.HasValue)
+            level = level.AtLeast(config.IsolationLevelOverride.Value);
 
         if (step.RequiredAutonomyLevel is AutonomyLevel.Supervised or AutonomyLevel.Restricted)
-        {
-            if (level < SandboxIsolationLevel.Container)
-                level = SandboxIsolationLevel.Container;
-        }
+            level = level.AtLeast(SandboxIsolationLevel.Container);
 
         // Floor None to Process: no ISandboxExecutor is keyed for None (only Process and
         // Container are registered). A tool that doesn't override ITool.MinimumIsolation resolves
         // to a profile with MinimumIsolation = None, which would otherwise throw
         // InvalidOperationException at keyed-service resolution. Process is the default
         // subprocess executor and the safe minimum for "direct-execution" tools.
-        if (level < SandboxIsolationLevel.Process)
-            level = SandboxIsolationLevel.Process;
-
-        return level;
+        return level.AtLeast(SandboxIsolationLevel.Process);
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -93,7 +93,7 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
 
         var profile = await _capabilityEnforcer.ResolveProfileAsync(config.ToolName, ct);
         var isolationLevel = DetermineIsolation(config, profile, step);
-        profile = SyncProfileIsolation(profile, isolationLevel);
+        profile = profile.WithMinimumIsolationAtLeast(isolationLevel);
 
         var (sandboxResult, sandboxFailure) = await RunSandboxAsync(
             config, step, profile, isolationLevel, arguments, admission, sw, ct);
@@ -330,31 +330,6 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         });
     }
 
-
-    /// <summary>
-    /// Rebuilds <paramref name="profile"/> so its own <see cref="ToolPermissionProfile.MinimumIsolation"/>
-    /// matches <paramref name="isolationLevel"/> — the tier <see cref="DetermineIsolation"/> actually
-    /// selected, which can be elevated above the profile's declared floor by
-    /// <c>config.IsolationLevelOverride</c> or a <c>Supervised</c>/<c>Restricted</c> step (#420).
-    /// </summary>
-    /// <remarks>
-    /// <see cref="DetermineIsolation"/> only ever raises the level, never lowers it, so
-    /// <paramref name="isolationLevel"/> is always ≥ <paramref name="profile"/>'s own
-    /// <see cref="ToolPermissionProfile.MinimumIsolation"/> — the equality check below only guards
-    /// against an unnecessary record rebuild, not against ever lowering the floor.
-    /// <see cref="Infrastructure.AI.Sandbox.DockerSandboxExecutor.HandleDockerUnavailableAsync"/> reads
-    /// this embedded field to decide whether a Docker outage is a hard, attested refusal or a soft,
-    /// unattested fallback hint — an un-elevated profile can misroute an autonomy-elevated step into
-    /// the unattested branch. <c>McpConnectionManager</c>'s own sandbox-session dispatch
-    /// (<c>resolvedProfile with { MinimumIsolation = Math.Max(...) }</c>) and
-    /// <c>ToolPermissionProfileResolver.ResolveForUngovernedDispatch</c> already follow this same
-    /// sync-before-embed pattern independently — see #433 for consolidating all three into one helper.
-    /// </remarks>
-    private static ToolPermissionProfile SyncProfileIsolation(
-        ToolPermissionProfile profile, SandboxIsolationLevel isolationLevel) =>
-        isolationLevel == profile.MinimumIsolation
-            ? profile
-            : profile with { MinimumIsolation = isolationLevel };
 
     private static SandboxIsolationLevel DetermineIsolation(
         ToolUseConfig config,

--- a/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
@@ -1,0 +1,73 @@
+using Domain.AI.Sandbox;
+using Xunit;
+
+namespace Domain.AI.Tests.Sandbox;
+
+/// <summary>
+/// Guards the shared isolation-floor helpers extracted from four independently-duplicated call
+/// sites (#433): <see cref="SandboxIsolationLevelExtensions.AtLeast"/> and
+/// <see cref="SandboxIsolationLevelExtensions.WithMinimumIsolationAtLeast"/>.
+/// </summary>
+public sealed class SandboxIsolationLevelExtensionsTests
+{
+    [Theory]
+    [InlineData(SandboxIsolationLevel.None, SandboxIsolationLevel.None, SandboxIsolationLevel.None)]
+    [InlineData(SandboxIsolationLevel.None, SandboxIsolationLevel.Process, SandboxIsolationLevel.Process)]
+    [InlineData(SandboxIsolationLevel.Process, SandboxIsolationLevel.None, SandboxIsolationLevel.Process)]
+    [InlineData(SandboxIsolationLevel.Process, SandboxIsolationLevel.Container, SandboxIsolationLevel.Container)]
+    [InlineData(SandboxIsolationLevel.Container, SandboxIsolationLevel.Process, SandboxIsolationLevel.Container)]
+    [InlineData(SandboxIsolationLevel.Container, SandboxIsolationLevel.Container, SandboxIsolationLevel.Container)]
+    public void AtLeast_ReturnsTheStricterLevel(
+        SandboxIsolationLevel level, SandboxIsolationLevel floor, SandboxIsolationLevel expected)
+    {
+        Assert.Equal(expected, level.AtLeast(floor));
+    }
+
+    [Fact]
+    public void WithMinimumIsolationAtLeast_AlreadyAtFloor_ReturnsSameInstance()
+    {
+        var profile = new ToolPermissionProfile
+        {
+            RequiredCapabilities = ToolCapability.None,
+            MinimumIsolation = SandboxIsolationLevel.Container
+        };
+
+        var result = profile.WithMinimumIsolationAtLeast(SandboxIsolationLevel.Process);
+
+        Assert.Same(profile, result);
+    }
+
+    [Fact]
+    public void WithMinimumIsolationAtLeast_AboveFloor_ReturnsSameInstance()
+    {
+        var profile = new ToolPermissionProfile
+        {
+            RequiredCapabilities = ToolCapability.None,
+            MinimumIsolation = SandboxIsolationLevel.Container
+        };
+
+        var result = profile.WithMinimumIsolationAtLeast(SandboxIsolationLevel.None);
+
+        Assert.Same(profile, result);
+    }
+
+    [Fact]
+    public void WithMinimumIsolationAtLeast_BelowFloor_RaisesMinimumIsolationAndPreservesOtherFields()
+    {
+        var profile = new ToolPermissionProfile
+        {
+            RequiredCapabilities = ToolCapability.FileWrite,
+            DeniedCapabilities = ToolCapability.NetworkAccess,
+            AllowedPrograms = ["dotnet"],
+            MinimumIsolation = SandboxIsolationLevel.Process
+        };
+
+        var result = profile.WithMinimumIsolationAtLeast(SandboxIsolationLevel.Container);
+
+        Assert.NotSame(profile, result);
+        Assert.Equal(SandboxIsolationLevel.Container, result.MinimumIsolation);
+        Assert.Equal(ToolCapability.FileWrite, result.RequiredCapabilities);
+        Assert.Equal(ToolCapability.NetworkAccess, result.DeniedCapabilities);
+        Assert.Equal(profile.AllowedPrograms, result.AllowedPrograms);
+    }
+}

--- a/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
@@ -49,15 +49,19 @@ public sealed class SandboxIsolationLevelExtensionsTests
     }
 
     [Fact]
-    public void WithMinimumIsolationAtLeast_AlreadyAtFloor_ReturnsSameInstance()
+    public void WithMinimumIsolationAtLeast_ExactlyAtFloor_ReturnsSameInstance()
     {
+        // correctness-review follow-up on PR #443: the two existing "same instance" cases were both
+        // strictly above the floor (Container vs Process, Container vs None) — neither exercised the
+        // exact-equality short-circuit (raised == profile.MinimumIsolation) the implementation is
+        // actually written around. This is that case.
         var profile = new ToolPermissionProfile
         {
             RequiredCapabilities = ToolCapability.None,
             MinimumIsolation = SandboxIsolationLevel.Container
         };
 
-        var result = profile.WithMinimumIsolationAtLeast(SandboxIsolationLevel.Process);
+        var result = profile.WithMinimumIsolationAtLeast(SandboxIsolationLevel.Container);
 
         Assert.Same(profile, result);
     }

--- a/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
@@ -33,17 +33,19 @@ public sealed class SandboxIsolationLevelExtensionsTests
         // than Container) would silently invert every floor merge at once. This pins that ordering
         // invariant directly.
         //
-        // Enum.GetValues() itself returns members already sorted by numeric value, so it cannot be
-        // used to detect a declaration-order/value-order mismatch — reflection over the fields in
-        // their declared source order is required to catch that.
-        var declaredValues = typeof(SandboxIsolationLevel)
-            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
-            .Select(f => (int)f.GetValue(null)!)
-            .ToList();
+        // Correctness-review follow-up on the first version of this test: reflection field order
+        // (Type.GetFields) is metadata order in practice on CoreCLR but not a contractual guarantee,
+        // so this asserts the intended sequence explicitly by name and value rather than relying on
+        // that ordering — the test fails loudly on a reordering regardless of reflection behavior.
+        Assert.Equal(0, (int)SandboxIsolationLevel.None);
+        Assert.Equal(1, (int)SandboxIsolationLevel.Process);
+        Assert.Equal(2, (int)SandboxIsolationLevel.Container);
 
-        var ascending = declaredValues.OrderBy(v => v).ToList();
-        Assert.Equal(ascending, declaredValues);
-        Assert.Equal(declaredValues.Distinct().Count(), declaredValues.Count);
+        var allMembers = new[]
+        {
+            SandboxIsolationLevel.None, SandboxIsolationLevel.Process, SandboxIsolationLevel.Container,
+        };
+        Assert.Equal(allMembers.Length, Enum.GetValues<SandboxIsolationLevel>().Length);
     }
 
     [Fact]

--- a/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Sandbox/SandboxIsolationLevelExtensionsTests.cs
@@ -24,6 +24,29 @@ public sealed class SandboxIsolationLevelExtensionsTests
     }
 
     [Fact]
+    public void SandboxIsolationLevel_DeclaredValues_AreStrictlyAscendingInIsolationStrength()
+    {
+        // security-review follow-up on PR #443: AtLeast relies entirely on the enum's declared
+        // numeric values being strictly ascending in isolation strength (its own remarks say so).
+        // Every isolation-elevation call site in the sandbox subsystem now funnels through this one
+        // method, so a future member added out of order (e.g. a weaker tier given a higher value
+        // than Container) would silently invert every floor merge at once. This pins that ordering
+        // invariant directly.
+        //
+        // Enum.GetValues() itself returns members already sorted by numeric value, so it cannot be
+        // used to detect a declaration-order/value-order mismatch — reflection over the fields in
+        // their declared source order is required to catch that.
+        var declaredValues = typeof(SandboxIsolationLevel)
+            .GetFields(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+            .Select(f => (int)f.GetValue(null)!)
+            .ToList();
+
+        var ascending = declaredValues.OrderBy(v => v).ToList();
+        Assert.Equal(ascending, declaredValues);
+        Assert.Equal(declaredValues.Distinct().Count(), declaredValues.Count);
+    }
+
+    [Fact]
     public void WithMinimumIsolationAtLeast_AlreadyAtFloor_ReturnsSameInstance()
     {
         var profile = new ToolPermissionProfile

--- a/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
@@ -48,8 +48,9 @@ internal static class TestScopeFactory
     /// Registers <paramref name="sandbox"/> under both the <see cref="SandboxIsolationLevel.Process"/>
     /// and <see cref="SandboxIsolationLevel.Container"/> keys (plus <paramref name="isolationLevel"/>
     /// itself, if different) — not just <paramref name="isolationLevel"/> alone. The runner now
-    /// resolves the keyed executor for <c>Math.Max(defaultIsolationLevel, profile.MinimumIsolation)</c>
-    /// (#405 follow-up), so a test exercising an operator's <c>MinimumIsolation: Container</c> override
+    /// resolves the keyed executor for <c>defaultIsolationLevel.AtLeast(profile.MinimumIsolation)</c>
+    /// (#405 follow-up, consolidated onto the shared helper in #433), so a test exercising an
+    /// operator's <c>MinimumIsolation: Container</c> override
     /// needs the Container key resolvable even though the tool's own floor is Process.
     /// </remarks>
     public static IServiceScopeFactory ForSandbox(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
@@ -48,10 +48,12 @@ internal static class TestScopeFactory
     /// Registers <paramref name="sandbox"/> under both the <see cref="SandboxIsolationLevel.Process"/>
     /// and <see cref="SandboxIsolationLevel.Container"/> keys (plus <paramref name="isolationLevel"/>
     /// itself, if different) — not just <paramref name="isolationLevel"/> alone. The runner now
-    /// resolves the keyed executor for <c>defaultIsolationLevel.AtLeast(profile.MinimumIsolation)</c>
-    /// (#405 follow-up, consolidated onto the shared helper in #433), so a test exercising an
-    /// operator's <c>MinimumIsolation: Container</c> override
-    /// needs the Container key resolvable even though the tool's own floor is Process.
+    /// resolves the keyed executor for the profile's own already-merged
+    /// <c>MinimumIsolation</c> — computed via <c>defaultIsolationLevel.AtLeast(overrideIsolation)</c>
+    /// inside <c>ToolPermissionProfileResolver</c> (#405 follow-up, consolidated onto the shared
+    /// <c>AtLeast</c> helper in #433) — so a test exercising an operator's
+    /// <c>MinimumIsolation: Container</c> override needs the Container key resolvable even though the
+    /// tool's own floor is Process.
     /// </remarks>
     public static IServiceScopeFactory ForSandbox(
         ISandboxExecutor sandbox,


### PR DESCRIPTION
## Summary

Four call sites across three files independently reimplemented the same "raise to at least this floor, never downgrade" shape: `(SandboxIsolationLevel)Math.Max((int)a, (int)b)`, or a hand-rolled overwrite in `ToolUseStepExecutor`'s `SyncProfileIsolation`. This is exactly the recurring defect shape CLAUDE.md already records against this history (#405 follow-up, #420) -- a stale/un-synced isolation tier landing twice before.

Adds two extension methods in `Domain.AI/Sandbox/SandboxIsolationLevelExtensions.cs`:
- `SandboxIsolationLevel.AtLeast(floor)` -- the raw enum merge, used by `ToolPermissionProfileResolver`'s two isolation-merge branches.
- `ToolPermissionProfile.WithMinimumIsolationAtLeast(floor)` -- built on `AtLeast`, used by `ToolUseStepExecutor` and `McpConnectionManager`.

**Deliberate, behaviour-improving change in `ToolUseStepExecutor`:** converts an unconditional overwrite to a floor. `DetermineIsolation` is documented to only ever raise the level, so this is a no-op for every current call pattern, but makes the "never lowers" property structural instead of a documented caller obligation the next editor could violate.

## Review

A `/code-review` pass found one issue: a stale XML doc comment in `ToolPermissionProfileResolver.cs` still quoted the old `Math.Max` formula after the implementation switched to `AtLeast()`. Fixed, and swept for (and fixed) two more stale references describing the exact sites this PR changed (`TestScopeFactory.cs`, `McpConnectionManager.cs`).

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` -- 0 errors, 0 new warnings
- [x] New `SandboxIsolationLevelExtensionsTests` -- 9/9 (table-driven `AtLeast` coverage + `WithMinimumIsolationAtLeast` same-instance/new-instance/field-preservation cases)
- [x] All four affected call sites' existing test suites -- 27/27 (`ToolUseStepExecutor`), 37/37 (`McpConnectionManager`), 40/40 (`ToolPermissionProfileResolver`) -- **zero existing assertions needed changes**, confirming the consolidation is behaviour-preserving
- [x] `AtLeast` mutation-tested: made it always return the floor argument regardless of the current level -- 4/9 new tests failed as expected, reverted

Closes #433

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW