### PR TITLE
Give each bundle run its own stdio MCP session (#455)

### DIFF
--- a/documentation/security/05-sandbox-and-execution.html
+++ b/documentation/security/05-sandbox-and-execution.html
@@ -456,8 +456,11 @@
                             <tr>
                                 <td><code>StdioMcpServers.MaxServersPerBundle</code></td>
                                 <td>2</td>
-                                <td>How many stdio servers one bundle may declare — each one is a long-lived container
-                                    for the life of the bundle's staged handle.</td>
+                                <td>How many distinct stdio servers one bundle may declare. Not a container count on
+                                    its own: each concurrent run against the bundle's staged handle gets its own
+                                    container per declared server (a stdio session cannot safely be shared across
+                                    callers), so this multiplies by however many runs are concurrent — see
+                                    <code>MaxConcurrentSessions</code> below for the actual host-wide cap.</td>
                             </tr>
                             <tr>
                                 <td><code>StdioMcpServers.MaxConcurrentSessions</code></td>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleMcpServerRegistrar.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Bundles/IBundleMcpServerRegistrar.cs
@@ -18,4 +18,21 @@ public interface IBundleMcpServerRegistrar
     /// </summary>
     /// <param name="serverNames">The bundle-scoped, namespaced server names to deregister.</param>
     Task DeregisterAsync(IReadOnlyList<string> serverNames);
+
+    /// <summary>
+    /// Tears down one run's own stdio MCP sessions for <paramref name="serverNames"/>, called when that
+    /// run completes — the run-scoped counterpart to <see cref="DeregisterAsync"/>'s handle-scoped
+    /// teardown.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Deliberately does not touch <c>IBundleOwnedMcpServerRegistry</c>.</strong> A run ending
+    /// does not mean the bundle's handle is gone — the server's definition must stay registered so the
+    /// next run against the same staged handle can still find it and start its own fresh session.
+    /// Disconnecting only the client is what makes this safe to call unconditionally at the end of every
+    /// run, whether or not that run actually contacted the server (idempotent, same as
+    /// <see cref="DeregisterAsync"/>).
+    /// </remarks>
+    /// <param name="serverNames">The bundle-scoped, namespaced server names this run's staged bundle declares.</param>
+    /// <param name="runId">The completed run's job id — the same value that scoped its sessions.</param>
+    Task DisconnectRunScopedAsync(IReadOnlyList<string> serverNames, string runId);
 }

--- a/src/Content/Application/Application.AI.Common/Services/Bundles/BundleRunIdAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Bundles/BundleRunIdAccessor.cs
@@ -1,0 +1,62 @@
+namespace Application.AI.Common.Services.Bundles;
+
+/// <summary>
+/// Ambient accessor that publishes the job id of the bundle run active for the current async flow, so
+/// <c>McpConnectionManager</c> can give each run its own stdio MCP session instead of sharing one across
+/// concurrent runs of the same staged bundle.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Follows the same pattern as the host's other per-flow accessors
+/// (<see cref="EphemeralAgentOverlayAccessor"/>, <c>CapabilityEnvelopeAccessor</c>,
+/// <c>ToolAdmissionAccessor</c>): an <see cref="AsyncLocal{T}"/> the run path sets at the start of a
+/// bundle run and clears in a <c>finally</c>, read at connection time by
+/// <c>Infrastructure.AI.MCP.Services.McpConnectionManager</c>.
+/// </para>
+/// <para>
+/// <strong>Absence is not a safe default for a bundle-owned stdio server.</strong> The MCP stdio
+/// transport is single-session by design (its own SDK documents this as unsuitable for multi-tenant
+/// sharing), so a caller resolving one with no run id armed must refuse rather than fall back to a
+/// shared, unscoped session — the exact bug this accessor exists to close. Non-bundle and remote
+/// bundle-owned servers never consult this accessor at all.
+/// </para>
+/// <para>
+/// Prefer <see cref="Begin"/> to publish a run id: it restores the previous ambient value on dispose, so
+/// nested or sequential runs on the same flow cannot leak one run's id into another's work.
+/// </para>
+/// </remarks>
+public static class BundleRunIdAccessor
+{
+    private static readonly AsyncLocal<string?> s_current = new();
+
+    /// <summary>The run id for the current async flow, or <see langword="null"/> when not inside a bundle run.</summary>
+    public static string? Current => s_current.Value;
+
+    /// <summary>
+    /// Publishes <paramref name="runId"/> as the ambient run id for the current async flow and returns a
+    /// handle that restores the previous ambient value when disposed. Use with <c>using</c> so the run id
+    /// is guaranteed to be torn down when the run completes, even on exception.
+    /// </summary>
+    /// <param name="runId">The bundle run's job id; must not be null or empty.</param>
+    public static IDisposable Begin(string runId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(runId);
+        var previous = s_current.Value;
+        s_current.Value = runId;
+        return new RunIdScope(previous);
+    }
+
+    private sealed class RunIdScope(string? previous) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            s_current.Value = previous;
+        }
+    }
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleStdioMcpServersConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/BundleExecution/BundleStdioMcpServersConfig.cs
@@ -44,20 +44,25 @@ public sealed class BundleStdioMcpServersConfig
     public string ContainerImage { get; set; } = string.Empty;
 
     /// <summary>
-    /// Maximum number of stdio MCP servers a single bundle may register. Each registered server becomes a
-    /// long-lived sandbox container for the life of the bundle's staged handle, so this bounds how many
-    /// concurrent containers one uploaded bundle can pin on the host. Must be positive.
+    /// Maximum number of distinct stdio MCP servers a single bundle may declare. Each is a separate
+    /// container image/command a bundle registers — not a count of live sessions: since each concurrent
+    /// <em>run</em> against the bundle's staged handle gets its own sandbox container per declared
+    /// server (a stdio session cannot safely be shared across callers — see
+    /// <c>Application.AI.Common.Services.Bundles.BundleRunIdAccessor</c>), the number of containers one
+    /// bundle can pin at once is this value times however many of its runs are concurrent, further
+    /// bounded by <see cref="MaxConcurrentSessions"/> host-wide. Must be positive.
     /// </summary>
     /// <value>Default: 2</value>
     public int MaxServersPerBundle { get; set; } = 2;
 
     /// <summary>
     /// Maximum number of bundle-owned stdio sandbox sessions live across the WHOLE host at once —
-    /// distinct from <see cref="MaxServersPerBundle"/>, which bounds one bundle's own container count
-    /// but has nothing to say about how many bundles are concurrently staged. Enforced in
-    /// <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c> as a caller admitted with upload +
-    /// run permission could otherwise pin <see cref="MaxServersPerBundle"/> containers per bundle
-    /// times an unbounded number of concurrently-staged bundles. Must be positive.
+    /// distinct from <see cref="MaxServersPerBundle"/>, which bounds one bundle's distinct server
+    /// declarations, not concurrently-live containers. Since each concurrent run of a staged bundle now
+    /// gets its own session per declared server, this is the cap that actually bounds host-wide
+    /// container count: it is what a caller admitted with upload + run permission is refused against
+    /// once exceeded, regardless of how many bundles or runs are in play. Enforced in
+    /// <c>McpConnectionManager.StartSandboxedStdioSessionAsync</c>. Must be positive.
     /// </summary>
     /// <value>Default: 8</value>
     public int MaxConcurrentSessions { get; set; } = 8;

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -62,4 +62,31 @@ public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
                 serverName);
         }
     }
+
+    /// <inheritdoc />
+    public async Task DisconnectRunScopedAsync(IReadOnlyList<string> serverNames, string runId)
+    {
+        // Same fan-out reasoning as DeregisterAsync: independent per-server teardown, so one server's
+        // failure can never stop or delay another's.
+        await Task.WhenAll(serverNames.Select(serverName => DisconnectRunScopedOneAsync(serverName, runId)))
+            .ConfigureAwait(false);
+    }
+
+    private async Task DisconnectRunScopedOneAsync(string serverName, string runId)
+    {
+        // Deliberately does NOT call _bundleOwnedMcpServers.TryRemove — a run ending is not the bundle's
+        // handle being evicted, and the next run against the same staged handle must still find this
+        // server's definition registered so it can start its own fresh session.
+        try
+        {
+            await _connectionManager.DisconnectRunScopedAsync(serverName, runId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to disconnect run-scoped MCP client for bundle server '{Server}' (run {RunId}); " +
+                "it will be cleaned up when the bundle's handle is evicted",
+                serverName, runId);
+        }
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BundleMcpServerRegistrar.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Application.AI.Common.Interfaces.Bundles;
+using Domain.Common.Config.AI.MCP;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.MCP.Services;
@@ -74,6 +75,12 @@ public sealed class BundleMcpServerRegistrar : IBundleMcpServerRegistrar
 
     private async Task DisconnectRunScopedOneAsync(string serverName, string runId)
     {
+        // Only a stdio server can ever have a run-scoped session (McpConnectionManager scopes stdio
+        // only — see RequiresRunScope) — a remote (http/sse) bundle-owned server never reaches
+        // _runScopedClients, so calling DisconnectRunScopedAsync for one would be provably-empty work.
+        if (!_bundleOwnedMcpServers.TryGetValue(serverName, out var definition) || definition.Type != McpServerType.Stdio)
+            return;
+
         // Deliberately does NOT call _bundleOwnedMcpServers.TryRemove — a run ending is not the bundle's
         // handle being evicted, and the next run against the same staged handle must still find this
         // server's definition registered so it can start its own fresh session.

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -422,6 +422,14 @@ public sealed class McpConnectionManager : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        // /code-review finding (#455): a bundle-owned stdio server's session can go stale mid-run just
+        // like any other (#385) — McpToolProvider.RetryAfterReconnectAsync reaches this path for it too
+        // — and reconnecting into the SHARED cache here would recreate the exact cross-run sharing bug
+        // this file exists to close, while leaving the run's own _runScopedClients entry stuck on the
+        // broken client it never actually recovers from. Must branch the same way GetClientAsync does.
+        if (TryGetRunScopeRequirement(serverName, out var runId))
+            return await ReconnectRunScopedAsync(serverName, runId, failedClient, cancellationToken);
+
         using var _ = await AcquireConnectionLockAsync(serverName, cancellationToken);
 
         if (_clients.TryGetValue(serverName, out var current) && !ReferenceEquals(current, failedClient))
@@ -440,6 +448,31 @@ public sealed class McpConnectionManager : IAsyncDisposable
         await Task.WhenAll(disposeStale, connect);
 
         return await connect;
+    }
+
+    /// <summary>
+    /// The run-scoped counterpart to <see cref="ReconnectAsync"/>'s shared-cache reconnect, mirroring
+    /// its shape exactly over <see cref="_runScopedClients"/> and a run-qualified lock key instead of
+    /// <see cref="_clients"/>. Never touches the shared cache, and never resolves another run's entry
+    /// for the same server name — only this run's own (server, run) key.
+    /// </summary>
+    private async Task<McpClient> ReconnectRunScopedAsync(
+        string serverName, string runId, McpClient failedClient, CancellationToken cancellationToken)
+    {
+        var key = (serverName, runId);
+        using var _ = await AcquireConnectionLockAsync(RunScopedLockKey(serverName, runId), cancellationToken);
+
+        if (_runScopedClients.TryGetValue(key, out var current) && !ReferenceEquals(current, failedClient))
+            return current;
+
+        _runScopedClients.TryRemove(key, out var stale);
+        var disposeStale = stale is not null ? DisposeStaleClientAsync(stale, serverName) : Task.CompletedTask;
+        var connect = CreateClientAsync(serverName, cancellationToken);
+        await Task.WhenAll(disposeStale, connect);
+
+        var fresh = await connect;
+        _runScopedClients[key] = fresh;
+        return fresh;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -5,6 +5,7 @@ using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Egress;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Services.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
@@ -58,6 +59,16 @@ public sealed class McpConnectionManager : IAsyncDisposable
     // {pluginName}:{name}; bundle names are {bundleId GUID}:{name}). A future change that restructures
     // these into per-source caches should preserve that invariant, not merely mirror the field shapes.
     private readonly ConcurrentDictionary<string, McpClient> _clients = new();
+
+    /// <summary>
+    /// Clients for bundle-owned STDIO servers, keyed by (server name, owning run's job id) rather than
+    /// by server name alone. The MCP stdio transport is single-session by design — its own SDK
+    /// documents it as unsuitable for sharing across concurrent callers — so unlike every other server
+    /// this manager resolves, one of these must never be shared between two runs of the same staged
+    /// bundle. See <see cref="BundleRunIdAccessor"/> and <see cref="TryGetRunScopeRequirement"/>.
+    /// </summary>
+    private readonly ConcurrentDictionary<(string ServerName, string RunId), McpClient> _runScopedClients = new();
+
     private readonly ConcurrentDictionary<string, HttpClient> _entraClients = new();
 
     /// <summary>
@@ -160,6 +171,9 @@ public sealed class McpConnectionManager : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        if (TryGetRunScopeRequirement(serverName, out var runId))
+            return await GetRunScopedClientAsync(serverName, runId, cancellationToken);
+
         if (_clients.TryGetValue(serverName, out var existing))
             return existing;
 
@@ -170,6 +184,73 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
         return await CreateAndCacheClientAsync(serverName, cancellationToken);
     }
+
+    /// <summary>
+    /// Whether <paramref name="serverName"/> resolves to a bundle-owned STDIO server — the one transport
+    /// the MCP SDK documents as unsuitable for sharing across concurrent callers — and if so, the
+    /// ambient run id every session for it must be scoped to. Remote (http/sse) bundle-owned servers and
+    /// every non-bundle server are unaffected: they never reach this check and keep using the single
+    /// shared cache exactly as before this method existed.
+    /// </summary>
+    /// <exception cref="McpConnectionException">
+    /// The server is bundle-owned stdio but no run id is ambient. Refuses rather than falling back to a
+    /// shared, unscoped session — the exact bug this check exists to close (see
+    /// <see cref="BundleRunIdAccessor"/>'s remarks on why absence is not a safe default here).
+    /// </exception>
+    private bool TryGetRunScopeRequirement(string serverName, out string runId)
+    {
+        runId = string.Empty;
+
+        if (!_bundleOwnedServers.TryGetValue(serverName, out var definition) || definition.Type != McpServerType.Stdio)
+            return false;
+
+        if (BundleRunIdAccessor.Current is not { } current)
+        {
+            throw new McpConnectionException(
+                $"Bundle-owned stdio MCP server '{serverName}' was resolved with no ambient bundle run id. " +
+                "This transport cannot be shared across callers; every caller must resolve it from inside " +
+                "a bundle run so its session can be scoped to that run.");
+        }
+
+        runId = current;
+        return true;
+    }
+
+    /// <summary>
+    /// Gets or creates the calling run's own client for <paramref name="serverName"/>, keyed by
+    /// (server, run) rather than by server alone. Same double-checked-lock shape as
+    /// <see cref="GetClientAsync"/>'s shared path, over <see cref="_runScopedClients"/> instead of
+    /// <see cref="_clients"/> and a run-qualified lock key so two different runs creating their own
+    /// sessions for the same server name never contend on one lock.
+    /// </summary>
+    private async Task<McpClient> GetRunScopedClientAsync(string serverName, string runId, CancellationToken cancellationToken)
+    {
+        var key = (serverName, runId);
+        if (_runScopedClients.TryGetValue(key, out var existing))
+            return existing;
+
+        using var _ = await AcquireConnectionLockAsync(RunScopedLockKey(serverName, runId), cancellationToken);
+
+        if (_runScopedClients.TryGetValue(key, out existing))
+            return existing;
+
+        // CreateClientAsync already resolves this same definition from _bundleOwnedServers and builds a
+        // SandboxedStdioClientTransport for it via CreateTransport — nothing about session creation
+        // itself needs the run id, only which cache entry the result is filed under.
+        var client = await CreateClientAsync(serverName, cancellationToken);
+        _runScopedClients[key] = client;
+        return client;
+    }
+
+    /// <summary>
+    /// Composite lock key for a run-scoped session. '#' never appears in a configured server name
+    /// (host names are plain or {pluginName}:{name}) or a bundle-namespaced one
+    /// ({bundleId GUID}:{name}) -- both use ':' as their only separator -- and a run id is always a
+    /// bare 32-character hex job id (Guid.NewGuid().ToString("N"), see RunBundleCommandHandler.JobId),
+    /// which contains neither ':' nor '#'. So serverName + '#' + runId is unambiguous: no two
+    /// distinct (server, run) pairs can ever produce the same composite string.
+    /// </summary>
+    private static string RunScopedLockKey(string serverName, string runId) => $"{serverName}#{runId}";
 
     /// <summary>
     /// Checks if a server connection is active and healthy.
@@ -239,11 +320,84 @@ public sealed class McpConnectionManager : IAsyncDisposable
         try
         {
             await EvictAsync(serverName);
+            await EvictAllRunScopedAsync(serverName);
         }
         finally
         {
             lockScope?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Disconnects one run's own session for <paramref name="serverName"/>, without touching the shared
+    /// cache, the server's registration, or any other run's session for the same server name. The
+    /// run-scoped counterpart to <see cref="DisconnectAsync"/> — called by
+    /// <c>BundleMcpServerRegistrar.DisconnectRunScopedAsync</c> when a bundle run completes, so its
+    /// stdio session does not outlive the run. Idempotent: a run that never actually connected to this
+    /// server is a no-op, same as <see cref="DisconnectAsync"/> for a server with no live client.
+    /// </summary>
+    public async Task DisconnectRunScopedAsync(string serverName, string runId)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var lockKey = RunScopedLockKey(serverName, runId);
+        using var timeoutCts = new CancellationTokenSource(DisconnectLockTimeout);
+        IDisposable? lockScope = null;
+        try
+        {
+            lockScope = await AcquireConnectionLockAsync(lockKey, timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "Disconnect from run-scoped MCP server '{ServerName}' (run {RunId}) proceeded without the " +
+                "connection lock after waiting {Timeout} — a connect attempt for this run was still in flight.",
+                serverName, runId, DisconnectLockTimeout);
+        }
+
+        try
+        {
+            if (_runScopedClients.TryRemove((serverName, runId), out var client))
+            {
+                await client.DisposeAsync();
+                _logger.LogInformation(
+                    "Disconnected run-scoped MCP server '{ServerName}' for run {RunId}", serverName, runId);
+            }
+        }
+        finally
+        {
+            lockScope?.Dispose();
+            // Run-scoped lock keys are unbounded (one per run, not one per server), unlike every other
+            // key this dictionary holds — without this, a long-lived host leaks one SemaphoreSlim per
+            // bundle run that ever touched a stdio server, for the life of the process.
+            _connectionLocks.TryRemove(lockKey, out _);
+        }
+    }
+
+    /// <summary>
+    /// Backstop for the handle-level teardown path (<see cref="DisconnectAsync"/>): disposes every
+    /// run-scoped session for <paramref name="serverName"/>, regardless of which run created it. Under
+    /// normal operation every run already disconnects its own session via
+    /// <see cref="DisconnectRunScopedAsync"/> when it completes, so this finds nothing to do — it exists
+    /// only to guarantee a staged handle going away takes every container tied to it with it, including
+    /// one whose run crashed before its own cleanup ran.
+    /// </summary>
+    private async Task EvictAllRunScopedAsync(string serverName)
+    {
+        var keys = _runScopedClients.Keys.Where(k => k.ServerName == serverName).ToList();
+        if (keys.Count == 0)
+            return;
+
+        await Task.WhenAll(keys.Select(async key =>
+        {
+            if (_runScopedClients.TryRemove(key, out var client))
+                await client.DisposeAsync();
+            _connectionLocks.TryRemove(RunScopedLockKey(key.ServerName, key.RunId), out _);
+        }));
+
+        _logger.LogInformation(
+            "Disconnected {Count} run-scoped session(s) for MCP server '{ServerName}' during handle teardown",
+            keys.Count, serverName);
     }
 
     /// <summary>
@@ -813,6 +967,13 @@ public sealed class McpConnectionManager : IAsyncDisposable
         }
 
         _clients.Clear();
+
+        foreach (var kvp in _runScopedClients)
+        {
+            await kvp.Value.DisposeAsync();
+        }
+
+        _runScopedClients.Clear();
 
         // Both per-server client caches were built with disposeHandler:false, so disposing each client
         // releases the wrapper only, without touching the shared AntiSSRF handler its own handler(s)

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpConnectionManager.cs
@@ -65,7 +65,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// by server name alone. The MCP stdio transport is single-session by design — its own SDK
     /// documents it as unsuitable for sharing across concurrent callers — so unlike every other server
     /// this manager resolves, one of these must never be shared between two runs of the same staged
-    /// bundle. See <see cref="BundleRunIdAccessor"/> and <see cref="TryGetRunScopeRequirement"/>.
+    /// bundle. See <see cref="BundleRunIdAccessor"/> and <see cref="RequiresRunScope"/>.
     /// </summary>
     private readonly ConcurrentDictionary<(string ServerName, string RunId), McpClient> _runScopedClients = new();
 
@@ -171,7 +171,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        if (TryGetRunScopeRequirement(serverName, out var runId))
+        if (RequiresRunScope(serverName, out var runId))
             return await GetRunScopedClientAsync(serverName, runId, cancellationToken);
 
         if (_clients.TryGetValue(serverName, out var existing))
@@ -197,7 +197,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// shared, unscoped session — the exact bug this check exists to close (see
     /// <see cref="BundleRunIdAccessor"/>'s remarks on why absence is not a safe default here).
     /// </exception>
-    private bool TryGetRunScopeRequirement(string serverName, out string runId)
+    private bool RequiresRunScope(string serverName, out string runId)
     {
         runId = string.Empty;
 
@@ -253,11 +253,15 @@ public sealed class McpConnectionManager : IAsyncDisposable
     private static string RunScopedLockKey(string serverName, string runId) => $"{serverName}#{runId}";
 
     /// <summary>
-    /// Checks if a server connection is active and healthy.
+    /// Checks if a server connection is active and healthy. True if either the shared cache holds a
+    /// client for <paramref name="serverName"/>, or at least one run currently has its own run-scoped
+    /// session for it — checking only <see cref="_clients"/> would report a bundle-owned stdio server as
+    /// disconnected while runs are actively using it.
     /// </summary>
     public bool IsConnected(string serverName)
     {
-        return _clients.ContainsKey(serverName);
+        return _clients.ContainsKey(serverName)
+            || _runScopedClients.Keys.Any(key => key.ServerName == serverName);
     }
 
     /// <summary>
@@ -271,6 +275,31 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// handshake) cannot block teardown for more than this.
     /// </summary>
     private static readonly TimeSpan DisconnectLockTimeout = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Shared lock-acquisition ceremony for <see cref="DisconnectAsync"/> and
+    /// <see cref="DisconnectRunScopedAsync"/>: acquires <paramref name="lockKey"/> bounded by
+    /// <see cref="DisconnectLockTimeout"/>, logging and proceeding lock-free (returning
+    /// <see langword="null"/>) rather than throwing if a connect attempt is still in flight past that
+    /// bound. <paramref name="logContext"/> is used only for the warning log's identification of what
+    /// was being disconnected.
+    /// </summary>
+    private async Task<IDisposable?> AcquireDisconnectLockAsync(string lockKey, string logContext)
+    {
+        using var timeoutCts = new CancellationTokenSource(DisconnectLockTimeout);
+        try
+        {
+            return await AcquireConnectionLockAsync(lockKey, timeoutCts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogWarning(
+                "Disconnect from {Context} proceeded without the connection lock after waiting {Timeout} " +
+                "— a connect attempt was still in flight.",
+                logContext, DisconnectLockTimeout);
+            return null;
+        }
+    }
 
     /// <summary>
     /// Disconnects from a specific server and removes the cached connection.
@@ -303,20 +332,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        using var timeoutCts = new CancellationTokenSource(DisconnectLockTimeout);
-        IDisposable? lockScope = null;
-        try
-        {
-            lockScope = await AcquireConnectionLockAsync(serverName, timeoutCts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            _logger.LogWarning(
-                "Disconnect from MCP server '{ServerName}' proceeded without the connection lock after " +
-                "waiting {Timeout} — a connect attempt for this server was still in flight.",
-                serverName, DisconnectLockTimeout);
-        }
-
+        var lockScope = await AcquireDisconnectLockAsync(serverName, $"MCP server '{serverName}'");
         try
         {
             await EvictAsync(serverName);
@@ -341,20 +357,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         var lockKey = RunScopedLockKey(serverName, runId);
-        using var timeoutCts = new CancellationTokenSource(DisconnectLockTimeout);
-        IDisposable? lockScope = null;
-        try
-        {
-            lockScope = await AcquireConnectionLockAsync(lockKey, timeoutCts.Token);
-        }
-        catch (OperationCanceledException)
-        {
-            _logger.LogWarning(
-                "Disconnect from run-scoped MCP server '{ServerName}' (run {RunId}) proceeded without the " +
-                "connection lock after waiting {Timeout} — a connect attempt for this run was still in flight.",
-                serverName, runId, DisconnectLockTimeout);
-        }
-
+        var lockScope = await AcquireDisconnectLockAsync(lockKey, $"run-scoped MCP server '{serverName}' (run {runId})");
         try
         {
             if (_runScopedClients.TryRemove((serverName, runId), out var client))
@@ -384,11 +387,19 @@ public sealed class McpConnectionManager : IAsyncDisposable
     /// </summary>
     private async Task EvictAllRunScopedAsync(string serverName)
     {
-        var keys = _runScopedClients.Keys.Where(k => k.ServerName == serverName).ToList();
-        if (keys.Count == 0)
+        // Lock-free enumeration over the live dictionary rather than a Keys.Where(...).ToList() snapshot
+        // — Keys copies every entry under a full-dictionary lock before the filter even runs.
+        var matching = new List<(string ServerName, string RunId)>();
+        foreach (var kvp in _runScopedClients)
+        {
+            if (kvp.Key.ServerName == serverName)
+                matching.Add(kvp.Key);
+        }
+
+        if (matching.Count == 0)
             return;
 
-        await Task.WhenAll(keys.Select(async key =>
+        await Task.WhenAll(matching.Select(async key =>
         {
             if (_runScopedClients.TryRemove(key, out var client))
                 await client.DisposeAsync();
@@ -397,7 +408,7 @@ public sealed class McpConnectionManager : IAsyncDisposable
 
         _logger.LogInformation(
             "Disconnected {Count} run-scoped session(s) for MCP server '{ServerName}' during handle teardown",
-            keys.Count, serverName);
+            matching.Count, serverName);
     }
 
     /// <summary>
@@ -422,12 +433,11 @@ public sealed class McpConnectionManager : IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        // /code-review finding (#455): a bundle-owned stdio server's session can go stale mid-run just
-        // like any other (#385) — McpToolProvider.RetryAfterReconnectAsync reaches this path for it too
-        // — and reconnecting into the SHARED cache here would recreate the exact cross-run sharing bug
-        // this file exists to close, while leaving the run's own _runScopedClients entry stuck on the
-        // broken client it never actually recovers from. Must branch the same way GetClientAsync does.
-        if (TryGetRunScopeRequirement(serverName, out var runId))
+        // A bundle-owned stdio server's session can go stale mid-run just like any other (#385) —
+        // McpToolProvider.RetryAfterReconnectAsync reaches this path for it too — so this must branch
+        // the same way GetClientAsync does, or a reconnect would recreate the shared-session bug this
+        // file exists to close.
+        if (RequiresRunScope(serverName, out var runId))
             return await ReconnectRunScopedAsync(serverName, runId, failedClient, cancellationToken);
 
         using var _ = await AcquireConnectionLockAsync(serverName, cancellationToken);
@@ -994,18 +1004,14 @@ public sealed class McpConnectionManager : IAsyncDisposable
         if (_disposed) return;
         _disposed = true;
 
-        foreach (var kvp in _clients)
-        {
-            await kvp.Value.DisposeAsync();
-        }
+        // Parallel, not sequential: each entry is a live connection (a sandboxed stdio session's
+        // container stop can take up to Docker's default 10s stop timeout), so disposing N of them one
+        // at a time serializes shutdown for no benefit — nothing here depends on disposal order.
+        await Task.WhenAll(
+            _clients.Values.Select(client => client.DisposeAsync().AsTask())
+                .Concat(_runScopedClients.Values.Select(client => client.DisposeAsync().AsTask())));
 
         _clients.Clear();
-
-        foreach (var kvp in _runScopedClients)
-        {
-            await kvp.Value.DisposeAsync();
-        }
-
         _runScopedClients.Clear();
 
         // Both per-server client caches were built with disposeHandler:false, so disposing each client

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
@@ -57,6 +57,15 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
     /// <paramref name="mcpToolProvider"/>. Used only to tear down this run's own bundle-owned stdio MCP
     /// sessions once the run ends; see <see cref="RunConversationAsync"/>.
     /// </param>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="mcpToolProvider"/> is registered but <paramref name="mcpRegistrar"/> is not. Tool
+    /// discovery (<see cref="WithBundleOwnedToolGrantsAsync"/>) only needs the former, so a composition
+    /// root that wires one without the other would still create run-scoped bundle-owned stdio sandbox
+    /// sessions with nothing to tear them down — the every-run container leak this fails loudly against
+    /// rather than letting it silently exhaust <c>McpConnectionManager</c>'s host-wide session cap. The
+    /// two are always registered together in this template's own <c>AddMcpClientDependencies</c>, so
+    /// this never fires for the shipped default; it exists for a consumer who re-wires DI by hand.
+    /// </exception>
     public BundleRunExecutor(
         IBundleRunJobStore jobStore,
         IBundleHandleStore handleStore,
@@ -71,6 +80,14 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(time);
         ArgumentNullException.ThrowIfNull(logger);
+        if (mcpToolProvider is not null && mcpRegistrar is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(BundleRunExecutor)} was constructed with an {nameof(IMcpToolProvider)} but no " +
+                $"{nameof(IBundleMcpServerRegistrar)}. Bundle-owned tool discovery can create run-scoped " +
+                "stdio MCP sandbox sessions that only IBundleMcpServerRegistrar.DisconnectRunScopedAsync " +
+                "tears down — register both or neither, never one without the other.");
+        }
 
         _jobStore = jobStore;
         _handleStore = handleStore;
@@ -176,7 +193,7 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         StagedBundle staged,
         CancellationToken cancellationToken)
     {
-        // Armed around the WHOLE run, not just the conversation below: WithBundleOwnedToolGrantsAsync
+        // Armed around the WHOLE run, not just the conversation core below: WithBundleOwnedToolGrantsAsync
         // contacts the bundle's own MCP servers for tool discovery before either of the other two
         // ambients is armed, and that first contact is exactly where a bundle-owned stdio server's
         // session gets created and cached — it must see the same run id every later resolution inside
@@ -185,39 +202,7 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         {
             try
             {
-                var overlay = new EphemeralAgentOverlay
-                {
-                    Agent = staged.Agent,
-                    OwnedSkills = staged.OwnedSkills
-                };
-
-                var envelope = await WithBundleOwnedToolGrantsAsync(record.Envelope, staged, cancellationToken)
-                    .ConfigureAwait(false);
-
-                await using var scope = _scopeFactory.CreateAsyncScope();
-                var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-
-                // Arm BOTH ambients for the whole conversation: the overlay so the ephemeral agent + its owned skills
-                // resolve, and the envelope so the governor enforces the per-caller grant. Disposed in reverse when the
-                // (materialised) conversation returns.
-                using (EphemeralAgentOverlayAccessor.Begin(overlay))
-                using (CapabilityEnvelopeAccessor.Begin(envelope))
-                {
-                    // A run that names a conversation continues it; one that does not gets an id of its own so
-                    // its budget and telemetry still have somewhere to accumulate. The owner rides along only in
-                    // the first case — it is what switches the shared loop into durable mode, so passing it for
-                    // a self-contained run would make every one-shot run write a transcript nobody asked for.
-                    var command = new RunConversationCommand
-                    {
-                        AgentName = record.AgentName,
-                        UserMessages = record.UserMessages,
-                        MaxTurns = record.MaxTurns,
-                        ConversationId = record.ConversationId ?? record.JobId,
-                        ConversationOwnerId = record.ConversationId is null ? null : record.OwnerId
-                    };
-
-                    return await mediator.Send(command, cancellationToken).ConfigureAwait(false);
-                }
+                return await RunConversationCoreAsync(record, staged, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -232,6 +217,49 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
                         .ConfigureAwait(false);
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Discovers the bundle's own tool grants, drives the conversation, and returns its result. Split
+    /// out from <see cref="RunConversationAsync"/> so that method's ambient-arming and teardown ceremony
+    /// isn't nested four levels deep around the actual conversation logic.
+    /// </summary>
+    private async Task<ConversationResult> RunConversationCoreAsync(
+        BundleRunRecord record, StagedBundle staged, CancellationToken cancellationToken)
+    {
+        var overlay = new EphemeralAgentOverlay
+        {
+            Agent = staged.Agent,
+            OwnedSkills = staged.OwnedSkills
+        };
+
+        var envelope = await WithBundleOwnedToolGrantsAsync(record.Envelope, staged, cancellationToken)
+            .ConfigureAwait(false);
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        // Arm BOTH ambients for the whole conversation: the overlay so the ephemeral agent + its owned skills
+        // resolve, and the envelope so the governor enforces the per-caller grant. Disposed in reverse when the
+        // (materialised) conversation returns.
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(envelope))
+        {
+            // A run that names a conversation continues it; one that does not gets an id of its own so
+            // its budget and telemetry still have somewhere to accumulate. The owner rides along only in
+            // the first case — it is what switches the shared loop into durable mode, so passing it for
+            // a self-contained run would make every one-shot run write a transcript nobody asked for.
+            var command = new RunConversationCommand
+            {
+                AgentName = record.AgentName,
+                UserMessages = record.UserMessages,
+                MaxTurns = record.MaxTurns,
+                ConversationId = record.ConversationId ?? record.JobId,
+                ConversationOwnerId = record.ConversationId is null ? null : record.OwnerId
+            };
+
+            return await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleRunExecutor.cs
@@ -43,6 +43,7 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly TimeProvider _time;
     private readonly IMcpToolProvider? _mcpToolProvider;
+    private readonly IBundleMcpServerRegistrar? _mcpRegistrar;
     private readonly ILogger<BundleRunExecutor> _logger;
 
     /// <summary>Initializes a new <see cref="BundleRunExecutor"/>.</summary>
@@ -51,13 +52,19 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
     /// tool names a bundle's own registered MCP servers publish, so they can be additively granted for
     /// invocation; see <see cref="WithBundleOwnedToolGrantsAsync"/>.
     /// </param>
+    /// <param name="mcpRegistrar">
+    /// Optional — null on a host with no MCP client dependencies registered, matching
+    /// <paramref name="mcpToolProvider"/>. Used only to tear down this run's own bundle-owned stdio MCP
+    /// sessions once the run ends; see <see cref="RunConversationAsync"/>.
+    /// </param>
     public BundleRunExecutor(
         IBundleRunJobStore jobStore,
         IBundleHandleStore handleStore,
         IServiceScopeFactory scopeFactory,
         TimeProvider time,
         ILogger<BundleRunExecutor> logger,
-        IMcpToolProvider? mcpToolProvider = null)
+        IMcpToolProvider? mcpToolProvider = null,
+        IBundleMcpServerRegistrar? mcpRegistrar = null)
     {
         ArgumentNullException.ThrowIfNull(jobStore);
         ArgumentNullException.ThrowIfNull(handleStore);
@@ -71,6 +78,7 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         _time = time;
         _logger = logger;
         _mcpToolProvider = mcpToolProvider;
+        _mcpRegistrar = mcpRegistrar;
     }
 
     /// <inheritdoc />
@@ -168,38 +176,62 @@ public sealed class BundleRunExecutor : IBundleRunExecutor
         StagedBundle staged,
         CancellationToken cancellationToken)
     {
-        var overlay = new EphemeralAgentOverlay
+        // Armed around the WHOLE run, not just the conversation below: WithBundleOwnedToolGrantsAsync
+        // contacts the bundle's own MCP servers for tool discovery before either of the other two
+        // ambients is armed, and that first contact is exactly where a bundle-owned stdio server's
+        // session gets created and cached — it must see the same run id every later resolution inside
+        // the conversation does, or McpConnectionManager has nothing to scope the session to.
+        using (BundleRunIdAccessor.Begin(record.JobId))
         {
-            Agent = staged.Agent,
-            OwnedSkills = staged.OwnedSkills
-        };
-
-        var envelope = await WithBundleOwnedToolGrantsAsync(record.Envelope, staged, cancellationToken)
-            .ConfigureAwait(false);
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
-
-        // Arm BOTH ambients for the whole conversation: the overlay so the ephemeral agent + its owned skills
-        // resolve, and the envelope so the governor enforces the per-caller grant. Disposed in reverse when the
-        // (materialised) conversation returns.
-        using (EphemeralAgentOverlayAccessor.Begin(overlay))
-        using (CapabilityEnvelopeAccessor.Begin(envelope))
-        {
-            // A run that names a conversation continues it; one that does not gets an id of its own so
-            // its budget and telemetry still have somewhere to accumulate. The owner rides along only in
-            // the first case — it is what switches the shared loop into durable mode, so passing it for
-            // a self-contained run would make every one-shot run write a transcript nobody asked for.
-            var command = new RunConversationCommand
+            try
             {
-                AgentName = record.AgentName,
-                UserMessages = record.UserMessages,
-                MaxTurns = record.MaxTurns,
-                ConversationId = record.ConversationId ?? record.JobId,
-                ConversationOwnerId = record.ConversationId is null ? null : record.OwnerId
-            };
+                var overlay = new EphemeralAgentOverlay
+                {
+                    Agent = staged.Agent,
+                    OwnedSkills = staged.OwnedSkills
+                };
 
-            return await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+                var envelope = await WithBundleOwnedToolGrantsAsync(record.Envelope, staged, cancellationToken)
+                    .ConfigureAwait(false);
+
+                await using var scope = _scopeFactory.CreateAsyncScope();
+                var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+                // Arm BOTH ambients for the whole conversation: the overlay so the ephemeral agent + its owned skills
+                // resolve, and the envelope so the governor enforces the per-caller grant. Disposed in reverse when the
+                // (materialised) conversation returns.
+                using (EphemeralAgentOverlayAccessor.Begin(overlay))
+                using (CapabilityEnvelopeAccessor.Begin(envelope))
+                {
+                    // A run that names a conversation continues it; one that does not gets an id of its own so
+                    // its budget and telemetry still have somewhere to accumulate. The owner rides along only in
+                    // the first case — it is what switches the shared loop into durable mode, so passing it for
+                    // a self-contained run would make every one-shot run write a transcript nobody asked for.
+                    var command = new RunConversationCommand
+                    {
+                        AgentName = record.AgentName,
+                        UserMessages = record.UserMessages,
+                        MaxTurns = record.MaxTurns,
+                        ConversationId = record.ConversationId ?? record.JobId,
+                        ConversationOwnerId = record.ConversationId is null ? null : record.OwnerId
+                    };
+
+                    return await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                // Tears down this run's OWN stdio sessions — never the bundle's registration, which must
+                // survive for the next run against the same staged handle. Idempotent and safe to call
+                // unconditionally: a run that never contacted any of the bundle's servers, or one with
+                // none declared, is a no-op. Runs even when the conversation threw, so a failed run never
+                // leaks a container for the life of the handle's TTL.
+                if (_mcpRegistrar is not null && staged.McpServerNames.Count > 0)
+                {
+                    await _mcpRegistrar.DisconnectRunScopedAsync(staged.McpServerNames, record.JobId)
+                        .ConfigureAwait(false);
+                }
+            }
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.StdioMcp.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Bundles/BundleStagingService.StdioMcp.cs
@@ -40,7 +40,10 @@ public sealed partial class BundleStagingService
     /// a URL for remote servers.</description></item>
     /// <item><description>The bundle has not already reached
     /// <see cref="BundleStdioMcpServersConfig.MaxServersPerBundle"/> — each registered stdio server
-    /// becomes a long-lived sandbox container for the life of the bundle's staged handle.</description></item>
+    /// gets its own sandbox container per concurrent run against the bundle's staged handle (#455;
+    /// before that, one shared container for the life of the handle), so this caps how many distinct
+    /// server <em>names</em> a bundle can declare, not how many containers can be live for it at
+    /// once.</description></item>
     /// </list>
     /// On success, tags <see cref="McpServerDefinition.SandboxSeedDirectory"/> with the bundle's staged
     /// root directory <strong>before</strong> <see cref="IBundleOwnedMcpServerRegistry.TryAdd"/> — tagged

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/BundleMcpServerRegistrarTests.cs
@@ -63,4 +63,43 @@ public sealed class BundleMcpServerRegistrarTests
 
         bundleOwned.TryGetValue("b1:echo", out _).Should().BeTrue();
     }
+
+    // -- Run-scoped teardown (#455) --
+
+    [Fact]
+    public async Task DisconnectRunScopedAsync_LeavesServerRegistrationIntact()
+    {
+        // The behavior that distinguishes this from DeregisterAsync: a run ending must not evict the
+        // bundle's own server definition — the next run against the same staged handle still needs to
+        // find it to start its own fresh session.
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:echo", new() { Command = "npx" });
+        var sut = CreateSut(bundleOwned);
+
+        await sut.DisconnectRunScopedAsync(["b1:echo"], "run-1");
+
+        bundleOwned.TryGetValue("b1:echo", out _).Should().BeTrue(
+            "a run ending must not deregister the bundle's server definition — only DeregisterAsync " +
+            "(handle eviction) does that");
+    }
+
+    [Fact]
+    public async Task DisconnectRunScopedAsync_UnconnectedServer_IsANoOpAndDoesNotThrow()
+    {
+        var sut = CreateSut(new BundleOwnedMcpServerRegistry());
+
+        var act = async () => await sut.DisconnectRunScopedAsync(["never-connected"], "run-1");
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task DisconnectRunScopedAsync_EmptyList_IsANoOp()
+    {
+        var sut = CreateSut(new BundleOwnedMcpServerRegistry());
+
+        var act = async () => await sut.DisconnectRunScopedAsync([], "run-1");
+
+        await act.Should().NotThrowAsync();
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -538,6 +538,31 @@ public sealed class McpConnectionManagerSandboxedStdioTests
     }
 
     [Fact]
+    public async Task ReconnectAsync_BundleOwnedStdioServer_NoAmbientRunId_RefusesTheSameWayGetClientAsyncDoes()
+    {
+        // /code-review finding: ReconnectAsync (the #385 stale-client recovery path) was not updated
+        // alongside GetClientAsync's run-scoping — it still went straight for the shared cache, which
+        // would have silently reintroduced this exact bug on every mid-run reconnect. Must route through
+        // the identical fail-closed check. The guard fires before failedClient is ever touched, so null
+        // is safe to pass here.
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Stdio,
+            Command = "node",
+            StartupTimeoutSeconds = 1,
+        });
+        var sut = CreateManager(new McpServersConfig(), bundleOwned);
+
+        var act = () => sut.ReconnectAsync("b1:local-tool", null!, CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<McpConnectionException>();
+        exception.Which.Message.Should().Contain("no ambient bundle run id");
+        _fakeSessionFactory.WasCalled.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task GetClientAsync_TwoRunsResolvingTheSameServerName_DoNotSerializeOnOneSharedLock()
     {
         // Distinguishes the run-scoped lock key from the old bare-server-name one. Before #455, every

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerSandboxedStdioTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Sandbox;
+using Application.AI.Common.Services.Bundles;
 using Domain.AI.Sandbox;
 using Domain.Common;
 using Domain.Common.Config;
@@ -15,6 +16,7 @@ using Infrastructure.AI.MCP.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using ModelContextProtocol.Client;
 using Moq;
 using Xunit;
 
@@ -60,6 +62,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             StartupTimeoutSeconds = 1
         });
         var sut = CreateManager(new McpServersConfig(), bundleOwned);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         var act = () => sut.GetClientAsync("b1:local-tool");
 
@@ -85,6 +88,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             StartupTimeoutSeconds = 1
         });
         var sut = CreateManager(new McpServersConfig(), bundleOwned);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
@@ -129,6 +133,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
@@ -189,6 +194,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
@@ -238,6 +244,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         var firstCallTask = sut.GetClientAsync("b1:local-tool");
         await blockingFactory.EntrySignaled.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -289,6 +296,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned,
             throwingScopeFactory, McpConnectionManagerBundleEgressSupport.Args.AmbientScope, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
         var secondException = await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
@@ -335,6 +343,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         var act = () => sut.GetClientAsync("b1:local-tool");
 
@@ -385,6 +394,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         var firstCallTask = sut.GetClientAsync("b1:local-tool");
         await blockingFactory.EntrySignaled.Task.WaitAsync(TimeSpan.FromSeconds(5));
@@ -435,6 +445,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
@@ -466,6 +477,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
             Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
             TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
@@ -487,6 +499,7 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         });
         // BuildRootServices' default AppConfig has an empty (unconfigured) StdioMcpServers.ContainerImage.
         var sut = CreateManager(new McpServersConfig(), bundleOwned);
+        using var runScope = BundleRunIdAccessor.Begin("run-1");
 
         await Assert.ThrowsAsync<McpConnectionException>(() => sut.GetClientAsync("b1:local-tool"));
 
@@ -494,6 +507,105 @@ public sealed class McpConnectionManagerSandboxedStdioTests
         _fakeSessionFactory.LastRequest!.ContainerImage.Should().BeNull(
             "an unconfigured image must fall through to the session factory's own default resolution, " +
             "not an empty string that would fail Docker's image reference parsing");
+    }
+
+    // -- Per-run session isolation (#455) --
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedStdioServer_NoAmbientRunId_RefusesWithoutStartingASession()
+    {
+        // The MCP SDK's own docs: a stdio session is unsuitable for sharing across concurrent callers.
+        // Resolving one with no ambient run id armed (BundleRunIdAccessor.Current is null) must fail
+        // closed rather than silently falling back to the old shared-by-server-name cache — the exact
+        // bug #455 exists to close. No BundleRunIdAccessor.Begin scope is opened anywhere in this test.
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Stdio,
+            Command = "node",
+            StartupTimeoutSeconds = 1,
+        });
+        var sut = CreateManager(new McpServersConfig(), bundleOwned);
+
+        var act = () => sut.GetClientAsync("b1:local-tool");
+
+        var exception = await act.Should().ThrowAsync<McpConnectionException>();
+        exception.Which.Message.Should().Contain("no ambient bundle run id");
+        _fakeSessionFactory.WasCalled.Should().BeFalse(
+            "a missing run id must be refused before the sandbox session factory is ever called — " +
+            "falling back to a shared session is the bug this check exists to close");
+    }
+
+    [Fact]
+    public async Task GetClientAsync_TwoRunsResolvingTheSameServerName_DoNotSerializeOnOneSharedLock()
+    {
+        // Distinguishes the run-scoped lock key from the old bare-server-name one. Before #455, every
+        // caller resolving one server name funneled through a single SemaphoreSlim(1,1), so a second
+        // run's attempt would have blocked behind the first's in-flight (never-completing, here)
+        // session start. With the run id folded into the lock key, two DIFFERENT runs resolving the
+        // SAME server name must proceed independently — reaching (and each failing against) the
+        // factory on its own, not queuing behind the other.
+        var blockingFactory = new BlockingSandboxSessionFactory();
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:local-tool", new McpServerDefinition
+        {
+            Enabled = true, Type = McpServerType.Stdio, Command = "node", StartupTimeoutSeconds = 1,
+        });
+        var rootServices = McpConnectionManagerBundleEgressSupport.BuildRootServices(services =>
+        {
+            services.AddKeyedSingleton<ISandboxSessionFactory>(SandboxIsolationLevel.Container, blockingFactory);
+        });
+        var sut = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(), new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(), new McpServersConfig(), bundleOwned, rootServices);
+
+        Task<McpClient> firstCallTask;
+        using (BundleRunIdAccessor.Begin("run-1"))
+            firstCallTask = sut.GetClientAsync("b1:local-tool");
+        await blockingFactory.EntrySignaled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // If run-2 were still funneled through run-1's lock (the pre-#455 behavior), this call would
+        // block waiting for that lock rather than ever reaching the factory at all — so
+        // PeakConcurrentEntries would never rise above 1, however long this test waited. Polling
+        // rather than a single fixed delay avoids a flaky race against exactly how fast run-2's
+        // attempt reaches the factory.
+        Task<McpClient> secondCallTask;
+        using (BundleRunIdAccessor.Begin("run-2"))
+            secondCallTask = sut.GetClientAsync("b1:local-tool");
+
+        for (var attempt = 0; attempt < 200 && blockingFactory.PeakConcurrentEntries < 2; attempt++)
+            await Task.Delay(10);
+
+        blockingFactory.PeakConcurrentEntries.Should().Be(2,
+            "both runs must be inside the sandbox session factory at once — a run-scoped lock key " +
+            "must not serialize two different runs resolving the same server name");
+
+        blockingFactory.Release.SetResult();
+        await Assert.ThrowsAsync<McpConnectionException>(() => firstCallTask);
+        await Assert.ThrowsAsync<McpConnectionException>(() => secondCallTask);
+    }
+
+    [Fact]
+    public async Task GetClientAsync_BundleOwnedRemoteServer_NeverRequiresAnAmbientRunId()
+    {
+        // The run-scoping requirement is deliberately stdio-only: an http/sse transport has no
+        // single-session constraint (multiple independent requests to a remote endpoint are fine), so
+        // a bundle-owned REMOTE server must never hit the "no ambient run id" refusal a stdio one does.
+        var bundleOwned = new BundleOwnedMcpServerRegistry();
+        bundleOwned.TryAdd("b1:remote-tool", new McpServerDefinition
+        {
+            Enabled = true,
+            Type = McpServerType.Http,
+            Url = "http://localhost:19999/mcp", // no listener — fast connection-refused, not the run-id check
+            StartupTimeoutSeconds = 1,
+        });
+        var sut = CreateManager(new McpServersConfig(), bundleOwned);
+
+        var act = () => sut.GetClientAsync("b1:remote-tool");
+
+        var exception = await act.Should().ThrowAsync<McpConnectionException>();
+        exception.Which.Message.Should().NotContain("no ambient bundle run id");
     }
 
     [Fact]
@@ -552,18 +664,44 @@ public sealed class McpConnectionManagerSandboxedStdioTests
     /// <summary>
     /// A session factory whose <see cref="StartSessionAsync"/> does not complete until the test
     /// explicitly releases it — lets a test hold a "slot" open to prove the host-wide concurrency cap
-    /// rejects a second concurrent attempt while it's exhausted, without needing a real session.
+    /// rejects a second concurrent attempt while it's exhausted, without needing a real session. Also
+    /// tracks how many calls are inside <see cref="StartSessionAsync"/> at once (<see cref="PeakConcurrentEntries"/>),
+    /// which #455's non-serialization test uses to prove two callers actually overlapped rather than
+    /// queued one after the other.
     /// </summary>
     private sealed class BlockingSandboxSessionFactory : ISandboxSessionFactory
     {
         public TaskCompletionSource EntrySignaled { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        private int _concurrentEntries;
+        private int _peakConcurrentEntries;
+        public int PeakConcurrentEntries => Volatile.Read(ref _peakConcurrentEntries);
+
         public async Task<Result<ISandboxSession>> StartSessionAsync(SandboxSessionRequest request, CancellationToken ct)
         {
+            var now = Interlocked.Increment(ref _concurrentEntries);
+            InterlockedMax(ref _peakConcurrentEntries, now);
             EntrySignaled.TrySetResult();
-            await Release.Task;
-            return Result<ISandboxSession>.Fail("fake factory: not starting a real session");
+            try
+            {
+                await Release.Task;
+                return Result<ISandboxSession>.Fail("fake factory: not starting a real session");
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _concurrentEntries);
+            }
+        }
+
+        private static void InterlockedMax(ref int target, int candidate)
+        {
+            int seen;
+            while ((seen = Volatile.Read(ref target)) < candidate
+                   && Interlocked.CompareExchange(ref target, candidate, seen) != seen)
+            {
+                // Another thread moved the peak while we were deciding; re-read and try again.
+            }
         }
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -257,7 +257,11 @@ public sealed class BundleRunExecutorTests : IDisposable
         mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<AITool> { AIFunctionFactory.Create(() => "r", "echo_tool") });
 
-        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        // A bare, unverified registrar mock — the constructor now requires one whenever an
+        // IMcpToolProvider is present (see the leak-prevention test above); these tests are about
+        // discovery, not teardown, so nothing here asserts against it.
+        var (executor, jobStore, handleStore) = BuildSut(
+            mediator.Object, mcpToolProvider.Object, new Mock<IBundleMcpServerRegistrar>().Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
         Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id)
@@ -284,7 +288,11 @@ public sealed class BundleRunExecutorTests : IDisposable
         mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("server unreachable"));
 
-        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        // A bare, unverified registrar mock — the constructor now requires one whenever an
+        // IMcpToolProvider is present (see the leak-prevention test above); these tests are about
+        // discovery, not teardown, so nothing here asserts against it.
+        var (executor, jobStore, handleStore) = BuildSut(
+            mediator.Object, mcpToolProvider.Object, new Mock<IBundleMcpServerRegistrar>().Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
         Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id));
@@ -304,7 +312,11 @@ public sealed class BundleRunExecutorTests : IDisposable
         mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<AITool> { AIFunctionFactory.Create(() => "r", "echo_tool") });
 
-        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        // A bare, unverified registrar mock — the constructor now requires one whenever an
+        // IMcpToolProvider is present (see the leak-prevention test above); these tests are about
+        // discovery, not teardown, so nothing here asserts against it.
+        var (executor, jobStore, handleStore) = BuildSut(
+            mediator.Object, mcpToolProvider.Object, new Mock<IBundleMcpServerRegistrar>().Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
         Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id)
@@ -318,6 +330,24 @@ public sealed class BundleRunExecutorTests : IDisposable
     }
 
     // -- Per-run MCP session teardown (#455) --
+
+    [Fact]
+    public void Constructor_McpToolProviderRegisteredWithoutRegistrar_ThrowsRatherThanRiskingASilentContainerLeak()
+    {
+        // /code-review finding: tool discovery only needs IMcpToolProvider, so a composition root that
+        // wires it without IBundleMcpServerRegistrar would still create run-scoped bundle-owned stdio
+        // sandbox sessions every run with nothing to tear them down — a silent per-run container leak
+        // that eventually exhausts McpConnectionManager's host-wide session cap with no diagnostic
+        // trail. This template's own AddMcpClientDependencies always registers both together, so this
+        // never fires for the shipped default — it guards a consumer who re-wires DI by hand.
+        var mediator = new Mock<IMediator>();
+        var mcpToolProvider = new Mock<IMcpToolProvider>();
+
+        var act = () => BuildSut(mediator.Object, mcpToolProvider.Object, mcpRegistrar: null);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*IMcpToolProvider*IBundleMcpServerRegistrar*");
+    }
 
     [Fact]
     public async Task ExecuteAsync_BundleOwnsMcpServer_TearsDownRunScopedSessionAfterTheRunCompletes()
@@ -400,7 +430,11 @@ public sealed class BundleRunExecutorTests : IDisposable
                 return new List<AITool>();
             });
 
-        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        // A bare, unverified registrar mock — the constructor now requires one whenever an
+        // IMcpToolProvider is present (see the leak-prevention test above); these tests are about
+        // discovery, not teardown, so nothing here asserts against it.
+        var (executor, jobStore, handleStore) = BuildSut(
+            mediator.Object, mcpToolProvider.Object, new Mock<IBundleMcpServerRegistrar>().Object);
         var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
         var handle = handleStore.Register(staged, "owner-1");
         Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id));

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleRunExecutorTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Bundles;
+using Application.AI.Common.Services.Bundles;
 using Application.Core.CQRS.Agents.RunConversation;
 using Domain.AI.Agents;
 using Domain.AI.Bundles;
@@ -45,7 +46,7 @@ public sealed class BundleRunExecutorTests : IDisposable
     }
 
     private (BundleRunExecutor Executor, InMemoryBundleRunJobStore JobStore, InMemoryBundleHandleStore HandleStore)
-        BuildSut(IMediator mediator, IMcpToolProvider? mcpToolProvider = null)
+        BuildSut(IMediator mediator, IMcpToolProvider? mcpToolProvider = null, IBundleMcpServerRegistrar? mcpRegistrar = null)
     {
         var monitor = new StaticOptionsMonitor<AppConfig>(Config());
         var jobStore = new InMemoryBundleRunJobStore(monitor, _time);
@@ -56,7 +57,8 @@ public sealed class BundleRunExecutorTests : IDisposable
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
         var executor = new BundleRunExecutor(
-            jobStore, handleStore, scopeFactory, _time, NullLogger<BundleRunExecutor>.Instance, mcpToolProvider);
+            jobStore, handleStore, scopeFactory, _time, NullLogger<BundleRunExecutor>.Instance,
+            mcpToolProvider, mcpRegistrar);
         return (executor, jobStore, handleStore);
     }
 
@@ -313,6 +315,100 @@ public sealed class BundleRunExecutorTests : IDisposable
 
         jobStore.Get("j1")!.Envelope.AllowedTools.Should().BeEmpty(
             "the stored record's envelope must not be mutated by run-scoped tool discovery");
+    }
+
+    // -- Per-run MCP session teardown (#455) --
+
+    [Fact]
+    public async Task ExecuteAsync_BundleOwnsMcpServer_TearsDownRunScopedSessionAfterTheRunCompletes()
+    {
+        var mediator = MediatorReturning(Ok());
+        var mcpToolProvider = new Mock<IMcpToolProvider>();
+        mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AITool>());
+        var mcpRegistrar = new Mock<IBundleMcpServerRegistrar>();
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object, mcpRegistrar.Object);
+        var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = handleStore.Register(staged, "owner-1");
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id));
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        mcpRegistrar.Verify(
+            r => r.DisconnectRunScopedAsync(
+                It.Is<IReadOnlyList<string>>(names => names.SequenceEqual(new[] { "b1:echo" })), "j1"),
+            Times.Once,
+            "the run's own stdio session(s) must be torn down by job id once the run ends, without " +
+            "touching the bundle's registration (that's DeregisterAsync's job, at handle eviction)");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ConversationThrows_StillTearsDownRunScopedSession()
+    {
+        // A failed run must not leak a container for the life of the handle's TTL.
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<RunConversationCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+        var mcpToolProvider = new Mock<IMcpToolProvider>();
+        mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AITool>());
+        var mcpRegistrar = new Mock<IBundleMcpServerRegistrar>();
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object, mcpRegistrar.Object);
+        var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = handleStore.Register(staged, "owner-1");
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id));
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        mcpRegistrar.Verify(
+            r => r.DisconnectRunScopedAsync(It.IsAny<IReadOnlyList<string>>(), "j1"), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BundleDeclaresNoMcpServers_NeverCallsTeardown()
+    {
+        var mediator = MediatorReturning(Ok());
+        var mcpRegistrar = new Mock<IBundleMcpServerRegistrar>();
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpRegistrar: mcpRegistrar.Object);
+        var staged = StageOnDisk("b1"); // no mcpServerNames
+        var handle = handleStore.Register(staged, "owner-1");
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id));
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        mcpRegistrar.Verify(
+            r => r.DisconnectRunScopedAsync(It.IsAny<IReadOnlyList<string>>(), It.IsAny<string>()), Times.Never,
+            "a run whose bundle declares no MCP servers has nothing to tear down");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BundleOwnsMcpServer_ArmsAmbientRunIdDuringToolDiscovery()
+    {
+        // The ambient must be armed BEFORE WithBundleOwnedToolGrantsAsync's discovery call, not only
+        // around the conversation that follows it — discovery is the FIRST point a bundle-owned stdio
+        // server would be contacted, and McpConnectionManager needs to see the run id there too.
+        string? seenRunId = null;
+        var mediator = MediatorReturning(Ok());
+        var mcpToolProvider = new Mock<IMcpToolProvider>();
+        mcpToolProvider.Setup(p => p.GetToolsAsync("b1:echo", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                seenRunId = BundleRunIdAccessor.Current;
+                return new List<AITool>();
+            });
+
+        var (executor, jobStore, handleStore) = BuildSut(mediator.Object, mcpToolProvider.Object);
+        var staged = StageOnDisk("b1", mcpServerNames: ["b1:echo"]);
+        var handle = handleStore.Register(staged, "owner-1");
+        Store(jobStore, QueuedRecord("j1", handle, staged.Agent.Id));
+
+        await executor.ExecuteAsync("j1", CancellationToken.None);
+
+        seenRunId.Should().Be("j1");
+        BundleRunIdAccessor.Current.Should().BeNull("the ambient must not leak past the run");
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

#454 made background bundle-run dispatch genuinely parallel, which exposed a
pre-existing design defect: a bundle's own local ("stdio") MCP tool server was
connected once per staged handle and the resulting session shared by every
concurrent run against it. The MCP C# SDK documents stdio as inherently
single-session and unsuitable for sharing across concurrent callers, so two
runs of the same staged bundle mid-conversation could drive tool calls into
the same live process and misattribute results between them.

- Each `(server, run)` pair now gets its own sandboxed session
  (`McpConnectionManager._runScopedClients`), gated behind a new
  `BundleRunIdAccessor` ambient armed for the whole run by `BundleRunExecutor`.
  A bundle-owned stdio server resolved with no ambient run id fails closed
  rather than falling back to the old shared cache.
- `ReconnectAsync` (the existing #385 stale-client recovery path) routes
  through the same run-scoping — missed in the first commit, caught by
  `/code-review`, fixed in the second.
- `/simplify` pass (third commit): renamed a misleadingly `Try`-prefixed
  method that actually throws, fixed `IsConnected` to see run-scoped sessions,
  deduped the disconnect-lock ceremony, extracted `BundleRunExecutor`'s
  conversation core to cut ambient-arming nesting, and skipped provably-empty
  teardown work for remote (non-stdio) servers.
- Follow-up `/code-review` on the simplified diff caught a real gap:
  `BundleRunExecutor`'s constructor now fails fast if a composition root
  registers `IMcpToolProvider` without `IBundleMcpServerRegistrar` — that
  combination would otherwise leak one sandbox container per bundle run with
  no diagnostic trail. This template's own DI wiring always registers both
  together, so this guards a consumer who re-wires DI by hand, not the
  shipped default.
- Docs corrected: `BundleStdioMcpServersConfig`'s and
  `BundleStagingService.StdioMcp.cs`'s XML docs, plus
  `documentation/security/05-sandbox-and-execution.html`, no longer describe
  the old one-container-per-handle model.

Considered and deliberately not done: unifying `GetClientAsync`/`ReconnectAsync`'s
shared and run-scoped pairs into one generic primitive. Verified directly
against the code that `ReconnectAsync`'s shared path calls `DetachClient`,
which also evicts the per-server HTTP-transport caches (`_entraClients`,
`_bundleEgressClients`) — a real, transport-specific asymmetry the run-scoped
path deliberately does not replicate. A shared primitive would have to hide
or special-case that, so the four methods stay separate.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 new warnings
- [x] `Infrastructure.AI.MCP.Tests` — 135/135 passing
- [x] `Infrastructure.AI.Tests` (Bundles) — 15/15 passing
- [x] New regression test for the DI-misconfiguration guard, mutation-checked
      (disabled the guard, confirmed the test fails with the exact predicted
      error, restored it)
- [x] New regression tests from the original #455 commits: distinct sessions
      per run, no serialization on the run-scoped lock, fail-closed with no
      ambient run id (`GetClientAsync` and `ReconnectAsync`), handle-level
      teardown sweeps every run-scoped session
- [x] `/code-review` and `/simplify` receipts recorded for the final diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfjeQC1etfSmCwPskkPXWu