### PR TITLE
Fix bundle SSE wire contract to match AG-UI schema

### DIFF
--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -1165,8 +1165,10 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                         Frames are <code>data: {json}\n\n</code>, camelCase, with a <code>type</code> discriminator taken
                         from the AG-UI wire vocabulary — a hand-written client that switches on <code>type</code> works
                         unchanged. A strict AG-UI client library is not guaranteed to: tool-call frames can arrive while
-                        a <code>TEXT_MESSAGE</code> is still open (see below, some AG-UI client libraries reject that),
-                        and <code>TOOL_CALL_RESULT</code>'s fields have no AG-UI precedent to match against.
+                        a <code>TEXT_MESSAGE</code> is still open (see below, some AG-UI client libraries reject that).
+                        <code>TOOL_CALL_START</code>'s <code>parentMessageId</code> and <code>TOOL_CALL_RESULT</code>'s
+                        <code>messageId</code>/<code>content</code>/<code>role</code> match the AG-UI wire schema
+                        exactly.
                     </p>
                     <table>
                         <thead><tr><th>Frame <code>type</code></th><th>Payload</th><th>When</th></tr></thead>
@@ -1175,10 +1177,10 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                             <tr><td><code>TEXT_MESSAGE_START</code></td><td><code>messageId</code>, <code>role: "assistant"</code></td><td>Lazily, on the first real token. A run that emits no text emits no message frames at all.</td></tr>
                             <tr><td><code>TEXT_MESSAGE_CONTENT</code></td><td><code>messageId</code>, <code>delta</code></td><td>Per token batch. Append to your buffer.</td></tr>
                             <tr><td><code>TEXT_MESSAGE_END</code></td><td><code>messageId</code></td><td>Once, if the message was opened.</td></tr>
-                            <tr><td><code>TOOL_CALL_START</code></td><td><code>toolCallId</code>, <code>toolCallName</code></td><td>When the agent decides to call a tool. May arrive before the first <code>TEXT_MESSAGE_START</code>.</td></tr>
+                            <tr><td><code>TOOL_CALL_START</code></td><td><code>toolCallId</code>, <code>toolCallName</code>, <code>parentMessageId</code> (only present once the assistant message has opened)</td><td>When the agent decides to call a tool. May arrive before the first <code>TEXT_MESSAGE_START</code>.</td></tr>
                             <tr><td><code>TOOL_CALL_ARGS</code></td><td><code>toolCallId</code>, <code>delta</code>, <code>withheld</code> (only present when <code>true</code>)</td><td>Immediately after <code>TOOL_CALL_START</code> — the complete arguments JSON in one frame, not an incremental delta.</td></tr>
                             <tr><td><code>TOOL_CALL_END</code></td><td><code>toolCallId</code></td><td>Immediately after <code>TOOL_CALL_ARGS</code>.</td></tr>
-                            <tr><td><code>TOOL_CALL_RESULT</code></td><td><code>toolCallId</code>, <code>result</code> (redacted preview)</td><td>Once the tool has actually run.</td></tr>
+                            <tr><td><code>TOOL_CALL_RESULT</code></td><td><code>toolCallId</code>, <code>messageId</code> (a fresh id for this result's own message), <code>content</code> (redacted, never truncated), <code>role: "tool"</code>, <code>withheld</code> (only present when <code>true</code>)</td><td>Once the tool has actually run.</td></tr>
                             <tr><td><code>RUN_FINISHED</code></td><td><code>threadId</code>, <code>runId</code></td><td>Terminal, on success.</td></tr>
                             <tr><td><code>RUN_ERROR</code></td><td><code>message</code> (caller-safe)</td><td>Terminal, on failure. Never both this and <code>RUN_FINISHED</code>.</td></tr>
                         </tbody>
@@ -1193,17 +1195,18 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                         assistant message ever opens — a client cannot assume text comes first.
                     </p>
                     <p>
-                        <code>TOOL_CALL_ARGS.delta</code> and <code>TOOL_CALL_RESULT.result</code> are never the raw
+                        <code>TOOL_CALL_ARGS.delta</code> and <code>TOOL_CALL_RESULT.content</code> are never the raw
                         payload — both pass through the same secret-redaction the harness applies before persisting
                         tool activity to its observability store, since a live stream to a browser is just as much
-                        an exposure point as disk. They differ in how they bound size: <code>result</code> is
-                        truncated to a fixed preview length, which is safe for free text. <code>delta</code> is
-                        never truncated — cutting JSON mid-token would hand the client invalid data — so above a
-                        size ceiling the real arguments are <strong>withheld</strong> instead: <code>delta</code>
-                        becomes the fixed placeholder <code>"{}"</code> and <code>withheld</code> is <code>true</code>.
-                        A client should treat a <code>withheld</code> frame as "arguments unavailable," not attempt
-                        to interpret <code>"{}"</code> as the tool's real (empty) arguments. If a tool call fails,
-                        <code>result</code> is a generic failure message, not the underlying exception text.
+                        an exposure point as disk. Neither is ever truncated: cutting JSON mid-token would hand the
+                        client invalid data for <code>delta</code>, and a truncated <code>content</code> preview
+                        past the redactor's structural-pass size ceiling could still contain an unredacted secret —
+                        so above a size ceiling both are <strong>withheld</strong> instead. <code>delta</code>
+                        becomes the fixed placeholder <code>"{}"</code>; <code>content</code> becomes an empty
+                        string. Either way <code>withheld</code> is <code>true</code>. A client should treat a
+                        <code>withheld</code> frame as "unavailable," not attempt to interpret the placeholder value
+                        as the tool's real (empty) output. If a tool call fails, <code>content</code> is a generic
+                        failure message, not the underlying exception text.
                     </p>
                     <div class="code-block">
                         <div class="code-block-header"><span class="code-block-lang">ts · consuming the stream</span></div>

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -351,9 +351,13 @@ paths:
         Frames are `data: {json}\n\n` with camelCase properties and a `type` discriminator matching
         the AG-UI wire vocabulary — a hand-written client that switches on `type` works unchanged.
         A strict `@ag-ui/client`-style consumer is not guaranteed to: tool-call frames can arrive
-        while a `TEXT_MESSAGE` is still open (see below), which some AG-UI client libraries reject,
-        and `TOOL_CALL_RESULT`'s fields (`toolCallId`, `result`) have no AG-UI precedent to match
-        against. Exactly one terminal frame is emitted: `RUN_FINISHED` or `RUN_ERROR`.
+        while a `TEXT_MESSAGE` is still open (see below), which some AG-UI client libraries reject.
+        `TOOL_CALL_START`'s `parentMessageId` and `TOOL_CALL_RESULT`'s `messageId`/`content`/`role`
+        match the AG-UI wire schema exactly; `parentMessageId` is omitted (not sent as `null`) when
+        the tool call precedes any assistant text — the parent message does not exist yet at that
+        point. `TOOL_CALL_RESULT`'s `content` is never truncated: above a size ceiling it is withheld
+        whole with `withheld: true` and empty `content`, the same treatment `TOOL_CALL_ARGS.delta`
+        already gets. Exactly one terminal frame is emitted: `RUN_FINISHED` or `RUN_ERROR`.
 
         A tool call interleaves as `TOOL_CALL_START` → `TOOL_CALL_ARGS` → `TOOL_CALL_END`, then
         `TOOL_CALL_RESULT` once the tool has run — freely interleaved with `TEXT_MESSAGE_*` frames,
@@ -388,7 +392,7 @@ paths:
 
                     data: {"type":"TOOL_CALL_END","toolCallId":"c-1a2b..."}
 
-                    data: {"type":"TOOL_CALL_RESULT","toolCallId":"c-1a2b...","result":"3 matching entries"}
+                    data: {"type":"TOOL_CALL_RESULT","toolCallId":"c-1a2b...","messageId":"9d4f...","content":"3 matching entries","role":"tool"}
 
                     data: {"type":"TEXT_MESSAGE_START","messageId":"7e2a...","role":"assistant"}
 
@@ -1311,6 +1315,13 @@ components:
           type: string
           description: The provider-assigned id for this call, shared by every event for it.
         toolCallName: { type: string }
+        parentMessageId:
+          type: string
+          description: >-
+            The id of the assistant message this tool call belongs to, per the AG-UI wire schema.
+            Absent (never sent as `null`) when the call is emitted before the assistant's
+            `TextMessageStartEvent` has streamed — the parent message does not exist yet from the
+            client's perspective at that point.
 
     ToolCallArgsEvent:
       type: object
@@ -1346,17 +1357,34 @@ components:
 
     ToolCallResultEvent:
       type: object
-      description: Emitted once a tool call has actually run and produced a result.
-      required: [type, toolCallId, result]
+      description: >-
+        Emitted once a tool call has actually run and produced a result. Field names match the AG-UI
+        wire schema's tool-call-result event exactly (`messageId`, `content`, `role`).
+      required: [type, toolCallId, messageId, content, role]
       properties:
         type: { type: string, const: TOOL_CALL_RESULT }
         toolCallId: { type: string }
-        result:
+        messageId:
           type: string
           description: >-
-            A redacted, truncated preview of the tool's output — never the raw payload. Secret-shaped
-            values are replaced with "[REDACTED]" before truncation. If the tool call failed, this is a
-            generic failure message, not the underlying exception text.
+            A fresh id for this result's own message, per the AG-UI wire schema — never a reuse of
+            the run's assistant message id. A tool result is its own message with role `tool`, not a
+            continuation of the assistant's text message.
+        content:
+          type: string
+          description: >-
+            The tool's redacted output — never the raw payload, and never truncated. Secret-shaped
+            values are replaced with "[REDACTED]". If the tool call failed, this is a generic failure
+            message, not the underlying exception text. Empty when `withheld` is `true`.
+        role:
+          type: string
+          const: tool
+          description: Message role for a tool result, per the AG-UI wire schema. Always `tool`.
+        withheld:
+          type: boolean
+          description: >-
+            Present and `true` only when the real result exceeded the streaming size ceiling and was
+            withheld whole rather than truncated. Absent on every normal frame.
 
     RunFinishedEvent:
       type: object

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
@@ -17,18 +17,19 @@ public static class ToolPayloadRedactor
     public const int MaxPayloadSummaryLength = 500;
 
     /// <summary>
-    /// The length, in UTF-16 characters of the serialized (pre-redaction) JSON, above which a
-    /// streamed tool call's arguments are withheld rather than sent. Unlike
-    /// <see cref="MaxPayloadSummaryLength"/>, arguments are never truncated — truncating mid-JSON
-    /// would hand a client invalid, unparseable data (see <see cref="Redact"/>'s remarks) — so
-    /// oversized arguments are withheld whole instead of cut. Checked against the pre-redaction
-    /// length deliberately: it is a resource ceiling, not a secrecy decision, so there is no reason
-    /// to pay for redaction on a payload that is about to be discarded. Sits comfortably below
-    /// <c>PatternSecretRedactor</c>'s own structural-redaction size ceiling (64KB), so any payload
-    /// that actually reaches a client has had the full structural JSON-aware redaction pass applied
-    /// to it — never just the regex-only fallback.
+    /// The length, in UTF-16 characters of the pre-redaction payload (serialized JSON for arguments,
+    /// plain text for a result), above which a streamed tool call's arguments or result are withheld
+    /// rather than sent. Unlike <see cref="MaxPayloadSummaryLength"/>, neither is ever truncated —
+    /// truncating mid-JSON would hand a client invalid, unparseable data, and truncating a result past
+    /// <see cref="MaxStructuralRedactionCeiling"/> could still contain an unredacted secret (see
+    /// <see cref="Redact"/>'s remarks) — so an oversized payload is withheld whole instead of cut.
+    /// Checked against the pre-redaction length deliberately: it is a resource ceiling, not a secrecy
+    /// decision, so there is no reason to pay for redaction on a payload that is about to be discarded.
+    /// Sits comfortably below <c>PatternSecretRedactor</c>'s own structural-redaction size ceiling
+    /// (64KB), so any payload that actually reaches a client has had the full structural JSON-aware
+    /// redaction pass applied to it — never just the regex-only fallback.
     /// </summary>
-    public const int MaxStreamedToolCallArgsLength = 16 * 1024;
+    public const int MaxStreamedToolCallPayloadLength = 16 * 1024;
 
     /// <summary>
     /// Mirrors <c>PatternSecretRedactor.MaxStructuralRedactionLength</c> (Infrastructure layer,
@@ -39,7 +40,7 @@ public static class ToolPayloadRedactor
     /// </summary>
     /// <remarks>
     /// The persistence path (<c>ToolDiagnosticsMiddleware</c>) has no size ceiling of its own, unlike
-    /// the streaming path (<see cref="MaxStreamedToolCallArgsLength"/>, 16KB). Above this size,
+    /// the streaming path (<see cref="MaxStreamedToolCallPayloadLength"/>, 16KB). Above this size,
     /// <see cref="Redact"/> silently falls back to regex-only redaction, which cannot see through
     /// escaped-nested JSON (the #391 shape) — so a payload larger than this must be withheld rather
     /// than previewed, or the persisted record's 500-char prefix could contain an unredacted secret.
@@ -88,7 +89,7 @@ public static class ToolPayloadRedactor
     /// consolidates the identical "check the ceiling, redact, wrap the result" shape that shipped
     /// independently (and inconsistently) in both <c>ExecuteAgentTurnCommandHandler</c> (bundle SSE)
     /// and <c>AgUiClientToolBridge</c> (AG-UI client round-trip). Above
-    /// <see cref="MaxStreamedToolCallArgsLength"/>, or if redaction itself throws (a redactor-contract
+    /// <see cref="MaxStreamedToolCallPayloadLength"/>, or if redaction itself throws (a redactor-contract
     /// violation), the result is withheld: <c>Json</c> is <c>"{}"</c> and <c>Withheld</c> is
     /// <see langword="true"/> — both failure modes collapse to the same client-visible signal, since
     /// either way the real arguments never reach the consumer and must not be mistaken for the tool's
@@ -107,7 +108,7 @@ public static class ToolPayloadRedactor
     public static StreamedToolCallArguments RedactForStreaming(
         string json, ISecretRedactor? redactor, ILogger logger, string toolName, string? callId)
     {
-        if (json.Length > MaxStreamedToolCallArgsLength)
+        if (json.Length > MaxStreamedToolCallPayloadLength)
             return new StreamedToolCallArguments("{}", Withheld: true);
 
         StreamedToolCallArguments result;
@@ -128,8 +129,51 @@ public static class ToolPayloadRedactor
         // (and HTML-sensitive ones) to \uXXXX — a redacted payload of mostly non-ASCII text can come
         // back several times longer than it went in. Re-check the OUTPUT so the ceiling is actually a
         // wire-size ceiling, not just an input-size one.
-        return result.Json.Length > MaxStreamedToolCallArgsLength
+        return result.Json.Length > MaxStreamedToolCallPayloadLength
             ? new StreamedToolCallArguments("{}", Withheld: true)
+            : result;
+    }
+
+    /// <summary>
+    /// Redacts and size-caps <paramref name="text"/> for a live tool-call-result stream — the
+    /// result-path counterpart to <see cref="RedactForStreaming"/>. Above
+    /// <see cref="MaxStreamedToolCallPayloadLength"/>, or if redaction itself throws, the result is
+    /// withheld: <see cref="StreamedToolCallResult.Text"/> is empty and
+    /// <see cref="StreamedToolCallResult.Withheld"/> is <see langword="true"/>. Unlike arguments,
+    /// result text has no fixed-placeholder convention to fall back to — it is free text, not JSON a
+    /// client parses structurally — so an empty string is enough: <see cref="StreamedToolCallResult.Withheld"/>
+    /// is what tells the client nothing meaningful was sent, not the shape of the empty value.
+    /// </summary>
+    /// <param name="text">The tool result's text, already substituted for a failure via <see cref="SafeResultText"/>.</param>
+    /// <param name="redactor">Optional secret redactor; a no-op when <see langword="null"/>.</param>
+    /// <param name="logger">Logs a warning if redaction throws.</param>
+    /// <param name="callId">
+    /// The provider-assigned call id, logged as a structured field (<c>{CallId}</c>). Unlike
+    /// <see cref="RedactForStreaming"/>, there is no tool-name field to log alongside it —
+    /// <see cref="Microsoft.Extensions.AI.FunctionResultContent"/> carries no name, only the call id
+    /// it resolves against.
+    /// </param>
+    public static StreamedToolCallResult RedactResultForStreaming(
+        string text, ISecretRedactor? redactor, ILogger logger, string? callId)
+    {
+        if (text.Length > MaxStreamedToolCallPayloadLength)
+            return new StreamedToolCallResult(string.Empty, Withheld: true);
+
+        StreamedToolCallResult result;
+        try
+        {
+            result = new StreamedToolCallResult(Redact(text, redactor), Withheld: false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to redact streamed tool-call result for CallId={CallId}", callId);
+            return new StreamedToolCallResult(string.Empty, Withheld: true);
+        }
+
+        // Same output-length re-check as RedactForStreaming, for the same reason: PatternSecretRedactor's
+        // structural pass can re-serialize non-ASCII text longer than it went in.
+        return result.Text.Length > MaxStreamedToolCallPayloadLength
+            ? new StreamedToolCallResult(string.Empty, Withheld: true)
             : result;
     }
 

--- a/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
+++ b/src/Content/Application/Application.AI.Common/Helpers/ToolPayloadRedactor.cs
@@ -108,30 +108,10 @@ public static class ToolPayloadRedactor
     public static StreamedToolCallArguments RedactForStreaming(
         string json, ISecretRedactor? redactor, ILogger logger, string toolName, string? callId)
     {
-        if (json.Length > MaxStreamedToolCallPayloadLength)
-            return new StreamedToolCallArguments("{}", Withheld: true);
-
-        StreamedToolCallArguments result;
-        try
-        {
-            result = new StreamedToolCallArguments(Redact(json, redactor), Withheld: false);
-        }
-        catch (Exception ex)
-        {
-            logger.LogWarning(ex,
-                "Failed to redact streamed tool-call arguments for {ToolName} CallId={CallId}",
-                toolName, callId);
-            return new StreamedToolCallArguments("{}", Withheld: true);
-        }
-
-        // The pre-check above bounds the INPUT, but PatternSecretRedactor's structural pass
-        // re-serializes via ToJsonString(), whose default encoder escapes every non-ASCII character
-        // (and HTML-sensitive ones) to \uXXXX — a redacted payload of mostly non-ASCII text can come
-        // back several times longer than it went in. Re-check the OUTPUT so the ceiling is actually a
-        // wire-size ceiling, not just an input-size one.
-        return result.Json.Length > MaxStreamedToolCallPayloadLength
-            ? new StreamedToolCallArguments("{}", Withheld: true)
-            : result;
+        var (value, withheld) = RedactWithCeiling(json, redactor,
+            ex => logger.LogWarning(ex,
+                "Failed to redact streamed tool-call arguments for {ToolName} CallId={CallId}", toolName, callId));
+        return new StreamedToolCallArguments(withheld ? "{}" : value, withheld);
     }
 
     /// <summary>
@@ -156,25 +136,48 @@ public static class ToolPayloadRedactor
     public static StreamedToolCallResult RedactResultForStreaming(
         string text, ISecretRedactor? redactor, ILogger logger, string? callId)
     {
-        if (text.Length > MaxStreamedToolCallPayloadLength)
-            return new StreamedToolCallResult(string.Empty, Withheld: true);
+        var (value, withheld) = RedactWithCeiling(text, redactor,
+            ex => logger.LogWarning(ex, "Failed to redact streamed tool-call result for CallId={CallId}", callId));
+        return new StreamedToolCallResult(withheld ? string.Empty : value, withheld);
+    }
 
-        StreamedToolCallResult result;
+    /// <summary>
+    /// Shared "check the ceiling, redact, re-check the ceiling" shape behind both
+    /// <see cref="RedactForStreaming"/> and <see cref="RedactResultForStreaming"/> — the two differ
+    /// only in their withheld-placeholder value (<c>"{}"</c> vs empty string) and log call site, both
+    /// of which the caller supplies. Returns the redacted value and whether it was withheld; on
+    /// withheld, the returned value is meaningless and the caller substitutes its own placeholder.
+    /// </summary>
+    /// <param name="payload">The pre-redaction text — serialized JSON for arguments, plain text for a result.</param>
+    /// <param name="redactor">Optional secret redactor; a no-op when <see langword="null"/>.</param>
+    /// <param name="logFailure">
+    /// Logs the caller's own structured warning (tool name and call id for arguments; call id only for
+    /// a result, which carries no tool name) when redaction throws — the exception the redaction call
+    /// actually threw, passed through rather than swallowed, so the log entry keeps its stack trace.
+    /// </param>
+    private static (string Value, bool Withheld) RedactWithCeiling(
+        string payload, ISecretRedactor? redactor, Action<Exception> logFailure)
+    {
+        if (payload.Length > MaxStreamedToolCallPayloadLength)
+            return (string.Empty, true);
+
+        string redacted;
         try
         {
-            result = new StreamedToolCallResult(Redact(text, redactor), Withheld: false);
+            redacted = Redact(payload, redactor);
         }
         catch (Exception ex)
         {
-            logger.LogWarning(ex, "Failed to redact streamed tool-call result for CallId={CallId}", callId);
-            return new StreamedToolCallResult(string.Empty, Withheld: true);
+            logFailure(ex);
+            return (string.Empty, true);
         }
 
-        // Same output-length re-check as RedactForStreaming, for the same reason: PatternSecretRedactor's
-        // structural pass can re-serialize non-ASCII text longer than it went in.
-        return result.Text.Length > MaxStreamedToolCallPayloadLength
-            ? new StreamedToolCallResult(string.Empty, Withheld: true)
-            : result;
+        // The pre-check above bounds the INPUT, but PatternSecretRedactor's structural pass
+        // re-serializes via ToJsonString(), whose default encoder escapes every non-ASCII character
+        // (and HTML-sensitive ones) to \uXXXX — a redacted payload of mostly non-ASCII text can come
+        // back several times longer than it went in. Re-check the OUTPUT so the ceiling is actually a
+        // wire-size ceiling, not just an input-size one.
+        return redacted.Length > MaxStreamedToolCallPayloadLength ? (string.Empty, true) : (redacted, false);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IAgentTurnStreamSink.cs
@@ -66,8 +66,12 @@ public interface IAgentTurnStreamSink
     /// Emits a tool call's result once the tool has actually run. Default no-op.
     /// </summary>
     /// <param name="toolCallId">The call this result belongs to.</param>
-    /// <param name="result">The tool's output.</param>
+    /// <param name="result">
+    /// The tool's output. <see cref="StreamedToolCallResult.Text"/> is empty when
+    /// <see cref="StreamedToolCallResult.Withheld"/> is <see langword="true"/> (the real result
+    /// exceeded the streaming size ceiling, or redaction failed) — see that type's remarks.
+    /// </param>
     /// <param name="cancellationToken">Cancels emission when the consumer goes away.</param>
-    Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken) =>
+    Task EmitToolCallResultAsync(string toolCallId, StreamedToolCallResult result, CancellationToken cancellationToken) =>
         Task.CompletedTask;
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/StreamedToolCallArguments.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/StreamedToolCallArguments.cs
@@ -11,7 +11,7 @@ namespace Application.AI.Common.Interfaces;
 /// </param>
 /// <param name="Withheld">
 /// <see langword="true"/> when the real arguments were not sent — either because their serialized
-/// length exceeded <c>ToolPayloadRedactor.MaxStreamedToolCallArgsLength</c> (arguments are withheld
+/// length exceeded <c>ToolPayloadRedactor.MaxStreamedToolCallPayloadLength</c> (arguments are withheld
 /// whole rather than truncated, since truncating mid-JSON would hand the client invalid data), or
 /// because serialization/redaction itself failed. <see langword="false"/> for a normal call, where
 /// <see cref="Json"/> carries the complete, redacted arguments.

--- a/src/Content/Application/Application.AI.Common/Interfaces/StreamedToolCallResult.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/StreamedToolCallResult.cs
@@ -1,0 +1,18 @@
+namespace Application.AI.Common.Interfaces;
+
+/// <summary>
+/// A tool call's result as streamed to a live client via <see cref="IAgentTurnStreamSink.EmitToolCallResultAsync"/>.
+/// </summary>
+/// <param name="Text">
+/// The tool result's redacted text. Never truncated — when <paramref name="Withheld"/> is
+/// <see langword="true"/>, this is empty, not a partial or truncated version of the real result.
+/// </param>
+/// <param name="Withheld">
+/// <see langword="true"/> when the real result was not sent — either because its length exceeded
+/// <c>ToolPayloadRedactor.MaxStreamedToolCallPayloadLength</c> (results are withheld whole rather than
+/// truncated, the same reasoning as <see cref="StreamedToolCallArguments.Withheld"/>: a truncated
+/// preview past a redactor's structural-pass ceiling could still contain an unredacted secret), or
+/// because redaction itself failed. <see langword="false"/> for a normal result, where <see cref="Text"/>
+/// carries the complete, redacted output.
+/// </param>
+public readonly record struct StreamedToolCallResult(string Text, bool Withheld);

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -88,7 +88,7 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
         foreach (var result in functionResults)
         {
             // A failed call's Result already carries the raw exception message baked in by
-            // IncludeDetailedErrors (see ExecuteAgentTurnCommandHandler.RedactedResultPreview) — this
+            // IncludeDetailedErrors (see ExecuteAgentTurnCommandHandler.RedactedResultForStreaming) — this
             // trace record feeds the dashboard's per-invocation page via ToolInvocationDetailDto,
             // which is just as much an exposure point as the streamed SSE frame, so it gets the same
             // generic-message substitution, not just redaction of the raw text.
@@ -101,7 +101,7 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
                 // cannot see through the escaped-nested-JSON secret shape #391 closed for smaller
                 // payloads — a 500-char slice of an oversized, only-partially-redacted result could
                 // still contain an unredacted secret persisted to the trace store indefinitely. Same
-                // guard ExecuteAgentTurnCommandHandler.RedactedResultPreview applies to the identical
+                // guard ExecuteAgentTurnCommandHandler.RedactedResultForStreaming applies to the identical
                 // exposure on the streamed path.
                 trimmedPayload = "[result too large to preview safely]";
             }

--- a/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AgentTurnStreamSink.cs
@@ -26,7 +26,7 @@ public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
 
     private readonly Func<string, CancellationToken, Task> _onDelta;
     private readonly Func<string, string, StreamedToolCallArguments, CancellationToken, Task>? _onToolCall;
-    private readonly Func<string, string, CancellationToken, Task>? _onToolCallResult;
+    private readonly Func<string, StreamedToolCallResult, CancellationToken, Task>? _onToolCallResult;
 
     /// <summary>
     /// Creates a sink that forwards each assistant text delta to <paramref name="onDelta"/>, each
@@ -42,7 +42,7 @@ public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
     public AgentTurnStreamSink(
         Func<string, CancellationToken, Task> onDelta,
         Func<string, string, StreamedToolCallArguments, CancellationToken, Task>? onToolCall = null,
-        Func<string, string, CancellationToken, Task>? onToolCallResult = null)
+        Func<string, StreamedToolCallResult, CancellationToken, Task>? onToolCallResult = null)
     {
         ArgumentNullException.ThrowIfNull(onDelta);
         _onDelta = onDelta;
@@ -59,6 +59,6 @@ public sealed class AgentTurnStreamSink : IAgentTurnStreamSink
         _onToolCall?.Invoke(toolCallId, toolCallName, args, cancellationToken) ?? Task.CompletedTask;
 
     /// <inheritdoc />
-    public Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken) =>
+    public Task EmitToolCallResultAsync(string toolCallId, StreamedToolCallResult result, CancellationToken cancellationToken) =>
         _onToolCallResult?.Invoke(toolCallId, result, cancellationToken) ?? Task.CompletedTask;
 }

--- a/src/Content/Application/Application.AI.Common/Services/ToolCallOrderingSink.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ToolCallOrderingSink.cs
@@ -60,7 +60,7 @@ public sealed class ToolCallOrderingSink : IAgentTurnStreamSink
     }
 
     /// <inheritdoc />
-    public Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken)
+    public Task EmitToolCallResultAsync(string toolCallId, StreamedToolCallResult result, CancellationToken cancellationToken)
     {
         if (!_startedCallIds.Contains(toolCallId))
             return Task.CompletedTask;

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -463,13 +463,17 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 
 	/// <summary>
 	/// Builds a safe, streamable representation of a tool's result — the result-path counterpart to
-	/// <see cref="RedactedArgsJson"/>, sharing the same withhold-above-a-ceiling treatment instead of
-	/// the fixed-length truncation this method used before (#417): a truncated preview past
+	/// <see cref="RedactedArgsJson"/>, sharing the same withhold-above-a-ceiling treatment
+	/// <see cref="ToolPayloadRedactor.RedactResultForStreaming"/> applies instead of the fixed-length
+	/// truncation this method used before (#417): a truncated preview past
 	/// <see cref="ToolPayloadRedactor.MaxStructuralRedactionCeiling"/> could still contain an
 	/// unredacted secret (<c>PatternSecretRedactor</c> falls back to a regex-only pass above that
 	/// size, which cannot see through the escaped-nested-JSON secret shape #391 closed for smaller
 	/// payloads), and a client parsing a streamed result as structured data — not just a human-read
-	/// preview — could receive truncated, invalid data either way.
+	/// preview — could receive truncated, invalid data either way. No separate 64KB pre-check is
+	/// needed here: <see cref="ToolPayloadRedactor.MaxStreamedToolCallPayloadLength"/> (16KB) is
+	/// already below <see cref="ToolPayloadRedactor.MaxStructuralRedactionCeiling"/> (64KB), so
+	/// <c>RedactResultForStreaming</c>'s own ceiling always withholds first.
 	/// <see cref="ToolPayloadRedactor.SafeResultText"/> substitutes a generic message when the call
 	/// failed, since <c>FunctionInvokingChatClient</c>'s <c>IncludeDetailedErrors</c> option (set
 	/// unconditionally by <c>AgentFactory</c>) bakes the raw exception message into
@@ -477,15 +481,8 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// applies before persisting to the trace store a dashboard later renders, since that is just as
 	/// much an exposure point as this client-facing SSE frame.
 	/// </summary>
-	private static StreamedToolCallResult RedactedResultForStreaming(FunctionResultContent result, ISecretRedactor? redactor, ILogger logger)
-	{
-		var resultText = ToolPayloadRedactor.SafeResultText(result);
-
-		if (resultText.Length > ToolPayloadRedactor.MaxStructuralRedactionCeiling)
-			return new StreamedToolCallResult(string.Empty, Withheld: true);
-
-		return ToolPayloadRedactor.RedactResultForStreaming(resultText, redactor, logger, result.CallId);
-	}
+	private static StreamedToolCallResult RedactedResultForStreaming(FunctionResultContent result, ISecretRedactor? redactor, ILogger logger) =>
+		ToolPayloadRedactor.RedactResultForStreaming(ToolPayloadRedactor.SafeResultText(result), redactor, logger, result.CallId);
 
 	private static void RecordTurnError(string agentName)
 	{

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -348,15 +348,15 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// <c>update.Contents</c> stream. Both are redacted via <see cref="ToolPayloadRedactor"/> before
 	/// reaching the sink — the same treatment <c>ToolDiagnosticsMiddleware</c> applies before the
 	/// identical data is persisted, since a live SSE stream is just as much an exposure point for
-	/// secrets as the observability store is. Arguments are redacted, never truncated — truncating
-	/// mid-JSON would silently hand a client invalid, unparseable data — but above
-	/// <see cref="ToolPayloadRedactor.MaxStreamedToolCallArgsLength"/> they are withheld whole instead
-	/// (<see cref="StreamedToolCallArguments.Withheld"/>), since a size cap and a truncation cap are
-	/// not the same thing; the result text has no such contract and gets the same redact-and-truncate
-	/// preview treatment the middleware uses — except when the tool failed, where a generic message is
-	/// streamed instead of
+	/// secrets as the observability store is. Neither is ever truncated — truncating mid-JSON would
+	/// silently hand a client invalid, unparseable data for arguments, and a truncated result past
+	/// <see cref="ToolPayloadRedactor.MaxStructuralRedactionCeiling"/> could still contain an
+	/// unredacted secret — so above <see cref="ToolPayloadRedactor.MaxStreamedToolCallPayloadLength"/>
+	/// both are withheld whole instead (<see cref="StreamedToolCallArguments.Withheld"/>,
+	/// <see cref="StreamedToolCallResult.Withheld"/>), since a size cap and a truncation cap are not
+	/// the same thing. When the tool failed, a generic message is streamed instead of
 	/// <see cref="FunctionResultContent.Result"/>'s raw text, since <c>IncludeDetailedErrors</c> bakes
-	/// the exception message into that string (see <see cref="RedactedResultPreview"/>). Usage and
+	/// the exception message into that string (see <see cref="RedactedResultForStreaming"/>). Usage and
 	/// tool-call capture still flow through the chat-client middleware, so the caller's post-turn
 	/// accounting is unchanged. The same <paramref name="cancellationToken"/> flows to
 	/// <c>RunStreamingAsync</c>, so a disconnected consumer aborts the model call.
@@ -423,7 +423,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			// no matching preceding TOOL_CALL_START (e.g. a call skipped above for an empty Name).
 			case FunctionResultContent { CallId.Length: > 0 } result:
 				await sink.EmitToolCallResultAsync(
-					result.CallId, RedactedResultPreview(result, redactor, logger), cancellationToken);
+					result.CallId, RedactedResultForStreaming(result, redactor, logger), cancellationToken);
 				break;
 		}
 	}
@@ -462,33 +462,29 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	}
 
 	/// <summary>
-	/// Builds a safe, streamable preview of a tool's result. <see cref="ToolPayloadRedactor.SafeResultText"/>
-	/// substitutes a generic message when the call failed, since <c>FunctionInvokingChatClient</c>'s
-	/// <c>IncludeDetailedErrors</c> option (set unconditionally by <c>AgentFactory</c>) bakes the raw
-	/// exception message into <see cref="FunctionResultContent.Result"/> — the same substitution
-	/// <c>ToolDiagnosticsMiddleware</c> applies before persisting to the trace store a dashboard later
-	/// renders, since that is just as much an exposure point as this client-facing SSE frame. A
-	/// redaction-contract violation from <paramref name="redactor"/> degrades the same way, via
-	/// <see cref="ToolPayloadRedactor.TryOrFallback"/>. Above
-	/// <see cref="ToolPayloadRedactor.MaxStructuralRedactionCeiling"/>, <c>PatternSecretRedactor</c>
-	/// falls back to its regex-only pass, which cannot see through the escaped-nested-JSON secret
-	/// shape #391 closed for smaller payloads — so a 500-char preview sliced from a redact-and-truncate
-	/// call on an oversized result could still contain an unredacted secret. A generic message is
-	/// streamed instead of attempting a preview at all, rather than silently degrading the redaction
-	/// guarantee this method otherwise provides.
+	/// Builds a safe, streamable representation of a tool's result — the result-path counterpart to
+	/// <see cref="RedactedArgsJson"/>, sharing the same withhold-above-a-ceiling treatment instead of
+	/// the fixed-length truncation this method used before (#417): a truncated preview past
+	/// <see cref="ToolPayloadRedactor.MaxStructuralRedactionCeiling"/> could still contain an
+	/// unredacted secret (<c>PatternSecretRedactor</c> falls back to a regex-only pass above that
+	/// size, which cannot see through the escaped-nested-JSON secret shape #391 closed for smaller
+	/// payloads), and a client parsing a streamed result as structured data — not just a human-read
+	/// preview — could receive truncated, invalid data either way.
+	/// <see cref="ToolPayloadRedactor.SafeResultText"/> substitutes a generic message when the call
+	/// failed, since <c>FunctionInvokingChatClient</c>'s <c>IncludeDetailedErrors</c> option (set
+	/// unconditionally by <c>AgentFactory</c>) bakes the raw exception message into
+	/// <see cref="FunctionResultContent.Result"/> — the same substitution <c>ToolDiagnosticsMiddleware</c>
+	/// applies before persisting to the trace store a dashboard later renders, since that is just as
+	/// much an exposure point as this client-facing SSE frame.
 	/// </summary>
-	private static string RedactedResultPreview(FunctionResultContent result, ISecretRedactor? redactor, ILogger logger)
+	private static StreamedToolCallResult RedactedResultForStreaming(FunctionResultContent result, ISecretRedactor? redactor, ILogger logger)
 	{
 		var resultText = ToolPayloadRedactor.SafeResultText(result);
 
 		if (resultText.Length > ToolPayloadRedactor.MaxStructuralRedactionCeiling)
-			return "[result too large to preview safely]";
+			return new StreamedToolCallResult(string.Empty, Withheld: true);
 
-		return ToolPayloadRedactor.TryOrFallback(
-			() => ToolPayloadRedactor.RedactAndTruncate(resultText, redactor),
-			logger,
-			$"Failed to redact streamed tool-call result for CallId={result.CallId}",
-			fallback: "[unavailable]");
+		return ToolPayloadRedactor.RedactResultForStreaming(resultText, redactor, logger, result.CallId);
 	}
 
 	private static void RecordTurnError(string agentName)

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleRunStreamer.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleRunStreamer.cs
@@ -75,15 +75,30 @@ public sealed class BundleRunStreamer
                 // The AG-UI wire protocol wants three separate frames; the sink itself only ever
                 // reports one complete tool call, so this is where that single call fans out into
                 // start/args/end — see IAgentTurnStreamSink.EmitToolCallAsync's remarks for why the
-                // seam doesn't carry that split.
-                await writer.WriteAsync(new BundleToolCallStartEvent(toolCallId, toolCallName), ct).ConfigureAwait(false);
+                // seam doesn't carry that split. parentMessageId is only sent once the assistant text
+                // message has actually opened on the wire (textStarted) — a tool call can arrive before
+                // the first text delta, and pointing a client at a message it has never seen would
+                // violate the schema it's optional for.
+                await writer.WriteAsync(
+                    new BundleToolCallStartEvent(toolCallId, toolCallName, textStarted ? messageId : null),
+                    ct).ConfigureAwait(false);
                 await writer.WriteAsync(
                     new BundleToolCallArgsEvent(toolCallId, args.Json, args.Withheld ? true : null),
                     ct).ConfigureAwait(false);
                 await writer.WriteAsync(new BundleToolCallEndEvent(toolCallId), ct).ConfigureAwait(false);
             },
             onToolCallResult: (toolCallId, result, ct) =>
-                writer.WriteAsync(new BundleToolCallResultEvent(toolCallId, result), ct));
+            {
+                // A fresh id per result — never a reuse of the run's assistant messageId above. In
+                // AG-UI, a tool result is its own message (role "tool"), distinct from the assistant
+                // message that requested the call.
+                var resultMessageId = Guid.NewGuid().ToString("N");
+                return writer.WriteAsync(
+                    new BundleToolCallResultEvent(
+                        toolCallId, resultMessageId, result.Withheld ? string.Empty : result.Text, "tool",
+                        result.Withheld ? true : null),
+                    ct);
+            });
 
         BundleRunExecution execution;
         try

--- a/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Streaming/BundleStreamEvents.cs
@@ -60,16 +60,24 @@ public sealed record BundleTextMessageEndEvent(
     [property: JsonPropertyName("messageId")] string MessageId) : BundleStreamEvent;
 
 /// <summary>
-/// Emitted when the agent decides to call a tool. Field names match the AgentHub's own AG-UI
-/// tool-call vocabulary (<c>Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs</c>) for consistency,
-/// even though this file deliberately does not reference those types directly — see this file's
-/// top-level remarks.
+/// Emitted when the agent decides to call a tool. <see cref="ToolCallId"/>/<see cref="ToolCallName"/>
+/// match the AgentHub's own AG-UI tool-call vocabulary (<c>Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs</c>)
+/// for consistency, even though this file deliberately does not reference those types directly — see
+/// this file's top-level remarks. <see cref="ParentMessageId"/> has no AgentHub counterpart — it is
+/// bundle-specific.
 /// </summary>
 public sealed record BundleToolCallStartEvent(
     /// <summary>The provider-assigned id for this call, shared by every event for it.</summary>
     [property: JsonPropertyName("toolCallId")] string ToolCallId,
     /// <summary>The name of the tool being called.</summary>
-    [property: JsonPropertyName("toolCallName")] string ToolCallName) : BundleStreamEvent;
+    [property: JsonPropertyName("toolCallName")] string ToolCallName,
+    /// <summary>
+    /// The id of the assistant message this tool call belongs to, per the AG-UI wire schema. Absent
+    /// (omitted from the wire) when the call is emitted before the assistant's
+    /// <see cref="BundleTextMessageStartEvent"/> has streamed — the parent message does not exist yet
+    /// from the client's perspective at that point, and the field is optional precisely for this case.
+    /// </summary>
+    [property: JsonPropertyName("parentMessageId")] string? ParentMessageId = null) : BundleStreamEvent;
 
 /// <summary>
 /// Carries a tool call's arguments. Unlike <see cref="BundleTextMessageContentEvent"/>, this is NOT an
@@ -101,18 +109,42 @@ public sealed record BundleToolCallEndEvent(
     [property: JsonPropertyName("toolCallId")] string ToolCallId) : BundleStreamEvent;
 
 /// <summary>
-/// Emitted once a tool call has actually run and produced a result. No precedent field-naming to
-/// match — <c>AgUiEventType.ToolCallResult</c> is a dead wire-vocabulary constant with no backing
-/// record anywhere in the repo.
+/// Emitted once a tool call has actually run and produced a result. Field names match the AG-UI wire
+/// schema's tool-call-result event (<c>messageId</c>, <c>content</c>, <c>role</c>) — confirmed against
+/// the AG-UI protocol repo's own <c>sdks/typescript/packages/core/src/events.ts</c> and this repo's
+/// pinned <c>@ag-ui/core</c> package, where <c>role</c> is optional but always <c>"tool"</c> in
+/// practice; sent unconditionally here rather than made nullable-and-omittable for a value that never
+/// varies. <c>AgUiEventType.ToolCallResult</c> in <c>Presentation.AgentHub</c> is a dead
+/// wire-vocabulary constant with no backing record, so there is no in-repo precedent to mirror for
+/// these field names beyond the shared <see cref="ToolCallId"/>.
 /// </summary>
 public sealed record BundleToolCallResultEvent(
     /// <summary>The call this result belongs to.</summary>
     [property: JsonPropertyName("toolCallId")] string ToolCallId,
     /// <summary>
-    /// A redacted, truncated preview of the tool's output — never the raw payload. On failure this is a
-    /// generic message, not the underlying exception text.
+    /// A fresh id for this result's own message, per the AG-UI wire schema — never a reuse of the run's
+    /// assistant message id, since a tool result is its own message with role <see cref="Role"/>, not a
+    /// continuation of the assistant's text message.
     /// </summary>
-    [property: JsonPropertyName("result")] string Result) : BundleStreamEvent;
+    [property: JsonPropertyName("messageId")] string MessageId,
+    /// <summary>
+    /// The tool's redacted output — never the raw payload, and never truncated. On failure this is a
+    /// generic message, not the underlying exception text. Empty when <see cref="Withheld"/> is
+    /// <see langword="true"/> — the real result exceeded the streaming size ceiling and was withheld
+    /// whole rather than truncated (truncating a redacted preview past that ceiling could still contain
+    /// an unredacted secret, and truncating data a client may parse as structured hands it invalid data
+    /// either way).
+    /// </summary>
+    [property: JsonPropertyName("content")] string Content,
+    /// <summary>Message role for a tool result, per the AG-UI wire schema. Always <c>tool</c>.</summary>
+    [property: JsonPropertyName("role")] string Role,
+    /// <summary>
+    /// <see langword="true"/> when the real result was withheld for exceeding the size ceiling. Nullable,
+    /// and only ever constructed as <see langword="true"/> or <see langword="null"/> — never
+    /// <see langword="false"/> — so the field is omitted from the wire on every normal frame, mirroring
+    /// <see cref="BundleToolCallArgsEvent.Withheld"/>.
+    /// </summary>
+    [property: JsonPropertyName("withheld")] bool? Withheld = null) : BundleStreamEvent;
 
 /// <summary>Emitted once on successful completion of a streamed run. Terminal; no further frames follow.</summary>
 public sealed record BundleRunFinishedEvent(

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
@@ -38,7 +38,7 @@ public sealed class ToolPayloadRedactorTests
     /// </summary>
     private sealed class InflatingRedactor : ISecretRedactor
     {
-        public string? Redact(string? input) => input + new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength);
+        public string? Redact(string? input) => input + new string('x', ToolPayloadRedactor.MaxStreamedToolCallPayloadLength);
         public bool IsSecretKey(string configKey) => false;
     }
 
@@ -107,7 +107,7 @@ public sealed class ToolPayloadRedactorTests
     [Fact]
     public void RedactForStreaming_AboveCeiling_WithholdsWithoutRedacting()
     {
-        var payload = new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength + 1);
+        var payload = new string('x', ToolPayloadRedactor.MaxStreamedToolCallPayloadLength + 1);
 
         var result = ToolPayloadRedactor.RedactForStreaming(payload, redactor: null, NullLogger.Instance, "search", "call-1");
 
@@ -126,7 +126,7 @@ public sealed class ToolPayloadRedactorTests
     public void RedactForStreaming_RedactionInflatesOutputPastCeiling_Withholds()
     {
         var payload = "small input, well under the ceiling";
-        payload.Length.Should().BeLessThan(ToolPayloadRedactor.MaxStreamedToolCallArgsLength,
+        payload.Length.Should().BeLessThan(ToolPayloadRedactor.MaxStreamedToolCallPayloadLength,
             "the test must exercise the OUTPUT check, not the input pre-check");
 
         var result = ToolPayloadRedactor.RedactForStreaming(payload, new InflatingRedactor(), NullLogger.Instance, "search", "call-1");

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/ToolPayloadRedactorTests.cs
@@ -1,7 +1,9 @@
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Helpers;
@@ -151,5 +153,94 @@ public sealed class ToolPayloadRedactorTests
 
         result.Withheld.Should().BeTrue();
         result.Json.Should().Be("{}");
+    }
+
+    /// <summary>
+    /// The warning must carry the actual exception the redactor threw, not just a message — the shared
+    /// RedactWithCeiling helper both call sites route through takes a caller-supplied logging callback
+    /// specifically so the exception (needed for its stack trace) isn't dropped along the way.
+    /// </summary>
+    [Fact]
+    public void RedactForStreaming_RedactorThrows_LogsTheActualException()
+    {
+        var redactor = new NullReturningRedactor();
+        var logger = new Mock<ILogger>();
+
+        ToolPayloadRedactor.RedactForStreaming("api_key=super-secret", redactor, logger.Object, "search", "call-1");
+
+        logger.Verify(l => l.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.Is<Exception>(ex => ex is InvalidOperationException),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    /// <summary>Result-path counterpart to <see cref="RedactForStreaming_RedactorThrows_LogsTheActualException"/>.</summary>
+    [Fact]
+    public void RedactResultForStreaming_RedactorThrows_LogsTheActualException()
+    {
+        var redactor = new NullReturningRedactor();
+        var logger = new Mock<ILogger>();
+
+        ToolPayloadRedactor.RedactResultForStreaming("some result text", redactor, logger.Object, "call-1");
+
+        logger.Verify(l => l.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.Is<Exception>(ex => ex is InvalidOperationException),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Result-path counterpart to <see cref="RedactForStreaming_RedactorThrows_WithholdsRatherThanReturningNormalEmptyObject"/>.
+    /// </summary>
+    [Fact]
+    public void RedactResultForStreaming_RedactorThrows_WithholdsRatherThanReturningNormalEmptyObject()
+    {
+        var redactor = new NullReturningRedactor();
+
+        var result = ToolPayloadRedactor.RedactResultForStreaming("some result text", redactor, NullLogger.Instance, "call-1");
+
+        result.Withheld.Should().BeTrue();
+        result.Text.Should().BeEmpty();
+    }
+
+    /// <summary>Result-path counterpart to the args ceiling/inflation tests above.</summary>
+    [Fact]
+    public void RedactResultForStreaming_AboveCeiling_WithholdsWithoutRedacting()
+    {
+        var oversized = new string('x', ToolPayloadRedactor.MaxStreamedToolCallPayloadLength + 1);
+
+        var result = ToolPayloadRedactor.RedactResultForStreaming(oversized, redactor: null, NullLogger.Instance, "call-1");
+
+        result.Withheld.Should().BeTrue();
+        result.Text.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RedactResultForStreaming_RedactionInflatesOutputPastCeiling_Withholds()
+    {
+        var payload = new string('x', ToolPayloadRedactor.MaxStreamedToolCallPayloadLength - 10);
+        payload.Length.Should().BeLessThan(ToolPayloadRedactor.MaxStreamedToolCallPayloadLength,
+            "the test must exercise the OUTPUT check, not the input pre-check");
+
+        var result = ToolPayloadRedactor.RedactResultForStreaming(payload, new InflatingRedactor(), NullLogger.Instance, "call-1");
+
+        result.Withheld.Should().BeTrue();
+        result.Text.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RedactResultForStreaming_UnderCeiling_ReturnsRedactedTextUnwithheld()
+    {
+        var result = ToolPayloadRedactor.RedactResultForStreaming(
+            $"contains {MarkerRedactor.Secret}", new MarkerRedactor(), NullLogger.Instance, "call-1");
+
+        result.Withheld.Should().BeFalse();
+        result.Text.Should().Be($"contains {MarkerRedactor.Replacement}");
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
@@ -100,7 +100,7 @@ public sealed class ToolDiagnosticsMiddlewareTests
         // FunctionInvokingChatClient's IncludeDetailedErrors option (set unconditionally by
         // AgentFactory) bakes Exception.Message verbatim into Result — this trace record feeds the
         // dashboard's per-invocation page via ToolInvocationDetailDto, an exposure point just as real
-        // as the streamed SSE frame ExecuteAgentTurnCommandHandler.RedactedResultPreview sanitizes.
+        // as the streamed SSE frame ExecuteAgentTurnCommandHandler.RedactedResultForStreaming sanitizes.
         var innerClient = MakeChatClient();
         var (writerMock, middleware) = MakeMiddlewareWithWriter(innerClient);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentTurnStreamSinkTests.cs
@@ -101,14 +101,14 @@ public class AgentTurnStreamSinkTests
     [Fact]
     public async Task EmitToolCallResultAsync_ForwardsToTheCallback()
     {
-        (string Id, string Result)? received = null;
+        (string Id, StreamedToolCallResult Result)? received = null;
         var sink = new AgentTurnStreamSink(
             (_, _) => Task.CompletedTask,
             onToolCallResult: (id, result, _) => { received = (id, result); return Task.CompletedTask; });
 
-        await sink.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+        await sink.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("42", false), CancellationToken.None);
 
-        received.Should().Be(("call-1", "42"));
+        received.Should().Be(("call-1", new StreamedToolCallResult("42", false)));
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class AgentTurnStreamSinkTests
     {
         var sink = new AgentTurnStreamSink((_, _) => Task.CompletedTask);
 
-        var act = () => sink.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+        var act = () => sink.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("42", false), CancellationToken.None);
 
         await act.Should().NotThrowAsync();
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ToolCallOrderingSinkTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ToolCallOrderingSinkTests.cs
@@ -28,7 +28,7 @@ public class ToolCallOrderingSinkTests
             return Task.CompletedTask;
         }
 
-        public Task EmitToolCallResultAsync(string toolCallId, string result, CancellationToken cancellationToken)
+        public Task EmitToolCallResultAsync(string toolCallId, StreamedToolCallResult result, CancellationToken cancellationToken)
         {
             Calls.Add($"result:{toolCallId}");
             return Task.CompletedTask;
@@ -53,7 +53,7 @@ public class ToolCallOrderingSinkTests
         var inner = new RecordingSink();
         var sut = new ToolCallOrderingSink(inner);
 
-        await sut.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("42", false), CancellationToken.None);
 
         inner.Calls.Should().BeEmpty();
     }
@@ -65,7 +65,7 @@ public class ToolCallOrderingSinkTests
         var sut = new ToolCallOrderingSink(inner);
 
         await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
-        await sut.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("42", false), CancellationToken.None);
 
         inner.Calls.Should().Equal("start:call-1", "result:call-1");
     }
@@ -78,8 +78,8 @@ public class ToolCallOrderingSinkTests
 
         await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
         await sut.EmitToolCallAsync("call-2", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
-        await sut.EmitToolCallResultAsync("call-1", "a", CancellationToken.None);
-        await sut.EmitToolCallResultAsync("call-2", "b", CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("a", false), CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-2", new StreamedToolCallResult("b", false), CancellationToken.None);
 
         inner.Calls.Should().Equal("start:call-1", "start:call-2", "result:call-1", "result:call-2");
     }
@@ -99,12 +99,12 @@ public class ToolCallOrderingSinkTests
         var sut = new ToolCallOrderingSink(inner);
 
         await sut.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
-        await sut.EmitToolCallResultAsync("call-1", "42", CancellationToken.None);
+        await sut.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("42", false), CancellationToken.None);
 
-        CapturedResult.Should().Be(("call-1", "42"));
+        CapturedResult.Should().Be(("call-1", new StreamedToolCallResult("42", false)));
     }
 
-    private (string Id, string Result)? CapturedResult { get; set; }
+    private (string Id, StreamedToolCallResult Result)? CapturedResult { get; set; }
 
     /// <summary>
     /// Two separate instances (one per turn) must not share state — pins the per-turn scoping that

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -143,7 +143,7 @@ public class ExecuteAgentTurnCommandHandlerTests
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (delta, _) => { events.Add($"delta:{delta}"); return Task.CompletedTask; },
                 onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args.Json}"); return Task.CompletedTask; },
-                onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result}"); return Task.CompletedTask; });
+                onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result.Text}"); return Task.CompletedTask; });
 
         try
         {
@@ -296,9 +296,9 @@ public class ExecuteAgentTurnCommandHandlerTests
     [Fact]
     public async Task Handle_ActiveStreamSink_OversizedToolCallArgs_StreamsWithheldPlaceholder_NotRawPayload()
     {
-        // Above ToolPayloadRedactor.MaxStreamedToolCallArgsLength (16 KB), the real arguments must
+        // Above ToolPayloadRedactor.MaxStreamedToolCallPayloadLength (16 KB), the real arguments must
         // never reach the client — withheld whole (Json="{}", Withheld=true), not truncated.
-        var oversizedValue = new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength + 1);
+        var oversizedValue = new string('x', ToolPayloadRedactor.MaxStreamedToolCallPayloadLength + 1);
         var agent = TestableAIAgent.StreamingContent(
             [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = oversizedValue })]);
         _agentCache
@@ -324,6 +324,86 @@ public class ExecuteAgentTurnCommandHandlerTests
             toolCallArgs.Withheld.Should().BeTrue();
             toolCallArgs.Json.Should().Be("{}");
             toolCallArgs.Json.Should().NotContain("x");
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_LongToolCallResult_AreNotTruncated()
+    {
+        // #417: results used to be hard-sliced at 500 chars — a client parsing a streamed result as
+        // structured data could receive truncated, invalid data. 600 chars is well under the streaming
+        // size ceiling (16 KB), so this must stream whole and un-withheld, mirroring the arguments path.
+        var longValue = new string('x', 600);
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = "docs" })],
+            [new FunctionResultContent("call-1", longValue)]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var toolResult = default(StreamedToolCallResult);
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCallResult: (_, r, _) => { toolResult = r; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            toolResult.Withheld.Should().BeFalse();
+            toolResult.Text.Length.Should().BeGreaterThan(500);
+            toolResult.Text.Should().Be(longValue);
+        }
+        finally
+        {
+            Application.AI.Common.Services.AgentTurnStreamSink.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ActiveStreamSink_OversizedToolCallResult_StreamsWithheldFlag_NotTruncatedPayload()
+    {
+        // #417: above ToolPayloadRedactor.MaxStreamedToolCallPayloadLength (16 KB), the real result
+        // must never reach the client — withheld whole (Text="", Withheld=true), not truncated. A
+        // truncated preview past MaxStructuralRedactionCeiling could still contain an unredacted
+        // secret, since PatternSecretRedactor falls back to a regex-only pass above that size.
+        var oversizedValue = new string('x', ToolPayloadRedactor.MaxStreamedToolCallPayloadLength + 1);
+        var agent = TestableAIAgent.StreamingContent(
+            [new FunctionCallContent("call-1", "search", new Dictionary<string, object?> { ["q"] = "docs" })],
+            [new FunctionResultContent("call-1", oversizedValue)]);
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var toolResult = default(StreamedToolCallResult);
+        Application.AI.Common.Services.AgentTurnStreamSink.Current =
+            new Application.AI.Common.Services.AgentTurnStreamSink(
+                onDelta: (_, _) => Task.CompletedTask,
+                onToolCallResult: (_, r, _) => { toolResult = r; return Task.CompletedTask; });
+
+        try
+        {
+            // Act
+            await _handler.Handle(CreateCommand(), CancellationToken.None);
+
+            // Assert
+            toolResult.Withheld.Should().BeTrue();
+            toolResult.Text.Should().BeEmpty();
         }
         finally
         {
@@ -425,7 +505,7 @@ public class ExecuteAgentTurnCommandHandlerTests
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (_, _) => Task.CompletedTask,
                 onToolCall: (id, name, args, _) => { events.Add($"call:{id}:{name}:{args.Json}"); return Task.CompletedTask; },
-                onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result}"); return Task.CompletedTask; });
+                onToolCallResult: (id, result, _) => { events.Add($"result:{id}:{result.Text}"); return Task.CompletedTask; });
 
         try
         {
@@ -478,7 +558,7 @@ public class ExecuteAgentTurnCommandHandlerTests
             redactor.Object);
 
         var args = string.Empty;
-        var toolResult = string.Empty;
+        var toolResult = default(Application.AI.Common.Interfaces.StreamedToolCallResult);
         Application.AI.Common.Services.AgentTurnStreamSink.Current =
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (_, _) => Task.CompletedTask,
@@ -492,7 +572,7 @@ public class ExecuteAgentTurnCommandHandlerTests
 
             // Assert
             args.Should().NotContain("secret-value").And.Contain("[REDACTED]");
-            toolResult.Should().Be("[REDACTED]");
+            toolResult.Text.Should().Be("[REDACTED]");
             // TOOL_CALL_ARGS.delta is documented as always-complete, parseable JSON — a redactor that
             // corrupts the surrounding structure (e.g. a greedy value matcher, see
             // PatternSecretRedactorTests.Redact_SecretKeywordInsideJsonStringValue_DoesNotConsumeRestOfDocument
@@ -530,7 +610,7 @@ public class ExecuteAgentTurnCommandHandlerTests
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(agent);
 
-        var toolResult = string.Empty;
+        var toolResult = default(Application.AI.Common.Interfaces.StreamedToolCallResult);
         Application.AI.Common.Services.AgentTurnStreamSink.Current =
             new Application.AI.Common.Services.AgentTurnStreamSink(
                 onDelta: (_, _) => Task.CompletedTask,
@@ -543,8 +623,9 @@ public class ExecuteAgentTurnCommandHandlerTests
             await _handler.Handle(CreateCommand(), CancellationToken.None);
 
             // Assert
-            toolResult.Should().NotContain("/etc/shadow");
-            toolResult.Should().NotBeEmpty();
+            toolResult.Text.Should().NotContain("/etc/shadow");
+            toolResult.Text.Should().NotBeEmpty();
+            toolResult.Withheld.Should().BeFalse();
         }
         finally
         {

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiClientToolBridgeTests.cs
@@ -162,7 +162,7 @@ public sealed class AgUiClientToolBridgeTests
         var accessor = new AgUiEventWriterAccessor { Writer = writer, ThreadId = "thread-o", CallerId = "user-o" };
         var registry = new PendingToolCallRegistry();
         var bridge = Bridge(accessor, registry);
-        var oversized = $$"""{"q":"{{new string('x', ToolPayloadRedactor.MaxStreamedToolCallArgsLength + 1)}}"}""";
+        var oversized = $$"""{"q":"{{new string('x', ToolPayloadRedactor.MaxStreamedToolCallPayloadLength + 1)}}"}""";
 
         var invokeTask = bridge.InvokeAsync("dashboard_control", oversized);
 

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleRunStreamerTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleRunStreamerTests.cs
@@ -139,7 +139,7 @@ public sealed class BundleRunStreamerTests
         {
             await sink.EmitAsync("Looking that up", ct);
             await sink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{\"q\":\"docs\"}", false), ct);
-            await sink.EmitToolCallResultAsync("call-1", "42 results", ct);
+            await sink.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("42 results", false), ct);
             await sink.EmitAsync(" — found it.", ct);
         });
 
@@ -153,13 +153,24 @@ public sealed class BundleRunStreamerTests
         var start = frames.Single(f => Type(f) == "TOOL_CALL_START");
         start.GetProperty("toolCallId").GetString().Should().Be("call-1");
         start.GetProperty("toolCallName").GetString().Should().Be("search");
+        // The assistant text message had already opened (TEXT_MESSAGE_START above the tool call in
+        // this sequence), so the tool call must be linked to it.
+        var textMessageId = frames.Single(f => Type(f) == "TEXT_MESSAGE_START").GetProperty("messageId").GetString();
+        start.GetProperty("parentMessageId").GetString().Should().Be(textMessageId);
 
         frames.Single(f => Type(f) == "TOOL_CALL_ARGS").GetProperty("delta").GetString()
             .Should().Be("{\"q\":\"docs\"}");
         frames.Single(f => Type(f) == "TOOL_CALL_END").GetProperty("toolCallId").GetString()
             .Should().Be("call-1");
-        frames.Single(f => Type(f) == "TOOL_CALL_RESULT").GetProperty("result").GetString()
-            .Should().Be("42 results");
+
+        var resultFrame = frames.Single(f => Type(f) == "TOOL_CALL_RESULT");
+        resultFrame.GetProperty("toolCallId").GetString().Should().Be("call-1");
+        resultFrame.GetProperty("content").GetString().Should().Be("42 results");
+        resultFrame.GetProperty("role").GetString().Should().Be("tool");
+        resultFrame.TryGetProperty("withheld", out _).Should().BeFalse("withheld must be omitted, not false, on a normal result");
+        // A fresh message id, distinct from both the assistant's text message and the tool-call-start's
+        // parentMessageId reference to it — per AG-UI, a tool result is its own message.
+        resultFrame.GetProperty("messageId").GetString().Should().NotBe(textMessageId);
     }
 
     [Fact]
@@ -174,6 +185,11 @@ public sealed class BundleRunStreamerTests
 
         frames.Select(Type).Should().Equal(
             "RUN_STARTED", "TOOL_CALL_START", "TOOL_CALL_ARGS", "TOOL_CALL_END", "RUN_FINISHED");
+
+        // No assistant text message ever opened, so the tool call has no parent to point at yet — the
+        // field must be omitted from the wire, not sent as null (it's optional for exactly this case).
+        frames.Single(f => Type(f) == "TOOL_CALL_START").TryGetProperty("parentMessageId", out _)
+            .Should().BeFalse();
     }
 
     /// <summary>
@@ -194,6 +210,25 @@ public sealed class BundleRunStreamerTests
         var argsFrame = frames.Single(f => Type(f) == "TOOL_CALL_ARGS");
         argsFrame.GetProperty("delta").GetString().Should().Be("{}");
         argsFrame.GetProperty("withheld").GetBoolean().Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A withheld tool-call result (the real result exceeded the streaming size ceiling) sets the wire
+    /// frame's <c>withheld</c> flag and streams empty content, never a truncated preview — #417.
+    /// </summary>
+    [Fact]
+    public async Task StreamAsync_OversizedToolCallResult_EmitsWithheldFrame_NotTruncatedPayload()
+    {
+        var executor = new FakeExecutor(BundleRunExecution.Ran(Record(BundleRunStatus.Succeeded)), async (sink, ct) =>
+        {
+            await sink.EmitToolCallResultAsync("call-1", new StreamedToolCallResult(string.Empty, true), ct);
+        });
+
+        var frames = await RunAndParseAsync(executor, Record());
+
+        var resultFrame = frames.Single(f => Type(f) == "TOOL_CALL_RESULT");
+        resultFrame.GetProperty("content").GetString().Should().BeEmpty();
+        resultFrame.GetProperty("withheld").GetBoolean().Should().BeTrue();
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleStreamEventsSerializationTests.cs
+++ b/src/Content/Tests/Presentation.ExecutionApi.Tests/BundleStreamEventsSerializationTests.cs
@@ -44,6 +44,29 @@ public sealed class BundleStreamEventsSerializationTests
         element.GetProperty("toolCallName").GetString().Should().Be("search");
     }
 
+    /// <summary>
+    /// <c>parentMessageId</c> is optional on the AG-UI wire schema and absent when the call is
+    /// constructed without one — mirrors <c>ToolCallArgsEvent_NotWithheld_OmitsWithheldFieldFromWire</c>'s
+    /// reasoning: a future refactor that starts constructing it as <see langword="null"/> vs. omitting
+    /// it entirely must not start serializing <c>"parentMessageId":null</c> on every frame.
+    /// </summary>
+    [Fact]
+    public async Task ToolCallStartEvent_NoParentMessageId_OmitsFieldFromWire()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallStartEvent("call-1", "search"));
+
+        element.TryGetProperty("parentMessageId", out _).Should().BeFalse();
+    }
+
+    /// <summary>A call linked to an already-open assistant message carries its id on the wire.</summary>
+    [Fact]
+    public async Task ToolCallStartEvent_WithParentMessageId_SerializesTheField()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallStartEvent("call-1", "search", "msg-1"));
+
+        element.GetProperty("parentMessageId").GetString().Should().Be("msg-1");
+    }
+
     [Fact]
     public async Task ToolCallArgsEvent_SerializesWithDiscriminatorAndFields()
     {
@@ -88,11 +111,32 @@ public sealed class BundleStreamEventsSerializationTests
     [Fact]
     public async Task ToolCallResultEvent_SerializesWithDiscriminatorAndFields()
     {
-        var element = await WriteAndParseAsync(new BundleToolCallResultEvent("call-1", "42 results"));
+        var element = await WriteAndParseAsync(new BundleToolCallResultEvent("call-1", "msg-2", "42 results", "tool"));
 
         element.GetProperty("type").GetString().Should().Be("TOOL_CALL_RESULT");
         element.GetProperty("toolCallId").GetString().Should().Be("call-1");
-        element.GetProperty("result").GetString().Should().Be("42 results");
+        element.GetProperty("messageId").GetString().Should().Be("msg-2");
+        element.GetProperty("content").GetString().Should().Be("42 results");
+        element.GetProperty("role").GetString().Should().Be("tool");
+    }
+
+    /// <summary>The <c>withheld</c> field is absent from the wire on a normal (non-withheld) result frame.</summary>
+    [Fact]
+    public async Task ToolCallResultEvent_NotWithheld_OmitsWithheldFieldFromWire()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallResultEvent("call-1", "msg-2", "42 results", "tool"));
+
+        element.TryGetProperty("withheld", out _).Should().BeFalse();
+    }
+
+    /// <summary>A withheld result frame carries an explicit <c>"withheld":true</c> on the wire.</summary>
+    [Fact]
+    public async Task ToolCallResultEvent_Withheld_SerializesTheFlag()
+    {
+        var element = await WriteAndParseAsync(new BundleToolCallResultEvent("call-1", "msg-2", string.Empty, "tool", true));
+
+        element.GetProperty("content").GetString().Should().BeEmpty();
+        element.GetProperty("withheld").GetBoolean().Should().BeTrue();
     }
 
     [Theory]
@@ -103,12 +147,12 @@ public sealed class BundleStreamEventsSerializationTests
     public void EachToolCallEventType_RoundTripsThroughThePolymorphicBase(Type derivedType)
     {
         BundleStreamEvent original = derivedType == typeof(BundleToolCallStartEvent)
-            ? new BundleToolCallStartEvent("call-1", "search")
+            ? new BundleToolCallStartEvent("call-1", "search", "msg-1")
             : derivedType == typeof(BundleToolCallArgsEvent)
                 ? new BundleToolCallArgsEvent("call-1", "{}")
                 : derivedType == typeof(BundleToolCallEndEvent)
                     ? new BundleToolCallEndEvent("call-1")
-                    : new BundleToolCallResultEvent("call-1", "ok");
+                    : new BundleToolCallResultEvent("call-1", "msg-2", "ok", "tool");
 
         var json = JsonSerializer.Serialize(original, typeof(BundleStreamEvent), DeserializeOptions);
         var roundTripped = JsonSerializer.Deserialize<BundleStreamEvent>(json, DeserializeOptions);


### PR DESCRIPTION
## Summary

**Bug 1 — wire-contract mismatch.** `BundleToolCallResultEvent.result` didn't match the AG-UI wire schema, which requires `messageId` and `content` on a tool-call-result event. Confirmed against two independent primary sources: the AG-UI protocol repo's own `sdks/typescript/packages/core/src/events.ts`, and this repo's own pinned `@ag-ui/core` package.

- **Clean rename, no back-compat alias**: `result` → `content` (deliberate breaking change to a published contract — the shipped docs already said these frames weren't AG-UI compliant).
- Added required `messageId` (a **fresh id per tool result**, never a reuse of the run's assistant message id — a tool result is its own message per AG-UI) and `role` (always `"tool"`).
- Added optional `parentMessageId` to `BundleToolCallStartEvent`, sent only once the assistant text message has actually opened on the wire (`textStarted`) — a tool call can arrive before any text, and the field is optional precisely for that case.

**Bug 2 — results truncated instead of withheld.** Tool-call results were hard-sliced at 500 characters (`RedactedResultPreview`) — unsafe for a payload a client may parse as structured data, and inconsistent with the arguments path's existing withhold-above-a-ceiling treatment (#392). Added `StreamedToolCallResult` (mirroring the existing `StreamedToolCallArguments`), widened `IAgentTurnStreamSink.EmitToolCallResultAsync`'s signature to carry it, and switched the result path to withhold whole above a 16KB ceiling instead of truncating.

**Review response (4 independent passes, 2 rounds after tool-orchestration instability produced duds on the first):** both rounds converged on the same finding — `RedactResultForStreaming` duplicated `RedactForStreaming`'s ceiling-check shape instead of sharing it. Fixed via a shared private `RedactWithCeiling` helper, and removed a now-dead 64KB pre-check at the `ExecuteAgentTurnCommandHandler` call site (unreachable once `RedactResultForStreaming`'s own 16KB ceiling always fires first).

**Docs updated in the same commit** per `Presentation.ExecutionApi/README.md`'s "Change the wire contract" procedure: `documentation/onboarding/assets/openapi/bundle-api.yaml` and `documentation/onboarding/17-bundle-api.html`, both of which previously claimed no AG-UI precedent existed for these fields — that claim was false and is now corrected.

Closes #417

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` — 0 errors
- [x] `dotnet test` — Application.AI.Common.Tests 2153/2153, Application.Core.Tests 1126/1126, Presentation.ExecutionApi.Tests 140/140, all pass
- [x] Full solution test run (exit code 0) confirms no regressions elsewhere
- [x] New tests: `parentMessageId` present/absent by `textStarted`, `messageId`/`content`/`role` wire shape, withheld-vs-normal result frames, oversized-result and redaction-failure paths — all mutation-tested (broke the fix, confirmed the test failed, reverted)
- [x] `/code-review` and `/simplify` receipts recorded for the final diff