### PR TITLE
chore: gh api permission widening + Stop-gate PATH fallback

### DIFF
--- a/.claude/hooks/stop-build-gate.ps1
+++ b/.claude/hooks/stop-build-gate.ps1
@@ -51,9 +51,28 @@ Set-Location $projectDir
 $solution = Join-Path $projectDir 'src/AgenticHarness.slnx'
 if (-not (Test-Path $solution)) { Allow }   # nothing to build here
 
+# --- Resolve git even when PATH is missing it. A long-running Claude Code process (or
+#     the hook subprocess it spawns) can inherit a stale PATH snapshot from before Git
+#     was installed/added to PATH, even though `git` resolves fine in a fresh shell. Fall
+#     back to Git for Windows' well-known install locations rather than wedging the gate.
+$gitCmd = Get-Command git -ErrorAction SilentlyContinue
+if ($gitCmd) {
+  $gitExe = $gitCmd.Source
+} else {
+  $gitExe = @(
+    (Join-Path $env:ProgramFiles 'Git\cmd\git.exe'),
+    (Join-Path $env:ProgramFiles 'Git\bin\git.exe'),
+    (Join-Path ${env:ProgramFiles(x86)} 'Git\cmd\git.exe')
+  ) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+}
+if (-not $gitExe) {
+  [Console]::Error.WriteLine('stop-build-gate: git not found (checked PATH and well-known install locations); skipping build gate.')
+  Allow
+}
+
 # --- Only gate when COMPILABLE source changed this session. Doc/json/asset edits
 #     under src/ shouldn't trigger a full solution build every turn.
-$dirtySrc = & git status --porcelain -- '*.cs' '*.csproj' '*.slnx' '*.props' '*.targets' '*.razor' '*.cshtml' 2>$null
+$dirtySrc = & $gitExe status --porcelain -- '*.cs' '*.csproj' '*.slnx' '*.props' '*.targets' '*.razor' '*.cshtml' 2>$null
 if (-not $dirtySrc) { Allow }
 
 # --- Tooling guard: don't trap the agent if dotnet isn't installed.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,7 +22,7 @@
       "Bash(gh pr checks:*)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
-      "Bash(gh api repos/:*)",
+      "Bash(gh api:*)",
       "Bash(git rev-parse:*)",
       "Bash(git ls-files:*)",
       "Bash(git merge-base:*)",
@@ -42,7 +42,6 @@
     ],
     "ask": [
       "Bash(git push:*)",
-      "Bash(gh api:*)",
       "Bash(scripts/rails/apply-branch-protection.sh:*)",
       "Edit(./.github/**)",
       "Edit(./.claude/settings.json)",


### PR DESCRIPTION
## Summary

Two small, unrelated `.claude/` housekeeping changes that came up during the #450/#451/#452 redaction-pass session — split out from that PR (#462) since neither touches source code or is part of that security fix.

- **`gh api` permission widening** — `permissions.allow` now covers `Bash(gh api:*)` (was scoped to `Bash(gh api repos/:*)`), and the now-redundant entry is removed from `permissions.ask`. Made per direct request during that session, with the tradeoff (broader auto-approved `gh api` surface) discussed at the time.
- **Stop-gate PATH fallback** — `stop-build-gate.ps1`'s `git status` check was failing with "term 'git' is not recognized" because its `pwsh` subprocess inherited a stale PATH snapshot. Now falls back to Git for Windows' well-known install locations before giving up, so the gate keeps working across a stale-PATH environment instead of silently skipping every turn until a full process restart.

## Test plan

- [x] Verified `git` resolves correctly through the new fallback path logic
- [x] No source code touched — no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfjeQC1etfSmCwPskkPXWu