### PR TITLE
Dedupe governance audit-gate check and audit MCP sandbox refusals

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
@@ -17,7 +17,7 @@ namespace Application.AI.Common.Interfaces.Governance;
 /// config as optional, defaulting an absent config to audit-on. That last variant is not a bug to
 /// normalize away — <c>ToolPermissionProfileResolver</c> is constructed in test and partially-composed
 /// hosts without a governance config at all, and defaulting to "audit if you can" is the safer
-/// direction to fail in. Both overloads below preserve it.
+/// direction to fail in. Every overload below preserves it.
 /// </remarks>
 public static class GovernanceAuditGateExtensions
 {
@@ -62,19 +62,20 @@ public static class GovernanceAuditGateExtensions
         string action,
         string decision)
     {
-        if (auditService is null)
-            return;
-        if (governanceConfig is not null && !governanceConfig.EnableAudit)
+        if (!ShouldLog(auditService, governanceConfig))
             return;
 
-        auditService.Log(agentId ?? "unknown", action, decision);
+        auditService!.Log(agentId ?? "unknown", action, decision);
     }
 
     /// <summary>
     /// As <see cref="LogIfAuditEnabled(IGovernanceAuditService?, GovernanceConfig?, string?, string, string)"/>,
     /// but for a caller whose <paramref name="decision"/> string is non-trivial to build (e.g. a LINQ
     /// projection over a findings collection) — deferred so the cost is paid only when the gate actually
-    /// passes, not on every call regardless of the operator's audit setting.
+    /// passes, not on every call regardless of the operator's audit setting. No monitor-based overload
+    /// of this one exists: at the time of writing, every lazy-decision caller already holds a resolved
+    /// <see cref="GovernanceConfig"/> snapshot rather than the live monitor, so a delegating overload
+    /// would have exactly one caller — add one if and when a second monitor-holding caller needs it.
     /// </summary>
     public static void LogIfAuditEnabled(
         this IGovernanceAuditService? auditService,
@@ -83,24 +84,20 @@ public static class GovernanceAuditGateExtensions
         string action,
         Func<string> decision)
     {
-        if (auditService is null)
-            return;
-        if (governanceConfig is not null && !governanceConfig.EnableAudit)
+        if (!ShouldLog(auditService, governanceConfig))
             return;
 
-        auditService.Log(agentId ?? "unknown", action, decision());
+        auditService!.Log(agentId ?? "unknown", action, decision());
     }
 
     /// <summary>
-    /// As <see cref="LogIfAuditEnabled(IGovernanceAuditService?, GovernanceConfig?, string?, string, Func{string})"/>,
-    /// but for a caller that holds the live <see cref="IOptionsMonitor{TOptions}"/> rather than a
-    /// snapshot — mirrors the eager overload's own monitor-to-snapshot delegation above.
+    /// The shared gate check both snapshot-based overloads apply before writing: a missing
+    /// <paramref name="auditService"/> means there is nothing to write to, and a present
+    /// <paramref name="governanceConfig"/> with <see cref="GovernanceConfig.EnableAudit"/> off means the
+    /// operator has explicitly opted out. Kept out of the two overloads' own bodies — rather than each
+    /// re-checking inline — specifically so the lazy overload can decide whether to log <em>before</em>
+    /// invoking <paramref name="governanceConfig"/>'s decision factory, not after.
     /// </summary>
-    public static void LogIfAuditEnabled(
-        this IGovernanceAuditService? auditService,
-        IOptionsMonitor<GovernanceConfig>? governanceConfig,
-        string? agentId,
-        string action,
-        Func<string> decision) =>
-        auditService.LogIfAuditEnabled(governanceConfig?.CurrentValue, agentId, action, decision);
+    private static bool ShouldLog(IGovernanceAuditService? auditService, GovernanceConfig? governanceConfig) =>
+        auditService is not null && (governanceConfig is null || governanceConfig.EnableAudit);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
@@ -90,4 +90,17 @@ public static class GovernanceAuditGateExtensions
 
         auditService.Log(agentId ?? "unknown", action, decision());
     }
+
+    /// <summary>
+    /// As <see cref="LogIfAuditEnabled(IGovernanceAuditService?, GovernanceConfig?, string?, string, Func{string})"/>,
+    /// but for a caller that holds the live <see cref="IOptionsMonitor{TOptions}"/> rather than a
+    /// snapshot — mirrors the eager overload's own monitor-to-snapshot delegation above.
+    /// </summary>
+    public static void LogIfAuditEnabled(
+        this IGovernanceAuditService? auditService,
+        IOptionsMonitor<GovernanceConfig>? governanceConfig,
+        string? agentId,
+        string action,
+        Func<string> decision) =>
+        auditService.LogIfAuditEnabled(governanceConfig?.CurrentValue, agentId, action, decision);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
@@ -45,15 +45,8 @@ public static class GovernanceAuditGateExtensions
         IOptionsMonitor<GovernanceConfig>? governanceConfig,
         string? agentId,
         string action,
-        string decision)
-    {
-        if (auditService is null)
-            return;
-        if (governanceConfig is not null && !governanceConfig.CurrentValue.EnableAudit)
-            return;
-
-        auditService.Log(agentId ?? "unknown", action, decision);
-    }
+        string decision) =>
+        auditService.LogIfAuditEnabled(governanceConfig?.CurrentValue, agentId, action, decision);
 
     /// <summary>
     /// As <see cref="LogIfAuditEnabled(IGovernanceAuditService?, IOptionsMonitor{GovernanceConfig}?, string?, string, string)"/>,
@@ -75,5 +68,26 @@ public static class GovernanceAuditGateExtensions
             return;
 
         auditService.Log(agentId ?? "unknown", action, decision);
+    }
+
+    /// <summary>
+    /// As <see cref="LogIfAuditEnabled(IGovernanceAuditService?, GovernanceConfig?, string?, string, string)"/>,
+    /// but for a caller whose <paramref name="decision"/> string is non-trivial to build (e.g. a LINQ
+    /// projection over a findings collection) — deferred so the cost is paid only when the gate actually
+    /// passes, not on every call regardless of the operator's audit setting.
+    /// </summary>
+    public static void LogIfAuditEnabled(
+        this IGovernanceAuditService? auditService,
+        GovernanceConfig? governanceConfig,
+        string? agentId,
+        string action,
+        Func<string> decision)
+    {
+        if (auditService is null)
+            return;
+        if (governanceConfig is not null && !governanceConfig.EnableAudit)
+            return;
+
+        auditService.Log(agentId ?? "unknown", action, decision());
     }
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/GovernanceAuditGateExtensions.cs
@@ -1,0 +1,79 @@
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Interfaces.Governance;
+
+/// <summary>
+/// The one correct way to write a governance decision to <see cref="IGovernanceAuditService"/>: gate
+/// on the operator's <see cref="GovernanceConfig.EnableAudit"/> toggle, default a missing agent id to
+/// <c>"unknown"</c>, then write.
+/// </summary>
+/// <remarks>
+/// This exact shape — <c>if (config.EnableAudit) auditService.Log(agentId ?? "unknown", action,
+/// decision)</c> — was independently reimplemented at nine call sites across seven files before this
+/// extraction (#430), with no two quite alike: some read <c>GovernanceConfig</c> from a captured
+/// <see cref="IOptionsMonitor{TOptions}"/> field, one received the snapshot as a method parameter, and
+/// one (<c>ToolPermissionProfileResolver.LogRefusal</c>) treated <em>both</em> the service and the
+/// config as optional, defaulting an absent config to audit-on. That last variant is not a bug to
+/// normalize away — <c>ToolPermissionProfileResolver</c> is constructed in test and partially-composed
+/// hosts without a governance config at all, and defaulting to "audit if you can" is the safer
+/// direction to fail in. Both overloads below preserve it.
+/// </remarks>
+public static class GovernanceAuditGateExtensions
+{
+    /// <summary>
+    /// Writes <paramref name="decision"/> to <paramref name="auditService"/> when
+    /// <paramref name="governanceConfig"/>'s current <see cref="GovernanceConfig.EnableAudit"/> is
+    /// <see langword="true"/> — the common case, where a caller holds a live
+    /// <see cref="IOptionsMonitor{TOptions}"/> rather than a single snapshot.
+    /// </summary>
+    /// <param name="auditService">
+    /// May be <see langword="null"/> in a host that has not registered a governance audit sink; the
+    /// write is then a no-op rather than a null-reference failure.
+    /// </param>
+    /// <param name="governanceConfig">
+    /// May be <see langword="null"/> in a partially-composed host (e.g. a unit test); a missing config
+    /// is treated as audit-on, matching <c>ToolPermissionProfileResolver.LogRefusal</c>'s original
+    /// semantic — an operator who never configured governance has not asked for audit logging to be
+    /// silently disabled.
+    /// </param>
+    /// <param name="agentId">The acting agent's id, or <see langword="null"/> if unknown to the caller.</param>
+    /// <param name="action">The action that was evaluated (e.g. a tool name).</param>
+    /// <param name="decision">The governance decision (allow, deny, warn, etc.).</param>
+    public static void LogIfAuditEnabled(
+        this IGovernanceAuditService? auditService,
+        IOptionsMonitor<GovernanceConfig>? governanceConfig,
+        string? agentId,
+        string action,
+        string decision)
+    {
+        if (auditService is null)
+            return;
+        if (governanceConfig is not null && !governanceConfig.CurrentValue.EnableAudit)
+            return;
+
+        auditService.Log(agentId ?? "unknown", action, decision);
+    }
+
+    /// <summary>
+    /// As <see cref="LogIfAuditEnabled(IGovernanceAuditService?, IOptionsMonitor{GovernanceConfig}?, string?, string, string)"/>,
+    /// but for a caller that already holds a resolved <see cref="GovernanceConfig"/> snapshot rather
+    /// than the live <see cref="IOptionsMonitor{TOptions}"/> — e.g. one that received the snapshot as
+    /// its own method parameter and would otherwise have to thread the monitor through separately just
+    /// to reach this gate.
+    /// </summary>
+    public static void LogIfAuditEnabled(
+        this IGovernanceAuditService? auditService,
+        GovernanceConfig? governanceConfig,
+        string? agentId,
+        string action,
+        string decision)
+    {
+        if (auditService is null)
+            return;
+        if (governanceConfig is not null && !governanceConfig.EnableAudit)
+            return;
+
+        auditService.Log(agentId ?? "unknown", action, decision);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/PromptInjectionBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/PromptInjectionBehavior.cs
@@ -63,8 +63,7 @@ public sealed class PromptInjectionBehavior<TRequest, TResponse>
             "Prompt injection detected: {InjectionType} (threat: {ThreatLevel}, confidence: {Confidence:F2})",
             result.InjectionType, result.ThreatLevel, result.Confidence);
 
-        if (cfg.EnableAudit)
-            _auditService.Log("system", "prompt_injection_scan", $"blocked:{result.InjectionType}");
+        _auditService.LogIfAuditEnabled(cfg, "system", "prompt_injection_scan", $"blocked:{result.InjectionType}");
 
         var reason = $"Prompt injection detected ({result.InjectionType}). Request blocked.";
         if (ResultHelper.TryCreateFailure<TResponse>(nameof(Result.GovernanceBlocked), reason, out var blocked))

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/ResponseSanitizationBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/ResponseSanitizationBehavior.cs
@@ -82,8 +82,8 @@ public sealed class ResponseSanitizationBehavior<TRequest, TResponse>
             GovernanceMetrics.ResponseBlocks.Add(1,
                 new KeyValuePair<string, object?>(GovernanceConventions.ToolName, toolRequest.ToolName));
 
-            if (cfg.EnableAudit)
-                _auditService.Log("system", "response_blocked", $"{result.HighestThreatLevel}:{toolRequest.ToolName}:{result.Findings.Count} findings");
+            _auditService.LogIfAuditEnabled(cfg, "system", "response_blocked",
+                $"{result.HighestThreatLevel}:{toolRequest.ToolName}:{result.Findings.Count} findings");
 
             var reason = $"Tool response blocked: {result.HighestThreatLevel} threat detected ({result.Findings.Count} finding(s))";
             if (ResultHelper.TryCreateFailure<TResponse>(nameof(Result.GovernanceBlocked), reason, out var blocked))
@@ -96,11 +96,8 @@ public sealed class ResponseSanitizationBehavior<TRequest, TResponse>
             "Response sanitized for tool {ToolName}: {Count} finding(s), highest threat {ThreatLevel}",
             toolRequest.ToolName, result.Findings.Count, result.HighestThreatLevel);
 
-        if (cfg.EnableAudit)
-        {
-            var categories = string.Join(",", result.Findings.Select(f => f.Category).Distinct());
-            _auditService.Log("system", "response_sanitized", $"{categories}:{toolRequest.ToolName}");
-        }
+        var categories = string.Join(",", result.Findings.Select(f => f.Category).Distinct());
+        _auditService.LogIfAuditEnabled(cfg, "system", "response_sanitized", $"{categories}:{toolRequest.ToolName}");
 
         return ReplaceSanitizedOutput(response, result.SanitizedContent);
     }

--- a/src/Content/Application/Application.AI.Common/MediatRBehaviors/ResponseSanitizationBehavior.cs
+++ b/src/Content/Application/Application.AI.Common/MediatRBehaviors/ResponseSanitizationBehavior.cs
@@ -96,8 +96,11 @@ public sealed class ResponseSanitizationBehavior<TRequest, TResponse>
             "Response sanitized for tool {ToolName}: {Count} finding(s), highest threat {ThreatLevel}",
             toolRequest.ToolName, result.Findings.Count, result.HighestThreatLevel);
 
-        var categories = string.Join(",", result.Findings.Select(f => f.Category).Distinct());
-        _auditService.LogIfAuditEnabled(cfg, "system", "response_sanitized", $"{categories}:{toolRequest.ToolName}");
+        _auditService.LogIfAuditEnabled(cfg, "system", "response_sanitized", () =>
+        {
+            var categories = string.Join(",", result.Findings.Select(f => f.Category).Distinct());
+            return $"{categories}:{toolRequest.ToolName}";
+        });
 
         return ReplaceSanitizedOutput(response, result.SanitizedContent);
     }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
@@ -97,13 +97,13 @@ public sealed class DefaultToolClassificationGate : IToolClassificationGate
                 "Classification lookup failed for tool {ToolName} (asset type {AssetType}); {Disposition}.",
                 toolName, asset.Type, enforcing ? "blocking (fail-closed)" : "allowing (audit mode)");
             RecordDecision(toolName, "error", asset.Type, LabelSource.None, config.Mode, enforcing);
-            Audit(governance, toolName, "classification:error");
+            _auditService.LogIfAuditEnabled(governance, _executionContext.AgentId, toolName, "classification:error");
             return enforcing ? ClassificationVerdict.Block(DeniedMessage(toolName)) : ClassificationVerdict.Allow();
         }
 
         var decision = _evaluator.Evaluate(label, config);
         RecordDecision(toolName, decision.Action.ToString(), asset.Type, label.Source, config.Mode, enforcing);
-        Audit(governance, toolName, $"classification:{decision.Action}");
+        _auditService.LogIfAuditEnabled(governance, _executionContext.AgentId, toolName, $"classification:{decision.Action}");
 
         // Audit mode records the would-be decision but never alters the call.
         if (!enforcing)
@@ -147,11 +147,6 @@ public sealed class DefaultToolClassificationGate : IToolClassificationGate
         return AssetReference.Unknown();
     }
 
-    private void Audit(GovernanceConfig governance, string toolName, string decision)
-    {
-        if (governance.EnableAudit)
-            _auditService.Log(_executionContext.AgentId ?? "unknown", toolName, decision);
-    }
 
     private static void RecordDecision(
         string toolName, string action, AssetType assetType, LabelSource source,

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
@@ -147,7 +147,6 @@ public sealed class DefaultToolClassificationGate : IToolClassificationGate
         return AssetReference.Unknown();
     }
 
-
     private static void RecordDecision(
         string toolName, string action, AssetType assetType, LabelSource source,
         ClassificationEnforcementMode mode, bool enforced)

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallObserverChain.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallObserverChain.cs
@@ -220,8 +220,8 @@ public sealed class ToolCallObserverChain : IToolCallObserverChain
             "Tool call observer '{Observer}' blocked {ToolName}: {Reason}",
             observerName, toolName, reason);
 
-        if (_governanceConfig.CurrentValue.EnableAudit)
-            _auditService.Log(_executionContext.AgentId ?? "unknown", toolName, $"observer:{observerName}:blocked");
+        _auditService.LogIfAuditEnabled(
+            _governanceConfig, _executionContext.AgentId, toolName, $"observer:{observerName}:blocked");
 
         // Correct the turn's governance trace — see IGovernanceTraceRecorder.RecordDownstreamBlock for
         // why this is routed through the recorder rather than skipped. It corrects the trace only; the

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionReporter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCompositionReporter.cs
@@ -100,8 +100,7 @@ public sealed class ToolCompositionReporter
                 "Tool composition finding for agent {AgentName}: {Path} (posture: {Posture})",
                 agentName, path, posture);
 
-            if (governance.EnableAudit)
-                _auditService.Log(agentName, $"tool_composition:{path}", posture.ToString());
+            _auditService.LogIfAuditEnabled(governance, agentName, $"tool_composition:{path}", posture.ToString());
         }
 
         if (assessment.UnclassifiedTools.Count > 0)

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -366,8 +366,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
             ApprovalGranted: approvedBy is not null,
             Enforced: true));
 
-        if (governance.EnableAudit)
-            _auditService.Log(agentId, toolName, ToolDecisionOutcome.Allowed.ToString());
+        _auditService.LogIfAuditEnabled(governance, agentId, toolName, ToolDecisionOutcome.Allowed.ToString());
 
         return approvedCall is { } call ? ToolInvocationDecision.Allow(call) : ToolInvocationDecision.Allow();
     }
@@ -382,8 +381,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         _trace.Record(new ToolDecisionRecord(toolName, outcome, reason, radius,
             RequiredApproval: requiredApproval, ApprovalGranted: false, Enforced: true));
 
-        if (_governanceConfig.CurrentValue.EnableAudit)
-            _auditService.Log(agentId, toolName, outcome.ToString());
+        _auditService.LogIfAuditEnabled(_governanceConfig, agentId, toolName, outcome.ToString());
 
         _logger.LogWarning(
             "Tool governance blocked agent {AgentId} tool {ToolName}: {Outcome} — {Reason}",

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -245,20 +245,13 @@ public sealed class ToolPermissionProfileResolver
     /// <summary>
     /// Writes a refusal to the durable audit trail — gated on <see cref="GovernanceConfig.EnableAudit"/>
     /// (#419 code-review finding), matching every other <see cref="IGovernanceAuditService"/> call site
-    /// in the codebase (<c>ToolInvocationGovernor</c>, <c>PromptInjectionBehavior</c>). An operator who
-    /// sets that flag <see langword="false"/> expects every tamper-evident write to stop, not just the
-    /// governed ones — a single unconditional call site here would silently break that contract.
+    /// in the codebase via the shared <see cref="GovernanceAuditGateExtensions.LogIfAuditEnabled(IGovernanceAuditService?, IOptionsMonitor{GovernanceConfig}?, string?, string, string)"/>
+    /// gate (#430). An operator who sets that flag <see langword="false"/> expects every tamper-evident
+    /// write to stop, not just the governed ones — a single unconditional call site here would silently
+    /// break that contract.
     /// </summary>
-    private void LogRefusal(string? agentId, string toolName)
-    {
-        if (_auditService is null)
-            return;
-
-        if (_governanceConfig is not null && !_governanceConfig.CurrentValue.EnableAudit)
-            return;
-
-        _auditService.Log(agentId ?? "unknown", toolName, ToolDecisionOutcome.Denied.ToString());
-    }
+    private void LogRefusal(string? agentId, string toolName) =>
+        _auditService.LogIfAuditEnabled(_governanceConfig, agentId, toolName, ToolDecisionOutcome.Denied.ToString());
 
     /// <summary>
     /// As <see cref="ResolveForUngovernedDispatch"/>, but also resolves the keyed-scoped

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -3,11 +3,13 @@ using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Egress;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Services.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
 using Domain.Common.Config;
+using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.BundleExecution;
 using Domain.Common.Config.AI.MCP;
 using Domain.Common.Helpers;
@@ -48,6 +50,8 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private readonly ILogger<EgressPolicyDelegatingHandler> _egressHandlerLogger;
     private readonly TimeProvider _timeProvider;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
+    private readonly IGovernanceAuditService? _governanceAuditService;
+    private readonly IOptionsMonitor<GovernanceConfig>? _governanceConfig;
 
     // A single flat cache keyed by bare serverName, shared across BOTH _config and _bundleOwnedServers —
     // safe today because the two namespacing schemes never collide (host names are plain or
@@ -138,6 +142,11 @@ public sealed class McpConnectionManager : IAsyncDisposable
         _egressHandlerLogger = rootServices.GetRequiredService<ILogger<EgressPolicyDelegatingHandler>>();
         _timeProvider = rootServices.GetService<TimeProvider>() ?? TimeProvider.System;
         _appConfig = rootServices.GetRequiredService<IOptionsMonitor<AppConfig>>();
+        // Optional, like ToolPermissionProfileResolver's identical convention (#419): a composition
+        // root that never calls AddGovernance still constructs this manager; the sandboxed-session
+        // refusal branches below (#431) just get no durable audit trail for this path.
+        _governanceAuditService = rootServices.GetService<IGovernanceAuditService>();
+        _governanceConfig = rootServices.GetService<IOptionsMonitor<GovernanceConfig>>();
     }
 
     /// <summary>
@@ -534,8 +543,9 @@ public sealed class McpConnectionManager : IAsyncDisposable
         if (Interlocked.Increment(ref _liveSandboxedStdioSessions) > maxConcurrentSessions)
         {
             Interlocked.Decrement(ref _liveSandboxedStdioSessions);
-            return Result<ISandboxSession>.Fail(
-                $"Host-wide bundle stdio sandbox session cap ({maxConcurrentSessions}) reached; refusing to start another.");
+            var capReason = $"Host-wide bundle stdio sandbox session cap ({maxConcurrentSessions}) reached; refusing to start another.";
+            _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, capReason);
+            return Result<ISandboxSession>.Fail(capReason);
         }
 
         // Nullable, and assigned only once CreateAsyncScope() itself succeeds — that call is not
@@ -569,8 +579,9 @@ public sealed class McpConnectionManager : IAsyncDisposable
                 // this field cannot turn "seed a sandbox workspace" into "copy an arbitrary host
                 // directory into an untrusted, bundle-launched container" without this check also
                 // having to be deliberately bypassed, not merely never written in the first place.
-                return Result<ISandboxSession>.Fail(
-                    "Sandbox workspace seed directory is outside the configured bundle staging root — refusing to seed.");
+                var containmentReason = "Sandbox workspace seed directory is outside the configured bundle staging root — refusing to seed.";
+                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, containmentReason);
+                return Result<ISandboxSession>.Fail(containmentReason);
             }
 
             var request = new SandboxSessionRequest
@@ -589,7 +600,11 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
             var result = await sessionFactory.StartSessionAsync(request, cancellationToken);
             if (!result.IsSuccess)
+            {
+                var factoryReason = result.Errors.Count > 0 ? string.Join("; ", result.Errors) : "unknown error";
+                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, $"session_factory_failed: {factoryReason}");
                 return result;
+            }
 
             // From here on, ownership of both the scope AND this session's claimed concurrency slot
             // transfers to the returned session — two composed decorators, each responsible for

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -544,7 +544,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         {
             Interlocked.Decrement(ref _liveSandboxedStdioSessions);
             var capReason = $"Host-wide bundle stdio sandbox session cap ({maxConcurrentSessions}) reached; refusing to start another.";
-            _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, capReason);
+            _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, $"session_cap_exceeded:{maxConcurrentSessions}");
             return Result<ISandboxSession>.Fail(capReason);
         }
 
@@ -580,7 +580,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
                 // directory into an untrusted, bundle-launched container" without this check also
                 // having to be deliberately bypassed, not merely never written in the first place.
                 var containmentReason = "Sandbox workspace seed directory is outside the configured bundle staging root — refusing to seed.";
-                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, containmentReason);
+                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, "refused:seed_outside_staging_root");
                 return Result<ISandboxSession>.Fail(containmentReason);
             }
 
@@ -601,8 +601,8 @@ public sealed class McpConnectionManager : IAsyncDisposable
             var result = await sessionFactory.StartSessionAsync(request, cancellationToken);
             if (!result.IsSuccess)
             {
-                var factoryReason = result.Errors.Count > 0 ? string.Join("; ", result.Errors) : "unknown error";
-                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, $"session_factory_failed: {factoryReason}");
+                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName,
+                    () => $"session_factory_failed:{(result.Errors.Count > 0 ? string.Join("; ", result.Errors) : "unknown error")}");
                 return result;
             }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -544,7 +544,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         {
             Interlocked.Decrement(ref _liveSandboxedStdioSessions);
             var capReason = $"Host-wide bundle stdio sandbox session cap ({maxConcurrentSessions}) reached; refusing to start another.";
-            _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, $"session_cap_exceeded:{maxConcurrentSessions}");
+            _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, $"host_session_cap_exceeded:{maxConcurrentSessions}");
             return Result<ISandboxSession>.Fail(capReason);
         }
 
@@ -580,7 +580,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
                 // directory into an untrusted, bundle-launched container" without this check also
                 // having to be deliberately bypassed, not merely never written in the first place.
                 var containmentReason = "Sandbox workspace seed directory is outside the configured bundle staging root — refusing to seed.";
-                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, "refused:seed_outside_staging_root");
+                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName, "seed_outside_staging_root");
                 return Result<ISandboxSession>.Fail(containmentReason);
             }
 
@@ -601,7 +601,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
             var result = await sessionFactory.StartSessionAsync(request, cancellationToken);
             if (!result.IsSuccess)
             {
-                _governanceAuditService.LogIfAuditEnabled(_governanceConfig, "system", serverName,
+                _governanceAuditService.LogIfAuditEnabled(_governanceConfig?.CurrentValue, "system", serverName,
                     () => $"session_factory_failed:{(result.Errors.Count > 0 ? string.Join("; ", result.Errors) : "unknown error")}");
                 return result;
             }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
@@ -155,34 +155,6 @@ public sealed class GovernanceAuditGateExtensionsTests
         factoryInvoked.Should().BeFalse("a missing audit sink means there is nothing to build the decision string for");
     }
 
-    [Fact]
-    public void LogIfAuditEnabled_LazyIOptionsMonitorOverload_EnableAuditTrue_LogsUsingFactoryResult()
-    {
-        var config = MonitorOf(new GovernanceConfig { EnableAudit = true });
-
-        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", () => "computed-decision");
-
-        _auditService.Verify(a => a.Log("agent-1", "tool_x", "computed-decision"), Times.Once);
-    }
-
-    [Fact]
-    public void LogIfAuditEnabled_LazyIOptionsMonitorOverload_EnableAuditFalse_NeverInvokesFactory()
-    {
-        // Exercises the McpConnectionManager.cs session-factory-failure call site's exact shape: a
-        // live IOptionsMonitor plus a Func<string> decision, delegating to the snapshot+lazy overload.
-        var config = MonitorOf(new GovernanceConfig { EnableAudit = false });
-        var factoryInvoked = false;
-
-        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", () =>
-        {
-            factoryInvoked = true;
-            return "computed-decision";
-        });
-
-        factoryInvoked.Should().BeFalse("the decision factory must not run when auditing is disabled");
-        _auditService.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
-    }
-
     private static IOptionsMonitor<GovernanceConfig> MonitorOf(GovernanceConfig config)
     {
         var monitor = new Mock<IOptionsMonitor<GovernanceConfig>>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
@@ -107,6 +107,54 @@ public sealed class GovernanceAuditGateExtensionsTests
         _auditService.Verify(a => a.Log("agent-1", "tool_x", "allowed"), Times.Once);
     }
 
+    [Fact]
+    public void LogIfAuditEnabled_LazySnapshotOverload_EnableAuditTrue_LogsUsingFactoryResult()
+    {
+        var config = new GovernanceConfig { EnableAudit = true };
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", () => "computed-decision");
+
+        _auditService.Verify(a => a.Log("agent-1", "tool_x", "computed-decision"), Times.Once);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_LazySnapshotOverload_EnableAuditFalse_NeverInvokesFactory()
+    {
+        // The whole reason this overload exists (#444 code-review/simplify finding): a caller with an
+        // expensive decision string (a LINQ projection) must not pay that cost when audit is off. If the
+        // gate check moved after the factory call, this would still pass on Times.Never for Log but the
+        // factory itself would already have run — so the assertion is on the factory invocation, not on
+        // the audit write.
+        var config = new GovernanceConfig { EnableAudit = false };
+        var factoryInvoked = false;
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", () =>
+        {
+            factoryInvoked = true;
+            return "computed-decision";
+        });
+
+        factoryInvoked.Should().BeFalse("the decision factory must not run when auditing is disabled");
+        _auditService.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_LazySnapshotOverload_NullAuditService_DoesNotInvokeFactory()
+    {
+        IGovernanceAuditService? nullService = null;
+        var config = new GovernanceConfig { EnableAudit = true };
+        var factoryInvoked = false;
+
+        var act = () => nullService.LogIfAuditEnabled(config, "agent-1", "tool_x", () =>
+        {
+            factoryInvoked = true;
+            return "computed-decision";
+        });
+
+        act.Should().NotThrow();
+        factoryInvoked.Should().BeFalse("a missing audit sink means there is nothing to build the decision string for");
+    }
+
     private static IOptionsMonitor<GovernanceConfig> MonitorOf(GovernanceConfig config)
     {
         var monitor = new Mock<IOptionsMonitor<GovernanceConfig>>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
@@ -155,6 +155,34 @@ public sealed class GovernanceAuditGateExtensionsTests
         factoryInvoked.Should().BeFalse("a missing audit sink means there is nothing to build the decision string for");
     }
 
+    [Fact]
+    public void LogIfAuditEnabled_LazyIOptionsMonitorOverload_EnableAuditTrue_LogsUsingFactoryResult()
+    {
+        var config = MonitorOf(new GovernanceConfig { EnableAudit = true });
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", () => "computed-decision");
+
+        _auditService.Verify(a => a.Log("agent-1", "tool_x", "computed-decision"), Times.Once);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_LazyIOptionsMonitorOverload_EnableAuditFalse_NeverInvokesFactory()
+    {
+        // Exercises the McpConnectionManager.cs session-factory-failure call site's exact shape: a
+        // live IOptionsMonitor plus a Func<string> decision, delegating to the snapshot+lazy overload.
+        var config = MonitorOf(new GovernanceConfig { EnableAudit = false });
+        var factoryInvoked = false;
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", () =>
+        {
+            factoryInvoked = true;
+            return "computed-decision";
+        });
+
+        factoryInvoked.Should().BeFalse("the decision factory must not run when auditing is disabled");
+        _auditService.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
     private static IOptionsMonitor<GovernanceConfig> MonitorOf(GovernanceConfig config)
     {
         var monitor = new Mock<IOptionsMonitor<GovernanceConfig>>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernanceAuditGateExtensionsTests.cs
@@ -1,0 +1,116 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// Unit tests for <see cref="GovernanceAuditGateExtensions"/> — the shared audit-gate helper
+/// consolidating nine independently-duplicated call sites (#430).
+/// </summary>
+public sealed class GovernanceAuditGateExtensionsTests
+{
+    private readonly Mock<IGovernanceAuditService> _auditService = new();
+
+    [Fact]
+    public void LogIfAuditEnabled_IOptionsMonitorOverload_EnableAuditTrue_Logs()
+    {
+        var config = MonitorOf(new GovernanceConfig { EnableAudit = true });
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", "allowed");
+
+        _auditService.Verify(a => a.Log("agent-1", "tool_x", "allowed"), Times.Once);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_IOptionsMonitorOverload_EnableAuditFalse_DoesNotLog()
+    {
+        var config = MonitorOf(new GovernanceConfig { EnableAudit = false });
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", "allowed");
+
+        _auditService.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_IOptionsMonitorOverload_NullAgentId_DefaultsToUnknown()
+    {
+        var config = MonitorOf(new GovernanceConfig { EnableAudit = true });
+
+        _auditService.Object.LogIfAuditEnabled(config, null, "tool_x", "allowed");
+
+        _auditService.Verify(a => a.Log("unknown", "tool_x", "allowed"), Times.Once);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_IOptionsMonitorOverload_NullAuditService_DoesNotThrow()
+    {
+        IGovernanceAuditService? nullService = null;
+        var config = MonitorOf(new GovernanceConfig { EnableAudit = true });
+
+        var act = () => nullService.LogIfAuditEnabled(config, "agent-1", "tool_x", "allowed");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_IOptionsMonitorOverload_NullConfig_DefaultsToAuditOn()
+    {
+        // Matches ToolPermissionProfileResolver.LogRefusal's original semantic: an absent config
+        // (a composition root that never wired governance) must not be treated as audit-off.
+        _auditService.Object.LogIfAuditEnabled(
+            (IOptionsMonitor<GovernanceConfig>?)null, "agent-1", "tool_x", "allowed");
+
+        _auditService.Verify(a => a.Log("agent-1", "tool_x", "allowed"), Times.Once);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_SnapshotOverload_EnableAuditTrue_Logs()
+    {
+        var config = new GovernanceConfig { EnableAudit = true };
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", "allowed");
+
+        _auditService.Verify(a => a.Log("agent-1", "tool_x", "allowed"), Times.Once);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_SnapshotOverload_EnableAuditFalse_DoesNotLog()
+    {
+        var config = new GovernanceConfig { EnableAudit = false };
+
+        _auditService.Object.LogIfAuditEnabled(config, "agent-1", "tool_x", "allowed");
+
+        _auditService.Verify(a => a.Log(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_SnapshotOverload_NullAuditService_DoesNotThrow()
+    {
+        IGovernanceAuditService? nullService = null;
+        var config = new GovernanceConfig { EnableAudit = true };
+
+        var act = () => nullService.LogIfAuditEnabled(config, "agent-1", "tool_x", "allowed");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void LogIfAuditEnabled_SnapshotOverload_NullConfig_DefaultsToAuditOn()
+    {
+        _auditService.Object.LogIfAuditEnabled(
+            (GovernanceConfig?)null, "agent-1", "tool_x", "allowed");
+
+        _auditService.Verify(a => a.Log("agent-1", "tool_x", "allowed"), Times.Once);
+    }
+
+    private static IOptionsMonitor<GovernanceConfig> MonitorOf(GovernanceConfig config)
+    {
+        var monitor = new Mock<IOptionsMonitor<GovernanceConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(config);
+        return monitor.Object;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -392,7 +392,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b2:local-tool"));
 
         auditService.Entries.Should().ContainSingle(
-            e => e.Action == "b2:local-tool" && e.Decision.Contains("Host-wide bundle stdio sandbox session cap"),
+            e => e.Action == "b2:local-tool" && e.Decision == "session_cap_exceeded:1",
             "the cap refusal must leave exactly one durable audit record naming the refused server");
 
         blockingFactory.Release.SetResult();
@@ -439,7 +439,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
         auditService.Entries.Should().ContainSingle(
-            e => e.Action == "b1:local-tool" && e.Decision.Contains("outside the configured bundle staging root"),
+            e => e.Action == "b1:local-tool" && e.Decision == "refused:seed_outside_staging_root",
             "the seed-containment refusal must leave exactly one durable audit record naming the refused server");
     }
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Exceptions;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
@@ -344,6 +345,137 @@ public sealed class McpConnectionManagerSandboxedStdioTests
     }
 
     [Fact]
+    public async Task GetClientAsync_ConcurrentSandboxedStdioSessions_RefusesBeyondTheHostWideCap_WritesOneAuditRecord()
+    {
+        // #431: the host-wide session-cap refusal above (RefusesBeyondTheHostWideCap) previously left
+        // no audit trail at all — an authenticated caller repeatedly hitting the cap was invisible to
+        // the governance audit chain. Same scenario as that test, plus a fake IGovernanceAuditService
+        // to prove the refusal is now recorded exactly once.
+        var auditService = new FakeGovernanceAuditService();
+        var blockingFactory = new BlockingSandboxSessionFactory();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true, Type = McpServerType.Stdio, Command = "node", StartupTimeoutSeconds = 1,
+        });
+        bundleOwned.TryAdd("b2:local-tool", new McpServerDefinition
+        {
+            Enabled = true, Type = McpServerType.Stdio, Command = "node", StartupTimeoutSeconds = 1,
+        });
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new BundleExecutionConfig
+                {
+                    StdioMcpServers = new BundleStdioMcpServersConfig
+                    {
+                        ContainerImage = "mcr.microsoft.com/node:20",
+                        MaxConcurrentSessions = 1,
+                    },
+                },
+            },
+        };
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, blockingFactory);
+            services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
+            services.AddSingleton<IGovernanceAuditService>(auditService);
+        });
+        var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+
+        var firstCallTask = sut.GetClientAsync("b1:local-tool");
+        await blockingFactory.EntrySignaled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b2:local-tool"));
+
+        auditService.Entries.Should().ContainSingle(
+            e => e.Action == "b2:local-tool" && e.Decision.Contains("Host-wide bundle stdio sandbox session cap"),
+            "the cap refusal must leave exactly one durable audit record naming the refused server");
+
+        blockingFactory.Release.SetResult();
+        await Assert.ThrowsAsync<McpConnectionException>(() => firstCallTask);
+    }
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedStdioServer_SeedDirectoryOutsideStagingRoot_WritesOneAuditRecord()
+    {
+        // #431: same containment scenario as SeedDirectoryOutsideStagingRoot_RefusesWithoutStartingASession
+        // above, plus a fake IGovernanceAuditService to prove the refusal is now recorded exactly once.
+        var auditService = new FakeGovernanceAuditService();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Stdio,
+            Command = "node",
+            StartupTimeoutSeconds = 1,
+            SandboxSeedDirectory = Path.Combine(Path.GetTempPath(), "definitely-not-the-staging-root", "evil"),
+        });
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                BundleExecution = new BundleExecutionConfig
+                {
+                    TempRoot = Path.Combine(Path.GetTempPath(), "staged"),
+                    StdioMcpServers = new BundleStdioMcpServersConfig { ContainerImage = "mcr.microsoft.com/node:20" },
+                },
+            },
+        };
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, _fakeSessionFactory);
+            services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
+            services.AddSingleton<IGovernanceAuditService>(auditService);
+        });
+        var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+
+        await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
+
+        auditService.Entries.Should().ContainSingle(
+            e => e.Action == "b1:local-tool" && e.Decision.Contains("outside the configured bundle staging root"),
+            "the seed-containment refusal must leave exactly one durable audit record naming the refused server");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedStdioServer_SessionFactoryFails_WritesOneAuditRecord()
+    {
+        // #431: StartSandboxedStdioSessionAsync's third refusal branch — the sandbox session factory
+        // itself returning a failed Result — previously left no audit trail. FakeSandboxSessionFactory
+        // always fails (see its own doc comment), so any successful connection attempt against it
+        // exercises exactly this branch.
+        var auditService = new FakeGovernanceAuditService();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Stdio,
+            Command = "node",
+            StartupTimeoutSeconds = 1,
+        });
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, _fakeSessionFactory);
+            services.AddSingleton<IGovernanceAuditService>(auditService);
+        });
+        var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+
+        await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
+
+        auditService.Entries.Should().ContainSingle(
+            e => e.Action == "b1:local-tool" && e.Decision.StartsWith("session_factory_failed:", StringComparison.Ordinal),
+            "the session-factory failure must leave exactly one durable audit record naming the refused server");
+    }
+
+    [Fact]
     public async Task GetClientAsync_BundleOwnedStdioServer_NoConfiguredImage_LeavesRequestImageNull()
     {
         var bundleOwned = new BundleOwnedMcpServerRegistry();
@@ -454,5 +586,17 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             LastRequest = request;
             return Task.FromResult(Result<ISandboxSession>.Fail("fake factory: not starting a real session"));
         }
+    }
+
+    /// <summary>Records every <see cref="Log"/> call for a test to assert against, instead of writing a real tamper-evident chain.</summary>
+    private sealed class FakeGovernanceAuditService : IGovernanceAuditService
+    {
+        public List<(string AgentId, string Action, string Decision)> Entries { get; } = [];
+
+        public void Log(string agentId, string action, string decision) => Entries.Add((agentId, action, decision));
+
+        public bool VerifyChainIntegrity() => true;
+
+        public int EntryCount => Entries.Count;
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -349,9 +349,9 @@ public sealed class McpConnectionManagerSandboxedStdioTests
     {
         // #431: the host-wide session-cap refusal above (RefusesBeyondTheHostWideCap) previously left
         // no audit trail at all — an authenticated caller repeatedly hitting the cap was invisible to
-        // the governance audit chain. Same scenario as that test, plus a fake IGovernanceAuditService
+        // the governance audit chain. Same scenario as that test, plus a mocked IGovernanceAuditService
         // to prove the refusal is now recorded exactly once.
-        var auditService = new FakeGovernanceAuditService();
+        var auditService = new Mock<IGovernanceAuditService>();
         var blockingFactory = new BlockingSandboxSessionFactory();
         var bundleOwned = new BundleOwnedMcpServerRegistry();
         bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
@@ -380,7 +380,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         {
             services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, blockingFactory);
             services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
-            services.AddSingleton<IGovernanceAuditService>(auditService);
+            services.AddSingleton(auditService.Object);
         });
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
@@ -391,9 +391,9 @@ public sealed class McpConnectionManagerSandboxedStdioTests
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b2:local-tool"));
 
-        auditService.Entries.Should().ContainSingle(
-            e => e.Action == "b2:local-tool" && e.Decision == "session_cap_exceeded:1",
-            "the cap refusal must leave exactly one durable audit record naming the refused server");
+        auditService.Verify(a => a.Log(It.IsAny<string>(), "b2:local-tool",
+                $"host_session_cap_exceeded:{appConfig.AI.BundleExecution.StdioMcpServers.MaxConcurrentSessions}"),
+            Times.Once, "the cap refusal must leave exactly one durable audit record naming the refused server");
 
         blockingFactory.Release.SetResult();
         await Assert.ThrowsAsync<McpConnectionException>(() => firstCallTask);
@@ -403,8 +403,8 @@ public sealed class McpConnectionManagerSandboxedStdioTests
     public async Task GetClientAsync_BundleOwnedStdioServer_SeedDirectoryOutsideStagingRoot_WritesOneAuditRecord()
     {
         // #431: same containment scenario as SeedDirectoryOutsideStagingRoot_RefusesWithoutStartingASession
-        // above, plus a fake IGovernanceAuditService to prove the refusal is now recorded exactly once.
-        var auditService = new FakeGovernanceAuditService();
+        // above, plus a mocked IGovernanceAuditService to prove the refusal is now recorded exactly once.
+        var auditService = new Mock<IGovernanceAuditService>();
         var bundleOwned = new BundleOwnedMcpServerRegistry();
         bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
         {
@@ -430,7 +430,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         {
             services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, _fakeSessionFactory);
             services.AddSingleton<IOptionsMonitor<AppConfig>>(new StaticAppConfigMonitor(appConfig));
-            services.AddSingleton<IGovernanceAuditService>(auditService);
+            services.AddSingleton(auditService.Object);
         });
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
@@ -438,8 +438,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
-        auditService.Entries.Should().ContainSingle(
-            e => e.Action == "b1:local-tool" && e.Decision == "refused:seed_outside_staging_root",
+        auditService.Verify(a => a.Log(It.IsAny<string>(), "b1:local-tool", "seed_outside_staging_root"), Times.Once,
             "the seed-containment refusal must leave exactly one durable audit record naming the refused server");
     }
 
@@ -450,7 +449,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         // itself returning a failed Result — previously left no audit trail. FakeSandboxSessionFactory
         // always fails (see its own doc comment), so any successful connection attempt against it
         // exercises exactly this branch.
-        var auditService = new FakeGovernanceAuditService();
+        var auditService = new Mock<IGovernanceAuditService>();
         var bundleOwned = new BundleOwnedMcpServerRegistry();
         bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
         {
@@ -462,7 +461,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
         {
             services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, _fakeSessionFactory);
-            services.AddSingleton<IGovernanceAuditService>(auditService);
+            services.AddSingleton(auditService.Object);
         });
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
@@ -470,9 +469,9 @@ public sealed class McpConnectionManagerSandboxedStdioTests
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
-        auditService.Entries.Should().ContainSingle(
-            e => e.Action == "b1:local-tool" && e.Decision.StartsWith("session_factory_failed:", StringComparison.Ordinal),
-            "the session-factory failure must leave exactly one durable audit record naming the refused server");
+        auditService.Verify(a => a.Log(It.IsAny<string>(), "b1:local-tool",
+                It.Is<string>(d => d.StartsWith("session_factory_failed:", StringComparison.Ordinal))),
+            Times.Once, "the session-factory failure must leave exactly one durable audit record naming the refused server");
     }
 
     [Fact]
@@ -586,17 +585,5 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             LastRequest = request;
             return Task.FromResult(Result<ISandboxSession>.Fail("fake factory: not starting a real session"));
         }
-    }
-
-    /// <summary>Records every <see cref="Log"/> call for a test to assert against, instead of writing a real tamper-evident chain.</summary>
-    private sealed class FakeGovernanceAuditService : IGovernanceAuditService
-    {
-        public List<(string AgentId, string Action, string Decision)> Entries { get; } = [];
-
-        public void Log(string agentId, string action, string decision) => Entries.Add((agentId, action, decision));
-
-        public bool VerifyChainIntegrity() => true;
-
-        public int EntryCount => Entries.Count;
     }
 }


### PR DESCRIPTION
## Summary
- Nine hand-rolled "if EnableAudit, write" sites collapsed onto a shared `GovernanceAuditGateExtensions.LogIfAuditEnabled`, preserving `ToolPermissionProfileResolver`'s deliberately-different absent-config-means-audit-on semantic.
- `McpConnectionManager.StartSandboxedStdioSessionAsync`'s three sandboxed-stdio refusal branches (host-wide session cap, seed-directory containment, session-factory failure) previously left no audit trail at all — all three now write through the same helper.
- `/code-review` and `/simplify` both ran against this diff. Two fixes applied: the monitor-based overload now delegates to the snapshot overload instead of duplicating its gate logic, and a lazy-decision overload defers `ResponseSanitizationBehavior`'s LINQ category projection so it only runs when audit is actually enabled (both independently flagged by the two review passes, and both mutation-tested). A third, more speculative finding — the session-cap refusal's audit write is now synchronous I/O on what used to be a lock-free fast path — was filed as #445 rather than fixed here, since a real fix means redesigning `IGovernanceAuditService`'s write path for all ~15 existing call sites, not just these three.

Closes #430, #431

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors
- [x] `dotnet test src/Content/Tests/Application.AI.Common.Tests` — 2143/2143 pass
- [x] `dotnet test src/Content/Tests/Infrastructure.AI.MCP.Tests` — 128/128 pass
- [x] 3 new regression tests proving each MCP refusal branch writes exactly one audit record — each mutation-tested (broke the fix, confirmed the test failed, reverted)
- [x] 3 new regression tests for the shared helper's lazy overload — including one proving the decision factory is never invoked when audit is off, mutation-tested
- [x] `/code-review` and `/simplify` receipts recorded for the final diff