### PR TITLE
fix: agent-turn escalation status and exported log redaction gaps (#441, #444)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Tools/AIToolConverter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/AIToolConverter.cs
@@ -75,19 +75,37 @@ public sealed class AIToolConverter : IToolConverter
             {
                 if (!activeOperations.Contains(operation, StringComparer.OrdinalIgnoreCase))
                 {
-                    return $"Error: Operation '{operation}' is not available. Valid operations: {string.Join(", ", activeOperations)}";
+                    return new ConvertedToolFailure(
+                        $"Error: Operation '{operation}' is not available. Valid operations: {string.Join(", ", activeOperations)}");
                 }
 
                 var parameters = ToolParameters.FromJson(parametersJson);
                 var result = await tool.ExecuteAsync(operation, parameters, cancellationToken);
                 return result.Success
-                    ? result.Output ?? "OK"
-                    : $"Error: {result.Error}";
+                    ? (object)(result.Output ?? "OK")
+                    : new ConvertedToolFailure($"Error: {result.Error}");
             },
             new AIFunctionFactoryOptions
             {
                 Name = tool.Name,
-                Description = description
+                Description = description,
+                // A ConvertedToolFailure must reach GovernedAIFunction as the CLR type it is — the
+                // framework's default marshaling JSON-serializes the delegate's return value before
+                // any decorator sees it, which would erase that identity. Only the marker bypasses
+                // it; the success string is re-serialized exactly as the default path would, so the
+                // model-facing shape for a genuine success is unchanged.
+                MarshalResult = (result, _, _) => new ValueTask<object?>(
+                    result is ConvertedToolFailure
+                        ? result
+                        : JsonSerializer.SerializeToElement((string)result!)),
+                // The delegate's two branches return different CLR types (a plain string on
+                // success, ConvertedToolFailure on failure) by design, so the compiler infers a
+                // common Task<object> rather than Task<string> — which would otherwise make this
+                // function advertise a generic/permissive return schema instead of the plain-text
+                // one a genuine success actually has. Nothing reads AIFunction.ReturnJsonSchema
+                // today, but excluding it is honest about that rather than leaving a misleading
+                // schema as an accidental side effect of the marker mechanism above.
+                ExcludeResultSchema = true
             });
 
         _logger.LogDebug(

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ConvertedToolFailure.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ConvertedToolFailure.cs
@@ -1,0 +1,25 @@
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Marks a value <see cref="AIToolConverter"/> returned as a tool failure rather than a genuine
+/// result, so <see cref="GovernedAIFunction"/> can report the correct escalation status instead of
+/// treating every no-throw return as <c>Succeeded</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Only reaches <see cref="GovernedAIFunction"/> intact because <c>AIToolConverter</c> pairs this
+/// type with an <see cref="Microsoft.Extensions.AI.AIFunctionFactoryOptions.MarshalResult"/> delegate
+/// that bypasses the framework's default return-value marshaling for it specifically. Without that,
+/// this record could not survive: <c>AIFunctionFactory</c>-created functions JSON-serialize their
+/// delegate's return value into a <see cref="System.Text.Json.JsonElement"/> inside their own
+/// <c>InvokeCoreAsync</c> — confirmed against the SDK source, not assumed — before
+/// <see cref="GovernedAIFunction"/> or any other decorator ever inspects the value, which would
+/// erase any CLR type identity a marker relied on.
+/// </para>
+/// <para>
+/// Never crosses into the framework layer beyond that: <see cref="GovernedAIFunction"/> unwraps this
+/// back to <see cref="ErrorText"/> before returning, on every exit path, so the model and every
+/// downstream consumer see the same plain string they always have.
+/// </para>
+/// </remarks>
+internal sealed record ConvertedToolFailure(string ErrorText);

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -128,13 +128,14 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
                 : new ToolExecutionReport(EscalationExecutionStatus.Failed, failure.ErrorText, null),
             ReportedBy, CancellationToken.None).ConfigureAwait(false);
 
-        return admissionPipeline.ApplyOutputPolicy(admission, Name, failure?.ErrorText ?? result);
+        return admissionPipeline.ApplyOutputPolicy(admission, Name, Unwrap(result));
     }
 
     /// <summary>
     /// Unwraps a <see cref="ConvertedToolFailure"/> back to its plain error text so the marker never
-    /// reaches the framework layer. Used only on the ungoverned bypass path above, which has no
-    /// admission pipeline to report against and so never computes a <c>failure</c> value of its own.
+    /// reaches the framework layer. The single definition of that transformation — both the bypass
+    /// path above and the reporting path route through it rather than each re-deriving the same
+    /// pattern match, so a future change to what "unwrapped" means can't update one and miss the other.
     /// </summary>
     private static object? Unwrap(object? result) =>
         result is ConvertedToolFailure failure ? failure.ErrorText : result;

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -120,6 +120,10 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     private async ValueTask<object?> ReportOutcomeAndApplyPolicyAsync(
         IToolCallAdmissionPipeline admissionPipeline, ToolCallAdmission admission, object? result)
     {
+        // failure.ErrorText is reported to ReportExecutionAsync before ApplyOutputPolicy runs below,
+        // so the classification gate's redaction verdict reaches the model-facing copy but not this
+        // one — matching DirectToolInvoker's identical reporting shape (result.Error, same ordering)
+        // rather than a gap this method introduces. Tracked as #452.
         var failure = result as ConvertedToolFailure;
         await admissionPipeline.ReportExecutionAsync(
             admission,

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -70,7 +70,7 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     {
         var admissionPipeline = ToolAdmissionAccessor.Current;
         if (admissionPipeline is null)
-            return await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false);
+            return Unwrap(await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false));
 
         var admission = await admissionPipeline
             .AdmitAsync(
@@ -95,19 +95,47 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
             throw;
         }
 
-        // A no-throw return is reported Succeeded. This is an imprecise signal for an ITool-backed
-        // function specifically: the generic converter (AIToolConverter) flattens ToolResult.Fail
-        // into a returned "Error: ..." string rather than throwing, which this layer cannot tell
-        // apart from a genuinely successful string result — it has no structured ToolResult to
-        // inspect, only whatever object the wrapped AIFunction returns, and that wrapped function is
-        // just as often MCP- or skill-provided as ITool-backed. Fixing that precisely would mean
-        // changing what every tool converter returns on failure, which is out of scope for wiring an
-        // existing report call into this path. Documented as a known limitation rather than guessed at.
+        return await ReportOutcomeAndApplyPolicyAsync(admissionPipeline, admission, result).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reports what a no-throw return actually was — Succeeded, or Failed with the tool's own error
+    /// text when <paramref name="result"/> unwraps to a <see cref="ConvertedToolFailure"/> — then
+    /// applies output policy to the unwrapped value.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="ConvertedToolFailure"/> came from <c>AIToolConverter</c>'s <c>ToolResult.Fail</c>
+    /// flattening — reported <see cref="EscalationExecutionStatus.Failed"/> with the tool's own error
+    /// text, the same status <c>DirectToolInvoker</c> already reports for the identical case. Every
+    /// other <see cref="AIFunction"/> source (MCP-provided, skill-provided) has no equivalent marker —
+    /// a non-throwing failure from one of those is still reported
+    /// <see cref="EscalationExecutionStatus.Succeeded"/>, since <see cref="ConvertedToolFailure"/> is
+    /// only ever produced by <c>AIToolConverter</c> (and only survives to here because it pairs the
+    /// marker with a <c>MarshalResult</c> delegate that bypasses the framework's default JSON
+    /// serialization — see the marker's own remarks). Fixing that would mean changing what every tool
+    /// source signals on failure, which is out of scope here — this closes the gap for ITool-backed
+    /// tools specifically, per the converter-wide framing the fix was scoped to. Tracked separately
+    /// as #451.
+    /// </remarks>
+    private async ValueTask<object?> ReportOutcomeAndApplyPolicyAsync(
+        IToolCallAdmissionPipeline admissionPipeline, ToolCallAdmission admission, object? result)
+    {
+        var failure = result as ConvertedToolFailure;
         await admissionPipeline.ReportExecutionAsync(
             admission,
-            new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null),
+            failure is null
+                ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
+                : new ToolExecutionReport(EscalationExecutionStatus.Failed, failure.ErrorText, null),
             ReportedBy, CancellationToken.None).ConfigureAwait(false);
 
-        return admissionPipeline.ApplyOutputPolicy(admission, Name, result);
+        return admissionPipeline.ApplyOutputPolicy(admission, Name, failure?.ErrorText ?? result);
     }
+
+    /// <summary>
+    /// Unwraps a <see cref="ConvertedToolFailure"/> back to its plain error text so the marker never
+    /// reaches the framework layer. Used only on the ungoverned bypass path above, which has no
+    /// admission pipeline to report against and so never computes a <c>failure</c> value of its own.
+    /// </summary>
+    private static object? Unwrap(object? result) =>
+        result is ConvertedToolFailure failure ? failure.ErrorText : result;
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Services.Governance;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Microsoft.Extensions.AI;
+using System.Text.Json;
 
 namespace Application.AI.Common.Services.Tools;
 
@@ -28,7 +29,11 @@ namespace Application.AI.Common.Services.Tools;
 /// </para>
 /// <para>
 /// This is the invocation-time chokepoint for the agent's autonomous tool calls, applied to every
-/// converted tool regardless of source (keyed-DI, MCP, or skill-provided).
+/// converted tool regardless of source (keyed-DI, MCP, or skill-provided) — the admission check
+/// itself runs unconditionally for all three. <strong>Failure detection on a no-throw return does
+/// not share that uniformity</strong>: it can only recognize a <see cref="ConvertedToolFailure"/>,
+/// which only a keyed-DI tool converted via <c>AIToolConverter</c> can produce (see
+/// <see cref="ReportOutcomeAndApplyPolicyAsync"/>'s remarks) — tracked as #451.
 /// </para>
 /// <para>
 /// <strong>Also the carrier for tool-composition findings.</strong> <c>ToolChainBuilder</c> stamps a
@@ -136,11 +141,24 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     }
 
     /// <summary>
-    /// Unwraps a <see cref="ConvertedToolFailure"/> back to its plain error text so the marker never
-    /// reaches the framework layer. The single definition of that transformation — both the bypass
-    /// path above and the reporting path route through it rather than each re-deriving the same
-    /// pattern match, so a future change to what "unwrapped" means can't update one and miss the other.
+    /// Unwraps a <see cref="ConvertedToolFailure"/> back to a value shaped exactly like a genuine
+    /// success, so the marker never reaches the framework layer. The single definition of that
+    /// transformation — both the bypass path above and the reporting path route through it rather
+    /// than each re-deriving the same pattern match, so a future change to what "unwrapped" means
+    /// can't update one and miss the other.
     /// </summary>
+    /// <remarks>
+    /// Re-wraps <see cref="ConvertedToolFailure.ErrorText"/> as a <see cref="JsonElement"/> rather
+    /// than returning the raw <see langword="string"/> — confirmed against the OpenAI chat client's
+    /// actual conversion source: it sends <see cref="FunctionResultContent.Result"/> to the model
+    /// verbatim when it's a raw <see langword="string"/>, but JSON-serializes (and so re-quotes) any
+    /// other shape, including a <c>JsonElement</c>. A genuine success already reaches here as a
+    /// <c>JsonElement</c> (the framework's own default marshaling — see <c>AIToolConverter</c>'s
+    /// <c>MarshalResult</c> override, which re-implements exactly that shape for the success case).
+    /// Returning the marker's text as a bare string instead would have sent the model differently
+    /// quoted text for a failure than for a success, silently contradicting this type's own contract
+    /// that unwrapping leaves the model-facing text unchanged.
+    /// </remarks>
     private static object? Unwrap(object? result) =>
-        result is ConvertedToolFailure failure ? failure.ErrorText : result;
+        result is ConvertedToolFailure failure ? JsonSerializer.SerializeToElement(failure.ErrorText) : result;
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
@@ -113,6 +113,17 @@ public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
             @"(?i)(AccountKey|Password|pwd|SharedAccessKey)\s*=\s*(?!\[REDACTED\])[^;""'\s]+",
             "$1=[REDACTED]"));
 
+        // Azure SAS query signatures — sv=...&sp=...&se=...&sig=<value>. The other query
+        // parameters that make up a SAS URL (sv, sp, se, spr, sr) are non-secret grants and
+        // expiry metadata; sig is the actual signing token and the only one worth redacting.
+        // A distinct rule from the AccountKey/SharedAccessKey one above: those cover connection
+        // strings, this covers a URL query string, a different shape a SAS-signed blob/queue URL
+        // is just as likely to appear as (e.g. a document ingest URI, per CLAUDE.md's own
+        // recorded history of SAS tokens leaking through exception messages).
+        b.Add(Compile(RedactionCategory.Generic,
+            @"(?i)([?&]sig=)(?!\[REDACTED\])[^&\s""']+",
+            "$1[REDACTED]"));
+
         b.Add(Compile(RedactionCategory.Generic,
             @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[=:]\s*(?!\[REDACTED\])\S+",
             "$1=[REDACTED]"));

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -24,9 +24,17 @@ namespace Infrastructure.Observability.Processors;
 /// serialized or copied for batching. Processor <see cref="BaseProcessor{T}.OnEnd"/>
 /// callbacks run in registration order on the emitting thread, and the batch
 /// exporter snapshots the pooled <see cref="LogRecord"/>; a redactor registered
-/// after the exporter would therefore export the raw record. Because the scrub
-/// happens before export, PII never transits the wire even when a downstream
-/// collector — not the app — forwards the logs to Event Hub / a SIEM.
+/// after the exporter would therefore export the raw record.
+/// <strong>Scope: the OTel logging bridge only.</strong> This processor governs
+/// what an OTLP (or other OTel) exporter sends off-box — nothing more. A
+/// standard <see cref="Microsoft.Extensions.Logging.ILoggerProvider"/> registered
+/// alongside the OTel bridge (e.g. the console provider, wired unconditionally
+/// wherever this host also adds one) receives the same <c>ILogger</c> calls
+/// through its own, entirely separate path and is never touched by this
+/// processor — it still writes the raw, unredacted exception. Because the
+/// scrub happens before the OTLP export specifically, PII never reaches that
+/// wire even when a downstream collector — not the app — forwards the logs to
+/// Event Hub / a SIEM; it says nothing about any other sink this host emits to.
 /// </para>
 /// <para>
 /// Four surfaces are scrubbed: the rendered <see cref="LogRecord.FormattedMessage"/>

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -122,13 +122,19 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
     /// scrubs in place.
     /// </summary>
     /// <remarks>
-    /// Checks the exception's full <c>ToString()</c> text (via the SDK's own culture-invariant
-    /// <c>ToInvariantString()</c>, confirmed against the OTLP exporter's serializer source as exactly
-    /// what it uses to populate <c>exception.stacktrace</c>), not just <see cref="Exception.Message"/>
-    /// — that representation recursively includes every <see cref="Exception.InnerException"/>'s own
+    /// Checks the exception's full <c>ToString()</c> text, not just <see cref="Exception.Message"/> —
+    /// that representation recursively includes every <see cref="Exception.InnerException"/>'s own
     /// message via its <c>" ---> "</c> chain, so a secret nested in a wrapped exception's inner
     /// message is still caught even when the outer message itself is clean (e.g. a generic "dispatch
-    /// failed" wrapping a lower-level exception whose message carries a connection string).
+    /// failed" wrapping a lower-level exception whose message carries a connection string). This is
+    /// the same text the OTLP exporter itself exports as <c>exception.stacktrace</c> — confirmed
+    /// against its serializer source, which calls the SDK's own internal, culture-invariant
+    /// <c>ToInvariantString()</c> on whatever <see cref="LogRecord.Exception"/> ends up being (that
+    /// internal helper isn't visible to this assembly, so this method calls the ordinary,
+    /// culture-sensitive <c>ToString()</c> instead — a difference confined to stack-frame boilerplate
+    /// like the localized "at"/"bei" prefix, never to a secret: an exception's own
+    /// <see cref="Exception.Message"/> text is a literal .NET string, not culture-translated, so what
+    /// the redaction filter scans for a match is identical either way).
     /// <para>
     /// <strong>Where the redacted text goes, and why not into <see cref="Exception.Message"/>.</strong>
     /// Confirmed against the OTLP exporter's serializer: it sets <c>exception.message</c> directly

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -10,9 +10,12 @@ namespace Infrastructure.Observability.Processors;
 
 /// <summary>
 /// Scrubs PII / secret content from OpenTelemetry <see cref="LogRecord"/>s before
-/// they reach any exporter. The log-signal counterpart to the span-side
-/// <see cref="PiiFilteringProcessor"/>: one PII processor per signal, both reusing
-/// the harness's content redactor.
+/// they reach any exporter. The log-signal sibling of the span-side
+/// <see cref="PiiFilteringProcessor"/> — both reuse the harness's content redactor,
+/// but the parity is partial: <see cref="PiiFilteringProcessor"/> only deletes/hashes
+/// span tags by exact key, it does not pattern-scan span exception events the way
+/// this processor's <see cref="RedactException"/> pattern-scans a log's exception —
+/// tracked as #450.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -26,13 +29,15 @@ namespace Infrastructure.Observability.Processors;
 /// collector — not the app — forwards the logs to Event Hub / a SIEM.
 /// </para>
 /// <para>
-/// Three surfaces are scrubbed: the rendered <see cref="LogRecord.FormattedMessage"/>
+/// Four surfaces are scrubbed: the rendered <see cref="LogRecord.FormattedMessage"/>
 /// (populated because the pipeline sets <c>IncludeFormattedMessage = true</c>),
-/// the <see cref="LogRecord.Body"/>, and every string-valued entry in
-/// <see cref="LogRecord.Attributes"/> (the promoted structured fields). The
-/// underlying <see cref="IContentRedactionFilter"/> is intentionally
-/// over-redactive: a false positive that masks a token is acceptable, a false
-/// negative that leaks a credit-card number is not.
+/// the <see cref="LogRecord.Body"/>, every string-valued entry in
+/// <see cref="LogRecord.Attributes"/> (the promoted structured fields), and
+/// <see cref="LogRecord.Exception"/> (see <see cref="RedactException"/> — the OTLP
+/// exporter serializes it independently of the other three, into its own
+/// standardized fields). The underlying <see cref="IContentRedactionFilter"/> is
+/// intentionally over-redactive: a false positive that masks a token is
+/// acceptable, a false negative that leaks a credit-card number is not.
 /// </para>
 /// </remarks>
 public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
@@ -100,6 +105,78 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
         }
 
         RedactAttributes(data);
+        RedactException(data);
+    }
+
+    /// <summary>
+    /// The attribute key the full redacted exception text is stored under — see
+    /// <see cref="RedactException"/> for why it isn't just <see cref="Exception.Message"/>.
+    /// </summary>
+    private const string RedactedExceptionDetailAttributeKey = "exception.redacted_details";
+
+    /// <summary>
+    /// Scrubs <see cref="LogRecord.Exception"/>, the one surface the three scrubs above never
+    /// touch — the OTLP exporter serializes it independently into <c>exception.message</c> /
+    /// <c>exception.stacktrace</c>, so an exception whose message embeds a secret (a connection
+    /// string, a credential-bearing URI) reaches the exporter unredacted even with the other three
+    /// scrubs in place.
+    /// </summary>
+    /// <remarks>
+    /// Checks the exception's full <c>ToString()</c> text (via the SDK's own culture-invariant
+    /// <c>ToInvariantString()</c>, confirmed against the OTLP exporter's serializer source as exactly
+    /// what it uses to populate <c>exception.stacktrace</c>), not just <see cref="Exception.Message"/>
+    /// — that representation recursively includes every <see cref="Exception.InnerException"/>'s own
+    /// message via its <c>" ---> "</c> chain, so a secret nested in a wrapped exception's inner
+    /// message is still caught even when the outer message itself is clean (e.g. a generic "dispatch
+    /// failed" wrapping a lower-level exception whose message carries a connection string).
+    /// <para>
+    /// <strong>Where the redacted text goes, and why not into <see cref="Exception.Message"/>.</strong>
+    /// Confirmed against the OTLP exporter's serializer: it sets <c>exception.message</c> directly
+    /// from <see cref="Exception.Message"/> and <c>exception.stacktrace</c> from
+    /// <c>ToInvariantString()</c> — both standardized, short-content fields dashboards group and
+    /// alert on. Putting the full redacted <c>ToString()</c> dump (original message, stack frames,
+    /// and the whole inner-exception chain, all flattened into one string) into
+    /// <see cref="Exception.Message"/> would blow both fields up into a multi-line, effectively
+    /// unique-per-call blob, breaking that grouping for every redacted log line — the opposite of
+    /// what a "short message" field is for. So the replacement's own <see cref="Exception.Message"/>
+    /// stays a short, fixed summary (type name plus a pointer to where the detail lives), and the
+    /// full redacted text goes into a new <see cref="LogRecord.Attributes"/> entry under
+    /// <see cref="RedactedExceptionDetailAttributeKey"/> instead — a normal structured field, not a
+    /// semantic-convention one anything expects to stay short.
+    /// </para>
+    /// <see cref="Exception.Message"/> has no public setter, so an in-place edit isn't possible
+    /// regardless; a replacement instance is built instead, with no
+    /// <see cref="Exception.InnerException"/> of its own, so nothing unredacted can still be reached
+    /// through it. The replacement is a <see cref="RedactedLogException"/>, not a bare
+    /// <see cref="Exception"/> — see its own remarks for why the exported <c>exception.type</c>
+    /// attribute needs to say "this was redacted" rather than silently reporting a generic type that
+    /// looks identical to an unrelated bare throw elsewhere. Only mutates the record when the filter
+    /// actually matched something, matching the no-op-when-nothing-matched contract every other
+    /// redaction call here honors.
+    /// </remarks>
+    private void RedactException(LogRecord data)
+    {
+        if (data.Exception is not { } exception)
+        {
+            return;
+        }
+
+        var original = exception.ToString();
+        var redacted = _filter.Redact(original, _categories);
+        if (redacted == original)
+        {
+            return;
+        }
+
+        var typeName = exception.GetType().Name;
+        data.Exception = new RedactedLogException(
+            $"{typeName} (redacted — see '{RedactedExceptionDetailAttributeKey}' attribute for detail)");
+
+        var attributes = data.Attributes is { } existing
+            ? new List<KeyValuePair<string, object?>>(existing)
+            : [];
+        attributes.Add(new KeyValuePair<string, object?>(RedactedExceptionDetailAttributeKey, redacted));
+        data.Attributes = attributes;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/RedactedLogException.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/RedactedLogException.cs
@@ -1,0 +1,25 @@
+namespace Infrastructure.Observability.Processors;
+
+/// <summary>
+/// Replaces an exception <see cref="LogRecordRedactionProcessor"/> redacted before it reaches the
+/// OTLP exporter, in place of the original type.
+/// </summary>
+/// <remarks>
+/// The OTLP log serializer derives the exported <c>exception.type</c> attribute from
+/// <c>LogRecord.Exception.GetType()</c> — there is no way to keep the original exception's real
+/// type there while replacing its message, short of dynamically reconstructing an instance of that
+/// exact type (fragile: most exception types have no guaranteed <c>(string)</c> constructor, and
+/// constructing one can have side effects). A generic <see cref="System.Exception"/> would report
+/// <c>exception.type = "System.Exception"</c>, indistinguishable from a genuine bare
+/// <c>throw new Exception(...)</c> elsewhere. This type exists only so the export self-announces
+/// that redaction happened — a responder sees <c>exception.type = "RedactedLogException"</c> and
+/// knows the original type name is embedded in the (redacted) message text instead of the type
+/// attribute, rather than silently losing that signal with no indication why.
+/// </remarks>
+/// <param name="message">
+/// A short, fixed summary — the original type name plus a pointer to where the full redacted detail
+/// lives. Deliberately not the full redacted text: the OTLP exporter reads this directly into the
+/// standardized <c>exception.message</c>/<c>exception.stacktrace</c> fields, which callers expect to
+/// stay short and stable for grouping and alerting — see <c>LogRecordRedactionProcessor.RedactException</c>.
+/// </param>
+public sealed class RedactedLogException(string message) : Exception(message);

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
@@ -166,8 +166,31 @@ public sealed class GovernedAIFunctionTests
                 "agent-turn", CancellationToken.None),
             Times.Once);
         // The model-facing text is unaffected by the marker — unwrapped back to the tool's own plain
-        // error text before being returned, never the ConvertedToolFailure wrapper itself.
-        Assert.Equal("Error: boom", result);
+        // error text before being returned, never the ConvertedToolFailure wrapper itself. Re-wrapped
+        // as a JsonElement, the same shape a genuine success already has: the OpenAI chat client
+        // sends a raw string verbatim but re-quotes anything else, so a bare string here would have
+        // sent the model differently-formatted text for a failure than for a success.
+        var resultStr = result is System.Text.Json.JsonElement je ? je.GetString() : result?.ToString();
+        Assert.Equal("Error: boom", resultStr);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ToolReturnsConvertedFailure_ReturnsSameRuntimeShapeAsSuccess()
+    {
+        // The OpenAI chat client (Microsoft.Extensions.AI.OpenAI's OpenAIChatClient) sends
+        // FunctionResultContent.Result to the model verbatim when it's a raw CLR string, but
+        // JSON-serializes (re-quoting) anything else, including a JsonElement. A genuine success
+        // already reaches the model as a JsonElement (AIToolConverter's default marshaling) — if a
+        // failure unwrapped to a bare string instead, the model would see differently-quoted text
+        // for a failure than for a success, contradicting Unwrap's own documented contract.
+        var (successInner, _) = MakeInner();
+        var failureInner = MakeFailingInner("Error: boom");
+
+        var successResult = await InvokeUnder(ApprovingPipeline(ApprovedCall()).Object, successInner);
+        var failureResult = await InvokeUnder(ApprovingPipeline(ApprovedCall()).Object, failureInner);
+
+        Assert.IsType<System.Text.Json.JsonElement>(successResult);
+        Assert.IsType<System.Text.Json.JsonElement>(failureResult);
     }
 
     [Fact]
@@ -181,7 +204,8 @@ public sealed class GovernedAIFunctionTests
         var result = await new GovernedAIFunction(inner)
             .InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
 
-        Assert.Equal("Error: boom", result);
+        var resultStr = result is System.Text.Json.JsonElement je ? je.GetString() : result?.ToString();
+        Assert.Equal("Error: boom", resultStr);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
@@ -24,6 +24,22 @@ public sealed class GovernedAIFunctionTests
         return (inner, () => invoked);
     }
 
+    /// <summary>
+    /// An inner function shaped like what <c>AIToolConverter</c> produces for a <c>ToolResult.Fail</c>:
+    /// a <see cref="ConvertedToolFailure"/> return, paired with the same <c>MarshalResult</c> override
+    /// that lets the marker reach this layer intact instead of being JSON-serialized away — see
+    /// <see cref="ConvertedToolFailure"/>'s remarks for why that pairing is required.
+    /// </summary>
+    private static AIFunction MakeFailingInner(string errorText) =>
+        AIFunctionFactory.Create(
+            () => new ConvertedToolFailure(errorText),
+            new AIFunctionFactoryOptions
+            {
+                Name = "file_system",
+                Description = "test tool",
+                MarshalResult = (result, _, _) => new ValueTask<object?>(result)
+            });
+
     private static async Task<object?> InvokeUnder(IToolCallAdmissionPipeline pipeline, AIFunction inner)
     {
         using var armed = ToolAdmissionAccessor.Begin(pipeline);
@@ -128,6 +144,44 @@ public sealed class GovernedAIFunctionTests
                 It.Is<ToolExecutionReport>(r => r.Status == EscalationExecutionStatus.Succeeded),
                 "agent-turn", CancellationToken.None),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ToolReturnsConvertedFailure_WithApproval_ReportsFailedWithReason()
+    {
+        // #441: a no-throw ToolResult.Fail, flattened by AIToolConverter into a plain string, used
+        // to be indistinguishable from a genuine success — this is the case that used to report
+        // Succeeded. The marker is how AIToolConverter tells this layer the call actually failed.
+        var inner = MakeFailingInner("Error: boom");
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        var result = await InvokeUnder(pipeline.Object, inner);
+
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r =>
+                    r.Status == EscalationExecutionStatus.Failed && r.FailureReason == "Error: boom"),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
+        // The model-facing text is unaffected by the marker — unwrapped back to the tool's own plain
+        // error text before being returned, never the ConvertedToolFailure wrapper itself.
+        Assert.Equal("Error: boom", result);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoAmbientChain_UnwrapsConvertedFailureToPlainText()
+    {
+        // The ungoverned bypass path never reports anything (no admission chain to report against),
+        // but it must still unwrap the marker before returning — otherwise an internal type leaks
+        // out to whatever called this AIFunction directly.
+        var inner = MakeFailingInner("Error: boom");
+
+        var result = await new GovernedAIFunction(inner)
+            .InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+
+        Assert.Equal("Error: boom", result);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/AIToolConverterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/AIToolConverterTests.cs
@@ -218,6 +218,62 @@ public class AIToolConverterTests
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task InvokeAsync_UnknownOperation_ReturnsConvertedToolFailure()
+    {
+        // #441: an unknown operation never reaches ToolResult at all, but it still didn't succeed —
+        // GovernedAIFunction must be able to tell, via the same marker ToolResult.Fail uses below.
+        // This survives intact (not JSON-serialized like an ordinary return) because Convert pairs it
+        // with a MarshalResult delegate — see ConvertedToolFailure's remarks for why that's required.
+        var mock = new Mock<ITool>();
+        mock.Setup(t => t.Name).Returns("file_system");
+        mock.Setup(t => t.Description).Returns("desc");
+        mock.Setup(t => t.SupportedOperations).Returns(["read"]);
+
+        var aiFunction = (AIFunction)_converter.Convert(mock.Object)!;
+        var args = new AIFunctionArguments { ["operation"] = "delete", ["parametersJson"] = null };
+
+        var result = await aiFunction.InvokeAsync(args);
+
+        var failure = result.Should().BeOfType<ConvertedToolFailure>().Subject;
+        failure.ErrorText.Should().Contain("not available");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ToolResultFails_ReturnsConvertedToolFailure()
+    {
+        // #441: GovernedAIFunction.InvokeCoreAsync unconditionally reported Succeeded for any
+        // no-throw return, because a plain "Error: ..." string is indistinguishable from a genuine
+        // successful string result. This marker is what makes them distinguishable.
+        var tool = CreateCapturingTool("file_system", ["read"], (op, p, ct) =>
+            Task.FromResult(ToolResult.Fail("boom")));
+
+        var aiFunction = (AIFunction)_converter.Convert(tool)!;
+        var args = new AIFunctionArguments { ["operation"] = "read", ["parametersJson"] = null };
+
+        var result = await aiFunction.InvokeAsync(args);
+
+        var failure = result.Should().BeOfType<ConvertedToolFailure>().Subject;
+        failure.ErrorText.Should().Be("Error: boom");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ToolResultSucceeds_ReturnsPlainJsonElementNotConvertedToolFailure()
+    {
+        // The success path is untouched by the #441 fix — still a JsonElement-wrapped string, the
+        // same shape MarshalResult explicitly re-implements for every non-failure return.
+        var tool = CreateCapturingTool("file_system", ["read"], (op, p, ct) =>
+            Task.FromResult(ToolResult.Ok("all good")));
+
+        var aiFunction = (AIFunction)_converter.Convert(tool)!;
+        var args = new AIFunctionArguments { ["operation"] = "read", ["parametersJson"] = null };
+
+        var result = await aiFunction.InvokeAsync(args);
+
+        result.Should().BeOfType<System.Text.Json.JsonElement>();
+        ((System.Text.Json.JsonElement)result!).GetString().Should().Be("all good");
+    }
+
     private static ITool CreateMockTool(string name, IReadOnlyList<string> operations)
     {
         var mock = new Mock<ITool>();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
@@ -98,6 +98,23 @@ public sealed class DefaultContentRedactionFilterTests
     }
 
     [Fact]
+    public void Redact_Generic_MasksSasQuerySignature()
+    {
+        // Security review on #444: SAS-signed blob/queue URLs (a document-ingest source URI is
+        // exactly the shape this can appear as) were leaking their sig= token unredacted — the
+        // AccountKey/SharedAccessKey rule covers connection strings, not this URL query shape.
+        var result = _filter.Redact(
+            "https://acct.blob.core.windows.net/c/b?sv=2021-08-06&sp=rwdlac&se=2026-01-01&sig=aBcD%2FeF9xyz",
+            [RedactionCategory.Generic]);
+
+        result.Should().NotContain("aBcD%2FeF9xyz");
+        result.Should().Contain("[REDACTED]");
+        // The non-secret grant/expiry parameters are left alone — only sig is a credential.
+        result.Should().Contain("sv=2021-08-06");
+        result.Should().Contain("sp=rwdlac");
+    }
+
+    [Fact]
     public void Redact_CategoryNotRequested_LeavesContentUnchanged()
     {
         // Only Email requested; the email stays intact because Email is excluded.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
@@ -109,8 +109,12 @@ public sealed class DefaultContentRedactionFilterTests
 
         result.Should().NotContain("aBcD%2FeF9xyz");
         result.Should().Contain("[REDACTED]");
-        // The non-secret grant/expiry parameters are left alone — only sig is a credential.
-        result.Should().Contain("sv=2021-08-06");
+        // The non-secret grant parameter is left alone under this rule specifically — only sig is a
+        // credential to the Generic category. This does NOT guarantee sv=/se='s date-shaped values
+        // survive redaction in general: with RedactionCategory.Phone also enabled (LogRecordRedactionProcessor
+        // falls back to every category when none are configured), the pre-existing Phone rule matches
+        // "2021-08-06"/"2026-01-01" too and redacts them — over-redaction, not a security gap, but
+        // this test's own claim is scoped to Generic alone, not a blanket "left alone" guarantee.
         result.Should().Contain("sp=rwdlac");
     }
 

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LogRecordRedactionProcessorTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Processors/LogRecordRedactionProcessorTests.cs
@@ -29,10 +29,10 @@ public sealed class LogRecordRedactionProcessorTests
     /// (LogRecords are pooled and recycled, so fields are copied out immediately).</summary>
     private sealed class CapturingProcessor : BaseProcessor<LogRecord>
     {
-        public List<(string? Message, List<KeyValuePair<string, object?>> Attributes)> Records { get; } = [];
+        public List<(string? Message, List<KeyValuePair<string, object?>> Attributes, Exception? Exception)> Records { get; } = [];
 
         public override void OnEnd(LogRecord data) =>
-            Records.Add((data.FormattedMessage, data.Attributes?.ToList() ?? []));
+            Records.Add((data.FormattedMessage, data.Attributes?.ToList() ?? [], data.Exception));
     }
 
     private static Mock<IContentRedactionFilter> MockFilter()
@@ -126,6 +126,107 @@ public sealed class LogRecordRedactionProcessorTests
         capture.Records[0].Message.Should().Be($"token is {Marker}");
         capture.Records[0].Attributes.Should()
             .Contain(kvp => kvp.Key == "Value" && (string?)kvp.Value == Marker);
+    }
+
+    private const string RedactedDetailKey = "exception.redacted_details";
+
+    [Fact]
+    public void OnEnd_ExceptionMessageMatchesFilter_ReplacesExceptionWithShortSummary()
+    {
+        var original = new InvalidOperationException($"AccountKey={Marker}");
+
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogError(original, "dispatch failed"));
+
+        var exception = capture.Records[0].Exception;
+        exception.Should().NotBeNull();
+        exception.Should().NotBeSameAs(original);
+        // A distinct type, not a bare Exception — so the exported exception.type attribute
+        // self-announces that redaction happened instead of reporting a generic, ambiguous type.
+        exception.Should().BeOfType<RedactedLogException>();
+        // Message stays a short, fixed summary — not the redacted detail itself — so the
+        // standardized exception.message/exception.stacktrace fields a dashboard groups on don't
+        // balloon into a multi-line, effectively unique-per-call blob.
+        exception!.Message.Should().Contain(nameof(InvalidOperationException));
+        exception.Message.Should().NotContain(Marker);
+        exception.Message.Should().NotContain(Redacted);
+    }
+
+    [Fact]
+    public void OnEnd_ExceptionMessageMatchesFilter_AddsRedactedDetailAttribute()
+    {
+        var original = new InvalidOperationException($"AccountKey={Marker}");
+
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogError(original, "dispatch failed"));
+
+        capture.Records[0].Attributes.Should().Contain(kvp =>
+            kvp.Key == RedactedDetailKey
+            && ((string?)kvp.Value)!.Contains(Redacted)
+            && !((string?)kvp.Value)!.Contains(Marker));
+    }
+
+    [Fact]
+    public void OnEnd_SecretIsInInnerExceptionOnly_StillRedacts()
+    {
+        // A clean outer message wrapping a lower-level exception whose OWN message carries the
+        // secret — the exact shape MediatorDispatchRunner/WorkspaceCommandRunner/IacSandboxRunner
+        // produce today (log the real ex, return a generic "dispatch failed: {TypeName}" outward).
+        // Filtering only the outer Message would miss this: the redacted-detail attribute is built
+        // from ToString(), which recursively includes the inner exception's message.
+        var inner = new InvalidOperationException($"AccountKey={Marker}");
+        var outer = new InvalidOperationException("dispatch failed", inner);
+
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogError(outer, "dispatch failed"));
+
+        capture.Records[0].Exception.Should().BeOfType<RedactedLogException>();
+        capture.Records[0].Attributes.Should().Contain(kvp =>
+            kvp.Key == RedactedDetailKey
+            && ((string?)kvp.Value)!.Contains(Redacted)
+            && !((string?)kvp.Value)!.Contains(Marker));
+    }
+
+    [Fact]
+    public void OnEnd_ExceptionMessageHasNoMatch_LeavesTheSameInstance()
+    {
+        var original = new InvalidOperationException("nothing sensitive here");
+
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogError(original, "dispatch failed"));
+
+        // Same instance, not just equal content — locks in the "only replace when something
+        // changed" behavior the other three scrubbed fields already honor.
+        capture.Records[0].Exception.Should().BeSameAs(original);
+        capture.Records[0].Attributes.Should().NotContain(kvp => kvp.Key == RedactedDetailKey);
+    }
+
+    [Fact]
+    public void OnEnd_NoException_IsANoOp()
+    {
+        var capture = RunPipeline(
+            CreateProcessor(EnabledConfig()),
+            logger => logger.LogInformation("no exception here"));
+
+        capture.Records[0].Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void OnEnd_RedactionDisabled_LeavesExceptionUntouched()
+    {
+        var config = EnabledConfig();
+        config.RedactionEnabled = false;
+        var original = new InvalidOperationException($"AccountKey={Marker}");
+
+        var capture = RunPipeline(
+            CreateProcessor(config),
+            logger => logger.LogError(original, "dispatch failed"));
+
+        capture.Records[0].Exception.Should().BeSameAs(original);
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/MediatorDispatchRunnerCallerAllowlistTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/MediatorDispatchRunnerCallerAllowlistTests.cs
@@ -1,0 +1,84 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Tests.Common;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Fences in who may call <c>MediatorDispatchRunner.RunAsync</c>, so a new caller cannot slip past
+/// review without its <c>failureContext</c> argument being checked for scrubbing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>MediatorDispatchRunner.RunAsync</c> logs its <c>failureContext</c> parameter verbatim on a
+/// dispatch failure (see #444) — the method's own contract says scrubbing anything
+/// credential-bearing out of it is the <em>caller's</em> job, not something the method itself
+/// inspects or redacts. Today's two callers honor that: <c>DocumentIngestTool</c> passes only the
+/// scheme/host/port/path of a document URI (no query string, no userinfo), and
+/// <c>WorkspaceWriteFileTool</c> passes an already-validated workspace-relative path. Nothing stops
+/// a third caller from passing something unscrubbed.
+/// </para>
+/// <para>
+/// <strong>Why a source scan and not a runtime guard.</strong> A source scan can't verify an
+/// argument's <em>content</em> is scrubbed — that's a judgment call a reviewer makes reading the
+/// caller's code, the same way <c>ToolCallAdmissionChokepointTests</c> can't verify a gate is
+/// consulted correctly, only that nothing outside the chain claims to consult it at all. What a scan
+/// <em>can</em> do is force the conversation: adding a file to this allowlist is the moment to ask
+/// whether the new <c>failureContext</c> argument is safe the same way the existing two are.
+/// </para>
+/// </remarks>
+public sealed class MediatorDispatchRunnerCallerAllowlistTests
+{
+    /// <summary>
+    /// Files permitted to call <c>MediatorDispatchRunner.RunAsync</c>. <c>MediatorDispatchRunner.cs</c>
+    /// itself is not listed — it declares <c>RunAsync</c>, it never calls it by the qualified name the
+    /// scan matches.
+    /// </summary>
+    private static readonly HashSet<string> Allowed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "DocumentIngestTool.cs",
+        "WorkspaceWriteFileTool.cs"
+    };
+
+    private const string CallPattern = @"\bMediatorDispatchRunner\.RunAsync\b";
+    private const string SourceGlob = "*.cs";
+
+    [Fact]
+    public void OnlyTheAllowlistedToolsCallMediatorDispatchRunner()
+    {
+        var contentRoot = Path.Combine(RepoRoot.Path, "src", "Content");
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(contentRoot, SourceGlob, SearchOption.AllDirectories))
+        {
+            if (SourceScan.IsExcluded(file, contentRoot) || Allowed.Contains(Path.GetFileName(file)))
+                continue;
+
+            var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(file));
+            if (Regex.IsMatch(code, CallPattern))
+                offenders.Add(Path.GetRelativePath(contentRoot, file));
+        }
+
+        offenders.Should().BeEmpty(
+            "a new MediatorDispatchRunner.RunAsync caller must be added to this test's allowlist "
+            + "deliberately — that is the moment to verify its failureContext argument is scrubbed "
+            + "the same way DocumentIngestTool's and WorkspaceWriteFileTool's are. Offenders:\n"
+            + string.Join("\n", offenders));
+    }
+
+    [Fact]
+    public void TheGuardWouldActuallyFire()
+    {
+        // Proves the matcher recognizes a violation and that a comment mentioning the call does not
+        // count as one — the same shape ToolCallAdmissionChokepointTests uses to prove its own scan
+        // isn't passing because nothing is being read.
+        var violating = SourceScan.StripCommentsAndStrings(
+            "return await MediatorDispatchRunner.RunAsync(scopeFactory, dispatch, logger, name, ctx, ct);");
+        var commentOnly = SourceScan.StripCommentsAndStrings(
+            "// delegates to MediatorDispatchRunner.RunAsync under the hood\npublic class X { }");
+
+        Regex.IsMatch(violating, CallPattern).Should().BeTrue();
+        Regex.IsMatch(commentOnly, CallPattern).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes two issues from the "audit-trail accuracy" cluster:

- **#441** — `GovernedAIFunction` unconditionally reported `EscalationExecutionStatus.Succeeded`
  for any no-throw tool call, because `AIToolConverter` flattens `ToolResult.Fail` into a plain
  string indistinguishable from a genuine success. Fixed with a `ConvertedToolFailure` marker,
  paired with an `AIFunctionFactoryOptions.MarshalResult` override that bypasses the framework's
  default JSON serialization for that marker specifically (verified against the
  `Microsoft.Extensions.AI` SDK source that the default path would otherwise erase the marker's
  CLR identity before `GovernedAIFunction` ever saw it). `GovernedAIFunction` now reports
  `Failed` with the real error text, and unwraps the marker back to a `JsonElement` — the same
  shape a genuine success already has — on every return path, so the model sees identical text
  and formatting either way.

- **#444** — `LogRecordRedactionProcessor` didn't scrub `LogRecord.Exception` before OTel log
  export, so a secret in an exception message (or a wrapped inner exception's message) could
  reach the OTLP exporter unredacted. Fixed via a new `RedactException` method that scrubs the
  exception's full text (catching secrets nested in an `InnerException` chain) and replaces it
  with a `RedactedLogException` whose `Message` stays a short, fixed summary — the full redacted
  detail goes into a new `exception.redacted_details` attribute instead, so the standardized
  `exception.message`/`exception.stacktrace` fields a dashboard groups/alerts on don't balloon
  into a multi-line blob on every redacted log line.

A new source-scan guard test fences in who may call `MediatorDispatchRunner.RunAsync`, so a
future caller's `failureContext` scrubbing gets reviewed rather than assumed.

## Review history

Both fixes went through six rounds of `/code-review` plus an independent security review before
merge. Corrections along the way, in order:

1. The original design (throw on failure) was found to be an active regression — it would trip
   `MaximumConsecutiveErrorsPerRequest` and silently degrade observability — before any code
   shipped; corrected to the marker+`MarshalResult` approach after verifying the actual SDK
   behavior.
2. Fixed an inner-exception redaction gap, a `ReturnJsonSchema` drift side effect, and a
   duplicated unwrap check.
3. Fixed `exception.type` collapsing to a generic, ambiguous type (added `RedactedLogException`)
   and `exception.message` field bloat breaking dashboard grouping (short-summary/attribute
   split).
4. Corrected a doc comment that overclaimed which SDK method the redaction code calls.
5. Security review found and I fixed a missing SAS-signature (`sig=`) redaction pattern — #444's
   coverage claim didn't hold for SAS-signed URLs specifically.
6. Final round found and I verified against the actual `OpenAIChatClient` SDK source: a tool
   failure was reaching the model with different JSON quoting than a tool success (raw string vs.
   `JsonElement`), contradicting this PR's own documented "model-facing text is unchanged"
   contract. Fixed to match the success path's shape exactly.

Three findings are deliberately out of scope for this diff and filed as tracked follow-ups:
- #450 — `PiiFilteringProcessor` (the span/trace-side equivalent) has the identical
  exception-leak gap on a different signal, and it's config-unfixable as currently structured.
- #451 — `GovernedAIFunction`'s fix only covers `ITool`-backed tools; MCP- and skill-provided
  tools still can't signal failure without throwing.
- #452 — `GovernedAIFunction` reports the failure reason to the audit trail before the
  classification gate's redaction runs, matching `DirectToolInvoker`'s pre-existing identical
  shape rather than a regression this PR introduces.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 errors
- [x] Full solution test suite green except two pre-existing, infra-dependent failure groups
      unrelated to this diff (PostgreSQL-backed KnowledgeGraph tests, Prometheus/metrics E2E
      tests — both need live services not running locally)
- [x] Every new test added across all six review rounds passes
- [x] Every behavioral fix (not just doc/test changes) was mutation-tested: broke the fix,
      confirmed the corresponding test failed, restored it

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GYTAVfKwGpN7J2VkLnymaW