### PR TITLE
fix: close redaction and audit-integrity gaps flagged by PR #453's review

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -134,7 +134,8 @@ public partial class AgentExecutionContextFactory
         // the three framework disclosure tools once per turn — orders of magnitude under the LLM call it
         // rides along with.
         providers.Add(new Services.Agent.GoverningToolContextProvider(
-            _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>()));
+            _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>(),
+            _serviceProvider.GetRequiredService<Interfaces.Telemetry.IContentRedactionFilter>()));
 
         AppendPerTurnBudgetProvider(providers, baseline);
 

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Tools;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -62,16 +63,24 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     private const string ChannelDescription = "AIContext.Tools contributed by an AIContextProvider";
 
     private readonly ILogger<GoverningToolContextProvider> _logger;
+    private readonly IContentRedactionFilter _redactionFilter;
 
     /// <summary>Initializes a new <see cref="GoverningToolContextProvider"/>.</summary>
     /// <param name="logger">Logger that receives reserved plan-capability collision reports.</param>
-    public GoverningToolContextProvider(ILogger<GoverningToolContextProvider> logger)
+    /// <param name="redactionFilter">
+    /// Passed through to every <see cref="GovernedAIFunction"/> this provider wraps a tool in.
+    /// </param>
+    public GoverningToolContextProvider(
+        ILogger<GoverningToolContextProvider> logger, IContentRedactionFilter redactionFilter)
         : base(
             provideInputMessageFilter: messages => messages,
             storeInputRequestMessageFilter: messages => messages,
             storeInputResponseMessageFilter: messages => messages)
     {
+        ArgumentNullException.ThrowIfNull(redactionFilter);
+
         _logger = logger;
+        _redactionFilter = redactionFilter;
     }
 
     /// <inheritdoc />
@@ -89,7 +98,7 @@ public sealed class GoverningToolContextProvider : AIContextProvider
         // every provider ahead of this one — then filter and wrap what it produced.
         var merged = await base.InvokingCoreAsync(context, cancellationToken).ConfigureAwait(false);
 
-        var tools = FilterAndGovern(merged.Tools, _logger);
+        var tools = FilterAndGovern(merged.Tools, _logger, _redactionFilter);
 
         // Nothing was dropped or needed wrapping — avoid allocating a new AIContext.
         if (tools is null)
@@ -111,7 +120,9 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     /// </summary>
     /// <param name="tools">The tools accumulated on the context, possibly null or empty.</param>
     /// <param name="logger">Logger that receives reserved plan-capability collision reports.</param>
-    internal static List<AITool>? FilterAndGovern(IEnumerable<AITool>? tools, ILogger logger)
+    /// <param name="redactionFilter">Passed through to every tool this call wraps for governance.</param>
+    internal static List<AITool>? FilterAndGovern(
+        IEnumerable<AITool>? tools, ILogger logger, IContentRedactionFilter redactionFilter)
     {
         var original = tools?.ToList();
         if (original is null or { Count: 0 })
@@ -123,7 +134,7 @@ public sealed class GoverningToolContextProvider : AIContextProvider
 
         for (var i = 0; i < permitted.Count; i++)
         {
-            var governed = Govern(permitted[i]);
+            var governed = Govern(permitted[i], redactionFilter);
             if (!ReferenceEquals(governed, permitted[i]))
             {
                 permitted[i] = governed;
@@ -160,10 +171,10 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     /// skill's script is a capability, and on a bundle run it is one the caller's envelope must grant.
     /// </para>
     /// </remarks>
-    internal static AITool Govern(AITool tool)
+    internal static AITool Govern(AITool tool, IContentRedactionFilter redactionFilter)
         => tool is AIFunction fn
            && tool is not GovernedAIFunction
            && !ToolPermissionFilter.SkillDisclosureToolNames.Contains(fn.Name)
-            ? new GovernedAIFunction(fn)
+            ? new GovernedAIFunction(fn, redactionFilter)
             : tool;
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -278,9 +278,10 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
                 ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
                 : new ToolExecutionReport(
                     EscalationExecutionStatus.Failed,
-                    _redactionFilter.Redact(
-                        ReportedFailureText.Cap(result.Error ?? "the tool reported failure with no message"),
-                        RedactionCategories.All),
+                    ReportedFailureText.Cap(
+                        _redactionFilter.Redact(
+                            result.Error ?? "the tool reported failure with no message",
+                            RedactionCategories.All)),
                     null))
             .ConfigureAwait(false);
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -1,11 +1,13 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.AI.Models;
+using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config.AI.DirectToolInvocation;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -61,6 +63,7 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     private readonly IToolCatalog _catalog;
     private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IOptionsMonitor<DirectToolInvocationConfig> _config;
+    private readonly IContentRedactionFilter _redactionFilter;
     private readonly ILogger<DirectToolInvoker> _logger;
 
     /// <summary>Initializes the invoker.</summary>
@@ -68,24 +71,28 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     /// <param name="catalog">Resolves the tool, filtered to the caller's grant.</param>
     /// <param name="sanitizer">Scrubs everything leaving the trust boundary.</param>
     /// <param name="config">The host's direct-invocation settings, read per request.</param>
+    /// <param name="redactionFilter">Scrubs a failed call's error text before it reaches the audit trail.</param>
     /// <param name="logger">Records denials, faults, and the governance trace.</param>
     public DirectToolInvoker(
         IServiceScopeFactory scopeFactory,
         IToolCatalog catalog,
         ICompositeResponseSanitizer sanitizer,
         IOptionsMonitor<DirectToolInvocationConfig> config,
+        IContentRedactionFilter redactionFilter,
         ILogger<DirectToolInvoker> logger)
     {
         ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(redactionFilter);
         ArgumentNullException.ThrowIfNull(logger);
 
         _scopeFactory = scopeFactory;
         _catalog = catalog;
         _sanitizer = sanitizer;
         _config = config;
+        _redactionFilter = redactionFilter;
         _logger = logger;
     }
 
@@ -271,7 +278,10 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
                 ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
                 : new ToolExecutionReport(
                     EscalationExecutionStatus.Failed,
-                    result.Error ?? "the tool reported failure with no message", null))
+                    _redactionFilter.Redact(
+                        ReportedFailureText.Cap(result.Error ?? "the tool reported failure with no message"),
+                        RedactionCategories.All),
+                    null))
             .ConfigureAwait(false);
 
         sw.Stop();

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -172,7 +172,7 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
                 ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
                 : new ToolExecutionReport(
                     EscalationExecutionStatus.Failed,
-                    _redactionFilter.Redact(ReportedFailureText.Cap(failureText), RedactionCategories.All),
+                    ReportedFailureText.Cap(_redactionFilter.Redact(failureText, RedactionCategories.All)),
                     null),
             ReportedBy, CancellationToken.None).ConfigureAwait(false);
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -1,7 +1,9 @@
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
+using Domain.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using System.Text.Json;
 
@@ -30,10 +32,11 @@ namespace Application.AI.Common.Services.Tools;
 /// <para>
 /// This is the invocation-time chokepoint for the agent's autonomous tool calls, applied to every
 /// converted tool regardless of source (keyed-DI, MCP, or skill-provided) — the admission check
-/// itself runs unconditionally for all three. <strong>Failure detection on a no-throw return does
-/// not share that uniformity</strong>: it can only recognize a <see cref="ConvertedToolFailure"/>,
-/// which only a keyed-DI tool converted via <c>AIToolConverter</c> can produce (see
-/// <see cref="ReportOutcomeAndApplyPolicyAsync"/>'s remarks) — tracked as #451.
+/// itself runs unconditionally for all three. Failure detection on a no-throw return recognizes two
+/// shapes: a <see cref="ConvertedToolFailure"/> (produced only by <c>AIToolConverter</c>, which every
+/// <c>ITool</c>-backed tool — keyed-DI or skill-provided — is converted through), and an MCP
+/// <c>CallToolResult</c> with <c>isError: true</c> (see <see cref="ReportOutcomeAndApplyPolicyAsync"/>'s
+/// remarks for why an MCP failure takes a different shape and how it's recognized).
 /// </para>
 /// <para>
 /// <strong>Also the carrier for tool-composition findings.</strong> <c>ToolChainBuilder</c> stamps a
@@ -52,11 +55,31 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     private const string ReportedBy = "agent-turn";
 
     private readonly ToolCompositionTaint? _compositionTaint;
+    private readonly IContentRedactionFilter _redactionFilter;
+    private readonly bool _isMcpSourced;
 
-    public GovernedAIFunction(AIFunction innerFunction, ToolCompositionTaint? compositionTaint = null)
+    /// <param name="innerFunction">The tool function this wrapper governs.</param>
+    /// <param name="redactionFilter">Scrubs a failed call's error text before it's reported.</param>
+    /// <param name="isMcpSourced">
+    /// Whether <paramref name="innerFunction"/> came from an MCP server — <see langword="false"/> by
+    /// default, which is the safe default for any caller that does not track provenance (e.g.
+    /// <c>GoverningToolContextProvider</c>, whose <c>AIContext.Tools</c> channel has no equivalent to
+    /// <c>ToolChainBuilder</c>'s <c>ProvisionedTool.McpServerName</c>). Gates
+    /// <see cref="TryGetMcpFailureText"/> — see that method's remarks for why an ungated check is
+    /// unsafe.
+    /// </param>
+    public GovernedAIFunction(
+        AIFunction innerFunction,
+        IContentRedactionFilter redactionFilter,
+        ToolCompositionTaint? compositionTaint = null,
+        bool isMcpSourced = false)
         : base(innerFunction)
     {
+        ArgumentNullException.ThrowIfNull(redactionFilter);
+
+        _redactionFilter = redactionFilter;
         _compositionTaint = compositionTaint;
+        _isMcpSourced = isMcpSourced;
     }
 
     /// <summary>
@@ -68,6 +91,13 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     /// the base member itself.
     /// </summary>
     internal AIFunction Inner => InnerFunction;
+
+    /// <summary>
+    /// Carries <see cref="_isMcpSourced"/> across a composition-taint rewrap, for the same reason
+    /// <see cref="Inner"/> exists — <c>ToolChainBuilder.ApplyCompositionTaint</c> constructs a new
+    /// instance around the same inner function and must not silently reset this to its default.
+    /// </summary>
+    internal bool IsMcpSourced => _isMcpSourced;
 
     protected override async ValueTask<object?> InvokeCoreAsync(
         AIFunctionArguments arguments,
@@ -105,39 +135,84 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
 
     /// <summary>
     /// Reports what a no-throw return actually was — Succeeded, or Failed with the tool's own error
-    /// text when <paramref name="result"/> unwraps to a <see cref="ConvertedToolFailure"/> — then
-    /// applies output policy to the unwrapped value.
+    /// text (redacted before it leaves this method) — then applies output policy to the unwrapped
+    /// value.
     /// </summary>
     /// <remarks>
-    /// A <see cref="ConvertedToolFailure"/> came from <c>AIToolConverter</c>'s <c>ToolResult.Fail</c>
-    /// flattening — reported <see cref="EscalationExecutionStatus.Failed"/> with the tool's own error
-    /// text, the same status <c>DirectToolInvoker</c> already reports for the identical case. Every
-    /// other <see cref="AIFunction"/> source (MCP-provided, skill-provided) has no equivalent marker —
-    /// a non-throwing failure from one of those is still reported
-    /// <see cref="EscalationExecutionStatus.Succeeded"/>, since <see cref="ConvertedToolFailure"/> is
-    /// only ever produced by <c>AIToolConverter</c> (and only survives to here because it pairs the
-    /// marker with a <c>MarshalResult</c> delegate that bypasses the framework's default JSON
-    /// serialization — see the marker's own remarks). Fixing that would mean changing what every tool
-    /// source signals on failure, which is out of scope here — this closes the gap for ITool-backed
-    /// tools specifically, per the converter-wide framing the fix was scoped to. Tracked separately
-    /// as #451.
+    /// Two failure shapes are recognized. A <see cref="ConvertedToolFailure"/> came from
+    /// <c>AIToolConverter</c>'s <c>ToolResult.Fail</c> flattening — every <c>ITool</c>-backed tool,
+    /// keyed-DI or skill-provided, is converted through <c>AIToolConverter</c>, so this covers both.
+    /// An MCP-provided tool has no such marker: confirmed against the MCP C# SDK's
+    /// <c>McpClientTool.InvokeCoreAsync</c> source, a tool call whose <c>CallToolResult.IsError</c> is
+    /// <see langword="true"/> returns normally — <c>JsonSerializer.SerializeToElement(result, ...)</c>
+    /// — it never throws. <see cref="TryGetMcpFailureText"/> recognizes that shape by structure
+    /// (<c>isError</c> + <c>content</c>, the MCP wire shape) rather than by depending on the MCP
+    /// client SDK's own types, keeping this generic invocation chokepoint free of a dependency on one
+    /// specific tool source's protocol library — but only runs when <see cref="_isMcpSourced"/> says
+    /// this instance actually wraps an MCP tool: a keyed-DI or skill-provided tool whose own genuine
+    /// success payload happens to be a JSON object shaped <c>{"isError":true,"content":[...]}</c> for
+    /// unrelated business reasons must not be misreported as a failed call — the same "shared field,
+    /// two meanings depending on the producer" trap this repo's own CLAUDE.md already tracks. Both
+    /// failure shapes report <see cref="EscalationExecutionStatus.Failed"/> with the tool's own error
+    /// text — the same status <c>DirectToolInvoker</c> already reports for the identical case — through
+    /// the redaction filter first: this text is about to reach the audit trail, the failure memory
+    /// replayed to a human approver, and the AG-UI event stream, none of which have seen the
+    /// classification gate's redaction verdict the way
+    /// <see cref="IToolCallAdmissionPipeline.ApplyOutputPolicy"/>'s model-facing copy does below.
     /// </remarks>
     private async ValueTask<object?> ReportOutcomeAndApplyPolicyAsync(
         IToolCallAdmissionPipeline admissionPipeline, ToolCallAdmission admission, object? result)
     {
-        // failure.ErrorText is reported to ReportExecutionAsync before ApplyOutputPolicy runs below,
-        // so the classification gate's redaction verdict reaches the model-facing copy but not this
-        // one — matching DirectToolInvoker's identical reporting shape (result.Error, same ordering)
-        // rather than a gap this method introduces. Tracked as #452.
         var failure = result as ConvertedToolFailure;
+        var failureText = failure?.ErrorText ?? (_isMcpSourced ? TryGetMcpFailureText(result) : null);
+
         await admissionPipeline.ReportExecutionAsync(
             admission,
-            failure is null
+            failureText is null
                 ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
-                : new ToolExecutionReport(EscalationExecutionStatus.Failed, failure.ErrorText, null),
+                : new ToolExecutionReport(
+                    EscalationExecutionStatus.Failed,
+                    _redactionFilter.Redact(ReportedFailureText.Cap(failureText), RedactionCategories.All),
+                    null),
             ReportedBy, CancellationToken.None).ConfigureAwait(false);
 
         return admissionPipeline.ApplyOutputPolicy(admission, Name, Unwrap(result));
+    }
+
+    /// <summary>
+    /// Recognizes an MCP tool failure by the shape the protocol actually puts on the wire — a JSON
+    /// object with <c>isError: true</c> and a <c>content</c> array of text blocks — without taking a
+    /// dependency on the MCP client SDK's <c>CallToolResult</c> type in this generic, source-agnostic
+    /// invocation chokepoint. Returns <see langword="null"/> for anything that isn't that shape,
+    /// including a genuine success (which reaches here as a <see cref="JsonElement"/> too, just
+    /// without <c>isError: true</c>).
+    /// </summary>
+    /// <remarks>
+    /// This is a structural, not a provenance, check — it recognizes the MCP wire shape wherever it
+    /// appears, and cannot on its own tell an MCP tool's genuine failure from some other tool's genuine
+    /// success that happens to be a JSON object using the same field names for unrelated reasons.
+    /// Callers must gate this on actually knowing the result came from an MCP tool (see
+    /// <see cref="_isMcpSourced"/>) rather than calling it unconditionally on every result.
+    /// </remarks>
+    private static string? TryGetMcpFailureText(object? result)
+    {
+        if (result is not JsonElement { ValueKind: JsonValueKind.Object } element)
+            return null;
+
+        if (!element.TryGetProperty("isError", out var isError) || isError.ValueKind != JsonValueKind.True)
+            return null;
+
+        if (element.TryGetProperty("content", out var content) && content.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var block in content.EnumerateArray())
+            {
+                if (block.ValueKind == JsonValueKind.Object
+                    && block.TryGetProperty("text", out var text) && text.ValueKind == JsonValueKind.String)
+                    return text.GetString();
+            }
+        }
+
+        return "MCP tool reported failure with no message.";
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
@@ -1,22 +1,46 @@
 namespace Application.AI.Common.Services.Tools;
 
 /// <summary>
-/// Bounds a failure message before it is redacted and reported, so a hostile or malfunctioning tool
-/// source cannot make the audit trail pay for an unbounded regex sweep and an unbounded persisted
-/// record.
+/// Bounds an already-redacted failure message before it is reported, so an unbounded tool failure
+/// cannot make <c>EscalationExecutionRecord.FailureReason</c> pay for an unbounded persisted record.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Shared by <see cref="GovernedAIFunction"/> and <see cref="DirectToolInvoker"/> — both reporting
 /// chokepoints face the same threat model: an MCP server (or any other tool source this process does
-/// not control) can return arbitrarily large failure text, which <see cref="Interfaces.Telemetry.IContentRedactionFilter"/>
-/// would otherwise run its full rule set over, and which <c>EscalationExecutionRecord.FailureReason</c>
+/// not control) can return arbitrarily large failure text, which <c>EscalationExecutionRecord.FailureReason</c>
 /// would otherwise persist without limit.
+/// </para>
+/// <para>
+/// Callers MUST call <see cref="Cap"/> on the result of
+/// <see cref="Interfaces.Telemetry.IContentRedactionFilter.Redact"/>, never the other way round: capping
+/// first can slice a real secret in half at the length boundary, and the truncated fragment that
+/// survives is never run back through the redaction filter, so it reaches the audit trail as-is.
+/// Redacting the full, uncapped text first and bounding the (already-safe) result afterward is the
+/// only ordering that can't leak a fragment.
+/// </para>
 /// </remarks>
 internal static class ReportedFailureText
 {
     private const int MaxLength = 4096;
 
-    /// <summary>Truncates <paramref name="text"/> to a bounded length, if it exceeds one.</summary>
-    public static string Cap(string text) =>
-        text.Length > MaxLength ? string.Concat(text.AsSpan(0, MaxLength), "…[truncated]") : text;
+    /// <summary>
+    /// Truncates <paramref name="text"/> to a bounded length, if it exceeds one. Never splits a
+    /// surrogate pair — a cut that would land inside one backs off by one character instead, so the
+    /// result is always a well-formed string.
+    /// </summary>
+    public static string Cap(string text)
+    {
+        if (text.Length <= MaxLength)
+        {
+            return text;
+        }
+
+        var cutIndex = MaxLength;
+        if (char.IsHighSurrogate(text[cutIndex - 1]))
+        {
+            cutIndex--;
+        }
+        return string.Concat(text.AsSpan(0, cutIndex), "…[truncated]");
+    }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
@@ -1,0 +1,22 @@
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Bounds a failure message before it is redacted and reported, so a hostile or malfunctioning tool
+/// source cannot make the audit trail pay for an unbounded regex sweep and an unbounded persisted
+/// record.
+/// </summary>
+/// <remarks>
+/// Shared by <see cref="GovernedAIFunction"/> and <see cref="DirectToolInvoker"/> — both reporting
+/// chokepoints face the same threat model: an MCP server (or any other tool source this process does
+/// not control) can return arbitrarily large failure text, which <see cref="Interfaces.Telemetry.IContentRedactionFilter"/>
+/// would otherwise run its full rule set over, and which <c>EscalationExecutionRecord.FailureReason</c>
+/// would otherwise persist without limit.
+/// </remarks>
+internal static class ReportedFailureText
+{
+    private const int MaxLength = 4096;
+
+    /// <summary>Truncates <paramref name="text"/> to a bounded length, if it exceeds one.</summary>
+    public static string Cap(string text) =>
+        text.Length > MaxLength ? string.Concat(text.AsSpan(0, MaxLength), "…[truncated]") : text;
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/SafeFailureText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/SafeFailureText.cs
@@ -1,0 +1,25 @@
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Formats a caught exception into a failure message that names the exception's type without ever
+/// echoing <see cref="Exception.Message"/>.
+/// </summary>
+/// <remarks>
+/// A caught exception's message can carry a secret (a connection string, a SAS token, a credential
+/// embedded in a malformed argument) that the caller never intended to surface. The type name alone
+/// is enough for a human or an agent to recognize the failure shape without risking that leak — the
+/// same convention this harness already used before this helper existed
+/// (<c>MediatorDispatchRunner.cs</c>, <c>WorkspaceCommandRunner.cs</c>) and that a security review
+/// found hand-copied, with no shared mechanism, into eight more call sites across gates and tools.
+/// Centralizing it here means the next catch block added anywhere can't reintroduce the raw-message
+/// leak by hand.
+/// </remarks>
+public static class SafeFailureText
+{
+    /// <summary>
+    /// Returns <c>"{prefix}: {ex.GetType().Name}."</c> — never <paramref name="ex"/>'s own message.
+    /// </summary>
+    /// <param name="prefix">What was being attempted, e.g. <c>"Invalid ingest arguments"</c>.</param>
+    /// <param name="ex">The caught exception. Only its type name is used.</param>
+    public static string For(string prefix, Exception ex) => $"{prefix}: {ex.GetType().Name}.";
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Governance;
@@ -24,6 +25,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
 {
     private readonly ILogger<ToolChainBuilder> _logger;
     private readonly IServiceProvider _serviceProvider;
+    private readonly IContentRedactionFilter _redactionFilter;
     private readonly IToolConverter? _toolConverter;
     private readonly IMcpToolProvider? _mcpToolProvider;
     private readonly IMcpToolSurfaceScanner? _surfaceScanner;
@@ -34,6 +36,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
     public ToolChainBuilder(
         ILogger<ToolChainBuilder> logger,
         IServiceProvider serviceProvider,
+        IContentRedactionFilter redactionFilter,
         IToolConverter? toolConverter = null,
         IMcpToolProvider? mcpToolProvider = null,
         IMcpToolSurfaceScanner? surfaceScanner = null,
@@ -41,8 +44,11 @@ public partial class ToolChainBuilder : IToolChainBuilder
         IToolCompositionAnalyzer? compositionAnalyzer = null,
         ToolCompositionReporter? compositionReporter = null)
     {
+        ArgumentNullException.ThrowIfNull(redactionFilter);
+
         _logger = logger;
         _serviceProvider = serviceProvider;
+        _redactionFilter = redactionFilter;
         _toolConverter = toolConverter;
         _mcpToolProvider = mcpToolProvider;
         _surfaceScanner = surfaceScanner;
@@ -257,7 +263,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         var survivors = ReservedPlanCapabilityFilter.Exclude(provisioned.Select(p => p.Tool), source, _logger);
         var afterReservedFilter = KeepSurviving(provisioned, survivors);
 
-        var wrapped = WrapGoverned(afterReservedFilter.Select(p => p.Tool));
+        var wrapped = WrapGoverned(afterReservedFilter);
         return afterReservedFilter.Zip(wrapped, (p, w) => p with { Tool = w }).ToList();
     }
 
@@ -278,9 +284,17 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// Applied at this single shared builder so every agent-callable tool — keyed-DI, MCP, or
     /// skill-provided — is governed exactly once.
     /// </summary>
-    private static List<AITool> WrapGoverned(IEnumerable<AITool> tools)
-        => tools
-            .Select(t => t is AIFunction fn and not GovernedAIFunction ? new GovernedAIFunction(fn) : t)
+    /// <remarks>
+    /// Passes each tool's own <see cref="ProvisionedTool.McpServerName"/> through as
+    /// <c>isMcpSourced</c> so <see cref="GovernedAIFunction"/>'s MCP-failure-shape detection only runs
+    /// for tools that actually came from an MCP server — this is the provenance this builder already
+    /// tracks positionally (see <see cref="ProvisionedTool"/>'s remarks), not re-derived.
+    /// </remarks>
+    private List<AITool> WrapGoverned(IEnumerable<ProvisionedTool> provisioned)
+        => provisioned
+            .Select(p => p.Tool is AIFunction fn and not GovernedAIFunction
+                ? new GovernedAIFunction(fn, _redactionFilter, isMcpSourced: p.McpServerName is not null)
+                : p.Tool)
             .ToList();
 
     /// <inheritdoc />
@@ -414,7 +428,8 @@ public partial class ToolChainBuilder : IToolChainBuilder
             // Re-wrap rather than mutate: the taint is set once, in the constructor, so carrying a
             // finding discovered by THIS analysis means unwrapping to the same inner function and
             // rewrapping — never double-governing, since InnerFunction always points at the real tool.
-            return (AITool)new GovernedAIFunction(governed.Inner, new ToolCompositionTaint(findings));
+            return (AITool)new GovernedAIFunction(
+                governed.Inner, _redactionFilter, new ToolCompositionTaint(findings), governed.IsMcpSourced);
         }).ToList();
     }
 

--- a/src/Content/Application/Application.Common/MediatRBehaviors/RequestTracingBehavior.cs
+++ b/src/Content/Application/Application.Common/MediatRBehaviors/RequestTracingBehavior.cs
@@ -45,11 +45,20 @@ public sealed class RequestTracingBehavior<TRequest, TResponse>
         }
         catch (Exception ex)
         {
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            // Type name only, never ex.Message — this behavior wraps every command/query in the
+            // app, so a request handler that throws with a secret in its message (connection
+            // string, SAS token) must not have that message land in the exported span. Matches
+            // the convention MediatorDispatchRunner/WorkspaceCommandRunner already use; this file
+            // (Application.Common) has no reachable IContentRedactionFilter — that interface lives
+            // in Application.AI.Common, a layer above this one — so pattern-based redaction isn't
+            // an option here without moving the interface, which is a bigger architectural change
+            // than this fix.
+            var typeName = ex.GetType().Name;
+            activity?.SetStatus(ActivityStatusCode.Error, typeName);
             activity?.AddEvent(new ActivityEvent("exception", tags: new ActivityTagsCollection
             {
                 { "exception.type", ex.GetType().FullName },
-                { "exception.message", ex.Message }
+                { "exception.message", typeName }
             }));
             throw;
         }

--- a/src/Content/Domain/Domain.AI/Telemetry/Redaction/RedactionCategory.cs
+++ b/src/Content/Domain/Domain.AI/Telemetry/Redaction/RedactionCategory.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+
 namespace Domain.AI.Telemetry.Redaction;
 
 /// <summary>
@@ -37,4 +39,26 @@ public enum RedactionCategory
 
     /// <summary>Catch-all bucket for harness-vendored generic secret patterns.</summary>
     Generic = 7,
+}
+
+/// <summary>
+/// The canonical "every category" source for a caller that redacts unconditionally rather than
+/// against a configured subset.
+/// </summary>
+/// <remarks>
+/// Before this existed, every unconditional-redaction call site declared its own private
+/// <c>Enum.GetValues&lt;RedactionCategory&gt;()</c> array with a near-identical justification
+/// comment — four independent copies across the log, span, and tool-reporting redaction paths.
+/// A category added to the enum only needs this one array updated implicitly (it's computed, not
+/// enumerated by hand) for every caller that references it to pick it up.
+/// </remarks>
+public static class RedactionCategories
+{
+    /// <summary>
+    /// Every <see cref="RedactionCategory"/> value. Use where redaction must always run in full —
+    /// the audit trail, escalation memory, and AG-UI stream a failed tool call's error text reaches,
+    /// and the OTLP trace exporter a recorded exception reaches — none of which are optional
+    /// telemetry a consumer can choose to leave unredacted.
+    /// </summary>
+    public static readonly ImmutableArray<RedactionCategory> All = [.. Enum.GetValues<RedactionCategory>()];
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -268,10 +268,16 @@ public sealed partial class CapabilityMatchSupervisor
         }
         catch (Exception ex)
         {
+            // Full detail stays in the structured log only — ex.Message can carry a secret (connection
+            // string, SAS token), and RecordFailure/DelegationResult.Fail both write into surfaces that
+            // reach the audit trail and, via DelegateToSubagentTool.cs's ToolResult.Fail(result.FailureReason
+            // ?? ...), a governed tool's reported failure text. Matches the ex.GetType().Name-only
+            // convention MediatorDispatchRunner/WorkspaceCommandRunner already use.
             _logger.LogError(ex, "Delegation {DelegationId} to {AgentId} failed",
                 delegationId, selection.SelectedAgent.AgentId);
-            await RecordFailure(pendingRecord, ex.Message, ct);
-            return DelegationResult.Fail(ex.Message);
+            var reason = $"Delegation failed: {ex.GetType().Name}.";
+            await RecordFailure(pendingRecord, reason, ct);
+            return DelegationResult.Fail(reason);
         }
         finally
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services;
+using Application.AI.Common.Services.Tools;
 using Domain.Common.Helpers;
 using Domain.AI.Agents;
 using Domain.AI.Escalation;
@@ -275,7 +276,7 @@ public sealed partial class CapabilityMatchSupervisor
             // convention MediatorDispatchRunner/WorkspaceCommandRunner already use.
             _logger.LogError(ex, "Delegation {DelegationId} to {AgentId} failed",
                 delegationId, selection.SelectedAgent.AgentId);
-            var reason = $"Delegation failed: {ex.GetType().Name}.";
+            var reason = SafeFailureText.For("Delegation failed", ex);
             await RecordFailure(pendingRecord, reason, ct);
             return DelegationResult.Fail(reason);
         }

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
@@ -95,7 +95,7 @@ public sealed class PolicyGate : IChangeProposalGate
                     "Policy '{PolicyKey}' threw evaluating proposal {ProposalId}.",
                     policy.Key,
                     proposal.Id);
-                return GateResult.Fail($"Policy '{policy.Key}' threw: {ex.GetType().Name}: {ex.Message}");
+                return GateResult.Fail($"Policy '{policy.Key}' threw: {ex.GetType().Name}.");
             }
 
             allFindings.AddRange(findings);

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Services.Tools;
 using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.Common.Config;
@@ -95,7 +96,7 @@ public sealed class PolicyGate : IChangeProposalGate
                     "Policy '{PolicyKey}' threw evaluating proposal {ProposalId}.",
                     policy.Key,
                     proposal.Id);
-                return GateResult.Fail($"Policy '{policy.Key}' threw: {ex.GetType().Name}.");
+                return GateResult.Fail(SafeFailureText.For($"Policy '{policy.Key}' threw", ex));
             }
 
             allFindings.AddRange(findings);

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/SelfValidationGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/SelfValidationGate.cs
@@ -85,7 +85,7 @@ public sealed class SelfValidationGate : IChangeProposalGate
                     "Validator '{ValidatorKey}' threw evaluating proposal {ProposalId}.",
                     validator.Key,
                     proposal.Id);
-                return GateResult.Fail($"Validator '{validator.Key}' threw: {ex.GetType().Name}: {ex.Message}");
+                return GateResult.Fail($"Validator '{validator.Key}' threw: {ex.GetType().Name}.");
             }
 
             switch (result.Action)

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/SelfValidationGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/SelfValidationGate.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Changes;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Changes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -85,7 +86,7 @@ public sealed class SelfValidationGate : IChangeProposalGate
                     "Validator '{ValidatorKey}' threw evaluating proposal {ProposalId}.",
                     validator.Key,
                     proposal.Id);
-                return GateResult.Fail($"Validator '{validator.Key}' threw: {ex.GetType().Name}.");
+                return GateResult.Fail(SafeFailureText.For($"Validator '{validator.Key}' threw", ex));
             }
 
             switch (result.Action)

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
@@ -135,7 +135,16 @@ public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
     // are catastrophically backtracking (bounded repetition throughout), but content reaching this
     // filter can originate from an external MCP server the caller does not control, so a timeout is
     // defense in depth against a future rule — or a consumer's own added rule — that isn't as careful.
-    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(200);
+    //
+    // 2 seconds, not the 200ms this started at: this repo's sibling regex-based redactor
+    // (Infrastructure.AI/Security/PatternSecretRedactor.cs) measured 100ms as too tight in
+    // practice — it reproduced RegexMatchTimeoutException on a 20-character input under nothing
+    // more exotic than a full-solution parallel test run, CPU scheduling contention alone, not
+    // backtracking, pushed a trivial match past the deadline. This filter runs the same shape of
+    // single flat scan (Redact() loops over a handful of independent patterns, same as that
+    // sibling's regex-only path), so it carries the identical exposure and gets the identical,
+    // already-proven fix rather than a tighter, untested value.
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromSeconds(2);
 
     private static CompiledRule Compile(RedactionCategory category, string pattern, string replacement)
         => new(category,

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
@@ -131,9 +131,15 @@ public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
         return b.ToImmutable();
     }
 
+    // A caller-supplied match timeout, not just RegexOptions.Compiled: none of the built-in patterns
+    // are catastrophically backtracking (bounded repetition throughout), but content reaching this
+    // filter can originate from an external MCP server the caller does not control, so a timeout is
+    // defense in depth against a future rule — or a consumer's own added rule — that isn't as careful.
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(200);
+
     private static CompiledRule Compile(RedactionCategory category, string pattern, string replacement)
         => new(category,
-            new Regex(pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant),
+            new Regex(pattern, RegexOptions.Compiled | RegexOptions.CultureInvariant, MatchTimeout),
             replacement);
 
     private sealed record CompiledRule(RedactionCategory Category, Regex Pattern, string Replacement);

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Changes;
 using Domain.AI.Models;
 
@@ -99,7 +100,7 @@ public abstract class BlockingProxyTool : ITool
         }
         catch (InvalidOperationException ex)
         {
-            return ToolResult.Fail($"{Name} invocation failed: {ex.GetType().Name}.");
+            return ToolResult.Fail(SafeFailureText.For($"{Name} invocation failed", ex));
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/BlockingProxyTool.cs
@@ -99,7 +99,7 @@ public abstract class BlockingProxyTool : ITool
         }
         catch (InvalidOperationException ex)
         {
-            return ToolResult.Fail(ex.Message);
+            return ToolResult.Fail($"{Name} invocation failed: {ex.GetType().Name}.");
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
@@ -159,7 +159,7 @@ public sealed class DelegateToSubagentTool : ITool
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Delegation threw; surfacing as a tool failure");
-            return ToolResult.Fail($"Delegation failed: {ex.Message}");
+            return ToolResult.Fail($"Delegation failed: {ex.GetType().Name}.");
         }
         finally
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Domain.Common.Helpers;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
@@ -159,7 +160,7 @@ public sealed class DelegateToSubagentTool : ITool
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Delegation threw; surfacing as a tool failure");
-            return ToolResult.Fail($"Delegation failed: {ex.GetType().Name}.");
+            return ToolResult.Fail(SafeFailureText.For("Delegation failed", ex));
         }
         finally
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -129,7 +129,8 @@ public sealed class DocumentIngestTool : ITool
         }
         catch (ArgumentException ex)
         {
-            return ToolResult.Fail(ex.Message);
+            _logger.LogWarning(ex, "Ingest arguments rejected");
+            return ToolResult.Fail($"Invalid ingest arguments: {ex.GetType().Name}.");
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentIngestTool.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Application.Core.CQRS.RAG.IngestDocument;
 using Domain.AI.Changes;
 using Domain.Common.Config.AI.Governance;
@@ -130,7 +131,7 @@ public sealed class DocumentIngestTool : ITool
         catch (ArgumentException ex)
         {
             _logger.LogWarning(ex, "Ingest arguments rejected");
-            return ToolResult.Fail($"Invalid ingest arguments: {ex.GetType().Name}.");
+            return ToolResult.Fail(SafeFailureText.For("Invalid ingest arguments", ex));
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Changes;
 using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
@@ -120,7 +121,7 @@ public sealed class DocumentSearchTool : ITool
         }
         catch (ArgumentException ex)
         {
-            return ToolResult.Fail($"Invalid search arguments: {ex.GetType().Name}.");
+            return ToolResult.Fail(SafeFailureText.For("Invalid search arguments", ex));
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DocumentSearchTool.cs
@@ -120,7 +120,7 @@ public sealed class DocumentSearchTool : ITool
         }
         catch (ArgumentException ex)
         {
-            return ToolResult.Fail(ex.Message);
+            return ToolResult.Fail($"Invalid search arguments: {ex.GetType().Name}.");
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RestrictedSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RestrictedSearchTool.cs
@@ -166,7 +166,8 @@ public sealed class RestrictedSearchTool : ITool
         }
         catch (Exception ex)
         {
-            return ToolResult.Fail($"Invalid path: {ex.Message}");
+            _logger.LogWarning(ex, "Path resolution rejected for working directory or trace root");
+            return ToolResult.Fail($"Invalid path: {ex.GetType().Name}.");
         }
 
         if (!IsPathSafe(resolvedWorkingDir, resolvedRoot))
@@ -215,7 +216,8 @@ public sealed class RestrictedSearchTool : ITool
         }
         catch (Exception ex)
         {
-            return ToolResult.Fail($"Failed to start process '{binary}': {ex.Message}");
+            _logger.LogWarning(ex, "Failed to start restricted process {Binary}", binary);
+            return ToolResult.Fail($"Failed to start process '{binary}': {ex.GetType().Name}.");
         }
 
         // Step 5: Output cap + timeout (both stdout and stderr capped to prevent OOM)

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/RestrictedSearchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/RestrictedSearchTool.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.AI.Sandbox;
@@ -167,7 +168,7 @@ public sealed class RestrictedSearchTool : ITool
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Path resolution rejected for working directory or trace root");
-            return ToolResult.Fail($"Invalid path: {ex.GetType().Name}.");
+            return ToolResult.Fail(SafeFailureText.For("Invalid path", ex));
         }
 
         if (!IsPathSafe(resolvedWorkingDir, resolvedRoot))
@@ -217,7 +218,7 @@ public sealed class RestrictedSearchTool : ITool
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to start restricted process {Binary}", binary);
-            return ToolResult.Fail($"Failed to start process '{binary}': {ex.GetType().Name}.");
+            return ToolResult.Fail(SafeFailureText.For($"Failed to start process '{binary}'", ex));
         }
 
         // Step 5: Output cap + timeout (both stdout and stderr capped to prevent OOM)

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -11,11 +11,13 @@ namespace Infrastructure.Observability.Processors;
 /// <summary>
 /// Scrubs PII / secret content from OpenTelemetry <see cref="LogRecord"/>s before
 /// they reach any exporter. The log-signal sibling of the span-side
-/// <see cref="PiiFilteringProcessor"/> — both reuse the harness's content redactor,
-/// but the parity is partial: <see cref="PiiFilteringProcessor"/> only deletes/hashes
-/// span tags by exact key, it does not pattern-scan span exception events the way
-/// this processor's <see cref="RedactException"/> pattern-scans a log's exception —
-/// tracked as #450.
+/// <see cref="PiiFilteringProcessor"/> — both reuse the harness's content redactor, though the two
+/// scrub at different points for the same reason: <see cref="PiiFilteringProcessor"/> only
+/// deletes/hashes span tags by exact key and cannot pattern-scan a span's exception event after the
+/// fact — <c>ActivityEvent</c> is immutable once added — so the equivalent free-text scrub for
+/// exception content on spans happens earlier, in
+/// <c>Presentation.Common.Extensions.OpenTelemetryServiceCollectionExtensions.BuildRedactingExceptionEnricher</c>,
+/// rather than in a processor here.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -51,7 +53,7 @@ namespace Infrastructure.Observability.Processors;
 public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
 {
     private readonly IContentRedactionFilter _filter;
-    private readonly RedactionCategory[] _categories;
+    private readonly IReadOnlyList<RedactionCategory> _categories;
     private readonly bool _enabled;
 
     /// <summary>
@@ -79,25 +81,25 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
         // redaction is requested but no category resolves, over-redact with the full set rather
         // than silently emitting unredacted PII. Matches the redactor's conservative-by-default
         // posture (a false positive that masks text is acceptable; a leaked PAN is not).
-        if (_enabled && _categories.Length == 0)
+        if (_enabled && _categories.Count == 0)
         {
-            _categories = Enum.GetValues<RedactionCategory>();
+            _categories = RedactionCategories.All;
             logger.LogWarning(
                 "Log redaction is enabled but no valid categories were configured; falling back " +
                 "to the full redaction set ({CategoryCount} categories) to avoid emitting unredacted PII.",
-                _categories.Length);
+                _categories.Count);
         }
 
         logger.LogInformation(
             "Log-record redaction initialized: enabled={Enabled}, {CategoryCount} categories active.",
             _enabled,
-            _categories.Length);
+            _categories.Count);
     }
 
     /// <inheritdoc />
     public override void OnEnd(LogRecord data)
     {
-        if (!_enabled || _categories.Length == 0 || data is null)
+        if (!_enabled || _categories.Count == 0 || data is null)
         {
             return;
         }

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Application.AI.Common.Interfaces.Telemetry;
 using Domain.Common.Helpers;
 using Domain.AI.Telemetry.Redaction;
@@ -53,7 +54,7 @@ namespace Infrastructure.Observability.Processors;
 public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
 {
     private readonly IContentRedactionFilter _filter;
-    private readonly IReadOnlyList<RedactionCategory> _categories;
+    private readonly ImmutableArray<RedactionCategory> _categories;
     private readonly bool _enabled;
 
     /// <summary>
@@ -81,25 +82,25 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
         // redaction is requested but no category resolves, over-redact with the full set rather
         // than silently emitting unredacted PII. Matches the redactor's conservative-by-default
         // posture (a false positive that masks text is acceptable; a leaked PAN is not).
-        if (_enabled && _categories.Count == 0)
+        if (_enabled && _categories.Length == 0)
         {
             _categories = RedactionCategories.All;
             logger.LogWarning(
                 "Log redaction is enabled but no valid categories were configured; falling back " +
                 "to the full redaction set ({CategoryCount} categories) to avoid emitting unredacted PII.",
-                _categories.Count);
+                _categories.Length);
         }
 
         logger.LogInformation(
             "Log-record redaction initialized: enabled={Enabled}, {CategoryCount} categories active.",
             _enabled,
-            _categories.Count);
+            _categories.Length);
     }
 
     /// <inheritdoc />
     public override void OnEnd(LogRecord data)
     {
-        if (!_enabled || _categories.Count == 0 || data is null)
+        if (!_enabled || _categories.Length == 0 || data is null)
         {
             return;
         }
@@ -234,7 +235,7 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
     /// (<c>LogsConfigValidator</c>) already rejects unknown names, so this is defence in
     /// depth for hosts that bypass the validated-options pipeline.
     /// </summary>
-    private static RedactionCategory[] ParseCategories(
+    private static ImmutableArray<RedactionCategory> ParseCategories(
         IReadOnlyList<string>? names,
         ILogger logger)
     {

--- a/src/Content/Presentation/Presentation.Common/Extensions/OpenTelemetryServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/OpenTelemetryServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config;
 using Domain.Common.Config.Observability;
 using Domain.Common.Telemetry;
@@ -14,6 +15,7 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using System.Diagnostics;
 using System.Reflection;
 
 namespace Presentation.Common.Extensions;
@@ -95,27 +97,36 @@ public static class OpenTelemetryServiceCollectionExtensions
     /// to defer configurator resolution until the real <see cref="IServiceProvider"/> is built,
     /// avoiding the <c>BuildServiceProvider()</c> anti-pattern that creates duplicate singletons.
     /// </remarks>
-    private static IServiceCollection AddWebTelemetry(this IServiceCollection services, AppConfig appConfig)
+    /// <remarks>
+    /// <c>internal</c> rather than <c>private</c> so
+    /// <c>OpenTelemetryTracingExceptionRedactionTests</c> can call it directly to verify the redaction
+    /// wiring against real DI-resolved options — <see cref="AddOpenTelemetry"/>'s own web/desktop
+    /// branch keys off <see cref="System.Reflection.Assembly.GetEntryAssembly"/>, which is the test
+    /// host in a test process, not a project named in <c>Observability:WebTelemetryProjects</c>, so
+    /// that entry point never reaches this method from a test.
+    /// </remarks>
+    internal static IServiceCollection AddWebTelemetry(this IServiceCollection services, AppConfig appConfig)
     {
-        services.Configure<AspNetCoreTraceInstrumentationOptions>(options =>
-        {
-            options.RecordException = true;
-            options.EnrichWithException = (activity, exception) =>
+        // PostConfigure, not Configure: this template is meant to be cloned and extended, and a
+        // consumer's own AddAspNetCoreInstrumentation(o => ...)/AddHttpClientInstrumentation(o => ...)
+        // call elsewhere in their composition root would otherwise be free to run after this Configure
+        // and silently flip RecordException back on or replace EnrichWithException, undoing the
+        // redaction with no signal that it happened. PostConfigure always runs after every Configure
+        // delegate for these options, regardless of registration order, closing that gap structurally
+        // instead of relying on this method running last.
+        services.AddOptions<AspNetCoreTraceInstrumentationOptions>()
+            .PostConfigure<IContentRedactionFilter>((options, filter) =>
             {
-                activity.SetTag("exception.type", exception.GetType().FullName);
-                activity.SetTag("exception.message", exception.Message);
-            };
-        });
+                options.RecordException = false;
+                options.EnrichWithException = BuildRedactingExceptionEnricher(filter);
+            });
 
-        services.Configure<HttpClientTraceInstrumentationOptions>(options =>
-        {
-            options.RecordException = true;
-            options.EnrichWithException = (activity, exception) =>
+        services.AddOptions<HttpClientTraceInstrumentationOptions>()
+            .PostConfigure<IContentRedactionFilter>((options, filter) =>
             {
-                activity.SetTag("exception.type", exception.GetType().FullName);
-                activity.SetTag("exception.message", exception.Message);
-            };
-        });
+                options.RecordException = false;
+                options.EnrichWithException = BuildRedactingExceptionEnricher(filter);
+            });
 
         services.AddOpenTelemetry()
             .WithTracing(builder =>
@@ -151,6 +162,58 @@ public static class OpenTelemetryServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Builds the exception-enrichment callback shared by ASP.NET Core and HttpClient trace
+    /// instrumentation. Redacts the exception's message and full <see cref="Exception.ToString"/>
+    /// text through <paramref name="filter"/> before either reaches the span — as the
+    /// <c>exception.type</c> / <c>exception.message</c> tags this callback sets directly on the
+    /// activity, and as the "exception" span event this callback constructs itself.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why this callback creates the span event itself instead of scrubbing the one the
+    /// instrumentation library creates.</strong> Confirmed against the .NET runtime source:
+    /// <see cref="ActivityEvent"/> is an immutable <see langword="readonly struct"/> — its tags are
+    /// copied into a private linked list at construction, with no public API to mutate an event
+    /// already added to <see cref="Activity.Events"/>, and <see cref="Activity.Events"/> itself has
+    /// no setter. A processor running after the span ends (the span-side sibling of
+    /// <see cref="LogRecordRedactionProcessor"/>) cannot scrub that event's tags after the fact — so
+    /// both instrumentation options this callback is registered on have <c>RecordException</c> set to
+    /// <see langword="false"/> (see <see cref="AddWebTelemetry"/>), suppressing the library's own
+    /// unredacted <c>Activity.AddException</c> call, and this callback calls it instead with content
+    /// that is already safe.
+    /// </para>
+    /// <para>
+    /// Passes an explicit <see cref="TagList"/> to <see cref="Activity.AddException"/> carrying both
+    /// the short redacted message and the full redacted detail — confirmed against the runtime's
+    /// <c>Activity.AddException</c> source: it only fills a tag from the exception's own (raw)
+    /// <see cref="Exception.Message"/> / <see cref="Exception.ToString"/> when that tag is not already
+    /// present in the list it's given, so pre-populating both here means none of the framework's own
+    /// unredacted population ever runs. The full <see cref="Exception.ToString"/> text (not just
+    /// <see cref="Exception.Message"/>) is what gets redacted for <c>exception.stacktrace</c> — it
+    /// recursively includes every <see cref="Exception.InnerException"/>'s own message, so a secret
+    /// nested in a wrapped exception's inner message is still caught even when the outer message is
+    /// clean, matching <see cref="LogRecordRedactionProcessor"/>'s <c>RedactException</c> — identical
+    /// reasoning on the log side.
+    /// </para>
+    /// </remarks>
+    internal static Action<Activity, Exception> BuildRedactingExceptionEnricher(IContentRedactionFilter filter) =>
+        (activity, exception) =>
+        {
+            var redactedMessage = filter.Redact(exception.Message, RedactionCategories.All);
+            var redactedDetail = filter.Redact(exception.ToString(), RedactionCategories.All);
+
+            activity.SetTag("exception.type", exception.GetType().FullName);
+            activity.SetTag("exception.message", redactedMessage);
+
+            var eventTags = new TagList
+            {
+                { "exception.message", redactedMessage },
+                { "exception.stacktrace", redactedDetail }
+            };
+            activity.AddException(new RedactedSpanException(redactedMessage), in eventTags);
+        };
 
     /// <summary>
     /// Configures OpenTelemetry for desktop/console applications by creating

--- a/src/Content/Presentation/Presentation.Common/Extensions/RedactedSpanException.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/RedactedSpanException.cs
@@ -1,0 +1,19 @@
+namespace Presentation.Common.Extensions;
+
+/// <summary>
+/// Replaces an exception before <see cref="System.Diagnostics.Activity.AddException"/> turns it into
+/// the span's "exception" event, in place of the original type. The span-side counterpart of
+/// <c>Infrastructure.Observability.Processors.RedactedLogException</c> — see that type's remarks for
+/// why a generic <see cref="System.Exception"/> would not do: the exported <c>exception.type</c>
+/// attribute is derived from <see cref="object.GetType"/>, so a bare <see cref="System.Exception"/>
+/// would report <c>exception.type = "System.Exception"</c>, indistinguishable from a genuine bare
+/// <c>throw new Exception(...)</c> elsewhere. This type's name is the signal that redaction happened.
+/// </summary>
+/// <param name="message">
+/// The already-redacted exception message. <see cref="System.Diagnostics.Activity.AddException"/>
+/// uses this verbatim for the <c>exception.message</c> tag and this instance's
+/// <see cref="System.Exception.ToString"/> (which, with no inner exception, is just the type name
+/// plus this message) for <c>exception.stacktrace</c> — both already redacted by construction, so
+/// there is nothing left for the framework's own auto-population to fill in unredacted.
+/// </param>
+public sealed class RedactedSpanException(string message) : Exception(message);

--- a/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj
+++ b/src/Content/Presentation/Presentation.Common/Presentation.Common.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Presentation.Common.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Application layer -->
     <ProjectReference Include="..\..\Application\Application.Common\Application.Common.csproj" />
     <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Context;
@@ -16,6 +17,7 @@ using Domain.AI.Tools;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -128,6 +130,7 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
 
         var services = new ServiceCollection();
         services.AddKeyedSingleton<ITool>(AllowedTool, (_, _) => new StubTool(AllowedTool));
+        services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
         var sp = services.BuildServiceProvider();
 
         return new AgentExecutionContextFactory(
@@ -135,7 +138,9 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
             Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig),
             sp,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp, new PassThroughToolConverter()),
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, sp, TestRedactionFilter.Instance,
+                new PassThroughToolConverter()),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader());
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryDualModeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryDualModeTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
@@ -9,6 +10,7 @@ using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,10 +48,13 @@ public class AgentExecutionContextFactoryDualModeTests
 
         _mcpToolProvider = new Mock<IMcpToolProvider>();
 
-        var sp = new ServiceCollection().BuildServiceProvider();
+        var services = new ServiceCollection();
+        services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
+        var sp = services.BuildServiceProvider();
         var toolChainBuilder = new ToolChainBuilder(
             NullLogger<ToolChainBuilder>.Instance,
             sp,
+            sp.GetRequiredService<IContentRedactionFilter>(),
             mcpToolProvider: _mcpToolProvider.Object);
 
         _factory = new AgentExecutionContextFactory(

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryGovernanceTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryGovernanceTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
@@ -10,6 +11,7 @@ using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -46,11 +48,13 @@ public sealed class AgentExecutionContextFactoryGovernanceTests
 
         var services = new ServiceCollection();
         services.AddSingleton(_pluginRegistry.Object);
+        services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
         var sp = services.BuildServiceProvider();
 
         var toolChainBuilder = new ToolChainBuilder(
             NullLogger<ToolChainBuilder>.Instance,
             sp,
+            sp.GetRequiredService<IContentRedactionFilter>(),
             mcpToolProvider: _mcpToolProvider.Object);
 
         return new AgentExecutionContextFactory(

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Factories;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Context;
 using Application.AI.Common.Services.Skills;
@@ -12,6 +13,7 @@ using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -110,14 +112,17 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
             }
         };
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
-        var sp = new ServiceCollection().BuildServiceProvider();
+        var services = new ServiceCollection();
+        services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
+        var sp = services.BuildServiceProvider();
 
         return new AgentExecutionContextFactory(
             NullLogger<AgentExecutionContextFactory>.Instance,
             monitor,
             sp,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, sp, sp.GetRequiredService<IContentRedactionFilter>()),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             budgetTracker);

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Skills;
@@ -13,6 +14,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.ContextManagement;
 using FluentAssertions;
 using Infrastructure.AI.Prompts;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -64,7 +66,8 @@ public sealed class AgentExecutionContextFactoryPromptComposerTests
             config,
             serviceProvider,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, serviceProvider),
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, serviceProvider, TestRedactionFilter.Instance),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader());
 
@@ -79,6 +82,7 @@ public sealed class AgentExecutionContextFactoryPromptComposerTests
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
         services.AddSingleton(Mock.Of<IContextBudgetTracker>());
         services.AddSingleton<IAmbientRequestScope, AmbientRequestScope>();
+        services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
         services.AddSystemPromptComposition();
         return services.BuildServiceProvider(new ServiceProviderOptions { ValidateScopes = true });
     }
@@ -203,8 +207,12 @@ public sealed class AgentExecutionContextFactoryPromptComposerTests
     public async Task MapToAgentContext_EnabledButNoAmbientScope_FailsOpenToLegacyInstruction()
     {
         // A service provider WITHOUT IAmbientRequestScope registered — the factory cannot reach a
-        // request scope, so it must fall back to the legacy instruction rather than throw.
-        await using var barren = new ServiceCollection().BuildServiceProvider();
+        // request scope, so it must fall back to the legacy instruction rather than throw. Still
+        // registers IContentRedactionFilter, which every host does unconditionally in production
+        // (TryAddSingleton) — its absence is not the fail-open condition this test is pinning.
+        var barrenServices = new ServiceCollection();
+        barrenServices.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
+        await using var barren = barrenServices.BuildServiceProvider();
         var factory = CreateFactory(Config(promptCompositionEnabled: true), barren);
         var skill = Skill("research", "Search sources.");
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Context;
@@ -12,6 +13,7 @@ using Domain.AI.Tools;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -129,6 +131,8 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 
         // A real tool behind the name the skill grants, so the agent is actually built holding it.
         services.AddKeyedSingleton<ITool>(AllowedTool, (_, _) => new StubTool(AllowedTool));
+        var redactionFilter = TestRedactionFilter.Instance;
+        services.AddSingleton<IContentRedactionFilter>(redactionFilter);
         var sp = services.BuildServiceProvider();
 
         return new AgentExecutionContextFactory(
@@ -136,7 +140,8 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
             Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig),
             sp,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp, new PassThroughToolConverter()),
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, sp, redactionFilter, new PassThroughToolConverter()),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             budgetTracker

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Interfaces.Traces;
 using Application.AI.Common.Models;
@@ -13,6 +14,7 @@ using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.MetaHarness;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -30,6 +32,8 @@ namespace Application.AI.Common.Tests.Factories;
 /// </summary>
 public class AgentExecutionContextFactoryTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static AgentExecutionContextFactory CreateFactory(
         AIAgentFrameworkClientType configuredClientType = AIAgentFrameworkClientType.AzureOpenAI,
         string deployment = "default-model",
@@ -53,11 +57,13 @@ public class AgentExecutionContextFactoryTests
             }
         };
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
-        var services = serviceProvider ?? new ServiceCollection().BuildServiceProvider();
+        var services = serviceProvider
+            ?? new ServiceCollection().AddSingleton(RedactionFilter).BuildServiceProvider();
 
         var toolChainBuilder = new ToolChainBuilder(
             NullLogger<ToolChainBuilder>.Instance,
             services,
+            RedactionFilter,
             toolConverter,
             mcpToolProvider);
 
@@ -184,13 +190,13 @@ public class AgentExecutionContextFactoryTests
     {
         var appConfig = new AppConfig { AI = new AIConfig { AgentFramework = new AgentFrameworkConfig() } };
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
-        var sp = new ServiceCollection().BuildServiceProvider();
+        var sp = new ServiceCollection().AddSingleton(RedactionFilter).BuildServiceProvider();
         var factory = new AgentExecutionContextFactory(
             NullLogger<AgentExecutionContextFactory>.Instance,
             monitor,
             sp,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp, RedactionFilter),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader());
 
@@ -537,6 +543,7 @@ public class AgentExecutionContextFactoryTests
 
         var services = new ServiceCollection();
         services.AddKeyedSingleton<ITool>("calc", toolMock.Object);
+        services.AddSingleton(RedactionFilter);
         var sp = services.BuildServiceProvider();
 
         var factory = CreateFactory(

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
@@ -6,6 +7,7 @@ using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -38,14 +40,17 @@ public sealed class AgentExecutionContextFactoryToolCeilingTests
             }
         };
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
-        var sp = new ServiceCollection().BuildServiceProvider();
+        var services = new ServiceCollection();
+        services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
+        var sp = services.BuildServiceProvider();
 
         _factory = new AgentExecutionContextFactory(
             NullLogger<AgentExecutionContextFactory>.Instance,
             monitor,
             sp,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, sp, sp.GetRequiredService<IContentRedactionFilter>()),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader());
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolEnforcementTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
@@ -8,6 +9,7 @@ using Domain.AI.Tools;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -41,13 +43,16 @@ public class AgentExecutionContextFactoryToolEnforcementTests
         };
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
 
-        var sp = new ServiceCollection().BuildServiceProvider();
+        var services = new ServiceCollection();
+        services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
+        var sp = services.BuildServiceProvider();
         _factory = new AgentExecutionContextFactory(
             NullLogger<AgentExecutionContextFactory>.Instance,
             monitor,
             sp,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, sp, sp.GetRequiredService<IContentRedactionFilter>()),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader());
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Resilience;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
 using Application.AI.Common.Tests.Fakes;
@@ -11,6 +12,7 @@ using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Resilience;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -237,14 +239,18 @@ public sealed class AgentFactoryResilienceWiringTests
             }
         };
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
-        var services = new ServiceCollection().BuildServiceProvider();
+        var collection = new ServiceCollection();
+        collection.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
+        var services = collection.BuildServiceProvider();
 
         return new AgentExecutionContextFactory(
             NullLogger<AgentExecutionContextFactory>.Instance,
             monitor,
             services,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services),
+            new ToolChainBuilder(
+                NullLogger<ToolChainBuilder>.Instance, services,
+                services.GetRequiredService<IContentRedactionFilter>()),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             resilientChatClientProvider: resilientProvider);

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionClassificationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionClassificationTests.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Moq;
 using Xunit;
@@ -21,6 +23,8 @@ namespace Application.AI.Common.Tests.Governance;
 /// </remarks>
 public sealed class GovernedAIFunctionClassificationTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static (AIFunction inner, Func<bool> wasInvoked) MakeInner()
     {
         var invoked = false;
@@ -43,7 +47,7 @@ public sealed class GovernedAIFunctionClassificationTests
     private static async Task<object?> InvokeUnder(IToolCallAdmissionPipeline pipeline, AIFunction inner)
     {
         using var armed = ToolAdmissionAccessor.Begin(pipeline);
-        return await new GovernedAIFunction(inner).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+        return await new GovernedAIFunction(inner, RedactionFilter).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
     }
 
     [Fact]
@@ -109,7 +113,7 @@ public sealed class GovernedAIFunctionClassificationTests
     {
         var (inner, wasInvoked) = MakeInner();
 
-        var result = await new GovernedAIFunction(inner)
+        var result = await new GovernedAIFunction(inner, RedactionFilter)
             .InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
 
         Assert.True(wasInvoked());

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionProgressTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionProgressTests.cs
@@ -1,6 +1,8 @@
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Moq;
 using Xunit;
@@ -25,6 +27,8 @@ namespace Application.AI.Common.Tests.Governance;
 /// </remarks>
 public sealed class GovernedAIFunctionProgressTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static (AIFunction inner, Func<bool> wasInvoked) MakeInner()
     {
         var invoked = false;
@@ -37,7 +41,7 @@ public sealed class GovernedAIFunctionProgressTests
     private static async Task<object?> InvokeUnder(IToolCallAdmissionPipeline pipeline, AIFunction inner)
     {
         using var armed = ToolAdmissionAccessor.Begin(pipeline);
-        return await new GovernedAIFunction(inner).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+        return await new GovernedAIFunction(inner, RedactionFilter).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
     }
 
     [Fact]
@@ -71,7 +75,7 @@ public sealed class GovernedAIFunctionProgressTests
         // A tool invoked outside a governed turn — nothing is armed, so the wrapper is transparent.
         var (inner, wasInvoked) = MakeInner();
 
-        await new GovernedAIFunction(inner).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+        await new GovernedAIFunction(inner, RedactionFilter).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
 
         Assert.True(wasInvoked(), "inner tool must run when no admission chain is ambient");
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
@@ -1,8 +1,10 @@
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Escalation;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Moq;
 using Xunit;
@@ -15,6 +17,8 @@ namespace Application.AI.Common.Tests.Governance;
 /// </summary>
 public sealed class GovernedAIFunctionTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static (AIFunction inner, Func<bool> wasInvoked) MakeInner()
     {
         var invoked = false;
@@ -40,10 +44,12 @@ public sealed class GovernedAIFunctionTests
                 MarshalResult = (result, _, _) => new ValueTask<object?>(result)
             });
 
-    private static async Task<object?> InvokeUnder(IToolCallAdmissionPipeline pipeline, AIFunction inner)
+    private static async Task<object?> InvokeUnder(
+        IToolCallAdmissionPipeline pipeline, AIFunction inner, bool isMcpSourced = false)
     {
         using var armed = ToolAdmissionAccessor.Begin(pipeline);
-        return await new GovernedAIFunction(inner).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+        return await new GovernedAIFunction(inner, RedactionFilter, isMcpSourced: isMcpSourced)
+            .InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
     }
 
     [Fact]
@@ -76,7 +82,7 @@ public sealed class GovernedAIFunctionTests
     {
         var (inner, wasInvoked) = MakeInner();
 
-        await new GovernedAIFunction(inner).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
+        await new GovernedAIFunction(inner, RedactionFilter).InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
 
         Assert.True(wasInvoked(), "inner tool must run when no admission chain is ambient");
     }
@@ -174,6 +180,148 @@ public sealed class GovernedAIFunctionTests
         Assert.Equal("Error: boom", resultStr);
     }
 
+    /// <summary>
+    /// An inner function shaped like what an MCP-provided tool actually returns on failure —
+    /// confirmed against the MCP C# SDK's <c>McpClientTool.InvokeCoreAsync</c> source: on
+    /// <c>CallToolResult.IsError == true</c> it returns normally with
+    /// <c>JsonSerializer.SerializeToElement(result, ...)</c>, never throws, and never produces a
+    /// <see cref="ConvertedToolFailure"/> (that marker is <c>AIToolConverter</c>-only). The default
+    /// marshaling every other test here relies on already serializes this anonymous object into the
+    /// same <see cref="System.Text.Json.JsonElement"/> shape the real SDK call produces.
+    /// </summary>
+    private static AIFunction MakeMcpFailingInner(string errorText) =>
+        AIFunctionFactory.Create(
+            () => new { isError = true, content = new[] { new { type = "text", text = errorText } } },
+            new AIFunctionFactoryOptions { Name = "mcp_tool", Description = "test mcp tool" });
+
+    [Fact]
+    public async Task InvokeAsync_McpToolReportsIsError_WithApproval_ReportsFailedWithReason()
+    {
+        // #451: before this fix, an MCP tool's non-throwing failure had no marker GovernedAIFunction
+        // could recognize (ConvertedToolFailure is AIToolConverter-only), so it was reported
+        // Succeeded — this is the case that closes that gap.
+        var inner = MakeMcpFailingInner("Error: mcp boom");
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        var result = await InvokeUnder(pipeline.Object, inner, isMcpSourced: true);
+
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r =>
+                    r.Status == EscalationExecutionStatus.Failed && r.FailureReason == "Error: mcp boom"),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
+        // Unlike ConvertedToolFailure, the MCP shape is never unwrapped — it already reaches the
+        // model correctly today (that part was never broken); only the reporting decision changes.
+        Assert.IsType<System.Text.Json.JsonElement>(result);
+        var element = (System.Text.Json.JsonElement)result!;
+        Assert.True(element.GetProperty("isError").GetBoolean());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_McpFailureWithNonObjectContentBlock_DoesNotThrow()
+    {
+        // Regression: JsonElement.TryGetProperty throws InvalidOperationException when the element's
+        // ValueKind isn't Object (confirmed against the .NET docs) — a content array holding a bare
+        // string, e.g. {"isError":true,"content":["oops"]}, used to crash this chokepoint instead of
+        // falling through to the generic "no message" text every other malformed shape gets.
+        var inner = AIFunctionFactory.Create(
+            () => new { isError = true, content = new object[] { "a bare string, not a content block" } },
+            new AIFunctionFactoryOptions { Name = "mcp_tool", Description = "test mcp tool" });
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        await InvokeUnder(pipeline.Object, inner, isMcpSourced: true);
+
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r =>
+                    r.Status == EscalationExecutionStatus.Failed
+                    && r.FailureReason == "MCP tool reported failure with no message."),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_JsonObjectSuccessWithoutIsError_StillReportsSucceeded()
+    {
+        // Regression guard for the MCP-shape detection: a genuine structured success (not a plain
+        // string, not MCP-shaped) must never be misread as a failure just because it is a JsonElement.
+        var inner = AIFunctionFactory.Create(
+            () => new { status = "ok", value = 42 },
+            new AIFunctionFactoryOptions { Name = "file_system", Description = "test tool" });
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        await InvokeUnder(pipeline.Object, inner, isMcpSourced: true);
+
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r => r.Status == EscalationExecutionStatus.Succeeded),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NonMcpToolSuccessCoincidentallyShapedLikeMcpFailure_StillReportsSucceeded()
+    {
+        // The security-review finding this closes: TryGetMcpFailureText's isError+content check is
+        // structural, not provenance-based, so a keyed-DI or skill-provided tool whose genuine SUCCESS
+        // payload happens to use those same field names for unrelated business reasons (e.g. a
+        // connector tool passing through an upstream API body verbatim) must not be misreported as a
+        // failed call — the same "shared field, two meanings depending on the producer" trap this
+        // repo's CLAUDE.md already tracks. isMcpSourced defaults to false, so the MCP-shape check must
+        // never run for this tool at all, regardless of what its payload looks like.
+        var inner = AIFunctionFactory.Create(
+            () => new { isError = true, content = new[] { new { type = "text", text = "3 lint errors found" } } },
+            new AIFunctionFactoryOptions { Name = "lint_proxy_tool", Description = "test non-mcp tool" });
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        await InvokeUnder(pipeline.Object, inner); // isMcpSourced defaults to false
+
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r => r.Status == EscalationExecutionStatus.Succeeded),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FailureTextCarriesASecret_ReportedCopyIsRedacted_ModelFacingCopyIsNot()
+    {
+        // #452: the reported FailureReason is what reaches the audit trail, the failure memory
+        // replayed to a human approver, and the AG-UI stream — none of which had seen redaction
+        // before this fix. The model-facing text is a separate concern already governed by the
+        // classification gate's RedactsOutput verdict (mocked here as a pass-through), so it is
+        // deliberately NOT asserted to be redacted — only the reported copy is this method's job.
+        const string secret = "contact admin@example.com for access";
+        var inner = MakeFailingInner(secret);
+        var call = ApprovedCall();
+        var pipeline = ApprovingPipeline(call);
+
+        var result = await InvokeUnder(pipeline.Object, inner);
+
+        pipeline.Verify(
+            p => p.ReportExecutionAsync(
+                It.IsAny<ToolCallAdmission>(),
+                It.Is<ToolExecutionReport>(r =>
+                    r.Status == EscalationExecutionStatus.Failed
+                    && r.FailureReason != null
+                    && !r.FailureReason.Contains("admin@example.com")
+                    && r.FailureReason.Contains("[REDACTED:Email]")),
+                "agent-turn", CancellationToken.None),
+            Times.Once);
+
+        var resultStr = result is System.Text.Json.JsonElement je ? je.GetString() : result?.ToString();
+        Assert.Equal(secret, resultStr);
+    }
+
     [Fact]
     public async Task InvokeAsync_ToolReturnsConvertedFailure_ReturnsSameRuntimeShapeAsSuccess()
     {
@@ -201,7 +349,7 @@ public sealed class GovernedAIFunctionTests
         // out to whatever called this AIFunction directly.
         var inner = MakeFailingInner("Error: boom");
 
-        var result = await new GovernedAIFunction(inner)
+        var result = await new GovernedAIFunction(inner, RedactionFilter)
             .InvokeAsync(new AIFunctionArguments(), CancellationToken.None);
 
         var resultStr = result is System.Text.Json.JsonElement je ? je.GetString() : result?.ToString();
@@ -234,7 +382,7 @@ public sealed class GovernedAIFunctionTests
     public void Decorator_PreservesInnerNameAndSchema()
     {
         var (inner, _) = MakeInner();
-        var governed = new GovernedAIFunction(inner);
+        var governed = new GovernedAIFunction(inner, RedactionFilter);
 
         Assert.Equal(inner.Name, governed.Name);
         Assert.Equal(inner.JsonSchema.ToString(), governed.JsonSchema.ToString());

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
@@ -1,6 +1,8 @@
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Planner;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -15,6 +17,8 @@ namespace Application.AI.Common.Tests.Governance;
 /// </summary>
 public sealed class GoverningToolContextProviderTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static AIFunction MakeFunction(string name = "file_system") => AIFunctionFactory.Create(
         () => "ok", new AIFunctionFactoryOptions { Name = name, Description = "t" });
 
@@ -23,7 +27,7 @@ public sealed class GoverningToolContextProviderTests
     {
         var inner = MakeFunction();
 
-        var result = GoverningToolContextProvider.Govern(inner);
+        var result = GoverningToolContextProvider.Govern(inner, RedactionFilter);
 
         Assert.IsType<GovernedAIFunction>(result);
         Assert.NotSame(inner, result);
@@ -33,9 +37,9 @@ public sealed class GoverningToolContextProviderTests
     [Fact]
     public void Govern_AlreadyGoverned_ReturnsSameInstance_NoDoubleWrap()
     {
-        var alreadyGoverned = new GovernedAIFunction(MakeFunction());
+        var alreadyGoverned = new GovernedAIFunction(MakeFunction(), RedactionFilter);
 
-        var result = GoverningToolContextProvider.Govern(alreadyGoverned);
+        var result = GoverningToolContextProvider.Govern(alreadyGoverned, RedactionFilter);
 
         Assert.Same(alreadyGoverned, result);
     }
@@ -53,7 +57,7 @@ public sealed class GoverningToolContextProviderTests
         var tools = new List<AITool> { MakeFunction(reservedName), MakeFunction("file_system") };
 
         var result = GoverningToolContextProvider.FilterAndGovern(
-            tools, NullLogger<GoverningToolContextProviderTests>.Instance);
+            tools, NullLogger<GoverningToolContextProviderTests>.Instance, RedactionFilter);
 
         Assert.NotNull(result);
         Assert.Single(result);
@@ -66,7 +70,7 @@ public sealed class GoverningToolContextProviderTests
         var tools = new List<AITool> { MakeFunction() };
 
         var result = GoverningToolContextProvider.FilterAndGovern(
-            tools, NullLogger<GoverningToolContextProviderTests>.Instance);
+            tools, NullLogger<GoverningToolContextProviderTests>.Instance, RedactionFilter);
 
         Assert.NotNull(result);
         Assert.IsType<GovernedAIFunction>(Assert.Single(result));
@@ -76,10 +80,10 @@ public sealed class GoverningToolContextProviderTests
     public void FilterAndGovern_AlreadyGovernedAndNoCollisions_ReportsNoChange()
     {
         // Null means "keep the existing AIContext" — nothing was dropped and nothing needed wrapping.
-        var tools = new List<AITool> { new GovernedAIFunction(MakeFunction()) };
+        var tools = new List<AITool> { new GovernedAIFunction(MakeFunction(), RedactionFilter) };
 
         var result = GoverningToolContextProvider.FilterAndGovern(
-            tools, NullLogger<GoverningToolContextProviderTests>.Instance);
+            tools, NullLogger<GoverningToolContextProviderTests>.Instance, RedactionFilter);
 
         Assert.Null(result);
     }
@@ -88,8 +92,8 @@ public sealed class GoverningToolContextProviderTests
     public void FilterAndGovern_NoTools_ReportsNoChange()
     {
         Assert.Null(GoverningToolContextProvider.FilterAndGovern(
-            null, NullLogger<GoverningToolContextProviderTests>.Instance));
+            null, NullLogger<GoverningToolContextProviderTests>.Instance, RedactionFilter));
         Assert.Null(GoverningToolContextProvider.FilterAndGovern(
-            [], NullLogger<GoverningToolContextProviderTests>.Instance));
+            [], NullLogger<GoverningToolContextProviderTests>.Instance, RedactionFilter));
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/TestRedactionFilter.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/TestRedactionFilter.cs
@@ -1,0 +1,19 @@
+using Application.AI.Common.Interfaces.Telemetry;
+using Infrastructure.AI.Telemetry.Redaction;
+
+namespace Application.AI.Common.Tests;
+
+/// <summary>
+/// The one <see cref="IContentRedactionFilter"/> instance every test in this assembly that needs to
+/// satisfy a redaction-filter constructor dependency should use.
+/// </summary>
+/// <remarks>
+/// <see cref="DefaultContentRedactionFilter"/> is documented stateless and thread-safe, so a single
+/// shared instance is safe everywhere — before this existed, ~20 test files each declared their own
+/// local field, DI registration, or inline <c>new DefaultContentRedactionFilter()</c>, in at least
+/// four different idioms for the identical need.
+/// </remarks>
+internal static class TestRedactionFilter
+{
+    public static readonly IContentRedactionFilter Instance = new DefaultContentRedactionFilter();
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.KnowledgeGraph.Models;
@@ -10,6 +11,7 @@ using Domain.AI.Planner;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +50,7 @@ public sealed class AIContextProviderMergeContractTests
 {
     private const string SystemSentinel = "SYSTEM-PROMPT-SENTINEL";
     private const string UserQuery = "what did we learn?";
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
 
     /// <summary>
     /// Real functions, not mocks: <see cref="GoverningToolContextProvider"/> only wraps
@@ -79,7 +82,7 @@ public sealed class AIContextProviderMergeContractTests
     {
         [nameof(ToolPermissionFilter)] = () => new ToolPermissionFilter(["alpha", "beta"]),
         [nameof(GoverningToolContextProvider)] = () =>
-            new GoverningToolContextProvider(NullLogger<GoverningToolContextProvider>.Instance),
+            new GoverningToolContextProvider(NullLogger<GoverningToolContextProvider>.Instance, RedactionFilter),
         [nameof(KnowledgeMemoryContextProvider)] = BuildKnowledgeMemory,
         [nameof(LearningsRecallContextProvider)] = BuildLearningsRecall,
         [nameof(PerTurnBudgetContextProvider)] = () => new PerTurnBudgetContextProvider(
@@ -269,7 +272,7 @@ public sealed class AIContextProviderMergeContractTests
         };
 
         var result = await new GoverningToolContextProvider(
-            NullLogger<GoverningToolContextProvider>.Instance).InvokingAsync(MakeContext(input));
+            NullLogger<GoverningToolContextProvider>.Instance, RedactionFilter).InvokingAsync(MakeContext(input));
 
         var names = result.Tools?.Select(t => t.Name).ToList() ?? [];
         names.Should().NotContain(reservedName,
@@ -281,7 +284,7 @@ public sealed class AIContextProviderMergeContractTests
     public async Task GoverningProvider_PublishesOnlyTheGovernedCopyOfEachTool()
     {
         var result = await new GoverningToolContextProvider(
-            NullLogger<GoverningToolContextProvider>.Instance).InvokingAsync(MakeContext(ActiveInput()));
+            NullLogger<GoverningToolContextProvider>.Instance, RedactionFilter).InvokingAsync(MakeContext(ActiveInput()));
 
         var tools = result.Tools?.ToList() ?? [];
         tools.Should().HaveCount(2, "wrapping must replace each tool, not add a second copy alongside it");

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services;
 using Application.AI.Common.Services.Context;
 using Application.AI.Common.Services.Skills;
@@ -10,6 +11,7 @@ using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,14 +59,17 @@ public sealed class AgentConversationCacheTests
             }
         };
         var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
-        var services = new ServiceCollection().BuildServiceProvider();
+        var redactionFilter = TestRedactionFilter.Instance;
+        var services = new ServiceCollection()
+            .AddSingleton<IContentRedactionFilter>(redactionFilter)
+            .BuildServiceProvider();
 
         var contextFactory = new AgentExecutionContextFactory(
             NullLogger<AgentExecutionContextFactory>.Instance,
             monitor,
             services,
             NullLoggerFactory.Instance,
-            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services, null, null),
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services, redactionFilter, null),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader());
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Governance;
@@ -14,6 +15,7 @@ using Domain.AI.Models;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.DirectToolInvocation;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -684,6 +686,30 @@ public sealed class DirectToolInvokerTests
     }
 
     [Fact]
+    public async Task ToolReturnsFailure_WithASecretInTheErrorText_ReportedCopyIsRedacted()
+    {
+        // #452's DirectToolInvoker-side case: GovernedAIFunctionTests pins the identical fix on the
+        // agent-turn path. The reported text — what reaches the audit trail and a human approver
+        // replaying failure memory — must never carry the tool's raw secret-bearing message, even
+        // though the caller-facing outcome.Error is separately scrubbed by ICompositeResponseSanitizer
+        // (see Sanitizes_a_failing_tools_error_message) and is not this test's concern.
+        var call = ApprovedCall();
+        _governor.Decision = ToolInvocationDecision.Allow(call);
+
+        await Invoke(
+            Request("alpha"),
+            Tool("alpha", result: ToolResult.Fail("contact admin@example.com for access")));
+
+        _executionReporter.Verify(
+            r => r.ReportFailedAsync(
+                call,
+                It.Is<string>(reason =>
+                    !reason.Contains("admin@example.com") && reason.Contains("[REDACTED:Email]")),
+                "direct-invocation", CancellationToken.None),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task ToolThrows_WithApproval_ReportsFailedAndStillRethrows()
     {
         var call = ApprovedCall();
@@ -780,6 +806,7 @@ public sealed class DirectToolInvokerTests
             new ToolCatalog(provider, [tool.Name], NullLogger<ToolCatalog>.Instance),
             _sanitizer,
             new StaticOptionsMonitor<DirectToolInvocationConfig>(_config),
+            TestRedactionFilter.Instance,
             NullLogger<DirectToolInvoker>.Instance);
 
         return await sut.InvokeAsync(request, cancellationToken);

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderMcpEnvelopeTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
@@ -6,6 +7,7 @@ using Domain.AI.Bundles;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -23,9 +25,12 @@ namespace Application.AI.Common.Tests.Services.Tools;
 /// </summary>
 public sealed class ToolChainBuilderMcpEnvelopeTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static ToolChainBuilder Builder(IMcpToolProvider mcp, IServiceProvider? sp = null) => new(
         NullLogger<ToolChainBuilder>.Instance,
         sp ?? new ServiceCollection().BuildServiceProvider(),
+        RedactionFilter,
         toolConverter: null,
         mcpToolProvider: mcp);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderReservedCapabilityTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderReservedCapabilityTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Models;
@@ -6,6 +7,7 @@ using Domain.AI.Planner;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -31,9 +33,12 @@ namespace Application.AI.Common.Tests.Services.Tools;
 /// </remarks>
 public sealed class ToolChainBuilderReservedCapabilityTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static ToolChainBuilder Builder(IMcpToolProvider mcp) => new(
         NullLogger<ToolChainBuilder>.Instance,
         new ServiceCollection().BuildServiceProvider(),
+        RedactionFilter,
         toolConverter: null,
         mcpToolProvider: mcp);
 
@@ -146,6 +151,7 @@ public sealed class ToolChainBuilderReservedCapabilityTests
         var builder = new ToolChainBuilder(
             NullLogger<ToolChainBuilder>.Instance,
             services.BuildServiceProvider(),
+            RedactionFilter,
             new PassThroughToolConverter(),
             new Mock<IMcpToolProvider>().Object);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Skills;
@@ -10,6 +11,7 @@ using Domain.Common.Config.AI.Governance;
 using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
 using Infrastructure.AI.Governance.Adapters;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -26,6 +28,8 @@ namespace Application.AI.Common.Tests.Services.Tools;
 /// </summary>
 public class ToolChainBuilderTests
 {
+    private static readonly IContentRedactionFilter RedactionFilter = TestRedactionFilter.Instance;
+
     private static ToolChainBuilder CreateBuilder(
         IMcpToolProvider? mcpToolProvider = null,
         IToolConverter? toolConverter = null,
@@ -36,6 +40,7 @@ public class ToolChainBuilderTests
         return new ToolChainBuilder(
             NullLogger<ToolChainBuilder>.Instance,
             serviceProvider ?? new ServiceCollection().BuildServiceProvider(),
+            RedactionFilter,
             toolConverter,
             mcpToolProvider,
             surfaceScanner,

--- a/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/RequestTracingBehaviorTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/MediatRBehaviors/RequestTracingBehaviorTests.cs
@@ -65,7 +65,12 @@ public class RequestTracingBehaviorTests : IDisposable
         _activities.Should().ContainSingle();
         var activity = _activities[0];
         activity.Status.Should().Be(ActivityStatusCode.Error);
-        activity.StatusDescription.Should().Be("boom");
+        // Type name only, never the raw exception message — this behavior wraps every command/query
+        // in the app, so a handler that throws with a secret in its message must not have that text
+        // land in the exported span (matches MediatorDispatchRunner/WorkspaceCommandRunner's
+        // convention; see RequestTracingBehavior's remarks for why redaction isn't reachable here).
+        activity.StatusDescription.Should().Be(nameof(InvalidOperationException));
+        activity.StatusDescription.Should().NotContain("boom");
         activity.Events.Should().Contain(e => e.Name == "exception");
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
@@ -298,11 +298,18 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
             "test task", ["tool_a"], AutonomyLevel.Supervised);
 
         result.IsSuccess.Should().BeFalse();
-        result.FailureReason.Should().Contain("Agent creation failed");
+        // The exception's own message is never surfaced — only its type name (matching
+        // MediatorDispatchRunner/WorkspaceCommandRunner's convention) — because it can carry a secret
+        // this test's own "Agent creation failed" stands in for. It must NOT reach the failure record.
+        result.FailureReason.Should().Contain(nameof(InvalidOperationException));
+        result.FailureReason.Should().NotContain("Agent creation failed");
 
         _storeMock.Verify(
             s => s.AppendAsync(
-                It.Is<DelegationRecord>(r => r.State == DelegationState.Failed),
+                It.Is<DelegationRecord>(r =>
+                    r.State == DelegationState.Failed
+                    && r.FailureReason != null
+                    && !r.FailureReason.Contains("Agent creation failed")),
                 It.IsAny<CancellationToken>()),
             Times.Once());
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
@@ -9,6 +9,7 @@ using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
 using Infrastructure.AI.Plugins;
 using Infrastructure.AI.Skills;
+using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -146,6 +147,7 @@ public sealed class PluginGovernanceWiringTests : IDisposable
         var builder = new ToolChainBuilder(
             NullLogger<ToolChainBuilder>.Instance,
             services.BuildServiceProvider(),
+            new DefaultContentRedactionFilter(),
             toolConverter: null,
             mcpToolProvider: mcpProvider.Object);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/DelegateToSubagentToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/DelegateToSubagentToolTests.cs
@@ -163,7 +163,12 @@ public class DelegateToSubagentToolTests
         var result = await BuildTool().ExecuteAsync("delegate", Params(("task", "x")));
 
         result.Success.Should().BeFalse();
-        result.Error.Should().Contain("boom");
+        // The exception's own message is never surfaced — only its type name, matching the
+        // convention MediatorDispatchRunner/WorkspaceCommandRunner already use, because the raw
+        // message can carry a secret (connection string, SAS token) this test's own "boom" stands
+        // in for. "boom" must NOT reach the caller.
+        result.Error.Should().Contain(nameof(InvalidOperationException));
+        result.Error.Should().NotContain("boom");
     }
 
     [Fact]

--- a/src/Content/Tests/Presentation.Common.Tests/Extensions/OpenTelemetryTracingExceptionRedactionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Extensions/OpenTelemetryTracingExceptionRedactionTests.cs
@@ -1,0 +1,147 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Telemetry.Redaction;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpenTelemetry.Instrumentation.AspNetCore;
+using OpenTelemetry.Instrumentation.Http;
+using Presentation.Common.Extensions;
+using Xunit;
+
+namespace Presentation.Common.Tests.Extensions;
+
+/// <summary>
+/// Proves the span-side exception redaction (#450) closes both leak paths a secret-bearing
+/// exception can reach a trace through: the <c>exception.type</c>/<c>exception.message</c> tags
+/// <c>BuildRedactingExceptionEnricher</c> sets directly on the activity, and the "exception" span
+/// event it constructs itself (with <c>RecordException</c> switched off, so the instrumentation
+/// library's own unredacted <c>Activity.AddException</c> call never runs — see
+/// <see cref="OpenTelemetryServiceCollectionExtensions.AddOpenTelemetry"/>'s remarks).
+/// </summary>
+/// <remarks>
+/// Exercises <c>BuildRedactingExceptionEnricher</c> directly rather than through
+/// <c>AddOpenTelemetry(appConfig)</c>: the web/desktop host-shape branch that method itself picks
+/// keys off <see cref="System.Reflection.Assembly.GetEntryAssembly"/>, which in a test process is
+/// the test host, not a project named in <c>Observability:WebTelemetryProjects</c> — so the
+/// full-composition entry point never reaches the web-only wiring this callback lives on. Testing
+/// the callback itself is also the more precise unit: it pins exactly the redaction contract,
+/// independent of instrumentation-library wiring already covered by
+/// <c>OpenTelemetryLogsSignalTests</c>'s production-composition pattern on the log signal.
+/// </remarks>
+public sealed class OpenTelemetryTracingExceptionRedactionTests
+{
+    private static readonly IContentRedactionFilter Filter = new DefaultContentRedactionFilter();
+    private static readonly ActivitySource Source = new(nameof(OpenTelemetryTracingExceptionRedactionTests));
+
+    /// <summary>Starts a recorded activity — a listener must be registered or StartActivity returns null.</summary>
+    private static Activity StartActivity()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+        return Source.StartActivity("test-activity")!;
+    }
+
+    [Fact]
+    public void Enricher_ExceptionMessageCarriesASecret_ActivityTagIsRedacted()
+    {
+        using var activity = StartActivity();
+        var enrich = OpenTelemetryServiceCollectionExtensions.BuildRedactingExceptionEnricher(Filter);
+
+        enrich(activity, new InvalidOperationException("contact admin@example.com for the connection string"));
+
+        activity.GetTagItem("exception.message").Should().Be(
+            "contact [REDACTED:Email] for the connection string");
+        activity.GetTagItem("exception.type").Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public void Enricher_ExceptionMessageCarriesASecret_SpanEventIsRedactedNotRawException()
+    {
+        using var activity = StartActivity();
+        var enrich = OpenTelemetryServiceCollectionExtensions.BuildRedactingExceptionEnricher(Filter);
+
+        enrich(activity, new InvalidOperationException("contact admin@example.com for the connection string"));
+
+        var exceptionEvent = activity.Events.Should().ContainSingle(e => e.Name == "exception").Subject;
+        var tags = exceptionEvent.Tags.ToDictionary(t => t.Key, t => t.Value);
+
+        tags["exception.message"].Should().Be("contact [REDACTED:Email] for the connection string");
+        tags["exception.stacktrace"].As<string>().Should().NotContain("admin@example.com");
+        tags["exception.stacktrace"].As<string>().Should().Contain("[REDACTED:Email]");
+        // Self-announces redaction happened via the type name, rather than reporting the real
+        // exception type as if RecordException's own (unredacted) auto-population had run.
+        tags["exception.type"].Should().Be(typeof(RedactedSpanException).FullName);
+    }
+
+    [Fact]
+    public void Enricher_ExceptionMessageCarriesNoSecret_TextIsUnchanged()
+    {
+        using var activity = StartActivity();
+        var enrich = OpenTelemetryServiceCollectionExtensions.BuildRedactingExceptionEnricher(Filter);
+
+        enrich(activity, new InvalidOperationException("the operation timed out"));
+
+        activity.GetTagItem("exception.message").Should().Be("the operation timed out");
+    }
+
+    /// <summary>
+    /// A wrapped exception's inner message can carry a secret the outer message never shows —
+    /// <see cref="Exception.ToString"/> (not just <see cref="Exception.Message"/>) is what gets
+    /// redacted for the event's <c>exception.stacktrace</c> tag specifically so this is still caught,
+    /// matching <c>LogRecordRedactionProcessor.RedactException</c>'s identical reasoning on the log
+    /// side.
+    /// </summary>
+    [Fact]
+    public void Enricher_SecretOnlyInInnerException_StillRedactedInSpanEventDetail()
+    {
+        using var activity = StartActivity();
+        var enrich = OpenTelemetryServiceCollectionExtensions.BuildRedactingExceptionEnricher(Filter);
+        var inner = new InvalidOperationException("dispatch failed: admin@example.com");
+        var outer = new InvalidOperationException("generic wrapper failure", inner);
+
+        enrich(activity, outer);
+
+        var exceptionEvent = activity.Events.Should().ContainSingle(e => e.Name == "exception").Subject;
+        var stacktrace = exceptionEvent.Tags.ToDictionary(t => t.Key, t => t.Value)["exception.stacktrace"].As<string>();
+
+        stacktrace.Should().NotContain("admin@example.com");
+        stacktrace.Should().Contain("[REDACTED:Email]");
+    }
+
+    /// <summary>
+    /// Pins the production DI wiring itself, not just the enricher function in isolation — a future
+    /// OpenTelemetry package bump could change how <c>AddAspNetCoreInstrumentation</c>/
+    /// <c>AddHttpClientInstrumentation</c> read their options and silently stop calling
+    /// <c>EnrichWithException</c>, or a regression in <see cref="OpenTelemetryServiceCollectionExtensions.AddWebTelemetry"/>
+    /// itself could drop the <c>PostConfigure</c> call. Resolving the real, DI-composed
+    /// <see cref="IOptions{TOptions}"/> catches either without needing to build the full
+    /// <c>TracerProvider</c> (which needs a live OTLP endpoint or exporters disabled).
+    /// </summary>
+    [Fact]
+    public void AddWebTelemetry_ProductionWiring_RecordExceptionOffAndEnricherSet()
+    {
+        var appConfig = new AppConfig();
+        appConfig.Observability.Exporters.Otlp.Enabled = false;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IContentRedactionFilter>(Filter);
+        services.AddWebTelemetry(appConfig);
+
+        using var provider = services.BuildServiceProvider();
+
+        var aspNetCoreOptions = provider.GetRequiredService<IOptions<AspNetCoreTraceInstrumentationOptions>>().Value;
+        aspNetCoreOptions.RecordException.Should().BeFalse(
+            "the enricher builds the redacted exception event itself; the library's own auto-population must stay off");
+        aspNetCoreOptions.EnrichWithException.Should().NotBeNull();
+
+        var httpClientOptions = provider.GetRequiredService<IOptions<HttpClientTraceInstrumentationOptions>>().Value;
+        httpClientOptions.RecordException.Should().BeFalse();
+        httpClientOptions.EnrichWithException.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

PR #453 fixed a secret leak on the log signal and a false "success" report on a failed tool call. The reviewer who checked that fix flagged three siblings as one coordinated follow-up (per #452's own text, which asked whether it belonged with #450/#451 "given all three surfaced from the same review"):

- **#450** — the OpenTelemetry *trace* signal had no equivalent to the log signal's exception redaction, so a secret in an exception message reached the OTLP trace exporter unredacted.
- **#451** — `GovernedAIFunction` only recognized a keyed-DI tool's structured failure marker; an MCP tool that fails without throwing was still reported `Succeeded`.
- **#452** — a failed tool's raw error text reached the audit trail, the human-approval replay, and the live event stream before any redaction ran.

## What changed

- `GovernedAIFunction` now recognizes an MCP tool's wire-level failure shape (`isError` + `content`), gated by real provenance (`ProvisionedTool.McpServerName`) so a non-MCP tool's coincidentally-shaped success payload is never misreported as failed.
- A failed tool's error text is redacted before it reaches the audit trail, matching the contract already applied to the log signal.
- The trace signal gets the same exception redaction the log signal already had: `RecordException` is switched off on ASP.NET Core/HttpClient instrumentation, and a redacting enricher builds the span's exception event and tags itself.

## Fixes from review

This PR went through `/code-review` → `/simplify` → a security-reviewer pass, twice (once on the initial diff, once after the first round of fixes). Real findings applied:

- **Ordering bug**: both reporting chokepoints truncated failure text to 4096 chars *before* redacting it — a secret straddling that cutoff could survive as an unredacted fragment. Now redacts the full text first, caps the already-safe result.
- A crash on a non-object MCP content block (`JsonElement.TryGetProperty` throws on the wrong `ValueKind`).
- The redaction filter's regex timeout was raised from 200ms to 2s, matching this repo's own sibling redactor's already-proven fix for the same `RegexMatchTimeoutException`-under-CPU-contention risk.
- `ReportedFailureText.Cap` no longer splits a UTF-16 surrogate pair at the truncation boundary.
- A shared `RedactionCategories.All` constant replaces four independent copies of `Enum.GetValues<RedactionCategory>()`.
- A shared `SafeFailureText.For(prefix, ex)` helper replaces eight hand-copied instances of the `"{prefix}: {ex.GetType().Name}."` pattern.
- `PostConfigure`-based DI wiring so the redaction filter is picked up regardless of registration order.

## Follow-ups filed as separate issues (deliberately not fixed here)

- `AuditTrailBehavior.cs` still puts a raw `ex.Message` into a persisted audit record for `ForbiddenAccessException` — this file wasn't touched by this diff.
- `GoverningToolContextProvider.Govern()` defaults `isMcpSourced` to `false`, so an MCP tool reaching the agent through the `AIContext.Tools` provider channel (rather than `ToolChainBuilder`) wouldn't get the new MCP-failure-shape check. Needs investigation into whether that channel ever actually carries MCP-backed tools.
- `BlockingProxyTool`'s 5-subclass family and `DocumentSearchTool` discard exception detail with no compensating log call — fixing this cascades into every subclass's constructor, out of scope here.
- `DirectToolInvoker`'s new `ReportedFailureText.Cap` duplicates the existing `ScrubAndBound`/`TruncationMarker` truncation convention already in that same class family — worth converging, not blocking.
- A deeper architectural question: should MCP-failure detection normalize at the point an MCP tool becomes an `AIFunction` (producing the same `ConvertedToolFailure` marker `AIToolConverter` already does), rather than threading an `isMcpSourced` flag through four call sites?

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] `dotnet test src/AgenticHarness.slnx` — fully green across the entire solution (Docker-dependent KnowledgeGraph/Neo4j/PostgreSQL and AgentHub/Prometheus suites included), zero failures
- [x] `/code-review`, `/simplify`, security-reviewer all run against the final diff

Closes #450, #452
Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfjeQC1etfSmCwPskkPXWu