### PR TITLE
fix: bound bundle run dispatch parallelism, add admission control (#449)

### DIFF
--- a/documentation/onboarding/17-bundle-api.html
+++ b/documentation/onboarding/17-bundle-api.html
@@ -1123,9 +1123,12 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                     </p>
                     <p>
                         One property of the dispatcher matters a great deal when you set your poll interval: it drains
-                        the queue <strong>one run at a time</strong>. Your run waits behind every other queued run on
-                        that host. So the time to a result is not just how long the model takes to think — it is that
-                        plus however long the queue ahead of you takes. Budget for both.
+                        the queue with <strong>bounded parallelism</strong> — up to <code>MaxConcurrentDispatchedBundleRuns</code>
+                        runs at once (default 4), host-wide, across every caller. An unrelated caller's run does not
+                        wait behind yours, but the degree is still finite: once every slot is busy, the next queued
+                        run waits for one to free up. So the time to a result is not just how long the model takes to
+                        think — it is that plus however long you wait for a slot. Budget for both. A host that sets
+                        the degree to <code>1</code> is back to strictly serial dispatch.
                     </p>
                     <p>
                         Poll until <code>status</code> is <code>Succeeded</code> or <code>Failed</code>, then read
@@ -1359,6 +1362,8 @@ curl -sS -H "Authorization: Bearer $TOKEN" \
                             <tr><td><code>RunRecordTtl</code></td><td><code>00:30:00</code></td><td>How long a terminal run stays pollable.</td></tr>
                             <tr><td><code>StreamReservationTtl</code></td><td><code>00:05:00</code></td><td>How long an unclaimed stream reservation survives.</td></tr>
                             <tr><td><code>MaxConcurrentStreamsPerCaller</code></td><td><code>4</code></td><td>Open streams one caller may hold.</td></tr>
+                            <tr><td><code>MaxConcurrentDispatchedBundleRuns</code></td><td><code>4</code></td><td>Background runs the host executes at once, across all callers.</td></tr>
+                            <tr><td><code>MaxActiveBundleRunsPerOwner</code></td><td><code>10</code></td><td>Runs one caller may hold queued or executing at once, any dispatch mode.</td></tr>
                             <tr><td><code>CleanupInterval</code></td><td><code>00:01:00</code></td><td>Sweeper period.</td></tr>
                             <tr><td><code>Envelopes</code></td><td>fail-closed</td><td>The per-caller grant table (see above).</td></tr>
                             <tr><td><code>Auth:TenantId</code> / <code>Auth:ClientId</code></td><td>unset</td><td>This API's own Entra audience. Supply both or neither.</td></tr>

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -218,8 +218,10 @@ paths:
           reclaimed after `StreamReservationTtl` (default 5 minutes).
 
         A run against an unknown, expired, or foreign handle returns `404`. A run naming a
-        `conversationId` that already has a live run, or a caller already at `MaxActiveBundleRunsPerOwner`
-        concurrent runs, returns `409`.
+        `conversationId` that already has a live run returns `409` (wait for that run to finish — the
+        conflict is with a specific run, not with you). A caller already at `MaxActiveBundleRunsPerOwner`
+        concurrent runs returns `400` (the caller fixes this by finishing its own work, not by waiting
+        on anyone else's).
       requestBody:
         required: true
         content:
@@ -263,10 +265,9 @@ paths:
           $ref: "#/components/responses/NotFoundProblem"
         "409":
           description: >-
-            Refused by admission. Two distinct causes, distinguishable by the response's `detail` text:
-            this conversation already has a live bundle run (wait for it to finish before starting
-            another), or the caller already holds the maximum concurrent bundle runs allowed per owner
-            (`MaxActiveBundleRunsPerOwner`).
+            This conversation already has a live bundle run. Wait for it to finish before starting
+            another. (A caller past `MaxActiveBundleRunsPerOwner` gets `400` instead — see above — since
+            that refusal is about the caller's own volume, not a conflict with another run.)
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -209,13 +209,17 @@ paths:
         Two dispatch modes, chosen by `stream`:
 
         * `stream: false` (default) — the run is enqueued and executed by the host's background
-          dispatcher. Poll `statusUrl` for the result. The dispatcher drains its queue **one run at a
-          time**, so a queued run waits behind other queued runs on the same host.
+          dispatcher. Poll `statusUrl` for the result. The dispatcher drains its queue with **bounded
+          parallelism** — up to `MaxConcurrentDispatchedBundleRuns` runs at once (default 4), host-wide,
+          across every caller — so an unrelated caller's run does not wait behind yours. A host that
+          sets the degree to `1` restores strictly serial dispatch.
         * `stream: true` — the run is **reserved but not enqueued**. Nothing executes until you open
           `streamUrl`; opening it is what drives the run. If you never open it, the reservation is
           reclaimed after `StreamReservationTtl` (default 5 minutes).
 
-        A run against an unknown, expired, or foreign handle returns `404`.
+        A run against an unknown, expired, or foreign handle returns `404`. A run naming a
+        `conversationId` that already has a live run, or a caller already at `MaxActiveBundleRunsPerOwner`
+        concurrent runs, returns `409`.
       requestBody:
         required: true
         content:
@@ -257,6 +261,10 @@ paths:
           $ref: "#/components/responses/DisabledProblem"
         "404":
           $ref: "#/components/responses/NotFoundProblem"
+        "409":
+          description: >-
+            This conversation already has a live bundle run, or the caller holds the maximum
+            concurrent bundle runs allowed per owner.
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":

--- a/documentation/onboarding/assets/openapi/bundle-api.yaml
+++ b/documentation/onboarding/assets/openapi/bundle-api.yaml
@@ -263,8 +263,10 @@ paths:
           $ref: "#/components/responses/NotFoundProblem"
         "409":
           description: >-
-            This conversation already has a live bundle run, or the caller holds the maximum
-            concurrent bundle runs allowed per owner.
+            Refused by admission. Two distinct causes, distinguishable by the response's `detail` text:
+            this conversation already has a live bundle run (wait for it to finish before starting
+            another), or the caller already holds the maximum concurrent bundle runs allowed per owner
+            (`MaxActiveBundleRunsPerOwner`).
         "429":
           $ref: "#/components/responses/RateLimited"
         "500":

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -125,9 +125,10 @@ public sealed class RunBundleCommandHandler
             CreatedAt = _time.GetUtcNow()
         };
 
-        var admission = _jobStore.TryCreate(record, _config.CurrentValue.AI.BundleExecution.MaxActiveBundleRunsPerOwner);
+        var maxActiveRuns = _config.CurrentValue.AI.BundleExecution.MaxActiveBundleRunsPerOwner;
+        var admission = _jobStore.TryCreate(record, maxActiveRuns);
         if (admission != BundleRunAdmission.Accepted)
-            return Result<RunBundleResult>.Conflict(AdmissionRefusalMessage(admission));
+            return Refuse(admission, request.ConversationId, maxActiveRuns);
 
         // A streaming run is NOT enqueued: its sole driver is the caller opening the stream endpoint, which
         // claims and drives it on the connection thread. Enqueuing it too would let the background dispatcher
@@ -144,21 +145,27 @@ public sealed class RunBundleCommandHandler
     }
 
     /// <summary>
-    /// Reports which admission limit refused the run, distinctly. <see cref="BundleRunAdmission"/>'s own
-    /// remarks are explicit about why: the two refusals mean opposite things to a caller — capacity clears
-    /// on its own as the caller's own work finishes, a conversation conflict clears only when that
-    /// conversation's run ends — and collapsing them into one message would defeat the reason the outcome
-    /// is a named enum rather than a boolean.
+    /// Explains a refused admission in terms the caller can act on, mirroring
+    /// <c>StartWorkflowRunCommandHandler.Refuse</c>'s shape and status-code split for the identical
+    /// problem: a conversation conflict is about a specific run elsewhere and is reported <c>409</c>,
+    /// while being at capacity is about the caller's own accepted volume and is reported <c>400</c> —
+    /// the caller fixes it by finishing its own work, not by waiting on someone else's. Collapsing both
+    /// into one status or one message would defeat the reason the outcome is a named enum rather than a
+    /// boolean: <see cref="BundleRunAdmission"/>'s own remarks note the two refusals mean opposite things
+    /// to a caller, and clear under different conditions.
     /// </summary>
-    private static string AdmissionRefusalMessage(BundleRunAdmission admission) => admission switch
+    private static Result<RunBundleResult> Refuse(
+        BundleRunAdmission admission, string? conversationId, int maxActiveRuns) => admission switch
     {
-        BundleRunAdmission.ConversationAlreadyRunning =>
-            "This conversation already has a live bundle run. Wait for it to finish before starting another.",
-        BundleRunAdmission.OwnerAtCapacity =>
-            "The caller already holds the maximum concurrent bundle runs allowed per owner. "
-            + "Wait for one to finish, or poll and let it complete, before starting another.",
-        _ => throw new ArgumentOutOfRangeException(
-            nameof(admission), admission, $"{nameof(BundleRunAdmission.Accepted)} is not a refusal.")
+        BundleRunAdmission.ConversationAlreadyRunning => Result<RunBundleResult>.Conflict(
+            $"Conversation {conversationId} already has a live bundle run. Wait for it to finish "
+            + "before starting another."),
+
+        BundleRunAdmission.OwnerAtCapacity => Result<RunBundleResult>.ValidationFailure(
+            [$"This caller already has {maxActiveRuns} bundle run(s) in flight, the maximum this host "
+             + "permits. Wait for one to finish before starting another."]),
+
+        _ => Result<RunBundleResult>.Fail("The run could not be accepted.")
     };
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -12,15 +12,18 @@ namespace Application.AI.Common.CQRS.Bundles.RunBundle;
 
 /// <summary>
 /// Handles <see cref="RunBundleCommand"/>: refuses when bundle execution is disabled or the handle is
-/// unknown/expired, creates a <see cref="BundleRunStatus.Queued"/> run record carrying the resolved
+/// unknown/expired, admits a <see cref="BundleRunStatus.Queued"/> run record carrying the resolved
 /// capability envelope, and enqueues its job id for background dispatch. Returns the job id immediately —
 /// the multi-turn conversation runs out-of-band on the <c>BundleRunBackgroundService</c>.
 /// </summary>
 /// <remarks>
 /// The agent name is captured from the staged bundle here so the dispatcher never has to re-read the bundle
-/// to know what to run. Create-then-Enqueue: a host crash between the two leaves a queued record with no
+/// to know what to run. Admit-then-Enqueue: a host crash between the two leaves a queued record with no
 /// worker to pick it up — the same non-durable loss profile as the in-memory job store and dispatch queue,
-/// which is consistent with bundle runs not being persisted.
+/// which is consistent with bundle runs not being persisted. Admission (<see cref="IBundleRunJobStore.TryCreate"/>)
+/// refuses a second run against a conversation that already has one live, and refuses a caller already at
+/// its concurrent-run cap — both decided and inserted as one atomic step, mirroring
+/// <c>IRunJobStore.TryCreate</c>'s reasoning for workflow runs.
 /// </remarks>
 public sealed class RunBundleCommandHandler
     : IRequestHandler<RunBundleCommand, Result<RunBundleResult>>
@@ -122,7 +125,13 @@ public sealed class RunBundleCommandHandler
             CreatedAt = _time.GetUtcNow()
         };
 
-        _jobStore.Create(record);
+        var admission = _jobStore.TryCreate(record, _config.CurrentValue.AI.BundleExecution.MaxActiveBundleRunsPerOwner);
+        if (admission != BundleRunAdmission.Accepted)
+        {
+            return Result<RunBundleResult>.Conflict(
+                "This conversation already has a live bundle run, or the caller holds the maximum "
+                + "concurrent bundle runs allowed per owner.");
+        }
 
         // A streaming run is NOT enqueued: its sole driver is the caller opening the stream endpoint, which
         // claims and drives it on the connection thread. Enqueuing it too would let the background dispatcher

--- a/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/Bundles/RunBundle/RunBundleCommandHandler.cs
@@ -127,11 +127,7 @@ public sealed class RunBundleCommandHandler
 
         var admission = _jobStore.TryCreate(record, _config.CurrentValue.AI.BundleExecution.MaxActiveBundleRunsPerOwner);
         if (admission != BundleRunAdmission.Accepted)
-        {
-            return Result<RunBundleResult>.Conflict(
-                "This conversation already has a live bundle run, or the caller holds the maximum "
-                + "concurrent bundle runs allowed per owner.");
-        }
+            return Result<RunBundleResult>.Conflict(AdmissionRefusalMessage(admission));
 
         // A streaming run is NOT enqueued: its sole driver is the caller opening the stream endpoint, which
         // claims and drives it on the connection thread. Enqueuing it too would let the background dispatcher
@@ -146,6 +142,24 @@ public sealed class RunBundleCommandHandler
 
         return Result<RunBundleResult>.Success(new RunBundleResult { JobId = record.JobId });
     }
+
+    /// <summary>
+    /// Reports which admission limit refused the run, distinctly. <see cref="BundleRunAdmission"/>'s own
+    /// remarks are explicit about why: the two refusals mean opposite things to a caller — capacity clears
+    /// on its own as the caller's own work finishes, a conversation conflict clears only when that
+    /// conversation's run ends — and collapsing them into one message would defeat the reason the outcome
+    /// is a named enum rather than a boolean.
+    /// </summary>
+    private static string AdmissionRefusalMessage(BundleRunAdmission admission) => admission switch
+    {
+        BundleRunAdmission.ConversationAlreadyRunning =>
+            "This conversation already has a live bundle run. Wait for it to finish before starting another.",
+        BundleRunAdmission.OwnerAtCapacity =>
+            "The caller already holds the maximum concurrent bundle runs allowed per owner. "
+            + "Wait for one to finish, or poll and let it complete, before starting another.",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(admission), admission, $"{nameof(BundleRunAdmission.Accepted)} is not a refusal.")
+    };
 
     /// <summary>
     /// Additively unions the bundle's own registered MCP server names (<see cref="StagedBundle.McpServerNames"/>)

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunJobStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleRunJobStore.cs
@@ -33,11 +33,30 @@ namespace Application.AI.Common.Interfaces.Bundles;
 public interface IBundleRunJobStore
 {
     /// <summary>
-    /// Stores a newly created run record and starts its TTL. The record is expected to be
-    /// <see cref="BundleRunStatus.Queued"/>. Throws if a record with the same job id already exists.
+    /// Admits a newly created run, or refuses it, deciding and inserting as one atomic step. The record
+    /// is expected to be <see cref="BundleRunStatus.Queued"/>.
     /// </summary>
-    /// <param name="record">The run record to store.</param>
-    void Create(BundleRunRecord record);
+    /// <remarks>
+    /// <para>
+    /// Both refusals are read-then-write decisions over the same live-run survey, so they are answered
+    /// together under one lock: deciding them separately, or inserting afterwards, leaves a window in
+    /// which concurrent requests all observe a limit as unmet and all proceed.
+    /// </para>
+    /// <para>
+    /// A run with no <see cref="BundleRunRecord.ConversationId"/> can never be refused as
+    /// <see cref="BundleRunAdmission.ConversationAlreadyRunning"/> — there is no conversation for a
+    /// second run to conflict with.
+    /// </para>
+    /// </remarks>
+    /// <param name="record">The run to store, already stamped with its owner.</param>
+    /// <param name="maxActiveRunsPerOwner">
+    /// How many runs one owner may have queued or executing at once, across every dispatch mode.
+    /// Supplied by the caller rather than read here, because it is host policy rather than a property of
+    /// storage.
+    /// </param>
+    /// <returns>Whether the run was admitted, and if not, which limit refused it.</returns>
+    /// <exception cref="InvalidOperationException">The job id is already held.</exception>
+    BundleRunAdmission TryCreate(BundleRunRecord record, int maxActiveRunsPerOwner);
 
     /// <summary>
     /// Returns the current snapshot of the run with <paramref name="jobId"/>, or null when the job id is

--- a/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/BundleExecutionConfigValidator.cs
@@ -71,6 +71,14 @@ public sealed class BundleExecutionConfigValidator : AbstractValidator<BundleExe
             .GreaterThanOrEqualTo(1)
             .WithMessage("MaxConcurrentStreamsPerCaller must be >= 1 — a non-positive cap would deny every stream.");
 
+        RuleFor(x => x.MaxConcurrentDispatchedBundleRuns)
+            .GreaterThan(0)
+            .WithMessage("MaxConcurrentDispatchedBundleRuns must be > 0 — a non-positive degree would leave every accepted background run queued and never executed.");
+
+        RuleFor(x => x.MaxActiveBundleRunsPerOwner)
+            .GreaterThan(0)
+            .WithMessage("MaxActiveBundleRunsPerOwner must be > 0 — a non-positive cap would refuse every caller's first run.");
+
         RuleFor(x => x.StdioMcpServers.MaxServersPerBundle)
             .GreaterThan(0)
             .WithMessage("StdioMcpServers:MaxServersPerBundle must be > 0 — a non-positive cap would let no bundle register a stdio server even when the capability is enabled.");

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunAdmission.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunAdmission.cs
@@ -1,0 +1,38 @@
+namespace Domain.AI.Bundles;
+
+/// <summary>
+/// Outcome of offering a bundle run to the store: admitted, or refused by a named limit.
+/// </summary>
+/// <remarks>
+/// Named rather than boolean because the two refusals mean opposite things to a caller. Being at
+/// capacity is about the caller and clears on its own as its own work finishes; a conversation already
+/// running is about that one conversation and clears only when that run ends. A caller told merely "no"
+/// cannot tell whether to back off or to stop asking.
+/// </remarks>
+public enum BundleRunAdmission
+{
+    /// <summary>The run was stored and may be dispatched.</summary>
+    Accepted = 0,
+
+    /// <summary>
+    /// The run names a <see cref="BundleRunRecord.ConversationId"/> that already has a live run. A
+    /// conversation's turn lease is held for the whole multi-turn run, not per turn, so a second
+    /// concurrent run against the same conversation would not corrupt state the way two concurrent plan
+    /// runs would — it would simply queue behind the lease while occupying a dispatch slot doing nothing.
+    /// Refusing at admission is cheaper than discovering that by exhausting the parallel degree.
+    /// </summary>
+    ConversationAlreadyRunning = 1,
+
+    /// <summary>
+    /// The owner already holds as many live bundle runs — queued or executing, background or streaming —
+    /// as the host permits.
+    /// </summary>
+    /// <remarks>
+    /// Bounds how much work one caller may have <em>accepted</em>, which neither the per-request rate
+    /// limit nor the streaming concurrency limiter expresses on its own: a caller within both can
+    /// otherwise occupy every parallel dispatch slot by volume alone. It is not a statement about how
+    /// much runs concurrently; that is the host's dispatch degree, and it is not a fairness mechanism
+    /// either.
+    /// </remarks>
+    OwnerAtCapacity = 2
+}

--- a/src/Content/Domain/Domain.AI/Bundles/BundleRunAdmission.cs
+++ b/src/Content/Domain/Domain.AI/Bundles/BundleRunAdmission.cs
@@ -4,10 +4,23 @@ namespace Domain.AI.Bundles;
 /// Outcome of offering a bundle run to the store: admitted, or refused by a named limit.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Named rather than boolean because the two refusals mean opposite things to a caller. Being at
 /// capacity is about the caller and clears on its own as its own work finishes; a conversation already
 /// running is about that one conversation and clears only when that run ends. A caller told merely "no"
 /// cannot tell whether to back off or to stop asking.
+/// </para>
+/// <para>
+/// <strong>A separate type from <see cref="Domain.AI.Runs.RunAdmission"/>, not a reuse of it — the two
+/// conflict axes are not interchangeable.</strong> That enum's <c>TargetAlreadyRunning</c> asserts a
+/// second run would corrupt shared state ("a stored workflow's execution state is singular... a second
+/// concurrent run would share one state machine with the first"), which is false for bundles: a second
+/// run against a live conversation merely queues behind that conversation's turn lease, wasting a
+/// dispatch slot rather than corrupting anything (see <see cref="ConversationAlreadyRunning"/>).
+/// Attaching that doc comment, or that member name, to the bundle path would misdescribe the actual
+/// risk. <c>StartEvalRunCommandHandler</c> reuses <c>RunAdmission</c> across run kinds precisely because
+/// its target-conflict meaning transfers there unchanged; it does not transfer here.
+/// </para>
 /// </remarks>
 public enum BundleRunAdmission
 {

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleExecutionConfig.cs
@@ -27,7 +27,9 @@ namespace Domain.Common.Config.AI.BundleExecution;
 /// ├── MaxTotalUncompressedBytes     — Reject when the sum of entry sizes exceeds this (bomb guard)
 /// ├── MaxCompressionRatio           — Reject when uncompressed/compressed exceeds this (bomb guard)
 /// ├── AllowBundleDeclaredMcpServers — Allow a bundle's own REMOTE (http/sse) MCP server declarations
-/// └── StdioMcpServers               — Allow + configure a bundle's own LOCAL (stdio) MCP servers, sandboxed
+/// ├── StdioMcpServers               — Allow + configure a bundle's own LOCAL (stdio) MCP servers, sandboxed
+/// ├── MaxConcurrentDispatchedBundleRuns — How many background bundle runs the host executes at once, across all callers
+/// └── MaxActiveBundleRunsPerOwner   — Cap on how many bundle runs one caller may have queued or executing at once
 /// </code>
 /// </remarks>
 public class BundleExecutionConfig
@@ -166,4 +168,41 @@ public class BundleExecutionConfig
     /// full contract. Defaults to a disabled configuration.
     /// </summary>
     public BundleStdioMcpServersConfig StdioMcpServers { get; set; } = new();
+
+    /// <summary>
+    /// How many background bundle runs the host executes at once, across all callers.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Distinct from <see cref="MaxActiveBundleRunsPerOwner"/>, which bounds what one caller may have
+    /// <em>accepted</em>. This bounds what the host actually executes. At 1 the dispatcher is strictly
+    /// serial and a single long-running conversation delays every other caller's — which makes the
+    /// per-owner cap read as a concurrency guarantee the host does not provide.
+    /// </para>
+    /// <para>
+    /// <strong>This is not a fairness mechanism.</strong> Runs are dispatched in the order they were
+    /// accepted, so a caller that queues many runs at once still occupies the slots ahead of a caller
+    /// that queues one. Per-caller fair scheduling is a separate piece of work; raising this reduces
+    /// how long anyone waits but does not decide who waits.
+    /// </para>
+    /// <para>
+    /// Only governs background (non-streaming) dispatch. A streaming run is never enqueued — it executes
+    /// on the caller's own connection and is bounded separately by <see cref="MaxConcurrentStreamsPerCaller"/>.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: 4</value>
+    public int MaxConcurrentDispatchedBundleRuns { get; set; } = 4;
+
+    /// <summary>
+    /// Maximum number of bundle runs one caller may have queued or executing at once, across both
+    /// dispatch modes (background and streaming).
+    /// </summary>
+    /// <remarks>
+    /// Every other cap here bounds a <em>single</em> run or archive; the rate limiter bounds the
+    /// <em>rate</em> of run requests. Neither bounds the total in flight. Without this, a caller staying
+    /// politely within both could still occupy every parallel dispatch slot by volume alone — the
+    /// aggregate is the one quantity an otherwise carefully-capped surface would leave open.
+    /// </remarks>
+    /// <value>Default: 10</value>
+    public int MaxActiveBundleRunsPerOwner { get; set; } = 10;
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
@@ -27,6 +27,13 @@ namespace Infrastructure.AI.Bundles;
 /// conversation or a caller past its concurrent-run cap — the two conditions that would otherwise make
 /// parallel dispatch unsafe.
 /// </para>
+/// <para>
+/// <strong><c>Parallel.ForEachAsync</c>'s one sharp edge is that a body which throws tears down the whole
+/// loop.</strong> <see cref="DispatchGuardedAsync"/> is written never to — every exception it can observe
+/// is caught and logged rather than rethrown — so this ends only when the queue completes or the host
+/// stops. Removing a catch arm there silently kills every future dispatch on this host, not just the one
+/// run in flight.
+/// </para>
 /// </remarks>
 public sealed class BundleRunBackgroundService : BackgroundService
 {

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunBackgroundService.cs
@@ -1,62 +1,96 @@
 using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common.Config;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.AI.Bundles;
 
 /// <summary>
 /// Drains the <see cref="IBundleRunDispatchQueue"/> and drives each queued (non-streaming) bundle run to a
-/// terminal state through the shared <see cref="IBundleRunExecutor"/>. Mirrors <c>ChangeProposalBackgroundService</c>:
-/// failure-isolated so one bad run never stalls the queue. All the arm-the-ambients-and-run logic lives in the
-/// executor, which the streaming endpoint shares — see <see cref="IBundleRunExecutor"/>.
+/// terminal state through the shared <see cref="IBundleRunExecutor"/>, up to
+/// <see cref="Domain.Common.Config.AI.BundleExecution.BundleExecutionConfig.MaxConcurrentDispatchedBundleRuns"/>
+/// at once. Mirrors <c>RunDispatchBackgroundService</c>: failure-isolated so one bad run never stalls the
+/// queue, and bounded-parallel so one caller's long-running conversation never head-of-lines every other
+/// caller's. All the arm-the-ambients-and-run logic lives in the executor, which the streaming endpoint
+/// shares — see <see cref="IBundleRunExecutor"/>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Streaming runs are never enqueued (their driver is the stream endpoint), so this service only ever sees
 /// poll-only runs.
+/// </para>
+/// <para>
+/// <strong>Safe to run runs side by side because nothing here is what keeps them apart.</strong>
+/// <see cref="IBundleRunJobStore.TryBeginRun"/> arms each run exactly once, and
+/// <see cref="IBundleRunJobStore.TryCreate"/> already refused, at admission, a second run racing the same
+/// conversation or a caller past its concurrent-run cap — the two conditions that would otherwise make
+/// parallel dispatch unsafe.
+/// </para>
 /// </remarks>
 public sealed class BundleRunBackgroundService : BackgroundService
 {
     private readonly IBundleRunDispatchQueue _queue;
     private readonly IBundleRunExecutor _executor;
+    private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<BundleRunBackgroundService> _logger;
 
     /// <summary>Initializes a new <see cref="BundleRunBackgroundService"/>.</summary>
     public BundleRunBackgroundService(
         IBundleRunDispatchQueue queue,
         IBundleRunExecutor executor,
+        IOptionsMonitor<AppConfig> config,
         ILogger<BundleRunBackgroundService> logger)
     {
         ArgumentNullException.ThrowIfNull(queue);
         ArgumentNullException.ThrowIfNull(executor);
+        ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         _queue = queue;
         _executor = executor;
+        _config = config;
         _logger = logger;
     }
 
     /// <inheritdoc />
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        await foreach (var jobId in _queue.DequeueAllAsync(stoppingToken).ConfigureAwait(false))
-        {
-            if (stoppingToken.IsCancellationRequested)
-                break;
+        // The degree is read once, at start. A host that changes it takes effect on restart, which is the
+        // honest bound — reshaping a running drain loop mid-flight buys nothing and would make the number
+        // of in-flight runs unpredictable. Mirrors RunDispatchBackgroundService.ExecuteAsync exactly.
+        var degree = Math.Max(1, _config.CurrentValue.AI.BundleExecution.MaxConcurrentDispatchedBundleRuns);
 
-            try
-            {
-                await _executor.ExecuteAsync(jobId, stoppingToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-            {
-                break; // host shutdown — the executor already recorded the run as cancelled
-            }
-            catch (Exception ex)
-            {
-                // The executor records its own failures; this is a last-resort guard so a defect there can
-                // never tear down the drain loop and stall every subsequent run.
-                _logger.LogError(ex, "Bundle run {JobId} dispatch failed unexpectedly.", jobId);
-            }
+        try
+        {
+            await Parallel.ForEachAsync(
+                _queue.DequeueAllAsync(stoppingToken),
+                new ParallelOptions { MaxDegreeOfParallelism = degree, CancellationToken = stoppingToken },
+                async (jobId, token) => await DispatchGuardedAsync(jobId, token).ConfigureAwait(false))
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host shutdown.
+        }
+    }
+
+    /// <summary>Dispatches one run, never letting a failure escape into the drain loop.</summary>
+    private async Task DispatchGuardedAsync(string jobId, CancellationToken stoppingToken)
+    {
+        try
+        {
+            await _executor.ExecuteAsync(jobId, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Host shutdown — the executor already recorded the run as cancelled.
+        }
+        catch (Exception ex)
+        {
+            // The executor records its own failures; this is a last-resort guard so a defect there can
+            // never tear down the drain loop and stall every subsequent run.
+            _logger.LogError(ex, "Bundle run {JobId} dispatch failed unexpectedly.", jobId);
         }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
@@ -38,6 +38,7 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
     }
 
     private readonly ConcurrentDictionary<string, JobEntry> _entries = new(StringComparer.Ordinal);
+    private readonly Lock _admission = new();
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly TimeProvider _time;
 
@@ -55,19 +56,71 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
     private TimeSpan StreamReservationTtl => _config.CurrentValue.AI.BundleExecution.StreamReservationTtl;
 
     /// <inheritdoc />
-    public void Create(BundleRunRecord record)
+    public BundleRunAdmission TryCreate(BundleRunRecord record, int maxActiveRunsPerOwner)
     {
         ArgumentNullException.ThrowIfNull(record);
 
-        // A streaming reservation's initial expiry is the (separate, short) connect window — its own knob, so
-        // tightening the completed-result retention window never shrinks how long a caller has to connect. It
-        // is only consulted while the reservation is unclaimed; once claimed the run is in-flight and the
-        // expiry is irrelevant. Every other record's initial expiry is the run-record window (which only
-        // starts governing anything once the record is terminal).
-        var initialExpiry = _time.GetUtcNow() + (record.Streaming ? StreamReservationTtl : Ttl);
-        var entry = new JobEntry(record, initialExpiry);
-        if (!_entries.TryAdd(record.JobId, entry))
-            throw new InvalidOperationException($"A bundle run record with job id '{record.JobId}' already exists.");
+        lock (_admission)
+        {
+            var (conversationIsRunning, ownerActiveRuns) = SurveyActiveRuns(record);
+
+            if (conversationIsRunning)
+                return BundleRunAdmission.ConversationAlreadyRunning;
+
+            if (ownerActiveRuns >= maxActiveRunsPerOwner)
+                return BundleRunAdmission.OwnerAtCapacity;
+
+            // A streaming reservation's initial expiry is the (separate, short) connect window — its own knob,
+            // so tightening the completed-result retention window never shrinks how long a caller has to
+            // connect. It is only consulted while the reservation is unclaimed; once claimed the run is
+            // in-flight and the expiry is irrelevant. Every other record's initial expiry is the run-record
+            // window (which only starts governing anything once the record is terminal).
+            var initialExpiry = _time.GetUtcNow() + (record.Streaming ? StreamReservationTtl : Ttl);
+            var entry = new JobEntry(record, initialExpiry);
+            if (!_entries.TryAdd(record.JobId, entry))
+                throw new InvalidOperationException($"A bundle run record with job id '{record.JobId}' already exists.");
+
+            return BundleRunAdmission.Accepted;
+        }
+    }
+
+    /// <summary>
+    /// Answers both admission questions in one pass: whether <paramref name="candidate"/>'s conversation
+    /// (if any) already has a live run, and how many live runs its owner holds.
+    /// </summary>
+    /// <remarks>
+    /// The two questions are scoped differently on purpose. A conversation conflict is about that
+    /// conversation's turn lease, so it ignores who is asking — a second caller sharing access to the
+    /// same conversation would queue behind the lease just as surely. The capacity count is about the
+    /// caller, so it is scoped to that owner alone (bundle runs carry no tenant).
+    /// </remarks>
+    private (bool ConversationIsRunning, int OwnerActiveRuns) SurveyActiveRuns(BundleRunRecord candidate)
+    {
+        var conversationIsRunning = false;
+        var ownerActiveRuns = 0;
+
+        foreach (var entry in _entries.Values)
+        {
+            BundleRunRecord record;
+            lock (entry)
+            {
+                if (entry.Record.IsTerminal)
+                    continue;
+
+                record = entry.Record;
+            }
+
+            if (candidate.ConversationId is not null
+                && string.Equals(record.ConversationId, candidate.ConversationId, StringComparison.Ordinal))
+            {
+                conversationIsRunning = true;
+            }
+
+            if (string.Equals(record.OwnerId, candidate.OwnerId, StringComparison.Ordinal))
+                ownerActiveRuns++;
+        }
+
+        return (conversationIsRunning, ownerActiveRuns);
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
@@ -28,6 +28,13 @@ namespace Infrastructure.AI.Bundles;
 /// background dispatcher updates a given run, so contention is nil, but the lock keeps a concurrent sweep and
 /// update consistent.
 /// </para>
+/// <para>
+/// <strong>Admission is the one exception, and takes a store-wide lock.</strong> Deciding it means
+/// reading across entries — is this conversation already running, is this owner at capacity — so no
+/// per-entry lock can make it atomic. <c>_admission</c> is held while the per-entry locks are taken
+/// during the survey, never the reverse, so the two cannot deadlock. Mirrors
+/// <c>InMemoryRunJobStore</c>'s identical trade-off for workflow/plan runs.
+/// </para>
 /// </remarks>
 public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
 {
@@ -171,35 +178,37 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
     }
 
     /// <summary>
-    /// Whether <paramref name="entry"/> counts as a live run for admission purposes: not terminal, and not
-    /// an abandoned streaming reservation past its (short) connect window. Distinct from
-    /// <see cref="IsExpired"/>, which answers a different question — see <see cref="SurveyActiveRuns"/>'s
-    /// remarks for why conflating the two undercounts how quickly a completed run frees its slot. Callers
-    /// must hold the entry lock.
+    /// Whether <paramref name="entry"/> is a <see cref="BundleRunStatus.Queued"/> streaming reservation
+    /// nobody ever connected to. The one fact both <see cref="IsExpired"/> and <see cref="IsLive"/> need
+    /// and must agree on; named once so a future reclaimable shape is added to only one of them by
+    /// construction, not by remembering to touch both.
     /// </summary>
-    private static bool IsLive(JobEntry entry, DateTimeOffset now)
-    {
-        if (entry.Record.IsTerminal)
-            return false;
-
-        var isAbandonedStreamingReservation = entry.Record.Streaming
-            && entry.Record.Status == BundleRunStatus.Queued
-            && now >= entry.ExpiresAt;
-
-        return !isAbandonedStreamingReservation;
-    }
+    private static bool IsUnclaimedStreamReservation(JobEntry entry)
+        => entry.Record.Streaming && entry.Record.Status == BundleRunStatus.Queued;
 
     /// <summary>
     /// A record is reclaimable when it is terminal (past its pollable window) or an unclaimed streaming
-    /// reservation (a <see cref="BundleRunStatus.Queued"/> streaming run that was never picked up) past its
-    /// window. Every other non-terminal record is retained. Callers must hold the entry lock.
+    /// reservation (see <see cref="IsUnclaimedStreamReservation"/>) past its window. Every other
+    /// non-terminal record is retained. Callers must hold the entry lock.
     /// </summary>
     private static bool IsExpired(JobEntry entry, DateTimeOffset now)
     {
-        var reclaimable = entry.Record.IsTerminal
-            || (entry.Record.Streaming && entry.Record.Status == BundleRunStatus.Queued);
+        var reclaimable = entry.Record.IsTerminal || IsUnclaimedStreamReservation(entry);
         return reclaimable && now >= entry.ExpiresAt;
     }
+
+    /// <summary>
+    /// Whether <paramref name="entry"/> counts as a live run for admission purposes: not terminal, and not
+    /// an abandoned streaming reservation past its (short) connect window. Distinct from
+    /// <see cref="IsExpired"/>, which answers a different question — see <see cref="SurveyActiveRuns"/>'s
+    /// remarks for why conflating the two undercounts how quickly a completed run frees its slot.
+    /// Unlike <see cref="IsExpired"/>, a terminal record is never live regardless of <c>now</c> — its TTL
+    /// governs only how long it stays <em>pollable</em>, not whether it still occupies a capacity slot.
+    /// Callers must hold the entry lock.
+    /// </summary>
+    private static bool IsLive(JobEntry entry, DateTimeOffset now)
+        => !entry.Record.IsTerminal
+            && !(IsUnclaimedStreamReservation(entry) && now >= entry.ExpiresAt);
 
     /// <inheritdoc />
     public bool Update(BundleRunRecord record)

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/InMemoryBundleRunJobStore.cs
@@ -89,22 +89,37 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
     /// (if any) already has a live run, and how many live runs its owner holds.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The two questions are scoped differently on purpose. A conversation conflict is about that
     /// conversation's turn lease, so it ignores who is asking — a second caller sharing access to the
     /// same conversation would queue behind the lease just as surely. The capacity count is about the
     /// caller, so it is scoped to that owner alone (bundle runs carry no tenant).
+    /// </para>
+    /// <para>
+    /// <strong>Uses <see cref="IsLive"/>, not <see cref="IsExpired"/> or bare
+    /// <see cref="BundleRunRecord.IsTerminal"/>.</strong> The two are different questions.
+    /// <see cref="IsExpired"/> answers "has this record's TTL window elapsed" — for a terminal record
+    /// that window is the full poll-retention period, so reusing it here would count a run as live for
+    /// as long as it stays pollable, not merely for as long as it is doing work. <see cref="IsLive"/>
+    /// instead excludes a terminal record immediately, and additionally excludes an abandoned streaming
+    /// reservation — non-terminal but reclaimable once its short connect window elapses (see the class
+    /// remarks) — the moment it expires, not only once <see cref="SweepExpired"/> next runs. Without that
+    /// second case, a caller who never opened a stream would permanently occupy a capacity slot and block
+    /// every retry against its conversation until the next sweep, for a run that was never really live.
+    /// </para>
     /// </remarks>
     private (bool ConversationIsRunning, int OwnerActiveRuns) SurveyActiveRuns(BundleRunRecord candidate)
     {
         var conversationIsRunning = false;
         var ownerActiveRuns = 0;
+        var now = _time.GetUtcNow();
 
         foreach (var entry in _entries.Values)
         {
             BundleRunRecord record;
             lock (entry)
             {
-                if (entry.Record.IsTerminal)
+                if (!IsLive(entry, now))
                     continue;
 
                 record = entry.Record;
@@ -153,6 +168,25 @@ public sealed class InMemoryBundleRunJobStore : IBundleRunJobStore
             entry.Record = entry.Record with { Status = BundleRunStatus.Running, StartedAt = startedAt };
             return entry.Record;
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="entry"/> counts as a live run for admission purposes: not terminal, and not
+    /// an abandoned streaming reservation past its (short) connect window. Distinct from
+    /// <see cref="IsExpired"/>, which answers a different question — see <see cref="SurveyActiveRuns"/>'s
+    /// remarks for why conflating the two undercounts how quickly a completed run frees its slot. Callers
+    /// must hold the entry lock.
+    /// </summary>
+    private static bool IsLive(JobEntry entry, DateTimeOffset now)
+    {
+        if (entry.Record.IsTerminal)
+            return false;
+
+        var isAbandonedStreamingReservation = entry.Record.Streaming
+            && entry.Record.Status == BundleRunStatus.Queued
+            && now >= entry.ExpiresAt;
+
+        return !isAbandonedStreamingReservation;
     }
 
     /// <summary>

--- a/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.ExecutionApi/Extensions/ExecutionApiServiceCollectionExtensions.cs
@@ -32,8 +32,9 @@ public static class ExecutionApiServiceCollectionExtensions
 
     /// <summary>
     /// Per-caller <em>concurrency</em> policy for the live-stream endpoint. A streamed run executes inline on
-    /// its connection for the whole conversation and bypasses the single-threaded background dispatcher, so the
-    /// fixed-window request-rate limiter (which counts starts, not simultaneous connections) cannot bound it.
+    /// its connection for the whole conversation and bypasses the background dispatcher's queue entirely (it
+    /// is never enqueued), so the fixed-window request-rate limiter (which counts starts, not simultaneous
+    /// connections) cannot bound it.
     /// A concurrency limiter holds each permit for the connection's lifetime, capping how many agent
     /// conversations one caller can drive at once.
     /// </summary>

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -95,7 +95,7 @@ The disjointness check exists because the global registries scan discovery roots
 
 | Mode | `Stream` | Driver | Notes |
 |------|----------|--------|-------|
-| Background | `false` | `BundleRunBackgroundService` drains `IBundleRunDispatchQueue` | Serial -- one run at a time per host |
+| Background | `false` | `BundleRunBackgroundService` drains `IBundleRunDispatchQueue` | Bounded parallel -- up to `MaxConcurrentDispatchedBundleRuns` at once (default 4); `1` restores serial |
 | Live SSE | `true` | The caller opening `GET .../stream`, via `BundleRunStreamer` | **Not enqueued.** Reclaimed on `StreamReservationTtl` if never claimed |
 
 `BundleRunExecutor.ExecuteAsync` acquires the handle lease *before* claiming the run `Running` (so a run whose handle expired never carries a bogus start time), then claims via the atomic `IBundleRunJobStore.TryBeginRun` compare-and-set, so a stream racing the dispatcher for the same job yields exactly one winner. It arms `EphemeralAgentOverlayAccessor` (agent + owned skills resolve) and `CapabilityEnvelopeAccessor` (the governor enforces) around a materialised `RunConversationCommand`.
@@ -173,6 +173,8 @@ Everything lives under `AppConfig:AI:BundleExecution` (`Domain.Common/Config/AI/
 | `RunRecordTtl` | 30 min | Terminal records only |
 | `StreamReservationTtl` | 5 min | Unclaimed streaming reservations; deliberately independent of `RunRecordTtl` |
 | `MaxConcurrentStreamsPerCaller` | 4 | A concurrency limiter with `QueueLimit = 0` -- excess connections are rejected, not parked |
+| `MaxConcurrentDispatchedBundleRuns` | 4 | Background (non-streaming) runs the host dispatches at once, across all callers -- `1` is strictly serial |
+| `MaxActiveBundleRunsPerOwner` | 10 | Runs one caller may hold queued or executing at once, across both dispatch modes -- refused with `409` past this |
 | `CleanupInterval` | 60 s | `BundleWorkspaceCleanupService` period; a lease held by a running job blocks its directory's deletion |
 | `Envelopes` | fail-closed | `Default` / `BySubject` / `ByRole` |
 | `Auth:TenantId`, `Auth:ClientId` | unset | This host's **own** audience -- never shared with AgentHub or the MCP server |

--- a/src/Content/Presentation/Presentation.ExecutionApi/README.md
+++ b/src/Content/Presentation/Presentation.ExecutionApi/README.md
@@ -174,7 +174,7 @@ Everything lives under `AppConfig:AI:BundleExecution` (`Domain.Common/Config/AI/
 | `StreamReservationTtl` | 5 min | Unclaimed streaming reservations; deliberately independent of `RunRecordTtl` |
 | `MaxConcurrentStreamsPerCaller` | 4 | A concurrency limiter with `QueueLimit = 0` -- excess connections are rejected, not parked |
 | `MaxConcurrentDispatchedBundleRuns` | 4 | Background (non-streaming) runs the host dispatches at once, across all callers -- `1` is strictly serial |
-| `MaxActiveBundleRunsPerOwner` | 10 | Runs one caller may hold queued or executing at once, across both dispatch modes -- refused with `409` past this |
+| `MaxActiveBundleRunsPerOwner` | 10 | Runs one caller may hold queued or executing at once, across both dispatch modes -- refused with `400` past this (a conversation conflict is `409` instead; see below) |
 | `CleanupInterval` | 60 s | `BundleWorkspaceCleanupService` period; a lease held by a running job blocks its directory's deletion |
 | `Envelopes` | fail-closed | `Default` / `BySubject` / `ByRole` |
 | `Auth:TenantId`, `Auth:ClientId` | unset | This host's **own** audience -- never shared with AgentHub or the MCP server |

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -352,6 +352,7 @@ public sealed class RunBundleCommandHandlerTests
             .Handle(Command() with { ConversationId = "conv-1" }, CancellationToken.None);
 
         result.FailureType.Should().Be(ResultFailureType.Conflict);
+        result.Errors.Should().ContainSingle(e => e.Contains("conversation", StringComparison.OrdinalIgnoreCase));
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -366,6 +367,7 @@ public sealed class RunBundleCommandHandlerTests
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
         result.FailureType.Should().Be(ResultFailureType.Conflict);
+        result.Errors.Should().ContainSingle(e => e.Contains("maximum concurrent", StringComparison.OrdinalIgnoreCase));
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -79,7 +79,7 @@ public sealed class RunBundleCommandHandlerTests
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
         result.FailureType.Should().Be(ResultFailureType.NotFound);
-        _jobStore.Verify(j => j.Create(It.IsAny<BundleRunRecord>()), Times.Never);
+        _jobStore.Verify(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()), Times.Never);
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -89,7 +89,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
@@ -119,7 +121,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged(mcpServerNames: ["b1:echo", "b1:search"]));
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
@@ -138,7 +142,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
@@ -157,7 +163,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { ConversationId = "conv-1" }, CancellationToken.None);
@@ -174,7 +182,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
@@ -203,7 +213,7 @@ public sealed class RunBundleCommandHandlerTests
             .Handle(Command() with { ConversationId = "conv-theirs" }, CancellationToken.None);
 
         result.FailureType.Should().Be(ResultFailureType.NotFound);
-        _jobStore.Verify(j => j.Create(It.IsAny<BundleRunRecord>()), Times.Never);
+        _jobStore.Verify(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()), Times.Never);
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -215,7 +225,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { ConversationId = "conv-new" }, CancellationToken.None);
@@ -257,7 +269,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { Stream = true }, CancellationToken.None);
@@ -276,7 +290,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged(mcpServerNames: ["b1:echo"]));
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var callerEnvelope = new CapabilityEnvelope { AllowedMcpServers = ["host-server"] };
         var result = await BuildSut(enabled: true)
@@ -296,7 +312,9 @@ public sealed class RunBundleCommandHandlerTests
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.Create(It.IsAny<BundleRunRecord>())).Callback<BundleRunRecord>(r => created = r);
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => created = r)
+            .Returns(BundleRunAdmission.Accepted);
 
         var callerEnvelope = new CapabilityEnvelope { AllowedMcpServers = ["host-server"] };
         var result = await BuildSut(enabled: true)
@@ -316,7 +334,38 @@ public sealed class RunBundleCommandHandlerTests
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
         result.FailureType.Should().Be(ResultFailureType.NotFound);
-        _jobStore.Verify(j => j.Create(It.IsAny<BundleRunRecord>()), Times.Never);
+        _jobStore.Verify(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()), Times.Never);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // -- Admission (#449) --
+
+    [Fact]
+    public async Task Handle_ConversationAlreadyRunning_ReturnsConflict_AndDoesNotEnqueue()
+    {
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Returns(BundleRunAdmission.ConversationAlreadyRunning);
+
+        var result = await BuildSut(enabled: true)
+            .Handle(Command() with { ConversationId = "conv-1" }, CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
+        _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_OwnerAtCapacity_ReturnsConflict_AndDoesNotEnqueue()
+    {
+        _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
+        _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Returns(BundleRunAdmission.OwnerAtCapacity);
+
+        var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
+
+        result.FailureType.Should().Be(ResultFailureType.Conflict);
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Bundles/RunBundleCommandHandlerTests.cs
@@ -62,6 +62,14 @@ public sealed class RunBundleCommandHandlerTests
         MaxTurns = 4
     };
 
+    private BundleRunRecord? _created;
+
+    /// <summary>Stubs admission to accept, capturing the record the handler built into <see cref="_created"/>.</summary>
+    private void AcceptCreate() =>
+        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
+            .Callback<BundleRunRecord, int>((r, _) => _created = r)
+            .Returns(BundleRunAdmission.Accepted);
+
     [Fact]
     public async Task Handle_WhenDisabled_ReturnsForbidden_AndDoesNotEnqueue()
     {
@@ -88,22 +96,19 @@ public sealed class RunBundleCommandHandlerTests
     {
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created.Should().NotBeNull();
-        created!.Status.Should().Be(BundleRunStatus.Queued);
-        created.AgentName.Should().Be("the-agent");
-        created.Handle.Should().Be("handle-1");
-        created.OwnerId.Should().Be("owner-1");
-        created.MaxTurns.Should().Be(4);
-        result.Value!.JobId.Should().Be(created.JobId);
-        _queue.Verify(q => q.EnqueueAsync(created.JobId, It.IsAny<CancellationToken>()), Times.Once);
+        _created.Should().NotBeNull();
+        _created!.Status.Should().Be(BundleRunStatus.Queued);
+        _created.AgentName.Should().Be("the-agent");
+        _created.Handle.Should().Be("handle-1");
+        _created.OwnerId.Should().Be("owner-1");
+        _created.MaxTurns.Should().Be(4);
+        result.Value!.JobId.Should().Be(_created.JobId);
+        _queue.Verify(q => q.EnqueueAsync(_created.JobId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     // -- Bundle-owned MCP server envelope invariant (#376) --
@@ -120,18 +125,15 @@ public sealed class RunBundleCommandHandlerTests
         // host-trusted instead of bundle-owned.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged(mcpServerNames: ["b1:echo", "b1:search"]));
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created!.Envelope.AllowedMcpServers.Should().Contain(["b1:echo", "b1:search"]);
-        created.Envelope.BundleOwnedMcpServers.Should().Contain(["b1:echo", "b1:search"]);
-        created.Envelope.IsBundleOwnedMcpServer("b1:echo").Should().BeTrue();
-        created.Envelope.IsBundleOwnedMcpServer("b1:search").Should().BeTrue();
+        _created!.Envelope.AllowedMcpServers.Should().Contain(["b1:echo", "b1:search"]);
+        _created.Envelope.BundleOwnedMcpServers.Should().Contain(["b1:echo", "b1:search"]);
+        _created.Envelope.IsBundleOwnedMcpServer("b1:echo").Should().BeTrue();
+        _created.Envelope.IsBundleOwnedMcpServer("b1:search").Should().BeTrue();
     }
 
     [Fact]
@@ -141,15 +143,12 @@ public sealed class RunBundleCommandHandlerTests
         // fabricate entries in either list from the caller's own pre-existing grants.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created!.Envelope.BundleOwnedMcpServers.Should().BeEmpty();
+        _created!.Envelope.BundleOwnedMcpServers.Should().BeEmpty();
     }
 
     // -- Conversation continuity (#235) --
@@ -162,16 +161,13 @@ public sealed class RunBundleCommandHandlerTests
         // this whole issue is about.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { ConversationId = "conv-1" }, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created!.ConversationId.Should().Be("conv-1");
+        _created!.ConversationId.Should().Be("conv-1");
     }
 
     [Fact]
@@ -181,14 +177,11 @@ public sealed class RunBundleCommandHandlerTests
         // bundle run pay for a lookup it has no use for.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
-        created!.ConversationId.Should().BeNull();
+        _created!.ConversationId.Should().BeNull();
         _conversations.Verify(
             c => c.GetHistoryForDispatch(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
@@ -224,16 +217,13 @@ public sealed class RunBundleCommandHandlerTests
         // store returns null by default, which is exactly that case.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { ConversationId = "conv-new" }, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created!.ConversationId.Should().Be("conv-new");
+        _created!.ConversationId.Should().Be("conv-new");
 
         // Asserting the probe HAPPENED, not just that the result was a success — success is the default
         // outcome, so without this the test stays green with the whole pre-check deleted.
@@ -268,17 +258,14 @@ public sealed class RunBundleCommandHandlerTests
         // the background dispatcher race the stream for the same job.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { Stream = true }, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created!.Streaming.Should().BeTrue();
-        created.Status.Should().Be(BundleRunStatus.Queued);
+        _created!.Streaming.Should().BeTrue();
+        _created.Status.Should().Be(BundleRunStatus.Queued);
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -289,19 +276,16 @@ public sealed class RunBundleCommandHandlerTests
     {
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged(mcpServerNames: ["b1:echo"]));
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var callerEnvelope = new CapabilityEnvelope { AllowedMcpServers = ["host-server"] };
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { Envelope = callerEnvelope }, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created!.Envelope.AllowedMcpServers.Should().BeEquivalentTo(["host-server", "b1:echo"],
+        _created!.Envelope.AllowedMcpServers.Should().BeEquivalentTo(["host-server", "b1:echo"],
             "the bundle's own server must be additively granted, never replacing the caller's own grant");
-        created.Envelope.BundleOwnedMcpServers.Should().BeEquivalentTo(["b1:echo"],
+        _created.Envelope.BundleOwnedMcpServers.Should().BeEquivalentTo(["b1:echo"],
             "the authoritative bundle-ownership record must be stamped at the same point the grant is made, " +
             "not left for a downstream caller to re-derive from the server name's shape");
     }
@@ -311,17 +295,14 @@ public sealed class RunBundleCommandHandlerTests
     {
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
-        BundleRunRecord? created = null;
-        _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
-            .Callback<BundleRunRecord, int>((r, _) => created = r)
-            .Returns(BundleRunAdmission.Accepted);
+        AcceptCreate();
 
         var callerEnvelope = new CapabilityEnvelope { AllowedMcpServers = ["host-server"] };
         var result = await BuildSut(enabled: true)
             .Handle(Command() with { Envelope = callerEnvelope }, CancellationToken.None);
 
         result.IsSuccess.Should().BeTrue();
-        created!.Envelope.Should().BeSameAs(callerEnvelope, "a bundle with no MCP servers must not allocate a new envelope");
+        _created!.Envelope.Should().BeSameAs(callerEnvelope, "a bundle with no MCP servers must not allocate a new envelope");
     }
 
     [Fact]
@@ -357,8 +338,12 @@ public sealed class RunBundleCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_OwnerAtCapacity_ReturnsConflict_AndDoesNotEnqueue()
+    public async Task Handle_OwnerAtCapacity_ReturnsValidationFailure_AndDoesNotEnqueue()
     {
+        // Distinct status from ConversationAlreadyRunning (409) on purpose, mirroring
+        // StartWorkflowRunCommandHandler.Refuse's split for the identical admission shape: capacity is
+        // about the caller's own accepted volume, which the caller fixes by finishing its own work —
+        // that is a 400, not a 409 naming a conflict with someone else's run.
         _handleStore.Setup(h => h.GetOwner("handle-1")).Returns("owner-1");
         _handleStore.Setup(h => h.TryGet("handle-1")).Returns(Staged());
         _jobStore.Setup(j => j.TryCreate(It.IsAny<BundleRunRecord>(), It.IsAny<int>()))
@@ -366,8 +351,8 @@ public sealed class RunBundleCommandHandlerTests
 
         var result = await BuildSut(enabled: true).Handle(Command(), CancellationToken.None);
 
-        result.FailureType.Should().Be(ResultFailureType.Conflict);
-        result.Errors.Should().ContainSingle(e => e.Contains("maximum concurrent", StringComparison.OrdinalIgnoreCase));
+        result.FailureType.Should().Be(ResultFailureType.Validation);
+        result.Errors.Should().ContainSingle(e => e.Contains("maximum", StringComparison.OrdinalIgnoreCase));
         _queue.Verify(q => q.EnqueueAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/src/Content/Tests/Application.Core.Tests/Validation/BundleExecutionConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/BundleExecutionConfigValidatorTests.cs
@@ -213,6 +213,28 @@ public class BundleExecutionConfigValidatorTests
     }
 
     [Fact]
+    public async Task Validate_ZeroMaxConcurrentDispatchedBundleRuns_HasError()
+    {
+        var config = new BundleExecutionConfig { MaxConcurrentDispatchedBundleRuns = 0 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.MaxConcurrentDispatchedBundleRuns));
+    }
+
+    [Fact]
+    public async Task Validate_ZeroMaxActiveBundleRunsPerOwner_HasError()
+    {
+        var config = new BundleExecutionConfig { MaxActiveBundleRunsPerOwner = 0 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BundleExecutionConfig.MaxActiveBundleRunsPerOwner));
+    }
+
+    [Fact]
     public async Task Validate_DisabledConfigWithBadValue_StillFails()
     {
         // Rules are unconditional: switching the subsystem off does not license a non-positive TTL.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunBackgroundServiceTests.cs
@@ -36,11 +36,13 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         public IDisposable? OnChange(Action<T, string?> listener) => null;
     }
 
-    private AppConfig Config()
+    private AppConfig Config(int? maxConcurrentDispatchedBundleRuns = null)
     {
         var cfg = new AppConfig();
         cfg.AI.BundleExecution.HandleTtl = Ttl;
         cfg.AI.BundleExecution.RunRecordTtl = Ttl;
+        if (maxConcurrentDispatchedBundleRuns is { } degree)
+            cfg.AI.BundleExecution.MaxConcurrentDispatchedBundleRuns = degree;
         return cfg;
     }
 
@@ -75,9 +77,9 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
              InMemoryBundleRunDispatchQueue Queue,
              InMemoryBundleRunJobStore JobStore,
              InMemoryBundleHandleStore HandleStore)
-        BuildSut(IMediator mediator)
+        BuildSut(IMediator mediator, int? maxConcurrentDispatchedBundleRuns = null)
     {
-        var monitor = new StaticOptionsMonitor<AppConfig>(Config());
+        var monitor = new StaticOptionsMonitor<AppConfig>(Config(maxConcurrentDispatchedBundleRuns));
         var queue = new InMemoryBundleRunDispatchQueue();
         var jobStore = new InMemoryBundleRunJobStore(monitor, _time);
         var handleStore = new InMemoryBundleHandleStore(monitor, _time, NullLogger<InMemoryBundleHandleStore>.Instance);
@@ -89,7 +91,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         var executor = new BundleRunExecutor(
             jobStore, handleStore, scopeFactory, _time, NullLogger<BundleRunExecutor>.Instance);
         var service = new BundleRunBackgroundService(
-            queue, executor, NullLogger<BundleRunBackgroundService>.Instance);
+            queue, executor, monitor, NullLogger<BundleRunBackgroundService>.Instance);
 
         return (service, queue, jobStore, handleStore);
     }
@@ -138,7 +140,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         var staged = StageOnDisk("b1", out _);
         var handle = handleStore.Register(staged, "owner-1");
         var envelope = new CapabilityEnvelope { AllowedTools = ["read_file"], AutonomyCeiling = AutonomyLevel.Autonomous };
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, envelope));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, envelope), int.MaxValue);
         await queue.EnqueueAsync("j1", CancellationToken.None);
 
         _ = service.StartAsync(CancellationToken.None);
@@ -188,7 +190,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         var staged = StageOnDisk("b1", out var dir);
         dirRef = dir;
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()), int.MaxValue);
         await queue.EnqueueAsync("j1", CancellationToken.None);
 
         _ = service.StartAsync(CancellationToken.None);
@@ -217,7 +219,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1", out _);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()), int.MaxValue);
         // Remove the handle before the run is dispatched.
         handleStore.Remove(handle);
         await queue.EnqueueAsync("j1", CancellationToken.None);
@@ -243,7 +245,7 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1", out _);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, new CapabilityEnvelope()), int.MaxValue);
         await queue.EnqueueAsync("j1", CancellationToken.None);
 
         _ = service.StartAsync(CancellationToken.None);
@@ -254,6 +256,109 @@ public sealed class BundleRunBackgroundServiceTests : IDisposable
         record.Status.Should().Be(BundleRunStatus.Failed);
         record.Error.Should().Be("bundle_run.unhandled_exception");
         record.Error.Should().NotContain("secret internal detail");
+    }
+
+    // -- Bounded parallelism (#449) --
+
+    [Fact]
+    public async Task Dispatch_RunsExecuteConcurrentlyUpToTheConfiguredDegree()
+    {
+        // Awaiting each run before dequeuing the next would make host-wide throughput exactly one, so
+        // any caller's long-running conversation would head-of-line every other caller's.
+        var running = 0;
+        var peak = 0;
+        using var release = new SemaphoreSlim(0, 3);
+
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(async (RunConversationCommand _, CancellationToken _) =>
+            {
+                var now = Interlocked.Increment(ref running);
+                InterlockedMax(ref peak, now);
+                await release.WaitAsync();
+                Interlocked.Decrement(ref running);
+                return SampleResult();
+            });
+
+        var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object, maxConcurrentDispatchedBundleRuns: 3);
+        var staged = StageOnDisk("b1", out _);
+        var handle = handleStore.Register(staged, "owner-1");
+        for (var i = 0; i < 3; i++)
+        {
+            jobStore.TryCreate(QueuedRecord($"job-{i}", handle, staged.Agent.Id, new CapabilityEnvelope()), int.MaxValue);
+            await queue.EnqueueAsync($"job-{i}", CancellationToken.None);
+        }
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token);
+
+        for (var attempt = 0; attempt < 200 && Volatile.Read(ref peak) < 3; attempt++)
+            await Task.Delay(10);
+
+        release.Release(3);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+
+        peak.Should().Be(3, "the dispatcher must run up to its configured degree at once");
+    }
+
+    [Fact]
+    public async Task Dispatch_NoMoreRunsExecuteAtOnceThanTheConfiguredDegree()
+    {
+        // The other half of the same property. Unbounded dispatch would let one burst of queued runs
+        // start every job simultaneously, which is what the degree exists to prevent.
+        var running = 0;
+        var peak = 0;
+        using var release = new SemaphoreSlim(0, 6);
+
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(async (RunConversationCommand _, CancellationToken _) =>
+            {
+                var now = Interlocked.Increment(ref running);
+                InterlockedMax(ref peak, now);
+                await release.WaitAsync();
+                Interlocked.Decrement(ref running);
+                return SampleResult();
+            });
+
+        var (service, queue, jobStore, handleStore) = BuildSut(mediator.Object, maxConcurrentDispatchedBundleRuns: 2);
+        var staged = StageOnDisk("b1", out _);
+        var handle = handleStore.Register(staged, "owner-1");
+        for (var i = 0; i < 6; i++)
+        {
+            jobStore.TryCreate(QueuedRecord($"job-{i}", handle, staged.Agent.Id, new CapabilityEnvelope()), int.MaxValue);
+            await queue.EnqueueAsync($"job-{i}", CancellationToken.None);
+        }
+
+        using var cts = new CancellationTokenSource();
+        await service.StartAsync(cts.Token);
+
+        // Waits for dispatch to saturate rather than sleeping a fixed interval, then gives the loop a
+        // brief window to overshoot if it is going to. All six jobs are already queued before the
+        // service starts, so an unbounded loop would have all six running by the end of that window —
+        // the recorded peak is what catches it.
+        for (var attempt = 0; attempt < 200 && Volatile.Read(ref peak) < 2; attempt++)
+            await Task.Delay(10);
+
+        await Task.Delay(50);
+
+        peak.Should().Be(2, "dispatch must reach the configured degree and must never exceed it");
+        Volatile.Read(ref running).Should().BeLessThanOrEqualTo(2);
+
+        release.Release(6);
+        await cts.CancelAsync();
+        await service.StopAsync(CancellationToken.None);
+    }
+
+    private static void InterlockedMax(ref int target, int candidate)
+    {
+        int seen;
+        while ((seen = Volatile.Read(ref target)) < candidate
+               && Interlocked.CompareExchange(ref target, candidate, seen) != seen)
+        {
+            // Another thread moved the peak while we were deciding; re-read and try again.
+        }
     }
 
     public void Dispose()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -122,7 +122,7 @@ public sealed class BundleRunExecutorTests : IDisposable
 
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var handle = handleStore.Register(StageOnDisk("b1"), "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, "agent-b1") with { ConversationId = "conv-1" });
+        jobStore.TryCreate(QueuedRecord("j1", handle, "agent-b1") with { ConversationId = "conv-1" }, int.MaxValue);
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -144,7 +144,7 @@ public sealed class BundleRunExecutorTests : IDisposable
 
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var handle = handleStore.Register(StageOnDisk("b2"), "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, "agent-b2"));
+        jobStore.TryCreate(QueuedRecord("j1", handle, "agent-b2"), int.MaxValue);
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -170,7 +170,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id) with { Status = BundleRunStatus.Running });
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id) with { Status = BundleRunStatus.Running }, int.MaxValue);
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -185,7 +185,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true), int.MaxValue);
 
         // Another driver claims the run first (CAS win); this call must stand down and drive nothing.
         jobStore.TryBeginRun("j1", _time.GetUtcNow());
@@ -203,7 +203,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true), int.MaxValue);
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -223,7 +223,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true), int.MaxValue);
         handleStore.Remove(handle); // handle gone before the stream connected
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
@@ -254,9 +254,9 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id)
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id)
             with
-        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } });
+        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } }, int.MaxValue);
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -281,7 +281,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id));
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id), int.MaxValue);
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -301,9 +301,9 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.Create(QueuedRecord("j1", handle, staged.Agent.Id)
+        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id)
             with
-        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } });
+        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } }, int.MaxValue);
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -60,6 +60,10 @@ public sealed class BundleRunExecutorTests : IDisposable
         return (executor, jobStore, handleStore);
     }
 
+    /// <summary>Admits a record with no capacity cap — these tests exercise the executor, not admission.</summary>
+    private static void Store(InMemoryBundleRunJobStore store, BundleRunRecord record) =>
+        store.TryCreate(record, int.MaxValue);
+
     private StagedBundle StageOnDisk(string bundleId, IReadOnlyList<string>? mcpServerNames = null)
     {
         var dir = Path.Combine(Path.GetTempPath(), "bundle-executor-tests", bundleId);
@@ -122,7 +126,7 @@ public sealed class BundleRunExecutorTests : IDisposable
 
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var handle = handleStore.Register(StageOnDisk("b1"), "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, "agent-b1") with { ConversationId = "conv-1" }, int.MaxValue);
+        Store(jobStore, QueuedRecord("j1", handle, "agent-b1") with { ConversationId = "conv-1" });
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -144,7 +148,7 @@ public sealed class BundleRunExecutorTests : IDisposable
 
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var handle = handleStore.Register(StageOnDisk("b2"), "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, "agent-b2"), int.MaxValue);
+        Store(jobStore, QueuedRecord("j1", handle, "agent-b2"));
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -170,7 +174,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id) with { Status = BundleRunStatus.Running }, int.MaxValue);
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id) with { Status = BundleRunStatus.Running });
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -185,7 +189,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true), int.MaxValue);
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
 
         // Another driver claims the run first (CAS win); this call must stand down and drive nothing.
         jobStore.TryBeginRun("j1", _time.GetUtcNow());
@@ -203,7 +207,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true), int.MaxValue);
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -223,7 +227,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object);
         var staged = StageOnDisk("b1");
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id, streaming: true), int.MaxValue);
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id, streaming: true));
         handleStore.Remove(handle); // handle gone before the stream connected
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
@@ -254,9 +258,9 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id)
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id)
             with
-        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } }, int.MaxValue);
+        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } });
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -281,7 +285,7 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id), int.MaxValue);
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id));
 
         var result = await executor.ExecuteAsync("j1", CancellationToken.None);
 
@@ -301,9 +305,9 @@ public sealed class BundleRunExecutorTests : IDisposable
         var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
-        jobStore.TryCreate(QueuedRecord("j1", handle, staged.Agent.Id)
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id)
             with
-        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } }, int.MaxValue);
+        { Envelope = new CapabilityEnvelope { AllowedMcpServers = ["b1:echo"] } });
 
         await executor.ExecuteAsync("j1", CancellationToken.None);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
@@ -58,11 +58,15 @@ public sealed class InMemoryBundleRunJobStoreTests
         CreatedAt = _time.GetUtcNow()
     };
 
+    /// <summary>Admits a record with no capacity cap, for tests that don't exercise admission itself.</summary>
+    private static void Store(InMemoryBundleRunJobStore sut, BundleRunRecord record) =>
+        sut.TryCreate(record, int.MaxValue);
+
     [Fact]
     public void Create_ThenGet_ReturnsRecord()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue);
+        Store(sut, NewRecord());
 
         sut.Get("j1").Should().NotBeNull();
         sut.Get("j1")!.Status.Should().Be(BundleRunStatus.Queued);
@@ -72,9 +76,9 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Create_DuplicateJobId_Throws()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue);
+        Store(sut, NewRecord());
 
-        var act = () => sut.TryCreate(NewRecord(), int.MaxValue);
+        var act = () => Store(sut, NewRecord());
 
         act.Should().Throw<InvalidOperationException>();
     }
@@ -89,7 +93,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_NonTerminalRecord_NeverExpires()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue); // Queued
+        Store(sut, NewRecord()); // Queued
 
         _time.Advance(Ttl + TimeSpan.FromHours(1));
 
@@ -101,7 +105,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_TerminalRecord_AfterTtlElapses_ReturnsNull()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue);
+        Store(sut, NewRecord());
         sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
@@ -113,7 +117,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Update_ReplacesSnapshot()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue);
+        Store(sut, NewRecord());
 
         var updated = sut.Get("j1")! with { Status = BundleRunStatus.Running };
         sut.Update(updated).Should().BeTrue();
@@ -125,7 +129,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Update_TerminalStatus_ExtendsTtl()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue);
+        Store(sut, NewRecord());
 
         // Advance almost to the original expiry, then complete the run — which resets the TTL window.
         _time.Advance(Ttl - TimeSpan.FromMinutes(1));
@@ -148,8 +152,8 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void SweepExpired_RemovesExpiredTerminalRecords_ReturnsCount()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord("j1"), int.MaxValue);
-        sut.TryCreate(NewRecord("j2"), int.MaxValue);
+        Store(sut, NewRecord("j1"));
+        Store(sut, NewRecord("j2"));
         sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
         sut.Update(sut.Get("j2")! with { Status = BundleRunStatus.Failed });
 
@@ -164,7 +168,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void SweepExpired_LeavesNonTerminalRecords()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord("j1"), int.MaxValue); // Queued, in-flight
+        Store(sut, NewRecord("j1")); // Queued, in-flight
 
         _time.Advance(Ttl + TimeSpan.FromHours(1));
 
@@ -178,7 +182,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void TryBeginRun_QueuedRecord_TransitionsToRunning_StampsStartedAt()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue);
+        Store(sut, NewRecord());
         var startedAt = _time.GetUtcNow();
 
         var claimed = sut.TryBeginRun("j1", startedAt);
@@ -199,7 +203,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void TryBeginRun_NonQueuedRecord_ReturnsNull()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(status: BundleRunStatus.Running), int.MaxValue);
+        Store(sut, NewRecord(status: BundleRunStatus.Running));
 
         sut.TryBeginRun("j1", _time.GetUtcNow()).Should().BeNull();
     }
@@ -210,7 +214,7 @@ public sealed class InMemoryBundleRunJobStoreTests
         // The single guarantee that a run is driven once: whoever wins the CAS gets the record; the loser
         // gets null. This is what stops two stream connections, or a stream and the dispatcher, double-running.
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(), int.MaxValue);
+        Store(sut, NewRecord());
 
         var first = sut.TryBeginRun("j1", _time.GetUtcNow());
         var second = sut.TryBeginRun("j1", _time.GetUtcNow());
@@ -223,7 +227,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void TryBeginRun_ExpiredStreamingReservation_ReturnsNull()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(streaming: true), int.MaxValue); // unclaimed streaming reservation
+        Store(sut, NewRecord(streaming: true)); // unclaimed streaming reservation
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1)); // reservation window elapsed
 
@@ -236,7 +240,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_UnclaimedStreamingReservation_ExpiresAfterTtl()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(streaming: true), int.MaxValue); // Queued streaming, never claimed
+        Store(sut, NewRecord(streaming: true)); // Queued streaming, never claimed
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
 
@@ -248,7 +252,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_ClaimedStreamingRun_NeverExpires()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord(streaming: true), int.MaxValue);
+        Store(sut, NewRecord(streaming: true));
         sut.TryBeginRun("j1", _time.GetUtcNow()); // now Running
 
         _time.Advance(Ttl + TimeSpan.FromHours(1));
@@ -262,8 +266,8 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void SweepExpired_RemovesUnclaimedStreamingReservation_ButNotBackgroundQueued()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord("stream", streaming: true), int.MaxValue); // reclaimable once its window lapses
-        sut.TryCreate(NewRecord("bg"), int.MaxValue); // background-queued: never reclaimable until terminal
+        Store(sut, NewRecord("stream", streaming: true)); // reclaimable once its window lapses
+        Store(sut, NewRecord("bg")); // background-queued: never reclaimable until terminal
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
 
@@ -279,7 +283,7 @@ public sealed class InMemoryBundleRunJobStoreTests
         // NOT the (longer) result-retention TTL — so tightening result retention never shrinks the window a
         // caller has to connect.
         var sut = BuildSut(runRecordTtl: TimeSpan.FromMinutes(30), streamReservationTtl: TimeSpan.FromMinutes(2));
-        sut.TryCreate(NewRecord(streaming: true), int.MaxValue);
+        Store(sut, NewRecord(streaming: true));
 
         _time.Advance(TimeSpan.FromMinutes(3)); // past the 2-min reservation window, far within RunRecordTtl
 
@@ -292,7 +296,7 @@ public sealed class InMemoryBundleRunJobStoreTests
         // Once a streaming run is claimed and completes, its pollable window is the result-retention TTL like
         // any other terminal run — the short reservation window governs only the unclaimed phase.
         var sut = BuildSut(runRecordTtl: TimeSpan.FromMinutes(30), streamReservationTtl: TimeSpan.FromMinutes(2));
-        sut.TryCreate(NewRecord(streaming: true), int.MaxValue);
+        Store(sut, NewRecord(streaming: true));
         sut.TryBeginRun("j1", _time.GetUtcNow());
         sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
 
@@ -322,7 +326,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void TryCreate_SecondRunSameConversation_ButFirstIsTerminal_IsAccepted()
     {
         var sut = BuildSut();
-        sut.TryCreate(NewRecord("j1", conversationId: "conv-1"), int.MaxValue);
+        Store(sut, NewRecord("j1", conversationId: "conv-1"));
         sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
 
         var admission = sut.TryCreate(NewRecord("j2", conversationId: "conv-1"), int.MaxValue);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
@@ -42,17 +42,19 @@ public sealed class InMemoryBundleRunJobStoreTests
     }
 
     private BundleRunRecord NewRecord(
-        string jobId = "j1", BundleRunStatus status = BundleRunStatus.Queued, bool streaming = false) => new()
+        string jobId = "j1", BundleRunStatus status = BundleRunStatus.Queued, bool streaming = false,
+        string ownerId = "owner-1", string? conversationId = null) => new()
     {
         JobId = jobId,
         Handle = "h1",
-        OwnerId = "owner-1",
+        OwnerId = ownerId,
         AgentName = "agent-1",
         UserMessages = ["hello"],
         MaxTurns = 5,
         Envelope = new CapabilityEnvelope(),
         Status = status,
         Streaming = streaming,
+        ConversationId = conversationId,
         CreatedAt = _time.GetUtcNow()
     };
 
@@ -60,7 +62,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Create_ThenGet_ReturnsRecord()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord());
+        sut.TryCreate(NewRecord(), int.MaxValue);
 
         sut.Get("j1").Should().NotBeNull();
         sut.Get("j1")!.Status.Should().Be(BundleRunStatus.Queued);
@@ -70,9 +72,9 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Create_DuplicateJobId_Throws()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord());
+        sut.TryCreate(NewRecord(), int.MaxValue);
 
-        var act = () => sut.Create(NewRecord());
+        var act = () => sut.TryCreate(NewRecord(), int.MaxValue);
 
         act.Should().Throw<InvalidOperationException>();
     }
@@ -87,7 +89,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_NonTerminalRecord_NeverExpires()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord()); // Queued
+        sut.TryCreate(NewRecord(), int.MaxValue); // Queued
 
         _time.Advance(Ttl + TimeSpan.FromHours(1));
 
@@ -99,7 +101,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_TerminalRecord_AfterTtlElapses_ReturnsNull()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord());
+        sut.TryCreate(NewRecord(), int.MaxValue);
         sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
@@ -111,7 +113,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Update_ReplacesSnapshot()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord());
+        sut.TryCreate(NewRecord(), int.MaxValue);
 
         var updated = sut.Get("j1")! with { Status = BundleRunStatus.Running };
         sut.Update(updated).Should().BeTrue();
@@ -123,7 +125,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Update_TerminalStatus_ExtendsTtl()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord());
+        sut.TryCreate(NewRecord(), int.MaxValue);
 
         // Advance almost to the original expiry, then complete the run — which resets the TTL window.
         _time.Advance(Ttl - TimeSpan.FromMinutes(1));
@@ -146,8 +148,8 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void SweepExpired_RemovesExpiredTerminalRecords_ReturnsCount()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord("j1"));
-        sut.Create(NewRecord("j2"));
+        sut.TryCreate(NewRecord("j1"), int.MaxValue);
+        sut.TryCreate(NewRecord("j2"), int.MaxValue);
         sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
         sut.Update(sut.Get("j2")! with { Status = BundleRunStatus.Failed });
 
@@ -162,7 +164,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void SweepExpired_LeavesNonTerminalRecords()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord("j1")); // Queued, in-flight
+        sut.TryCreate(NewRecord("j1"), int.MaxValue); // Queued, in-flight
 
         _time.Advance(Ttl + TimeSpan.FromHours(1));
 
@@ -176,7 +178,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void TryBeginRun_QueuedRecord_TransitionsToRunning_StampsStartedAt()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord());
+        sut.TryCreate(NewRecord(), int.MaxValue);
         var startedAt = _time.GetUtcNow();
 
         var claimed = sut.TryBeginRun("j1", startedAt);
@@ -197,7 +199,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void TryBeginRun_NonQueuedRecord_ReturnsNull()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord(status: BundleRunStatus.Running));
+        sut.TryCreate(NewRecord(status: BundleRunStatus.Running), int.MaxValue);
 
         sut.TryBeginRun("j1", _time.GetUtcNow()).Should().BeNull();
     }
@@ -208,7 +210,7 @@ public sealed class InMemoryBundleRunJobStoreTests
         // The single guarantee that a run is driven once: whoever wins the CAS gets the record; the loser
         // gets null. This is what stops two stream connections, or a stream and the dispatcher, double-running.
         var sut = BuildSut();
-        sut.Create(NewRecord());
+        sut.TryCreate(NewRecord(), int.MaxValue);
 
         var first = sut.TryBeginRun("j1", _time.GetUtcNow());
         var second = sut.TryBeginRun("j1", _time.GetUtcNow());
@@ -221,7 +223,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void TryBeginRun_ExpiredStreamingReservation_ReturnsNull()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord(streaming: true)); // unclaimed streaming reservation
+        sut.TryCreate(NewRecord(streaming: true), int.MaxValue); // unclaimed streaming reservation
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1)); // reservation window elapsed
 
@@ -234,7 +236,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_UnclaimedStreamingReservation_ExpiresAfterTtl()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord(streaming: true)); // Queued streaming, never claimed
+        sut.TryCreate(NewRecord(streaming: true), int.MaxValue); // Queued streaming, never claimed
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
 
@@ -246,7 +248,7 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void Get_ClaimedStreamingRun_NeverExpires()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord(streaming: true));
+        sut.TryCreate(NewRecord(streaming: true), int.MaxValue);
         sut.TryBeginRun("j1", _time.GetUtcNow()); // now Running
 
         _time.Advance(Ttl + TimeSpan.FromHours(1));
@@ -260,8 +262,8 @@ public sealed class InMemoryBundleRunJobStoreTests
     public void SweepExpired_RemovesUnclaimedStreamingReservation_ButNotBackgroundQueued()
     {
         var sut = BuildSut();
-        sut.Create(NewRecord("stream", streaming: true)); // reclaimable once its window lapses
-        sut.Create(NewRecord("bg")); // background-queued: never reclaimable until terminal
+        sut.TryCreate(NewRecord("stream", streaming: true), int.MaxValue); // reclaimable once its window lapses
+        sut.TryCreate(NewRecord("bg"), int.MaxValue); // background-queued: never reclaimable until terminal
 
         _time.Advance(Ttl + TimeSpan.FromSeconds(1));
 
@@ -277,7 +279,7 @@ public sealed class InMemoryBundleRunJobStoreTests
         // NOT the (longer) result-retention TTL — so tightening result retention never shrinks the window a
         // caller has to connect.
         var sut = BuildSut(runRecordTtl: TimeSpan.FromMinutes(30), streamReservationTtl: TimeSpan.FromMinutes(2));
-        sut.Create(NewRecord(streaming: true));
+        sut.TryCreate(NewRecord(streaming: true), int.MaxValue);
 
         _time.Advance(TimeSpan.FromMinutes(3)); // past the 2-min reservation window, far within RunRecordTtl
 
@@ -290,7 +292,7 @@ public sealed class InMemoryBundleRunJobStoreTests
         // Once a streaming run is claimed and completes, its pollable window is the result-retention TTL like
         // any other terminal run — the short reservation window governs only the unclaimed phase.
         var sut = BuildSut(runRecordTtl: TimeSpan.FromMinutes(30), streamReservationTtl: TimeSpan.FromMinutes(2));
-        sut.Create(NewRecord(streaming: true));
+        sut.TryCreate(NewRecord(streaming: true), int.MaxValue);
         sut.TryBeginRun("j1", _time.GetUtcNow());
         sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
 
@@ -299,5 +301,96 @@ public sealed class InMemoryBundleRunJobStoreTests
 
         _time.Advance(TimeSpan.FromMinutes(30)); // ...and reclaimed only once the result window elapses
         sut.Get("j1").Should().BeNull();
+    }
+
+    // -- Admission (#449) --
+
+    [Fact]
+    public void TryCreate_SecondRunSameConversation_RefusesConflict()
+    {
+        var sut = BuildSut();
+        sut.TryCreate(NewRecord("j1", conversationId: "conv-1"), int.MaxValue)
+            .Should().Be(BundleRunAdmission.Accepted);
+
+        var admission = sut.TryCreate(NewRecord("j2", conversationId: "conv-1"), int.MaxValue);
+
+        admission.Should().Be(BundleRunAdmission.ConversationAlreadyRunning);
+        sut.Get("j2").Should().BeNull("a refused run must not be stored");
+    }
+
+    [Fact]
+    public void TryCreate_SecondRunSameConversation_ButFirstIsTerminal_IsAccepted()
+    {
+        var sut = BuildSut();
+        sut.TryCreate(NewRecord("j1", conversationId: "conv-1"), int.MaxValue);
+        sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
+
+        var admission = sut.TryCreate(NewRecord("j2", conversationId: "conv-1"), int.MaxValue);
+
+        admission.Should().Be(BundleRunAdmission.Accepted, "a finished run's conversation is no longer live");
+    }
+
+    [Fact]
+    public void TryCreate_TwoRunsNoConversationId_NeverConflict()
+    {
+        // A one-shot run has nothing to conflict on — only a shared ConversationId can collide.
+        var sut = BuildSut();
+        sut.TryCreate(NewRecord("j1"), int.MaxValue).Should().Be(BundleRunAdmission.Accepted);
+
+        sut.TryCreate(NewRecord("j2"), int.MaxValue).Should().Be(BundleRunAdmission.Accepted);
+    }
+
+    [Fact]
+    public void TryCreate_OwnerAtCapacity_RefusesConflict()
+    {
+        var sut = BuildSut();
+        sut.TryCreate(NewRecord("j1", ownerId: "owner-1"), maxActiveRunsPerOwner: 1)
+            .Should().Be(BundleRunAdmission.Accepted);
+
+        var admission = sut.TryCreate(NewRecord("j2", ownerId: "owner-1"), maxActiveRunsPerOwner: 1);
+
+        admission.Should().Be(BundleRunAdmission.OwnerAtCapacity);
+        sut.Get("j2").Should().BeNull("a refused run must not be stored");
+    }
+
+    [Fact]
+    public void TryCreate_TerminalRunsDoNotCountTowardCapacity()
+    {
+        var sut = BuildSut();
+        sut.TryCreate(NewRecord("j1", ownerId: "owner-1"), maxActiveRunsPerOwner: 1);
+        sut.Update(sut.Get("j1")! with { Status = BundleRunStatus.Succeeded });
+
+        var admission = sut.TryCreate(NewRecord("j2", ownerId: "owner-1"), maxActiveRunsPerOwner: 1);
+
+        admission.Should().Be(BundleRunAdmission.Accepted, "a finished run must not hold its owner's capacity slot");
+    }
+
+    [Fact]
+    public void TryCreate_DifferentOwners_DoNotShareCapacity()
+    {
+        var sut = BuildSut();
+        sut.TryCreate(NewRecord("j1", ownerId: "owner-1"), maxActiveRunsPerOwner: 1)
+            .Should().Be(BundleRunAdmission.Accepted);
+
+        var admission = sut.TryCreate(NewRecord("j2", ownerId: "owner-2"), maxActiveRunsPerOwner: 1);
+
+        admission.Should().Be(BundleRunAdmission.Accepted, "the cap is per owner, not host-wide");
+    }
+
+    [Fact]
+    public async Task TryCreate_ConcurrentCallsSameOwner_AdmitsExactlyUpToTheCap()
+    {
+        // Hammers TryCreate from many threads at once so the admission lock's atomicity is actually
+        // exercised, not just its single-threaded happy path — TryBeginRun's twin sequential-only test
+        // (TryBeginRun_CalledTwice_ClaimsExactlyOnce) does not catch a race here either.
+        var sut = BuildSut();
+        const int attempts = 50;
+        const int cap = 10;
+
+        var results = await Task.WhenAll(Enumerable.Range(0, attempts).Select(i => Task.Run(
+            () => sut.TryCreate(NewRecord($"job-{i}", ownerId: "owner-1"), cap))));
+
+        results.Count(a => a == BundleRunAdmission.Accepted).Should().Be(cap);
+        results.Count(a => a == BundleRunAdmission.OwnerAtCapacity).Should().Be(attempts - cap);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/InMemoryBundleRunJobStoreTests.cs
@@ -331,6 +331,27 @@ public sealed class InMemoryBundleRunJobStoreTests
     }
 
     [Fact]
+    public void TryCreate_AbandonedStreamingReservation_DoesNotCountTowardConversationOrCapacity()
+    {
+        // /code-review finding: SurveyActiveRuns originally excluded only terminal records, so a
+        // streaming reservation nobody ever connected to (Queued, Streaming, past its short connect
+        // window) stayed "live" from admission's point of view until the next sweep pass — permanently
+        // occupying a capacity slot and blocking every retry against its conversation for a run that
+        // never actually did anything. Get/TryBeginRun already treated it as gone the moment it expired;
+        // admission must too.
+        var sut = BuildSut();
+        sut.TryCreate(NewRecord("j1", conversationId: "conv-1", streaming: true), maxActiveRunsPerOwner: 1)
+            .Should().Be(BundleRunAdmission.Accepted);
+
+        _time.Advance(Ttl + TimeSpan.FromSeconds(1)); // past the reservation window, never claimed
+
+        var admission = sut.TryCreate(NewRecord("j2", conversationId: "conv-1"), maxActiveRunsPerOwner: 1);
+
+        admission.Should().Be(BundleRunAdmission.Accepted,
+            "an abandoned streaming reservation is reclaimable the moment it expires, not only once swept");
+    }
+
+    [Fact]
     public void TryCreate_TwoRunsNoConversationId_NeverConflict()
     {
         // A one-shot run has nothing to conflict on — only a shared ConversationId can collide.


### PR DESCRIPTION
## Summary

Fixes #449. `BundleRunBackgroundService` executed background bundle runs strictly one at a time per host, so two entirely independent runs (e.g. DVA's Pulse and Guardian observers) queued behind each other for no correctness reason.

The sibling `RunDispatchBackgroundService` hit the identical problem and was fixed in `15fbe8ef` by switching to bounded-parallel dispatch. That fix's own safety argument is two-part: single-arming **and** admission (one live run per target, a per-owner cap). Bundle runs only had the first half — `IBundleRunJobStore.Create` was unconditional, with no per-caller cap and no check for two runs racing one conversation's turn lease. Shipping the parallelism half alone would have traded head-of-line latency for caller starvation, including a new hazard the turn lease creates under parallel dispatch: N runs against one conversation would each occupy a dispatch slot while blocked on the same lease.

**What shipped:**
- `BundleRunBackgroundService` now drains via bounded `Parallel.ForEachAsync`, degree configurable via `MaxConcurrentDispatchedBundleRuns` (default 4; `1` restores today's exact serial behavior).
- Ported `IRunJobStore.TryCreate`'s admission pattern to bundles (`BundleRunAdmission`, `IBundleRunJobStore.TryCreate`), refusing a second run against a live conversation (`409`) or a caller past `MaxActiveBundleRunsPerOwner` (default 10, `400` — matching `StartWorkflowRunCommandHandler`'s established split for the identical admission shape).
- Independently verified every safety claim in the issue against the code before implementing (subagent transcript, 7 claims checked file:line) — 5 of 7 held; the admission gap above is what the issue itself was missing.
- Both correctness fixes found by `/code-review` and all cleanups from `/simplify` are applied and mutation-checked.

## Verification

- [x] `dotnet build` clean, 0 warnings
- [x] Full solution `dotnet test` green (only pre-existing, unrelated Docker-dependent AgentHub failures — confirmed via `docker info`)
- [x] New concurrency tests + admission tests mutation-checked against the exact bugs they close
- [x] `check-docs-links.mjs` green before and after doc edits
- [x] `/code-review` and `/simplify` receipts recorded for the final diff

Filed as follow-up, out of scope here: two runs concurrently sharing the same staged bundle handle share one MCP server session (pre-existing, only marginally widened by this change, not newly introduced).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MfjeQC1etfSmCwPskkPXWu