### PR TITLE
fix: close sanitize/redact gaps for tier 2 (#470 #471 #472 #457)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/IDirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/IDirectToolInvoker.cs
@@ -51,6 +51,23 @@ public interface IDirectToolInvoker
     Task<DirectToolInvocationOutcome> InvokeAsync(
         DirectToolInvocationRequest request,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Invokes a tool published by a host-connected MCP server and returns its sanitized result, under
+    /// the identical governance <see cref="InvokeAsync"/> runs a keyed-DI tool under (#481).
+    /// </summary>
+    /// <param name="request">Which MCP tool to run, for whom, and under which grant.</param>
+    /// <param name="cancellationToken">Cancels the invocation; the caller disconnecting cancels it too.</param>
+    /// <returns>
+    /// The outcome, always — the same <see cref="DirectToolInvocationStatus"/> vocabulary
+    /// <see cref="InvokeAsync"/> uses. <see cref="DirectToolInvocationStatus.NotFound"/> additionally
+    /// covers a tool whose owning server the caller's envelope does not grant: an MCP tool is reached
+    /// only through a server in <see cref="Domain.AI.Bundles.CapabilityEnvelope.AllowedMcpServers"/>,
+    /// never by searching every configured server, so an ungranted server is never even contacted.
+    /// </returns>
+    Task<DirectToolInvocationOutcome> InvokeMcpToolAsync(
+        DirectMcpToolInvocationRequest request,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -97,6 +114,43 @@ public sealed record DirectToolInvocationRequest
     /// who requested ten minutes and was quietly given thirty seconds would experience an unexplainable
     /// timeout, with nothing in the response to attribute it to.
     /// </remarks>
+    public TimeSpan? RequestedTimeout { get; init; }
+}
+
+/// <summary>
+/// A request to run one MCP-published tool on behalf of one caller.
+/// </summary>
+/// <remarks>
+/// No <c>Operation</c> field: unlike a keyed-DI <see cref="ITool"/>, an MCP tool is a single named
+/// action described entirely by its own JSON schema — there is no host-declared operation to select.
+/// <see cref="Arguments"/> plays the role <see cref="DirectToolInvocationRequest.Parameters"/> plays for
+/// the keyed-DI path.
+/// </remarks>
+public sealed record DirectMcpToolInvocationRequest
+{
+    /// <summary>The MCP tool to run, matched case-insensitively against its published name.</summary>
+    public required string ToolName { get; init; }
+
+    /// <summary>The tool's arguments, matched against its own published JSON schema.</summary>
+    public IReadOnlyDictionary<string, object?> Arguments { get; init; } =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// The caller's stable identifier, resolved from their token at the transport boundary and never
+    /// accepted from the request body — identical provenance rule to
+    /// <see cref="DirectToolInvocationRequest.OwnerId"/>.
+    /// </summary>
+    public required string OwnerId { get; init; }
+
+    /// <summary>
+    /// The capability envelope the host grants this caller. <see cref="CapabilityEnvelope.AllowedMcpServers"/>
+    /// gates which servers may be contacted at all; <see cref="CapabilityEnvelope.AllowedTools"/> still
+    /// gates the specific tool name on top of that — a granted server does not imply every tool it
+    /// publishes is granted.
+    /// </summary>
+    public required CapabilityEnvelope Envelope { get; init; }
+
+    /// <summary>An optional shorter deadline for this invocation. Null means the configured ceiling.</summary>
     public TimeSpan? RequestedTimeout { get; init; }
 }
 

--- a/src/Content/Application/Application.AI.Common/OpenTelemetry/AiTelemetryConfigurator.cs
+++ b/src/Content/Application/Application.AI.Common/OpenTelemetry/AiTelemetryConfigurator.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.OpenTelemetry.Instruments;
 using Application.AI.Common.OpenTelemetry.Processors;
@@ -19,16 +20,21 @@ namespace Application.AI.Common.OpenTelemetry;
 /// </remarks>
 public sealed class AiTelemetryConfigurator : ITelemetryConfigurator
 {
+    private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IContentRedactionFilter _redactionFilter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AiTelemetryConfigurator"/> class.
     /// </summary>
+    /// <param name="sanitizer">Passed to <see cref="AgentFrameworkSpanProcessor"/> so tool-result
+    /// content is sanitized before it is redacted (#470).</param>
     /// <param name="redactionFilter">Passed to <see cref="AgentFrameworkSpanProcessor"/> so
     /// tool-result content is redacted before it reaches <c>gen_ai.event.content</c>.</param>
-    public AiTelemetryConfigurator(IContentRedactionFilter redactionFilter)
+    public AiTelemetryConfigurator(ICompositeResponseSanitizer sanitizer, IContentRedactionFilter redactionFilter)
     {
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(redactionFilter);
+        _sanitizer = sanitizer;
         _redactionFilter = redactionFilter;
     }
 
@@ -42,7 +48,7 @@ public sealed class AiTelemetryConfigurator : ITelemetryConfigurator
             .AddSource(AiSourceNames.MicrosoftAgentsAI)
             .AddSource(AiSourceNames.MicrosoftExtensionsAI)
             .AddSource(AiSourceNames.SemanticKernel)
-            .AddProcessor(new AgentFrameworkSpanProcessor(_redactionFilter))
+            .AddProcessor(new AgentFrameworkSpanProcessor(_sanitizer, _redactionFilter))
             .AddProcessor(new ConversationSpanProcessor());
     }
 

--- a/src/Content/Application/Application.AI.Common/OpenTelemetry/Processors/AgentFrameworkSpanProcessor.cs
+++ b/src/Content/Application/Application.AI.Common/OpenTelemetry/Processors/AgentFrameworkSpanProcessor.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.OpenTelemetry.Instruments;
+using Application.AI.Common.Services.Governance;
 using Domain.AI.Telemetry.Conventions;
 using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Telemetry;
@@ -21,18 +23,27 @@ namespace Application.AI.Common.OpenTelemetry.Processors;
 public sealed class AgentFrameworkSpanProcessor : BaseProcessor<Activity>
 {
     private const string EventContentTag = "gen_ai.event.content";
+    private const string TruncationMarker = "...[truncated]";
     // Centralized in AiSourceNames — single place to update at SDK GA
     private static readonly string AgentFrameworkSource = AiSourceNames.AgentFrameworkExact;
 
+    private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IContentRedactionFilter _filter;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AgentFrameworkSpanProcessor"/> class.
     /// </summary>
+    /// <param name="sanitizer">
+    /// Sanitizes the tool result before it is redacted (#470) — strips injection payloads and
+    /// canonicalizes invisible/zero-width characters, so a secret split by them can't dodge the
+    /// redaction filter's anchored patterns the way it could when this span only redacted.
+    /// </param>
     /// <param name="filter">Redacts the tool result before it is copied onto the span.</param>
-    public AgentFrameworkSpanProcessor(IContentRedactionFilter filter)
+    public AgentFrameworkSpanProcessor(ICompositeResponseSanitizer sanitizer, IContentRedactionFilter filter)
     {
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
+        _sanitizer = sanitizer;
         _filter = filter;
     }
 
@@ -49,12 +60,10 @@ public sealed class AgentFrameworkSpanProcessor : BaseProcessor<Activity>
         var toolResult = data.GetTagItem(ToolConventions.ToolCallResult) as string;
         if (toolResult is not null)
         {
-            // Redact before truncating: truncating first could split a secret in half and
-            // leave the surviving fragment unredacted.
-            var redacted = _filter.Redact(toolResult, RedactionCategories.All);
-            var truncated = redacted.Length > ToolConventions.MaxResultLength
-                ? string.Concat(redacted.AsSpan(0, ToolConventions.MaxResultLength), "...[truncated]")
-                : redacted;
+            // Sanitize before redact (#470), truncate last: truncating first could split a secret in
+            // half and leave the surviving fragment unredacted.
+            var treated = SanitizeThenRedact.Apply(toolResult, _sanitizer, _filter, RedactionCategories.All);
+            var (truncated, _) = BoundedText.Cap(treated, ToolConventions.MaxResultLength, TruncationMarker);
             data.SetTag(EventContentTag, truncated);
         }
     }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/BoundedText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/BoundedText.cs
@@ -1,0 +1,57 @@
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// The one "cut this text to a ceiling and say so with a marker" primitive every trust-boundary
+/// truncation call site shares (#467/#470).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Before this type existed, the same shape — cut at a length, append a marker, report whether
+/// anything was cut — had been independently rewritten at least three times: <c>ReportedFailureText.Cap</c>
+/// (a fixed 4096-char ceiling that appended its marker <em>after</em> cutting to the ceiling, so its real
+/// worst-case output ran the marker's length past the nominal cap), <c>DirectToolInvoker.Response.cs</c>'s
+/// <c>ScrubAndBound</c>/<c>FinalCut</c> (a caller-supplied ceiling that correctly reserves room for the
+/// marker, but never checked for a split surrogate pair), and <see cref="OpenTelemetry.Processors.AgentFrameworkSpanProcessor"/>'s
+/// inline truncation (same missing surrogate check, and a third, differently-spelled marker). Each
+/// difference was accidental, not a deliberate design choice for that call site — three copies drifting
+/// under maintenance, not three requirements.
+/// </para>
+/// <para>
+/// <strong>Never splits a surrogate pair.</strong> A cut that would land inside one backs off by one
+/// character instead, so the result is always a well-formed string. This is the one property worth
+/// stating explicitly: two of the three prior implementations didn't have it.
+/// </para>
+/// </remarks>
+public static class BoundedText
+{
+    /// <summary>
+    /// Cuts <paramref name="text"/> to at most <paramref name="ceiling"/> characters (marker included),
+    /// if it exceeds that length.
+    /// </summary>
+    /// <param name="text">The text to bound.</param>
+    /// <param name="ceiling">The maximum total length of the result, inclusive of <paramref name="marker"/>.</param>
+    /// <param name="marker">
+    /// Appended when a cut occurs, so the cut is visible in the text itself. When <paramref name="ceiling"/>
+    /// is not larger than the marker's own length, the marker is dropped rather than overshooting the
+    /// ceiling to fit it — the ceiling is the promise a caller sizing a downstream field is relying on.
+    /// </param>
+    /// <returns>The (possibly cut) text, and whether anything was cut.</returns>
+    public static (string Text, bool Truncated) Cap(string text, int ceiling, string marker)
+    {
+        if (text.Length <= ceiling)
+        {
+            return (text, false);
+        }
+
+        var cutIndex = ceiling > marker.Length ? ceiling - marker.Length : ceiling;
+        if (cutIndex > 0 && char.IsHighSurrogate(text[cutIndex - 1]))
+        {
+            cutIndex--;
+        }
+
+        var result = ceiling > marker.Length
+            ? string.Concat(text.AsSpan(0, cutIndex), marker)
+            : text[..cutIndex];
+        return (result, true);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/SanitizeThenRedact.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/SanitizeThenRedact.cs
@@ -1,0 +1,42 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Telemetry.Redaction;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// The one "scrub this before it crosses a trust boundary" ordering every redact-before-persist or
+/// redact-before-trace call site shares (#470): sanitize, then redact.
+/// </summary>
+/// <remarks>
+/// <strong>Sanitize before redact, always.</strong> Sanitizing first strips injection payloads before the
+/// text is ever persisted, traced, or redacted, and it means redaction runs against the sanitizer's
+/// output rather than the other way round — redacting first would hand the sanitizer already-inert
+/// <c>[REDACTED:...]</c> placeholders to scan, which helps nothing. <c>Tools.ReportedFailureText.PrepareForReporting</c>
+/// established this ordering for the tool-failure-reporting path; <see cref="OpenTelemetry.Processors.AgentFrameworkSpanProcessor"/>
+/// and <c>Infrastructure.AI.Orchestration.Magentic.MagenticSpanEmitter</c> redacted without sanitizing
+/// first until #470 — an attacker splitting a secret with invisible/zero-width characters (which the
+/// sanitizer's injection scrubber canonicalizes away, but the redaction filter's anchored patterns do
+/// not) could defeat redaction on those two paths while the identical string was caught on the
+/// tool-failure-reporting path.
+/// </remarks>
+public static class SanitizeThenRedact
+{
+    /// <summary>Sanitizes <paramref name="text"/>, then redacts the sanitizer's output.</summary>
+    /// <param name="text">The raw, untreated text.</param>
+    /// <param name="sanitizer">Strips injection payloads, invisible/zero-width characters, and exfiltration URLs.</param>
+    /// <param name="redactionFilter">Scrubs known secret patterns (emails, SSNs, AWS keys, JWTs, etc.).</param>
+    /// <param name="categories">Which redaction categories to scrub for.</param>
+    /// <param name="context">Passed to the sanitizer as context (e.g. a tool or span name).</param>
+    /// <returns>The sanitized-then-redacted text.</returns>
+    public static string Apply(
+        string text,
+        ICompositeResponseSanitizer sanitizer,
+        IContentRedactionFilter redactionFilter,
+        IReadOnlyList<RedactionCategory> categories,
+        string? context = null)
+    {
+        var sanitized = sanitizer.Sanitize(text, context).SanitizedContent;
+        return redactionFilter.Redact(sanitized, categories);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/SanitizeThenRedact.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/SanitizeThenRedact.cs
@@ -28,15 +28,26 @@ public static class SanitizeThenRedact
     /// <param name="redactionFilter">Scrubs known secret patterns (emails, SSNs, AWS keys, JWTs, etc.).</param>
     /// <param name="categories">Which redaction categories to scrub for.</param>
     /// <param name="context">Passed to the sanitizer as context (e.g. a tool or span name).</param>
-    /// <returns>The sanitized-then-redacted text.</returns>
+    /// <param name="onSanitizedEmpty">
+    /// Called with the sanitizer's output instead of redacting, when that output is null or whitespace —
+    /// for a caller (<c>Tools.ReportedFailureText.PrepareForReporting</c>) that needs to substitute a
+    /// placeholder rather than hand an empty string to a downstream consumer that rejects one. Omitted
+    /// by callers with nothing that cares about the distinction: <see cref="IContentRedactionFilter.Redact"/>
+    /// already treats a null/empty input as a no-op, so the ordering stays correct either way.
+    /// </param>
+    /// <returns>The sanitized-then-redacted text, or <paramref name="onSanitizedEmpty"/>'s result.</returns>
     public static string Apply(
         string text,
         ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter redactionFilter,
         IReadOnlyList<RedactionCategory> categories,
-        string? context = null)
+        string? context = null,
+        Func<string, string>? onSanitizedEmpty = null)
     {
         var sanitized = sanitizer.Sanitize(text, context).SanitizedContent;
+        if (onSanitizedEmpty is not null && string.IsNullOrWhiteSpace(sanitized))
+            return onSanitizedEmpty(sanitized ?? string.Empty);
+
         return redactionFilter.Redact(sanitized, categories);
     }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/SanitizeThenRedact.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/SanitizeThenRedact.cs
@@ -22,8 +22,17 @@ namespace Application.AI.Common.Services.Governance;
 /// </remarks>
 public static class SanitizeThenRedact
 {
+    /// <summary>
+    /// Bounds worst-case regex-scan cost on a remotely-triggered, attacker-controlled string before any
+    /// pattern in the sanitizer/redaction chain runs — the same ceiling and rationale
+    /// <c>Tools.ReportedFailureText.MaxScanLength</c> already established for the tool-failure-reporting
+    /// path. Independent security review found the three call sites that route through this shared
+    /// combinator (span/log content) had no such bound of their own, unlike that path.
+    /// </summary>
+    public const int MaxScanLength = 64 * 1024;
+
     /// <summary>Sanitizes <paramref name="text"/>, then redacts the sanitizer's output.</summary>
-    /// <param name="text">The raw, untreated text.</param>
+    /// <param name="text">The raw, untreated text. Cut to <see cref="MaxScanLength"/> before any pattern runs.</param>
     /// <param name="sanitizer">Strips injection payloads, invisible/zero-width characters, and exfiltration URLs.</param>
     /// <param name="redactionFilter">Scrubs known secret patterns (emails, SSNs, AWS keys, JWTs, etc.).</param>
     /// <param name="categories">Which redaction categories to scrub for.</param>
@@ -44,7 +53,11 @@ public static class SanitizeThenRedact
         string? context = null,
         Func<string, string>? onSanitizedEmpty = null)
     {
-        var sanitized = sanitizer.Sanitize(text, context).SanitizedContent;
+        // BoundedText.Cap, not a raw slice: guards the surrogate boundary the same way every other
+        // trust-boundary truncation site does.
+        var bounded = BoundedText.Cap(text, MaxScanLength, string.Empty).Text;
+
+        var sanitized = sanitizer.Sanitize(bounded, context).SanitizedContent;
         if (onSanitizedEmpty is not null && string.IsNullOrWhiteSpace(sanitized))
             return onSanitizedEmpty(sanitized ?? string.Empty);
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -341,7 +341,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             // the audit write and approver notification with no compensating log.
             { Status: EscalationExecutionStatus.Failed, FailureReason: { } reason } =>
                 _executionReporter.ReportFailedAsync(
-                    call, SafePrepareFailureText(reason, report.ToolName), reportedBy, cancellationToken),
+                    call, SafePrepareFailureText(reason, report.ToolName).Text, reportedBy, cancellationToken),
             { Status: EscalationExecutionStatus.NeverExecuted, NotExecutedReason: { } notExecuted } =>
                 _executionReporter.ReportNotExecutedAsync(call, notExecuted, reportedBy, cancellationToken),
             // An incoherent report (Failed with no reason, NeverExecuted with no reason) is a
@@ -358,7 +358,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// otherwise bypass entirely (the exception would propagate before <see cref="ReportExecutionAsync"/>
     /// ever reaches its own body). Fails closed: never returns the raw, untreated text on this path.
     /// </summary>
-    private string SafePrepareFailureText(string reason, string? toolName)
+    private PreparedFailureText SafePrepareFailureText(string reason, string? toolName)
     {
         try
         {
@@ -369,7 +369,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             _logger.LogError(ex,
                 "Failed to sanitize/redact failure text for {ToolName}; withholding raw text from the report",
                 toolName);
-            return "[tool failure text withheld: sanitization or redaction failed]";
+            return PreparedFailureText.Withheld("[tool failure text withheld: sanitization or redaction failed]");
         }
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -341,7 +341,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             // the audit write and approver notification with no compensating log.
             { Status: EscalationExecutionStatus.Failed, FailureReason: { } reason } =>
                 _executionReporter.ReportFailedAsync(
-                    call, SafePrepareFailureText(reason, report.ToolName).Text, reportedBy, cancellationToken),
+                    call, SafePrepareFailureText(reason, report.ToolName), reportedBy, cancellationToken),
             { Status: EscalationExecutionStatus.NeverExecuted, NotExecutedReason: { } notExecuted } =>
                 _executionReporter.ReportNotExecutedAsync(call, notExecuted, reportedBy, cancellationToken),
             // An incoherent report (Failed with no reason, NeverExecuted with no reason) is a
@@ -358,7 +358,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// otherwise bypass entirely (the exception would propagate before <see cref="ReportExecutionAsync"/>
     /// ever reaches its own body). Fails closed: never returns the raw, untreated text on this path.
     /// </summary>
-    private PreparedFailureText SafePrepareFailureText(string reason, string? toolName)
+    private string SafePrepareFailureText(string reason, string? toolName)
     {
         try
         {
@@ -369,7 +369,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             _logger.LogError(ex,
                 "Failed to sanitize/redact failure text for {ToolName}; withholding raw text from the report",
                 toolName);
-            return PreparedFailureText.Withheld("[tool failure text withheld: sanitization or redaction failed]");
+            return "[tool failure text withheld: sanitization or redaction failed]";
         }
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
@@ -145,6 +145,49 @@ internal static class ToolResultText
     }
 
     /// <summary>
+    /// Reduces <paramref name="result"/>'s free text to one flat string, across the same shapes
+    /// <see cref="Transform"/> recognizes — the extraction counterpart for a caller that needs plain
+    /// text rather than a shape-preserving rewrite (the direct-invocation HTTP surface, which returns a
+    /// flat string to its caller rather than replaying structured content back to a model). A
+    /// multi-block <see cref="AIContent"/>[] or content array joins every text-carrying block with a
+    /// newline, skipping non-text blocks (e.g. images) — there is no shape left to preserve them in once
+    /// reduced to a single string.
+    /// </summary>
+    public static string ExtractText(object? result) => result switch
+    {
+        null => string.Empty,
+        string text => text,
+        JsonElement { ValueKind: JsonValueKind.String } element => element.GetString() ?? string.Empty,
+        TextContent text => text.Text,
+        AIContent[] blocks => string.Join(Environment.NewLine, blocks.OfType<TextContent>().Select(b => b.Text)),
+        JsonElement { ValueKind: JsonValueKind.Object } element when TryGetContentArray(element, out var content) =>
+            ExtractContentArrayText(content),
+        JsonElement element => element.GetRawText(),
+        _ => JsonSerializer.Serialize(result)
+    };
+
+    /// <summary>
+    /// Joins every text-carrying block's text (plain <c>text</c> blocks and embedded <c>resource</c>
+    /// blocks, the same two shapes <see cref="TryGetBlockText"/> recognizes for rewriting) with a
+    /// newline, skipping blocks with nothing to extract (e.g. a binary <c>resource</c> or image block).
+    /// </summary>
+    private static string ExtractContentArrayText(JsonElement content)
+    {
+        List<string>? texts = null;
+        foreach (var block in content.EnumerateArray())
+        {
+            if (block.ValueKind == JsonValueKind.Object
+                && block.TryGetProperty("type", out var typeProp)
+                && typeProp.ValueKind == JsonValueKind.String
+                && TryGetBlockText(block, typeProp.GetString(), out var text, out _))
+            {
+                (texts ??= []).Add(text);
+            }
+        }
+        return texts is null ? string.Empty : string.Join(Environment.NewLine, texts);
+    }
+
+    /// <summary>
     /// Recognizes the MCP wire shape's top-level <c>content</c> array by structure — shared with
     /// <see cref="Tools.McpFailureNormalizingAIFunction"/>, which recognizes the same array to find a
     /// failure's text rather than to rewrite one. Kept as one structural check rather than two so the

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Governance;
@@ -293,7 +292,7 @@ public sealed partial class DirectToolInvoker
             };
         }
 
-        var raw = McpResultText(rawResult);
+        var raw = ToolResultText.ExtractText(rawResult);
         var (preCut, droppedByPreCut) = PreCutForScrub(raw, ceiling);
 
         if (!admissionPipeline.TryApplyTextOutputPolicy(admission, toolName, preCut, out var admitted))
@@ -313,18 +312,6 @@ public sealed partial class DirectToolInvoker
             Duration = duration
         };
     }
-
-    /// <summary>
-    /// Reduces an MCP tool's raw success result — typically a <see cref="JsonElement"/>, the framework's
-    /// own default marshaling — to the text every downstream scrub/bound step operates on.
-    /// </summary>
-    private static string McpResultText(object? result) => result switch
-    {
-        null => string.Empty,
-        string text => text,
-        JsonElement element => element.GetRawText(),
-        _ => JsonSerializer.Serialize(result)
-    };
 
     /// <summary>
     /// The result of MCP pre-flight: either a refusal to return as-is, or the resolved tool and caller

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -1,0 +1,344 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Planner;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Escalation;
+using Domain.AI.Governance;
+using Domain.Common.Config.AI.DirectToolInvocation;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// The MCP-tool half of direct invocation (#481): everything <see cref="DirectToolInvoker.InvokeAsync"/>
+/// does for a keyed-DI <see cref="ITool"/>, run instead against a tool published by a host-connected MCP
+/// server. Shares the identity/envelope/admission arming (<see cref="DirectToolInvoker.ArmGovernance"/>)
+/// and the response-shaping primitives (<c>DirectToolInvoker.Response.cs</c>) with the keyed-DI path —
+/// only tool resolution and invocation differ, which is the one place the two kinds of tool are
+/// genuinely different.
+/// </summary>
+public sealed partial class DirectToolInvoker
+{
+    private const string McpReportedBy = "direct-invocation-mcp";
+
+    /// <inheritdoc />
+    public async Task<DirectToolInvocationOutcome> InvokeMcpToolAsync(
+        DirectMcpToolInvocationRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var config = _config.CurrentValue;
+        if (!config.McpEnabled)
+        {
+            return DirectToolInvocationOutcome.Refused(
+                DirectToolInvocationStatus.Disabled, "MCP tool invocation is not enabled on this host.");
+        }
+
+        var preflight = await RunMcpPreflightAsync(request, config, cancellationToken).ConfigureAwait(false);
+        if (preflight.Refusal is { } refusal)
+            return refusal;
+
+        return await RunMcpArmedAsync(
+            request, preflight.Tool!, preflight.AgentId!, config, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Validates the request, resolves the tool against the caller's grant, and mints the identity the
+    /// invocation will run under — the MCP analogue of <c>DirectToolInvoker.Admission.cs</c>'s
+    /// <c>RunPreflight</c>, async because resolving an MCP tool means contacting a server.
+    /// </summary>
+    private async Task<McpPreflight> RunMcpPreflightAsync(
+        DirectMcpToolInvocationRequest request, DirectToolInvocationConfig config, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.ToolName))
+            return McpPreflight.Refuse(DirectToolInvocationStatus.Invalid, "A tool name is required.");
+
+        if (request.Arguments.Count > config.MaxParameterCount)
+        {
+            return McpPreflight.Refuse(
+                DirectToolInvocationStatus.Invalid,
+                $"An invocation may pass at most {config.MaxParameterCount} arguments.");
+        }
+
+        if (request.RequestedTimeout is { } requested
+            && !(requested > TimeSpan.Zero && requested <= config.InvocationTimeout))
+        {
+            return McpPreflight.Refuse(
+                DirectToolInvocationStatus.Invalid,
+                $"Requested timeout must be positive and no greater than {config.InvocationTimeout}.");
+        }
+
+        var agentId = SyntheticAgentPrefix + request.OwnerId;
+        if (!PlanRunRequest.IsWellFormedAgentId(agentId))
+        {
+            _logger.LogWarning(
+                "Direct MCP invocation rejected: caller identity is unusable as a permission subject (length {Length})",
+                request.OwnerId?.Length ?? 0);
+            return McpPreflight.Refuse(
+                DirectToolInvocationStatus.IdentityUnusable,
+                "The authenticated principal carries no usable identity.");
+        }
+
+        // AllowedTools gates the specific tool name on top of AllowedMcpServers (see
+        // CapabilityEnvelope's remarks: a granted server does not imply every tool it publishes is
+        // granted) — checked before any server is contacted, so an ungranted tool costs a list lookup,
+        // not an outbound call.
+        if (!request.Envelope.GrantsTool(request.ToolName))
+            return McpPreflight.Refuse(DirectToolInvocationStatus.NotFound, DirectToolInvocationErrors.NoSuchTool);
+
+        if (_mcpToolProvider is null)
+            return McpPreflight.Refuse(DirectToolInvocationStatus.NotFound, DirectToolInvocationErrors.NoSuchTool);
+
+        var tool = await ResolveGrantedMcpToolAsync(request.ToolName, request.Envelope, cancellationToken)
+            .ConfigureAwait(false);
+        if (tool is null)
+            return McpPreflight.Refuse(DirectToolInvocationStatus.NotFound, DirectToolInvocationErrors.NoSuchTool);
+
+        return McpPreflight.Accept(tool, agentId);
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="toolName"/> by contacting only the servers <paramref name="envelope"/>
+    /// grants, mirroring <c>ToolChainBuilder.ResolveInjectedMcpToolsAsync</c>'s SSRF-safe pattern — an
+    /// ungranted server is never contacted at all, no side-effect connection and no schema disclosure.
+    /// Unlike <see cref="IMcpToolProvider.GetToolByNameAsync"/>, which searches every configured server
+    /// regardless of grant, this never widens the search beyond <see cref="CapabilityEnvelope.AllowedMcpServers"/>.
+    /// </summary>
+    private async Task<AIFunction?> ResolveGrantedMcpToolAsync(
+        string toolName, CapabilityEnvelope envelope, CancellationToken cancellationToken)
+    {
+        foreach (var server in envelope.AllowedMcpServers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IList<AITool> tools;
+            try
+            {
+                tools = await _mcpToolProvider!.GetToolsAsync(server, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                // A granted server that cannot be reached costs this one caller a NotFound, not the
+                // whole invocation — the same "skip, don't fail the build" posture ToolChainBuilder
+                // takes for the identical failure.
+                _logger.LogWarning(ex,
+                    "Direct MCP invocation: granted server {Server} could not be reached while resolving {ToolName}",
+                    server, toolName);
+                continue;
+            }
+
+            var match = tools.OfType<AIFunction>()
+                .FirstOrDefault(t => string.Equals(t.Name, toolName, StringComparison.OrdinalIgnoreCase));
+            if (match is not null)
+                return match;
+        }
+
+        return null;
+    }
+
+    /// <summary>Arms the invocation and runs it, mirroring <see cref="DirectToolInvoker.RunArmedAsync"/>.</summary>
+    private async Task<DirectToolInvocationOutcome> RunMcpArmedAsync(
+        DirectMcpToolInvocationRequest request,
+        AIFunction tool,
+        string agentId,
+        DirectToolInvocationConfig config,
+        CancellationToken cancellationToken)
+    {
+        var sw = Stopwatch.StartNew();
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+
+        try
+        {
+            var (admissionPipeline, grantedEnvelope, armedAdmission) =
+                ArmGovernance(scope.ServiceProvider, agentId, request.Envelope);
+            using var _grantedEnvelope = grantedEnvelope;
+            using var _armedAdmission = armedAdmission;
+
+            try
+            {
+                return await AuthorizeAndRunMcpAsync(request, tool, admissionPipeline, config, sw, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                LogTrace(request.ToolName, agentId, admissionPipeline.GetTrace);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            sw.Stop();
+            _logger.LogWarning(
+                "Direct MCP invocation of {ToolName} exceeded its {Timeout} deadline",
+                request.ToolName, request.RequestedTimeout ?? config.InvocationTimeout);
+            return DirectToolInvocationOutcome.Refused(
+                DirectToolInvocationStatus.TimedOut, "The tool did not complete within its deadline.", sw.Elapsed);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            _logger.LogError(ex, "Direct MCP invocation of {ToolName} threw", request.ToolName);
+            return DirectToolInvocationOutcome.Refused(
+                DirectToolInvocationStatus.Faulted, DirectToolInvocationErrors.Failed, sw.Elapsed);
+        }
+    }
+
+    /// <summary>
+    /// Runs the admission chain and then the MCP tool itself, mirroring
+    /// <see cref="DirectToolInvoker.AuthorizeAndRunAsync"/> exactly — same gate call, same reporting
+    /// call, same fail-closed output policy — the only difference is how the tool is invoked and how
+    /// its result is told apart from a failure.
+    /// </summary>
+    private async Task<DirectToolInvocationOutcome> AuthorizeAndRunMcpAsync(
+        DirectMcpToolInvocationRequest request,
+        AIFunction tool,
+        IToolCallAdmissionPipeline admissionPipeline,
+        DirectToolInvocationConfig config,
+        Stopwatch sw,
+        CancellationToken cancellationToken)
+    {
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        deadline.CancelAfter(request.RequestedTimeout ?? config.InvocationTimeout);
+
+        var admission = await admissionPipeline
+            .AdmitAsync(
+                new ToolCallAdmissionRequest(request.ToolName, request.Arguments, CountsTowardLoopDetection: false),
+                deadline.Token)
+            .ConfigureAwait(false);
+
+        if (!admission.IsAllowed)
+            return Refused(DirectToolInvocationStatus.Denied, admission.DeniedMessage!, sw);
+
+        // Same failure normalization production tool chains apply to every MCP-sourced function before
+        // GovernedAIFunction ever sees the result — an MCP tool's own non-throwing failure shape is
+        // normalized to the one marker both this method and GovernedAIFunction recognize.
+        var normalized = new McpFailureNormalizingAIFunction(tool);
+        var arguments = new AIFunctionArguments(new Dictionary<string, object?>(request.Arguments));
+
+        object? rawResult;
+        try
+        {
+            rawResult = await normalized.InvokeAsync(arguments, deadline.Token).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            await ApprovalExecutionReporting
+                .ReportCallDidNotCompleteAsync(admissionPipeline, admission, McpReportedBy)
+                .ConfigureAwait(false);
+            throw;
+        }
+
+        var failure = rawResult as ConvertedToolFailure;
+        var failureText = failure?.ErrorText;
+
+        // #460: the raw failure text is passed through untreated — ShapeMcp sanitizes, redacts, and
+        // bounds it exactly once, at the same chokepoint the keyed-DI path's Shape uses.
+        await admissionPipeline.ReportExecutionAsync(
+            admission,
+            failureText is null
+                ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
+                : new ToolExecutionReport(EscalationExecutionStatus.Failed, failureText, null, ToolName: request.ToolName),
+            McpReportedBy, CancellationToken.None).ConfigureAwait(false);
+
+        sw.Stop();
+        return ShapeMcp(failureText, rawResult, request.ToolName, admissionPipeline, admission, config, sw.Elapsed);
+    }
+
+    /// <summary>
+    /// Redacts if the classification gate said to, sanitizes unconditionally, then bounds the length —
+    /// the MCP analogue of <c>DirectToolInvoker.Response.cs</c>'s <c>Shape</c>, reusing its scrub/bound
+    /// primitives (<c>ScrubAndBound</c>, <c>PreCutForScrub</c>) rather than re-deriving them, since an
+    /// MCP tool's raw result and a keyed-DI tool's <c>ToolResult.Output</c> need identical treatment
+    /// once both are reduced to text.
+    /// </summary>
+    private DirectToolInvocationOutcome ShapeMcp(
+        string? failureText,
+        object? rawResult,
+        string toolName,
+        IToolCallAdmissionPipeline admissionPipeline,
+        ToolCallAdmission admission,
+        DirectToolInvocationConfig config,
+        TimeSpan duration)
+    {
+        var ceiling = config.MaxOutputCharacters;
+
+        if (failureText is not null)
+        {
+            var (preCutError, _) = PreCutForScrub(failureText, ceiling);
+            if (!admissionPipeline.TryApplyTextOutputPolicy(admission, toolName, preCutError, out var admittedError))
+            {
+                return DirectToolInvocationOutcome.Refused(
+                    DirectToolInvocationStatus.Denied, GovernanceDenials.NotPermitted(toolName), duration);
+            }
+
+            var (error, _) = ScrubAndBound(admittedError ?? string.Empty, ceiling, toolName);
+            return new DirectToolInvocationOutcome
+            {
+                Status = DirectToolInvocationStatus.ToolFailed,
+                Error = error,
+                Duration = duration
+            };
+        }
+
+        var raw = McpResultText(rawResult);
+        var (preCut, droppedByPreCut) = PreCutForScrub(raw, ceiling);
+
+        if (!admissionPipeline.TryApplyTextOutputPolicy(admission, toolName, preCut, out var admitted))
+        {
+            return DirectToolInvocationOutcome.Refused(
+                DirectToolInvocationStatus.Denied, GovernanceDenials.NotPermitted(toolName), duration);
+        }
+
+        var (output, truncatedByOwnScrub) = ScrubAndBound(admitted ?? string.Empty, ceiling, toolName);
+        var truncated = droppedByPreCut || truncatedByOwnScrub;
+
+        return new DirectToolInvocationOutcome
+        {
+            Status = DirectToolInvocationStatus.Succeeded,
+            Output = output,
+            OutputTruncated = truncated,
+            Duration = duration
+        };
+    }
+
+    /// <summary>
+    /// Reduces an MCP tool's raw success result — typically a <see cref="JsonElement"/>, the framework's
+    /// own default marshaling — to the text every downstream scrub/bound step operates on.
+    /// </summary>
+    private static string McpResultText(object? result) => result switch
+    {
+        null => string.Empty,
+        string text => text,
+        JsonElement element => element.GetRawText(),
+        _ => JsonSerializer.Serialize(result)
+    };
+
+    /// <summary>
+    /// The result of MCP pre-flight: either a refusal to return as-is, or the resolved tool and caller
+    /// identity to run with. Kept separate from <c>DirectToolInvoker.Admission.cs</c>'s <c>Preflight</c>
+    /// rather than widening that type — the keyed-DI path resolves a name, this one resolves and keeps
+    /// the <see cref="AIFunction"/> itself, since re-resolving it in the run stage would mean a second
+    /// round trip to the server pre-flight already contacted.
+    /// </summary>
+    private readonly record struct McpPreflight(
+        DirectToolInvocationOutcome? Refusal, AIFunction? Tool, string? AgentId)
+    {
+        public static McpPreflight Refuse(DirectToolInvocationStatus status, string error) =>
+            new(DirectToolInvocationOutcome.Refused(status, error), null, null);
+
+        public static McpPreflight Accept(AIFunction tool, string agentId) => new(null, tool, agentId);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
@@ -170,7 +170,10 @@ public sealed partial class DirectToolInvoker
             : int.MaxValue;
 
         var dropped = text.Length > scanCeiling;
-        return (dropped ? text[..scanCeiling] : text, dropped);
+        // BoundedText.Cap, not a raw slice: guards the surrogate boundary the same way FinalCut's own
+        // cut does (found in independent security review — this was the one truncation site in this
+        // file that predated BoundedText and never migrated to it).
+        return dropped ? (Governance.BoundedText.Cap(text, scanCeiling, string.Empty).Text, true) : (text, false);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
@@ -174,7 +174,8 @@ public sealed partial class DirectToolInvoker
     }
 
     /// <summary>
-    /// Bounds already-sanitized text to <paramref name="ceiling"/> characters, and folds in whether
+    /// Bounds already-sanitized text to <paramref name="ceiling"/> characters via the shared
+    /// <see cref="Governance.BoundedText.Cap"/> primitive (#467/#470), and folds in whether
     /// <see cref="PreCutForScrub"/> already dropped anything ahead of sanitizing.
     /// </summary>
     private static (string Text, bool Truncated) FinalCut(string scrubbed, int ceiling, bool droppedBeforeScrubbing)
@@ -182,23 +183,12 @@ public sealed partial class DirectToolInvoker
         // Re-checked rather than inferred from the pre-cut: scrubbing changes length in both directions
         // (a placeholder is rarely the width of what it replaced), so whether the ceiling is still
         // exceeded is only knowable now.
-        var cutAfterScrubbing = scrubbed.Length > ceiling;
-        if (cutAfterScrubbing)
-        {
-            // The marker counts against the ceiling rather than being added on top of it: a caller that
-            // set the ceiling to satisfy a downstream size contract would otherwise receive a payload
-            // slightly over the limit they asked for, which is the one thing such a ceiling exists to
-            // prevent. A ceiling smaller than the marker drops the marker rather than overshoot — the
-            // ceiling is the promise, and the truncation flag is what carries the meaning.
-            scrubbed = ceiling > TruncationMarker.Length
-                ? string.Concat(scrubbed.AsSpan(0, ceiling - TruncationMarker.Length), TruncationMarker)
-                : scrubbed[..ceiling];
-        }
+        var (bounded, cutAfterScrubbing) = Governance.BoundedText.Cap(scrubbed, ceiling, TruncationMarker);
 
         // Reported from what was actually dropped, never from what the raw length suggested. A string
         // barely over the ceiling that scrubbing shortened below it lost nothing, and claiming
         // otherwise would send a caller looking for content that is all present.
-        return (scrubbed, droppedBeforeScrubbing || cutAfterScrubbing);
+        return (bounded, droppedBeforeScrubbing || cutAfterScrubbing);
     }
 
     /// <summary>Runs text through the response-sanitizer chain. Empty text is returned untouched.</summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
@@ -61,6 +62,7 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     private readonly IToolCatalog _catalog;
     private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IOptionsMonitor<DirectToolInvocationConfig> _config;
+    private readonly IMcpToolProvider? _mcpToolProvider;
     private readonly ILogger<DirectToolInvoker> _logger;
 
     /// <summary>Initializes the invoker.</summary>
@@ -68,13 +70,20 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     /// <param name="catalog">Resolves the tool, filtered to the caller's grant.</param>
     /// <param name="sanitizer">Scrubs everything leaving the trust boundary.</param>
     /// <param name="config">The host's direct-invocation settings, read per request.</param>
+    /// <param name="mcpToolProvider">
+    /// Resolves MCP-published tools for <see cref="InvokeMcpToolAsync"/> (#481). Optional, mirroring
+    /// <c>ToolChainBuilder</c>'s own MCP dependency: a host with no MCP servers configured need not
+    /// register a provider, and <see cref="InvokeMcpToolAsync"/> answers <see cref="DirectToolInvocationStatus.NotFound"/>
+    /// rather than throwing when it is absent.
+    /// </param>
     /// <param name="logger">Records denials, faults, and the governance trace.</param>
     public DirectToolInvoker(
         IServiceScopeFactory scopeFactory,
         IToolCatalog catalog,
         ICompositeResponseSanitizer sanitizer,
         IOptionsMonitor<DirectToolInvocationConfig> config,
-        ILogger<DirectToolInvoker> logger)
+        ILogger<DirectToolInvoker> logger,
+        IMcpToolProvider? mcpToolProvider = null)
     {
         ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(catalog);
@@ -86,6 +95,7 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         _catalog = catalog;
         _sanitizer = sanitizer;
         _config = config;
+        _mcpToolProvider = mcpToolProvider;
         _logger = logger;
     }
 
@@ -151,24 +161,10 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
             // reached through this surface is therefore not enforceable here — the call-once gate
             // fails open on a null scope, which is the documented, correct answer, not a gap. See
             // IAgentExecutionContext.CallOnceScopeId's remarks.
-            var executionContext = scope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
-            executionContext.Initialize(agentId, conversationId: Guid.NewGuid().ToString(), turnNumber: 1);
-
-            // Required, not GetService: the chain is registered unconditionally, and an absent one is
-            // indistinguishable at runtime from a host whose gates all happen to be off — so tolerating
-            // null here would let a broken composition run this path silently unguarded.
-            var admissionPipeline = scope.ServiceProvider.GetRequiredService<IToolCallAdmissionPipeline>();
-            admissionPipeline.Reset();
-
-            // Both ambient values are published with restoring scopes rather than assigned and nulled.
-            // The difference only shows under nesting, where it is the whole game: nulling on teardown
-            // disarms whatever an enclosing flow had armed, leaving the outer call ungoverned for the
-            // rest of its life. Restoring cannot do that.
-            //
-            // The chain is armed as well as called directly, because a tool that spawns an agent turn
-            // beneath it must reach the same chain rather than run unadmitted.
-            using var grantedEnvelope = CapabilityEnvelopeAccessor.Begin(request.Envelope);
-            using var armedAdmission = ToolAdmissionAccessor.Begin(admissionPipeline);
+            var (admissionPipeline, grantedEnvelope, armedAdmission) =
+                ArmGovernance(scope.ServiceProvider, agentId, request.Envelope);
+            using var _grantedEnvelope = grantedEnvelope;
+            using var _armedAdmission = armedAdmission;
 
             try
             {
@@ -205,6 +201,58 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.Faulted, DirectToolInvocationErrors.Failed, sw.Elapsed);
         }
+    }
+
+    /// <summary>
+    /// Establishes the caller's identity and capability envelope, then arms the ambient admission
+    /// chain — the fixed-order sequence every direct-invocation surface must run before its own
+    /// tool-specific resolution, whatever kind of tool that turns out to be (#481). Extracted so the
+    /// keyed-DI <see cref="ITool"/> path (<see cref="RunArmedAsync"/>) and the MCP path
+    /// (<c>DirectToolInvoker.Mcp.cs</c>) share the one implementation rather than each re-deriving this
+    /// order by hand — see this type's remarks for what goes wrong when that discipline is duplicated.
+    /// </summary>
+    /// <returns>
+    /// The scoped admission chain, reset and ready, plus the two restoring scopes the caller must
+    /// dispose (in either order — both restore independently) when the invocation ends.
+    /// </returns>
+    private (IToolCallAdmissionPipeline Pipeline, IDisposable EnvelopeScope, IDisposable AdmissionScope) ArmGovernance(
+        IServiceProvider scopedProvider, string agentId, Domain.AI.Bundles.CapabilityEnvelope envelope)
+    {
+        // Identity and envelope. Both must be in place before AdmitAsync — see the type remarks for
+        // what the governor reads, and when.
+        //
+        // The conversation id is deliberately NOT agentId. #325's retry-attribution memory is keyed on
+        // (conversation, agent, tool) precisely so it expires — but agentId here is the caller's stable
+        // synthetic identity, reused for every direct invocation that caller ever makes. Passing it as
+        // the conversation id too would give the failure-memory key no expiry at all. A direct
+        // invocation is a single, standalone call with no request-level session concept to key on, so
+        // each one mints its own one-shot id.
+        //
+        // callOnceScopeId is deliberately omitted (null), for the identical reason: a direct invocation
+        // has no request-level session to key a repeat-call check on either. A call-once tool reached
+        // through this surface is therefore not enforceable here — the call-once gate fails open on a
+        // null scope, which is the documented, correct answer, not a gap. See
+        // IAgentExecutionContext.CallOnceScopeId's remarks.
+        var executionContext = scopedProvider.GetRequiredService<IAgentExecutionContext>();
+        executionContext.Initialize(agentId, conversationId: Guid.NewGuid().ToString(), turnNumber: 1);
+
+        // Required, not GetService: the chain is registered unconditionally, and an absent one is
+        // indistinguishable at runtime from a host whose gates all happen to be off — so tolerating
+        // null here would let a broken composition run this path silently unguarded.
+        var admissionPipeline = scopedProvider.GetRequiredService<IToolCallAdmissionPipeline>();
+        admissionPipeline.Reset();
+
+        // Both ambient values are published with restoring scopes rather than assigned and nulled. The
+        // difference only shows under nesting, where it is the whole game: nulling on teardown disarms
+        // whatever an enclosing flow had armed, leaving the outer call ungoverned for the rest of its
+        // life. Restoring cannot do that.
+        //
+        // The chain is armed as well as called directly, because a tool that spawns an agent turn
+        // beneath it must reach the same chain rather than run unadmitted.
+        var grantedEnvelope = CapabilityEnvelopeAccessor.Begin(envelope);
+        var armedAdmission = ToolAdmissionAccessor.Begin(admissionPipeline);
+
+        return (admissionPipeline, grantedEnvelope, armedAdmission);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
@@ -60,6 +60,14 @@ internal static class ReportedFailureText
     /// </param>
     /// <param name="redactionFilter">Scrubs known secret patterns (emails, SSNs, AWS keys, JWTs, etc.).</param>
     /// <param name="toolName">The tool that produced <paramref name="text"/>, passed to the sanitizer as context.</param>
+    /// <returns>
+    /// #472: a <see cref="PreparedFailureText"/> rather than a bare string, so "this is one of the
+    /// placeholder cases below, not the tool's own message" is a field a caller checks
+    /// (<see cref="PreparedFailureText.WasWithheld"/>) instead of an implicit convention that the text
+    /// happens to string-equal one of three fixed constants. No caller branches on it today — the point
+    /// is that a future one, or a future edit that makes a placeholder templated (e.g. including the
+    /// tool name), has a type-checked case to handle rather than a string comparison to remember.
+    /// </returns>
     /// <remarks>
     /// <para>
     /// <strong>Sanitize before redact.</strong> Sanitizing first means an injection payload is stripped
@@ -78,7 +86,7 @@ internal static class ReportedFailureText
     /// (already-safe) result afterward is the only ordering that can't leak a fragment.
     /// </para>
     /// </remarks>
-    public static string PrepareForReporting(
+    public static PreparedFailureText PrepareForReporting(
         string text, ICompositeResponseSanitizer sanitizer, IContentRedactionFilter redactionFilter, string? toolName)
     {
         // Bounds the cost of every pattern in the sanitizer/redaction chain before any of them run,
@@ -86,36 +94,54 @@ internal static class ReportedFailureText
         // does nothing to bound how much text the dozens of regex passes upstream of it must scan.
         if (text.Length > MaxScanLength)
         {
-            return OversizedInputPlaceholder;
+            return PreparedFailureText.Withheld(OversizedInputPlaceholder);
         }
 
+        // Sanitize-then-redact ordering lives once in SanitizeThenRedact (#470) — this method no
+        // longer needs to know the empty-after-sanitization check requires the sanitize half to run
+        // first, only that it must, so the two steps stay split rather than folded into one call: the
+        // withheld-placeholder decision below depends on the sanitizer's output alone, before redaction
+        // ever runs.
         var sanitized = sanitizer.Sanitize(text, toolName).SanitizedContent;
         if (string.IsNullOrWhiteSpace(sanitized))
         {
-            return EmptyAfterSanitizationPlaceholder;
+            return PreparedFailureText.Withheld(EmptyAfterSanitizationPlaceholder);
         }
 
         var redacted = redactionFilter.Redact(sanitized, RedactionCategories.All);
-        return Cap(redacted);
+        return PreparedFailureText.Reported(Cap(redacted));
     }
 
     /// <summary>
-    /// Truncates <paramref name="text"/> to a bounded length, if it exceeds one. Never splits a
-    /// surrogate pair — a cut that would land inside one backs off by one character instead, so the
-    /// result is always a well-formed string.
+    /// Truncates <paramref name="text"/> to a bounded length, if it exceeds one, via the one
+    /// cut-and-mark primitive every trust-boundary truncation site shares (#467/#470).
     /// </summary>
-    public static string Cap(string text)
-    {
-        if (text.Length <= MaxLength)
-        {
-            return text;
-        }
+    public static string Cap(string text) =>
+        Services.Governance.BoundedText.Cap(text, MaxLength, "…[truncated]").Text;
+}
 
-        var cutIndex = MaxLength;
-        if (char.IsHighSurrogate(text[cutIndex - 1]))
-        {
-            cutIndex--;
-        }
-        return string.Concat(text.AsSpan(0, cutIndex), "…[truncated]");
-    }
+/// <summary>
+/// The result of <see cref="ReportedFailureText.PrepareForReporting"/> (#472): the text to report,
+/// plus a type-checked flag for whether it is the tool's own (sanitized/redacted/capped) message or one
+/// of the fixed withheld-placeholder cases.
+/// </summary>
+/// <remarks>
+/// Both cases carry a non-null, non-whitespace <see cref="Text"/> — <c>EscalationExecutionRecord.Failed</c>
+/// and <c>InProcessApprovalFailureMemory.RecordFailure</c> both reject one, so a withheld placeholder must
+/// remain a usable string for whichever downstream consumer receives it. <see cref="WasWithheld"/> is what
+/// lets a consumer tell the two apart without comparing <see cref="Text"/> against a magic constant.
+/// </remarks>
+/// <param name="Text">The text to report — either the tool's own prepared message, or a withheld placeholder.</param>
+/// <param name="WasWithheld">
+/// <see langword="true"/> when <see cref="Text"/> is one of the fixed placeholder cases (oversized input,
+/// empty after sanitization, or — via <c>ToolCallAdmissionPipeline.SafePrepareFailureText</c>'s
+/// catch — a sanitize/redact failure), rather than the tool's own text.
+/// </param>
+internal readonly record struct PreparedFailureText(string Text, bool WasWithheld)
+{
+    /// <summary>The tool's own text, sanitized, redacted, and capped — safe to report as-is.</summary>
+    public static PreparedFailureText Reported(string text) => new(text, WasWithheld: false);
+
+    /// <summary>One of the fixed placeholder cases, in place of the tool's own text.</summary>
+    public static PreparedFailureText Withheld(string placeholder) => new(placeholder, WasWithheld: true);
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
+using Application.AI.Common.Services.Governance;
 using Domain.AI.Telemetry.Redaction;
 
 namespace Application.AI.Common.Services.Tools;
@@ -61,12 +62,8 @@ internal static class ReportedFailureText
     /// <param name="redactionFilter">Scrubs known secret patterns (emails, SSNs, AWS keys, JWTs, etc.).</param>
     /// <param name="toolName">The tool that produced <paramref name="text"/>, passed to the sanitizer as context.</param>
     /// <returns>
-    /// #472: a <see cref="PreparedFailureText"/> rather than a bare string, so "this is one of the
-    /// placeholder cases below, not the tool's own message" is a field a caller checks
-    /// (<see cref="PreparedFailureText.WasWithheld"/>) instead of an implicit convention that the text
-    /// happens to string-equal one of three fixed constants. No caller branches on it today — the point
-    /// is that a future one, or a future edit that makes a placeholder templated (e.g. including the
-    /// tool name), has a type-checked case to handle rather than a string comparison to remember.
+    /// The text to report: either the tool's own sanitized/redacted/capped message, or one of the fixed
+    /// withheld placeholders below.
     /// </returns>
     /// <remarks>
     /// <para>
@@ -86,7 +83,7 @@ internal static class ReportedFailureText
     /// (already-safe) result afterward is the only ordering that can't leak a fragment.
     /// </para>
     /// </remarks>
-    public static PreparedFailureText PrepareForReporting(
+    public static string PrepareForReporting(
         string text, ICompositeResponseSanitizer sanitizer, IContentRedactionFilter redactionFilter, string? toolName)
     {
         // Bounds the cost of every pattern in the sanitizer/redaction chain before any of them run,
@@ -94,22 +91,17 @@ internal static class ReportedFailureText
         // does nothing to bound how much text the dozens of regex passes upstream of it must scan.
         if (text.Length > MaxScanLength)
         {
-            return PreparedFailureText.Withheld(OversizedInputPlaceholder);
+            return OversizedInputPlaceholder;
         }
 
-        // Sanitize-then-redact ordering lives once in SanitizeThenRedact (#470) — this method no
-        // longer needs to know the empty-after-sanitization check requires the sanitize half to run
-        // first, only that it must, so the two steps stay split rather than folded into one call: the
-        // withheld-placeholder decision below depends on the sanitizer's output alone, before redaction
-        // ever runs.
-        var sanitized = sanitizer.Sanitize(text, toolName).SanitizedContent;
-        if (string.IsNullOrWhiteSpace(sanitized))
-        {
-            return PreparedFailureText.Withheld(EmptyAfterSanitizationPlaceholder);
-        }
+        // Sanitize-then-redact ordering lives once in SanitizeThenRedact (#470); the withheld-placeholder
+        // decision plugs into its onSanitizedEmpty hook, so this method no longer hand-rolls the same
+        // sanitize → check → redact sequence every other call site already converged on.
+        var reported = SanitizeThenRedact.Apply(
+            text, sanitizer, redactionFilter, RedactionCategories.All, toolName,
+            onSanitizedEmpty: _ => EmptyAfterSanitizationPlaceholder);
 
-        var redacted = redactionFilter.Redact(sanitized, RedactionCategories.All);
-        return PreparedFailureText.Reported(Cap(redacted));
+        return Cap(reported);
     }
 
     /// <summary>
@@ -117,31 +109,5 @@ internal static class ReportedFailureText
     /// cut-and-mark primitive every trust-boundary truncation site shares (#467/#470).
     /// </summary>
     public static string Cap(string text) =>
-        Services.Governance.BoundedText.Cap(text, MaxLength, "…[truncated]").Text;
-}
-
-/// <summary>
-/// The result of <see cref="ReportedFailureText.PrepareForReporting"/> (#472): the text to report,
-/// plus a type-checked flag for whether it is the tool's own (sanitized/redacted/capped) message or one
-/// of the fixed withheld-placeholder cases.
-/// </summary>
-/// <remarks>
-/// Both cases carry a non-null, non-whitespace <see cref="Text"/> — <c>EscalationExecutionRecord.Failed</c>
-/// and <c>InProcessApprovalFailureMemory.RecordFailure</c> both reject one, so a withheld placeholder must
-/// remain a usable string for whichever downstream consumer receives it. <see cref="WasWithheld"/> is what
-/// lets a consumer tell the two apart without comparing <see cref="Text"/> against a magic constant.
-/// </remarks>
-/// <param name="Text">The text to report — either the tool's own prepared message, or a withheld placeholder.</param>
-/// <param name="WasWithheld">
-/// <see langword="true"/> when <see cref="Text"/> is one of the fixed placeholder cases (oversized input,
-/// empty after sanitization, or — via <c>ToolCallAdmissionPipeline.SafePrepareFailureText</c>'s
-/// catch — a sanitize/redact failure), rather than the tool's own text.
-/// </param>
-internal readonly record struct PreparedFailureText(string Text, bool WasWithheld)
-{
-    /// <summary>The tool's own text, sanitized, redacted, and capped — safe to report as-is.</summary>
-    public static PreparedFailureText Reported(string text) => new(text, WasWithheld: false);
-
-    /// <summary>One of the fixed placeholder cases, in place of the tool's own text.</summary>
-    public static PreparedFailureText Withheld(string placeholder) => new(placeholder, WasWithheld: true);
+        BoundedText.Cap(text, MaxLength, "…[truncated]").Text;
 }

--- a/src/Content/Application/Application.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/IServiceCollectionExtensions.cs
@@ -77,14 +77,34 @@ public static class IServiceCollectionExtensions
             builder.AddInMemoryRingBuffer();
         });
 
-        // #457: redact every local sink the same way the OTel logging bridge already does — one
-        // front door (ILoggerFactory.CreateLogger) rather than patching each current and future
-        // ILoggerProvider individually. Replaces AddLogging's own ILoggerFactory registration with an
-        // equivalent LoggerFactory (same providers, same filter/scope options, all resolved from this
-        // same container) wrapped in RedactingLoggerFactory. ILocalLogRedactor is resolved lazily and
-        // optionally: a host with no implementation registered (this project has no reference to
-        // wherever IContentRedactionFilter lives, by design — see ILocalLogRedactor's remarks) gets an
-        // unmodified pipeline, byte-identical to before this existed.
+        services.WrapWithLocalLogRedaction();
+
+        // Azure SDK EventSource-to-ILogger bridge (issue #383) — surfaces which credential
+        // DefaultAzureCredential selected at Information level, without full EventSource tracing.
+        services.AddAzureIdentityDiagnostics();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Redacts every local sink (console, file, JSONL, named pipe) the same way the OTel logging bridge
+    /// already does — one front door (<see cref="ILoggerFactory.CreateLogger"/>) rather than patching
+    /// each current and future <see cref="ILoggerProvider"/> individually (#457). Named and kept
+    /// separate from <see cref="ConfigureLogging"/>'s provider setup so this security-relevant wiring is
+    /// discoverable by name (IDE outline, a grep for "Redaction") rather than buried as an unlabeled
+    /// statement block inside a more generic method.
+    /// </summary>
+    /// <remarks>
+    /// Replaces <c>AddLogging</c>'s own <see cref="ILoggerFactory"/> registration with an equivalent
+    /// <see cref="LoggerFactory"/> (same providers, same filter/scope options, all resolved from this
+    /// same container) wrapped in <see cref="RedactingLoggerFactory"/>. <see cref="ILocalLogRedactor"/>
+    /// is resolved lazily and optionally: a host with no implementation registered (this project has no
+    /// reference to wherever <c>IContentRedactionFilter</c> lives, by design — see
+    /// <see cref="ILocalLogRedactor"/>'s remarks) gets an unmodified pipeline, byte-identical to before
+    /// this existed.
+    /// </remarks>
+    private static void WrapWithLocalLogRedaction(this IServiceCollection services)
+    {
         services.Replace(ServiceDescriptor.Singleton<ILoggerFactory>(sp =>
         {
             var providers = sp.GetServices<ILoggerProvider>();
@@ -99,11 +119,5 @@ public static class IServiceCollectionExtensions
             var redactor = sp.GetService<ILocalLogRedactor>();
             return redactor is null ? inner : new RedactingLoggerFactory(inner, redactor);
         }));
-
-        // Azure SDK EventSource-to-ILogger bridge (issue #383) — surfaces which credential
-        // DefaultAzureCredential selected at Information level, without full EventSource tracing.
-        services.AddAzureIdentityDiagnostics();
-
-        return services;
     }
 }

--- a/src/Content/Application/Application.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Application/Application.Common/Extensions/IServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 using Application.Common.Logging;
 using Domain.Common.Config;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
 
 namespace Application.Common.Extensions;
 
@@ -74,6 +76,29 @@ public static class IServiceCollectionExtensions
             // In-memory ring buffer for diagnostics endpoints (always enabled)
             builder.AddInMemoryRingBuffer();
         });
+
+        // #457: redact every local sink the same way the OTel logging bridge already does — one
+        // front door (ILoggerFactory.CreateLogger) rather than patching each current and future
+        // ILoggerProvider individually. Replaces AddLogging's own ILoggerFactory registration with an
+        // equivalent LoggerFactory (same providers, same filter/scope options, all resolved from this
+        // same container) wrapped in RedactingLoggerFactory. ILocalLogRedactor is resolved lazily and
+        // optionally: a host with no implementation registered (this project has no reference to
+        // wherever IContentRedactionFilter lives, by design — see ILocalLogRedactor's remarks) gets an
+        // unmodified pipeline, byte-identical to before this existed.
+        services.Replace(ServiceDescriptor.Singleton<ILoggerFactory>(sp =>
+        {
+            var providers = sp.GetServices<ILoggerProvider>();
+            var filterOptions = sp.GetRequiredService<IOptionsMonitor<LoggerFilterOptions>>();
+            var factoryOptions = sp.GetRequiredService<IOptions<LoggerFactoryOptions>>();
+            var scopeProvider = sp.GetService<IExternalScopeProvider>();
+
+            ILoggerFactory inner = scopeProvider is not null
+                ? new LoggerFactory(providers, filterOptions, factoryOptions, scopeProvider)
+                : new LoggerFactory(providers, filterOptions, factoryOptions);
+
+            var redactor = sp.GetService<ILocalLogRedactor>();
+            return redactor is null ? inner : new RedactingLoggerFactory(inner, redactor);
+        }));
 
         // Azure SDK EventSource-to-ILogger bridge (issue #383) — surfaces which credential
         // DefaultAzureCredential selected at Information level, without full EventSource tracing.

--- a/src/Content/Application/Application.Common/Logging/ILocalLogRedactor.cs
+++ b/src/Content/Application/Application.Common/Logging/ILocalLogRedactor.cs
@@ -1,0 +1,39 @@
+namespace Application.Common.Logging;
+
+/// <summary>
+/// Redacts free text before it reaches a local <see cref="Microsoft.Extensions.Logging.ILoggerProvider"/>
+/// sink — console, file, JSONL, named pipe, or any future provider (#457).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Owned here, in <c>Application.Common</c>, rather than alongside the concrete content redactor: this
+/// project has no reference to <c>Application.AI.Common</c> (where <c>IContentRedactionFilter</c> and
+/// <c>RedactionCategory</c> live) and adding one would invert the layering the two "Common" projects are
+/// split to preserve — <c>Application.Common</c> stays AI-agnostic; AI-specific concerns live one layer
+/// up. This interface is deliberately the smallest shape a redactor needs to be useful here: no
+/// categories, no tool-name context, just text in and text out. The richer decision (which categories,
+/// which config) is entirely the implementing adapter's business.
+/// </para>
+/// <para>
+/// <strong>Optional by design.</strong> <see cref="Extensions.IServiceCollectionExtensions.ConfigureLogging"/>
+/// resolves this via <c>IServiceProvider.GetService</c>, not <c>GetRequiredService</c> — a host that
+/// never registers an implementation gets a passthrough logging pipeline, identical to before this type
+/// existed, rather than a startup failure. The one real implementation lives in
+/// <c>Infrastructure.Observability</c>, wrapping the same <c>IContentRedactionFilter</c> and
+/// <c>LogsConfig</c> the OTel logging bridge's own redaction already uses — one config knob, both
+/// surfaces.
+/// </para>
+/// </remarks>
+public interface ILocalLogRedactor
+{
+    /// <summary>
+    /// Whether redaction is currently active. Checked once per log call so a disabled redactor costs
+    /// a property read, not a full scrub with nothing to show for it.
+    /// </summary>
+    bool Enabled { get; }
+
+    /// <summary>Redacts known secret/PII patterns from <paramref name="text"/>.</summary>
+    /// <param name="text">The raw text — a formatted log message, or an exception's full text.</param>
+    /// <returns>The redacted text. Identical to <paramref name="text"/> when nothing matched.</returns>
+    string Redact(string text);
+}

--- a/src/Content/Application/Application.Common/Logging/RedactedLocalLogException.cs
+++ b/src/Content/Application/Application.Common/Logging/RedactedLocalLogException.cs
@@ -1,0 +1,41 @@
+namespace Application.Common.Logging;
+
+/// <summary>
+/// Replaces an exception <see cref="RedactingLogger"/> caught something to redact in. Carries the
+/// already-redacted full text (type, message, stack frames, and the whole inner-exception chain) so
+/// whatever a local sink's formatter does with the exception — <c>.Message</c>, <c>.ToString()</c>, or
+/// both — reads the redacted text rather than the original.
+/// </summary>
+/// <remarks>
+/// Unlike the OTel bridge's <c>LogRecordRedactionProcessor</c> (which keeps <c>Exception.Message</c>
+/// short and stashes the full redacted text in a separate structured attribute, because the OTLP
+/// exporter treats <c>exception.message</c> as a standardized, dashboard-grouped field), a local sink
+/// has no such contract to protect — console and file output print the whole exception as one blob
+/// regardless — so <see cref="ToString"/> returning the complete redacted text directly is the simpler,
+/// equally-safe choice here.
+/// </remarks>
+public sealed class RedactedLocalLogException : Exception
+{
+    private readonly string _redactedText;
+
+    /// <param name="redactedText">The exception's full text, already redacted.</param>
+    public RedactedLocalLogException(string redactedText) : base(FirstLine(redactedText))
+    {
+        _redactedText = redactedText;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns the complete redacted text rather than the base <see cref="Exception.ToString"/>
+    /// formatting (which would prefix this type's own name and append its own, empty stack trace) —
+    /// a formatter calling <c>ToString()</c> on this exception should see exactly the redacted
+    /// original, not a wrapper's framing around it.
+    /// </remarks>
+    public override string ToString() => _redactedText;
+
+    private static string FirstLine(string text)
+    {
+        var newlineIndex = text.IndexOf('\n');
+        return newlineIndex >= 0 ? text[..newlineIndex] : text;
+    }
+}

--- a/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
+++ b/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
@@ -36,49 +36,47 @@ public sealed class RedactingLogger : ILogger
     }
 
     /// <summary>
-    /// Redacts scope state carrying free text — found in independent security review: forwarding
-    /// <paramref name="state"/> unchanged meant a secret or PII value placed in scope state (a
-    /// connection string, an email) reached every local sink in cleartext, since a console/file
-    /// formatter renders scope contents directly. Handles only the two shapes actually capable of
-    /// carrying arbitrary text: a plain <see cref="string"/>, and a structured scope
-    /// (<c>IEnumerable&lt;KeyValuePair&lt;string, object?&gt;&gt;</c>, from a dictionary or
-    /// <c>LoggerMessage.DefineScope</c>) has its string-valued entries redacted in place.
+    /// Redacts scope state, but only the one shape this type can safely redact without risking a
+    /// downstream regression: a plain <see cref="string"/>, pushed back as the redacted string itself —
+    /// no reconstruction, so nothing about it can differ from the original except the text.
     /// </summary>
     /// <remarks>
-    /// Anything else passes through <em>unchanged</em> — not redacted via its rendered
-    /// <see cref="object.ToString"/> text. An earlier version of this method did exactly that, and CI's
-    /// correctness-review caught the regression: <c>ExecutionScope</c> (this codebase's own domain scope
-    /// type, carrying executor/correlation ids and a step number — structural identifiers, never
-    /// arbitrary text, so nothing here needs redacting) does not implement the structured-KVP shape
-    /// above, so it fell through to the string-collapse branch. That replaced the pushed scope object
-    /// with a plain <see cref="string"/>, which broke <c>ExecutionScopeProvider.GetCurrentScope</c>'s
-    /// <c>scope is ExecutionScope</c> type check for every request — not merely a fidelity loss but a
-    /// silent breakage of an already-wired feature, for every local sink, whenever redaction is enabled
-    /// (the default). Transforming an unrecognized object risks exactly this: breaking a downstream
-    /// consumer that depends on the exact runtime type of what it pushed. Only the two shapes this type
-    /// can safely reconstruct after redacting are transformed; everything else is left alone.
+    /// <para>
+    /// Everything else passes through <em>completely unchanged</em>. Two earlier versions of this method
+    /// each tried to redact one more shape, and CI's correctness-review caught a real regression in both:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><description>
+    /// Collapsing any unrecognized object to a redacted string via <see cref="object.ToString"/> broke
+    /// <c>ExecutionScopeProvider.GetCurrentScope</c>'s <c>scope is ExecutionScope</c> type check — the
+    /// pushed object's runtime type must survive for that consumer to recognize it at all.
+    /// </description></item>
+    /// <item><description>
+    /// Reconstructing a structured scope (<c>IEnumerable&lt;KeyValuePair&lt;string, object?&gt;&gt;</c>)
+    /// as a plain <c>List&lt;KeyValuePair&lt;string, object?&gt;&gt;</c> broke every local formatter that
+    /// renders a scope by calling <see cref="object.ToString"/> on whatever was pushed —
+    /// <c>ColorfulConsoleFormatter.WriteScopeInformation</c> does exactly this — because a
+    /// compiler-generated templated <c>BeginScope("... {Arg} ...", args)</c> call's state implements that
+    /// same interface <em>and</em> overrides <c>ToString()</c> to render the interpolated text; the
+    /// reconstructed <c>List&lt;T&gt;</c> has no such override, so the rendered scope silently became
+    /// useless boilerplate instead of the original text, for every templated scope, everywhere.
+    /// </description></item>
+    /// </list>
+    /// <para>
+    /// A templated <c>BeginScope</c> call is also the one realistic way a secret reaches scope state in
+    /// this codebase — and it is exactly the shape the fix above cannot safely rewrite without breaking
+    /// its own rendering identity. That gap is real and tracked (issue #500) rather than "fixed" a third
+    /// time with the same category of regression; the plain-string case this method does handle is the
+    /// one already-common, already-safe pattern (<c>BeginScope("free text here")</c>) with zero
+    /// type-identity risk.
+    /// </para>
     /// </remarks>
     /// <inheritdoc />
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
-        if (!_redactor.Enabled)
-        {
-            return _inner.BeginScope(state);
-        }
-
-        if (state is string text)
+        if (_redactor.Enabled && state is string text)
         {
             return _inner.BeginScope(_redactor.Redact(text));
-        }
-
-        if (state is IEnumerable<KeyValuePair<string, object?>> pairs)
-        {
-            var redactedPairs = pairs
-                .Select(kv => kv.Value is string value
-                    ? new KeyValuePair<string, object?>(kv.Key, _redactor.Redact(value))
-                    : kv)
-                .ToList();
-            return _inner.BeginScope(redactedPairs);
         }
 
         return _inner.BeginScope(state);

--- a/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
+++ b/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
@@ -29,8 +29,37 @@ public sealed class RedactingLogger : ILogger
         _redactor = redactor;
     }
 
+    /// <summary>
+    /// Redacts scope state the same way <see cref="Log{TState}"/> redacts a message — found in
+    /// independent security review: forwarding <paramref name="state"/> unchanged meant a secret or PII
+    /// value placed in scope state (a connection string, an email — categories this redactor's default
+    /// set already covers) reached every local sink in cleartext, since a console/file formatter renders
+    /// scope contents directly. Handles the two shapes scope state actually takes: a structured scope
+    /// (<c>IEnumerable&lt;KeyValuePair&lt;string, object?&gt;&gt;</c>, from a dictionary or
+    /// <c>LoggerMessage.DefineScope</c>) has its string-valued entries redacted in place; anything else
+    /// is redacted via its rendered <see cref="object.ToString"/> text, mirroring how a formatter that
+    /// doesn't understand the structured shape would render it anyway.
+    /// </summary>
     /// <inheritdoc />
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => _inner.BeginScope(state);
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    {
+        if (!_redactor.Enabled)
+        {
+            return _inner.BeginScope(state);
+        }
+
+        if (state is IEnumerable<KeyValuePair<string, object?>> pairs)
+        {
+            var redactedPairs = pairs
+                .Select(kv => kv.Value is string value
+                    ? new KeyValuePair<string, object?>(kv.Key, _redactor.Redact(value))
+                    : kv)
+                .ToList();
+            return _inner.BeginScope(redactedPairs);
+        }
+
+        return _inner.BeginScope(_redactor.Redact(state.ToString() ?? string.Empty));
+    }
 
     /// <inheritdoc />
     public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);

--- a/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
+++ b/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Logging;
+
+namespace Application.Common.Logging;
+
+/// <summary>
+/// Wraps an <see cref="ILogger"/> so both the rendered message and any logged exception are redacted
+/// before they reach the inner logger — and therefore before they reach whatever local
+/// <see cref="ILoggerProvider"/> the inner logger belongs to (#457).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both halves funnel through the same <c>Log(logLevel, eventId, string, Exception?, ...)</c> overload
+/// regardless of the original <c>TState</c> shape. That is deliberate, not a loss of fidelity: every
+/// local <see cref="ILoggerProvider"/> in this harness (console, file, JSONL, named pipe, in-memory
+/// ring buffer) only ever reads the formatted message string and the exception, never <c>TState</c>'s
+/// own fields directly — confirmed by reading each one before writing this type. Re-invoking with the
+/// original, untouched <c>TState</c> would let a provider's own formatter re-render the unredacted
+/// original underneath this wrapper.
+/// </para>
+/// </remarks>
+public sealed class RedactingLogger : ILogger
+{
+    private readonly ILogger _inner;
+    private readonly ILocalLogRedactor _redactor;
+
+    public RedactingLogger(ILogger inner, ILocalLogRedactor redactor)
+    {
+        _inner = inner;
+        _redactor = redactor;
+    }
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => _inner.BeginScope(state);
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => _inner.IsEnabled(logLevel);
+
+    /// <inheritdoc />
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        if (!_redactor.Enabled || !IsEnabled(logLevel))
+        {
+            _inner.Log(logLevel, eventId, state, exception, formatter);
+            return;
+        }
+
+        var rendered = formatter(state, exception);
+        var redactedMessage = _redactor.Redact(rendered);
+        var redactedException = RedactException(exception);
+
+        _inner.Log(logLevel, eventId, redactedMessage, redactedException, static (message, _) => message);
+    }
+
+    /// <summary>
+    /// Redacts an exception's full text (not just <see cref="Exception.Message"/> — that
+    /// representation drops every <see cref="Exception.InnerException"/>'s own message, so a secret
+    /// nested in a wrapped exception's inner message would otherwise survive when the outer message
+    /// alone is clean), returning a replacement only when something actually matched.
+    /// </summary>
+    private Exception? RedactException(Exception? exception)
+    {
+        if (exception is null)
+        {
+            return null;
+        }
+
+        var original = exception.ToString();
+        var redacted = _redactor.Redact(original);
+        return redacted == original ? exception : new RedactedLocalLogException(redacted);
+    }
+}

--- a/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
+++ b/src/Content/Application/Application.Common/Logging/RedactingLogger.cs
@@ -9,13 +9,19 @@ namespace Application.Common.Logging;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Both halves funnel through the same <c>Log(logLevel, eventId, string, Exception?, ...)</c> overload
-/// regardless of the original <c>TState</c> shape. That is deliberate, not a loss of fidelity: every
-/// local <see cref="ILoggerProvider"/> in this harness (console, file, JSONL, named pipe, in-memory
-/// ring buffer) only ever reads the formatted message string and the exception, never <c>TState</c>'s
-/// own fields directly — confirmed by reading each one before writing this type. Re-invoking with the
-/// original, untouched <c>TState</c> would let a provider's own formatter re-render the unredacted
-/// original underneath this wrapper.
+/// <c>Log</c> re-invokes the inner logger with the <em>original, untouched</em> <c>state</c> — never a
+/// collapsed string — swapping in only a formatter that returns the already-redacted message text. An
+/// earlier version collapsed <c>state</c> to a plain string unconditionally; CI's correctness-review
+/// caught that this dropped every structured attribute (<c>{OriginalFormat}</c>, named arguments) the
+/// OTel logging bridge extracts by reading <c>state</c> directly, once <c>LogsConfig.OtelExportEnabled</c>
+/// is on. Preserving <c>state</c> is safe specifically because the OTel bridge is not left unprotected:
+/// <c>Infrastructure.Observability.Processors.LogRecordRedactionProcessor</c> is registered ahead of its
+/// exporter and independently redacts <c>LogRecord.Attributes</c>/<c>FormattedMessage</c>/<c>Exception</c>
+/// on that path already — this type's own job, per #457, is the local sinks that processor never reaches
+/// (console, file, JSONL, named pipe, in-memory ring buffer), and every one of those was confirmed, by
+/// reading each, to only ever consume the formatted message string and the exception — never
+/// <c>state</c>'s own fields directly. Whichever sink actually reads it, the formatted text it renders
+/// is the redacted one.
 /// </para>
 /// </remarks>
 public sealed class RedactingLogger : ILogger
@@ -30,22 +36,39 @@ public sealed class RedactingLogger : ILogger
     }
 
     /// <summary>
-    /// Redacts scope state the same way <see cref="Log{TState}"/> redacts a message — found in
-    /// independent security review: forwarding <paramref name="state"/> unchanged meant a secret or PII
-    /// value placed in scope state (a connection string, an email — categories this redactor's default
-    /// set already covers) reached every local sink in cleartext, since a console/file formatter renders
-    /// scope contents directly. Handles the two shapes scope state actually takes: a structured scope
+    /// Redacts scope state carrying free text — found in independent security review: forwarding
+    /// <paramref name="state"/> unchanged meant a secret or PII value placed in scope state (a
+    /// connection string, an email) reached every local sink in cleartext, since a console/file
+    /// formatter renders scope contents directly. Handles only the two shapes actually capable of
+    /// carrying arbitrary text: a plain <see cref="string"/>, and a structured scope
     /// (<c>IEnumerable&lt;KeyValuePair&lt;string, object?&gt;&gt;</c>, from a dictionary or
-    /// <c>LoggerMessage.DefineScope</c>) has its string-valued entries redacted in place; anything else
-    /// is redacted via its rendered <see cref="object.ToString"/> text, mirroring how a formatter that
-    /// doesn't understand the structured shape would render it anyway.
+    /// <c>LoggerMessage.DefineScope</c>) has its string-valued entries redacted in place.
     /// </summary>
+    /// <remarks>
+    /// Anything else passes through <em>unchanged</em> — not redacted via its rendered
+    /// <see cref="object.ToString"/> text. An earlier version of this method did exactly that, and CI's
+    /// correctness-review caught the regression: <c>ExecutionScope</c> (this codebase's own domain scope
+    /// type, carrying executor/correlation ids and a step number — structural identifiers, never
+    /// arbitrary text, so nothing here needs redacting) does not implement the structured-KVP shape
+    /// above, so it fell through to the string-collapse branch. That replaced the pushed scope object
+    /// with a plain <see cref="string"/>, which broke <c>ExecutionScopeProvider.GetCurrentScope</c>'s
+    /// <c>scope is ExecutionScope</c> type check for every request — not merely a fidelity loss but a
+    /// silent breakage of an already-wired feature, for every local sink, whenever redaction is enabled
+    /// (the default). Transforming an unrecognized object risks exactly this: breaking a downstream
+    /// consumer that depends on the exact runtime type of what it pushed. Only the two shapes this type
+    /// can safely reconstruct after redacting are transformed; everything else is left alone.
+    /// </remarks>
     /// <inheritdoc />
     public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         if (!_redactor.Enabled)
         {
             return _inner.BeginScope(state);
+        }
+
+        if (state is string text)
+        {
+            return _inner.BeginScope(_redactor.Redact(text));
         }
 
         if (state is IEnumerable<KeyValuePair<string, object?>> pairs)
@@ -58,7 +81,7 @@ public sealed class RedactingLogger : ILogger
             return _inner.BeginScope(redactedPairs);
         }
 
-        return _inner.BeginScope(_redactor.Redact(state.ToString() ?? string.Empty));
+        return _inner.BeginScope(state);
     }
 
     /// <inheritdoc />
@@ -82,7 +105,11 @@ public sealed class RedactingLogger : ILogger
         var redactedMessage = _redactor.Redact(rendered);
         var redactedException = RedactException(exception);
 
-        _inner.Log(logLevel, eventId, redactedMessage, redactedException, static (message, _) => message);
+        // state passes through unchanged — see this type's remarks for why that's safe. Only the
+        // formatter is replaced, so whatever reads state.ToString()-equivalent text gets the redacted
+        // message; whatever reads state's own fields directly gets the real ones, protected downstream
+        // on the one path that matters (OTel export) by LogRecordRedactionProcessor.
+        _inner.Log(logLevel, eventId, state, redactedException, (_, _) => redactedMessage);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Common/Logging/RedactingLoggerFactory.cs
+++ b/src/Content/Application/Application.Common/Logging/RedactingLoggerFactory.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Logging;
+
+namespace Application.Common.Logging;
+
+/// <summary>
+/// Wraps an <see cref="ILoggerFactory"/> so every <see cref="ILogger"/> it hands out is a
+/// <see cref="RedactingLogger"/> — the one front door every local sink (current or future) is reached
+/// through, closing #457 in a single place rather than patching each <see cref="ILoggerProvider"/>
+/// individually.
+/// </summary>
+/// <remarks>
+/// Wrapping the factory rather than each provider is what makes this cover providers this decorator
+/// was never told about: <see cref="AddProvider"/> forwards to the inner factory unchanged, so a
+/// provider added after this wrapper is constructed — by a consumer's own host code, not just this
+/// harness's built-in ones — is still reached through <see cref="CreateLogger"/>, and therefore still
+/// redacted.
+/// </remarks>
+public sealed class RedactingLoggerFactory : ILoggerFactory
+{
+    private readonly ILoggerFactory _inner;
+    private readonly ILocalLogRedactor _redactor;
+
+    public RedactingLoggerFactory(ILoggerFactory inner, ILocalLogRedactor redactor)
+    {
+        _inner = inner;
+        _redactor = redactor;
+    }
+
+    /// <inheritdoc />
+    public void AddProvider(ILoggerProvider provider) => _inner.AddProvider(provider);
+
+    /// <inheritdoc />
+    public ILogger CreateLogger(string categoryName) =>
+        new RedactingLogger(_inner.CreateLogger(categoryName), _redactor);
+
+    /// <inheritdoc />
+    public void Dispose() => _inner.Dispose();
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/DirectToolInvocation/DirectToolInvocationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/DirectToolInvocation/DirectToolInvocationConfig.cs
@@ -17,13 +17,17 @@ namespace Domain.Common.Config.AI.DirectToolInvocation;
 /// </para>
 /// <para>
 /// <strong>This section does not decide which tools a caller may invoke.</strong> That is the
-/// caller's <c>CapabilityEnvelope</c>, resolved per credential, and nothing here widens it. What this
-/// section bounds is the shape of a single invocation: how long it may run, how large its arguments may
-/// be, and how much output it may return. A caller granted a tool can still only use it within these.
+/// caller's <c>CapabilityEnvelope</c>, resolved per credential, and nothing here widens it — with one
+/// deliberate exception: <see cref="McpEnabled"/> covers a narrower surface (tools reached through a
+/// server the operator already connected this host to) and is on by default. See its own remarks.
+/// What this section bounds is the shape of a single invocation: how long it may run, how large its
+/// arguments may be, and how much output it may return. A caller granted a tool can still only use it
+/// within these.
 /// </para>
 /// <code>
 /// AppConfig.AI.DirectToolInvocation
-/// ├── Enabled              — Master toggle (default false)
+/// ├── Enabled              — Master toggle for keyed-DI tool invocation (default false)
+/// ├── McpEnabled           — Master toggle for MCP tool invocation (default true)
 /// ├── MaxRequestBytes      — Reject a request body larger than this, before deserialization
 /// ├── InvocationTimeout    — Server ceiling on how long one invocation may run
 /// ├── MaxOutputCharacters  — Truncate a tool's output beyond this before returning it
@@ -44,6 +48,30 @@ public class DirectToolInvocationConfig
     /// </remarks>
     /// <value>Default: false</value>
     public bool Enabled { get; set; }
+
+    /// <summary>
+    /// Master toggle for the MCP-tool half of direct invocation (#481's <c>InvokeMcpToolAsync</c>),
+    /// independent of <see cref="Enabled"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>On by default, unlike <see cref="Enabled"/>, and deliberately so.</strong> The two
+    /// surfaces grant materially different authority. <see cref="Enabled"/> gates a caller naming one
+    /// of the host's own first-party tools directly — file system access, sandboxed execution, whatever
+    /// this deployment registers — which is exactly the "materially larger grant" <see cref="Enabled"/>'s
+    /// own remarks describe. MCP invocation only reaches tools an operator already decided to trust
+    /// enough to connect this host to, via <c>AppConfig.AI.McpServers</c>; running one of those tools
+    /// from the WebUI's MCP panel is inspecting a connection the operator already made, not opening a
+    /// new one. The panel is expected to work out of the box.
+    /// </para>
+    /// <para>
+    /// Both surfaces still run every call through the identical admission/sanitize/redact/bound chain —
+    /// this flag and <see cref="Enabled"/> gate whether a caller can reach that chain at all, never what
+    /// the chain itself does once reached.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: true</value>
+    public bool McpEnabled { get; set; } = true;
 
     /// <summary>
     /// Maximum accepted size, in bytes, of an invocation request body. Enforced before deserialization,

--- a/src/Content/Domain/Domain.Common/Config/Observability/LogsConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/Observability/LogsConfig.cs
@@ -11,11 +11,13 @@ namespace Domain.Common.Config.Observability;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The local <c>ILogger</c> sinks are unaffected: this signal is
-/// <strong>additional</strong>, not a replacement. When enabled, PII is scrubbed
-/// in-process (see <see cref="RedactionEnabled"/>) before any log record leaves
-/// the process, so nothing sensitive transits the OTLP wire — even when the
-/// collector, not the app, ultimately forwards the logs.
+/// <see cref="OtelExportEnabled"/> itself is additional, not a replacement: the local <c>ILogger</c>
+/// sinks (console / file / JSONL / ring-buffer) keep running whether or not this signal is on. When
+/// export is enabled, PII is scrubbed in-process (see <see cref="RedactionEnabled"/>) before any log
+/// record leaves the process, so nothing sensitive transits the OTLP wire — even when the collector,
+/// not the app, ultimately forwards the logs. <see cref="RedactionEnabled"/> itself is independent of
+/// this flag (#457): it also governs the local sinks, on or off, so turning redaction on protects both
+/// surfaces regardless of whether OTel export is ever switched on.
 /// </para>
 /// <para>
 /// Binds from <c>AppConfig:Observability:Logs</c>. Validated at host start by
@@ -44,20 +46,25 @@ public sealed class LogsConfig
     public string MinExportLevel { get; set; } = "Information";
 
     /// <summary>
-    /// Whether PII / secret content is scrubbed from log records before export.
-    /// Default: <c>true</c> — a compliance-sensitive template must not leak PII
-    /// onto the wire, so redaction is on whenever export is on. The scrub runs
-    /// as the first pipeline stage (before any exporter), covering the formatted
-    /// message, the body, and every string-valued attribute.
+    /// Whether PII / secret content is scrubbed from logs. Default: <c>true</c> — a
+    /// compliance-sensitive template must not leak PII, in-process or on the wire.
     /// </summary>
+    /// <remarks>
+    /// Governs two independent surfaces, not just OTel export (#457): the OTel logging bridge's
+    /// <c>LogRecordRedactionProcessor</c> (active only when <see cref="OtelExportEnabled"/> is also
+    /// on — the scrub runs as the first pipeline stage, before any exporter, covering the formatted
+    /// message, the body, and every string-valued attribute), and every local <c>ILoggerProvider</c>
+    /// sink (console, file, JSONL, named pipe — active independent of <see cref="OtelExportEnabled"/>,
+    /// via <c>Application.Common.Logging.RedactingLoggerFactory</c>). One flag, one operator intent,
+    /// both surfaces.
+    /// </remarks>
     public bool RedactionEnabled { get; set; } = true;
 
     /// <summary>
-    /// Names of <c>Domain.AI.Telemetry.Redaction.RedactionCategory</c> values the
-    /// redactor applies before export. Unknown names fail validation at boot.
-    /// Default: the full set, so a consumer that flips
-    /// <see cref="OtelExportEnabled"/> on without tuning categories still gets the
-    /// safest (over-redactive) posture.
+    /// Names of <c>Domain.AI.Telemetry.Redaction.RedactionCategory</c> values the redactor applies —
+    /// on both surfaces <see cref="RedactionEnabled"/> governs. Unknown names fail validation at boot.
+    /// Default: the full set, so a consumer that turns redaction on without tuning categories still
+    /// gets the safest (over-redactive) posture.
     /// </summary>
     /// <remarks>
     /// Held as strings (not the enum) because the <c>AppConfig</c> hierarchy lives

--- a/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
@@ -164,6 +164,14 @@ public sealed class AgentEvaluationService : IEvaluationService
             // #482: arm the same ambient admission chain ExecuteAgentTurnCommandHandler arms for every
             // production turn. Begin (not assign-and-null) so a nested/enclosing governed flow is
             // restored rather than disarmed on the way out — see ToolAdmissionAccessor's remarks.
+            //
+            // Reset before arming, mirroring DirectToolInvoker.ArmGovernance: this pipeline is a single
+            // scoped instance shared across every eval task and candidate run in this scope (found in
+            // review), so without a reset here its loop-detection and call-once state accumulates across
+            // tasks — one task's tool-call pattern could trip (or silently satisfy) the loop guard for an
+            // unrelated later task in the same scope.
+            _admissionPipeline.Reset();
+
             AgentResponse response;
             using (ToolAdmissionAccessor.Begin(_admissionPipeline))
             {

--- a/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
@@ -2,8 +2,10 @@ using System.Text.RegularExpressions;
 using Application.AI.Common.Extensions;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Traces;
+using Application.AI.Common.Services.Governance;
 using Domain.AI.Agents;
 using Domain.Common.Config.MetaHarness;
 using Domain.Common.MetaHarness;
@@ -27,6 +29,9 @@ public sealed class AgentEvaluationService : IEvaluationService
     private readonly IOptionsMonitor<MetaHarnessConfig> _config;
     private readonly IExecutionTraceStore _traceStore;
     private readonly IAgentFactory _agentFactory;
+    private readonly IToolCallAdmissionPipeline _admissionPipeline;
+    private readonly ICompositeResponseSanitizer _sanitizer;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<AgentEvaluationService> _logger;
 
     // Candidate-proposed scripts are never executed during evaluation — running untrusted
@@ -35,15 +40,33 @@ public sealed class AgentEvaluationService : IEvaluationService
         (skill, script, arguments, serviceProvider, cancellationToken) =>
             Task.FromResult<object?>(null);
 
+    /// <param name="admissionPipeline">
+    /// The scoped admission chain armed around every eval run's <c>agent.RunAsync</c> call (#482) —
+    /// without it, <c>GovernedAIFunction</c>'s null-ambient early-return path leaves any tool a
+    /// candidate-loaded skill declares completely ungoverned, the same gap #478 closed for
+    /// <c>Presentation.FoundryHost</c>.
+    /// </param>
+    /// <param name="sanitizer">
+    /// Passed to the <see cref="Application.AI.Common.Services.Agent.GoverningToolContextProvider"/> this service now wires onto its own
+    /// context (#482), matching how <c>AgentExecutionContextFactory</c> wires it for every production
+    /// agent — otherwise eval's skill-disclosure tools (<c>load_skill</c>/<c>read_skill_resource</c>)
+    /// carry no sanitize coverage at all.
+    /// </param>
     public AgentEvaluationService(
         IOptionsMonitor<MetaHarnessConfig> config,
         IExecutionTraceStore traceStore,
         IAgentFactory agentFactory,
+        IToolCallAdmissionPipeline admissionPipeline,
+        ICompositeResponseSanitizer sanitizer,
+        ILoggerFactory loggerFactory,
         ILogger<AgentEvaluationService> logger)
     {
         _config = config;
         _traceStore = traceStore;
         _agentFactory = agentFactory;
+        _admissionPipeline = admissionPipeline;
+        _sanitizer = sanitizer;
+        _loggerFactory = loggerFactory;
         _logger = logger;
     }
 
@@ -129,7 +152,7 @@ public sealed class AgentEvaluationService : IEvaluationService
                 Instruction = candidate.Snapshot.SystemPromptSnapshot,
                 DeploymentName = string.IsNullOrEmpty(cfg.EvaluationModelVersion) ? null : cfg.EvaluationModelVersion,
                 TraceScope = scope,
-                AIContextProviders = BuildSkillsProviders(skillDirectory),
+                AIContextProviders = BuildContextProviders(skillDirectory),
                 AdditionalProperties = new Dictionary<string, object>
                 {
                     [ITraceWriter.AdditionalPropertiesKey] = traceWriter
@@ -137,9 +160,17 @@ public sealed class AgentEvaluationService : IEvaluationService
             };
 
             var agent = await _agentFactory.CreateAgentAsync(context, cancellationToken);
-            var response = await agent.RunAsync(
-                [new ChatMessage(ChatRole.User, task.InputPrompt)],
-                cancellationToken: cancellationToken);
+
+            // #482: arm the same ambient admission chain ExecuteAgentTurnCommandHandler arms for every
+            // production turn. Begin (not assign-and-null) so a nested/enclosing governed flow is
+            // restored rather than disarmed on the way out — see ToolAdmissionAccessor's remarks.
+            AgentResponse response;
+            using (ToolAdmissionAccessor.Begin(_admissionPipeline))
+            {
+                response = await agent.RunAsync(
+                    [new ChatMessage(ChatRole.User, task.InputPrompt)],
+                    cancellationToken: cancellationToken);
+            }
 
             var output = ExtractContent(response);
             var (passed, failureReason) = Grade(output, task.ExpectedOutputPattern);
@@ -228,22 +259,34 @@ public sealed class AgentEvaluationService : IEvaluationService
     }
 
     /// <summary>
-    /// Builds the eval context's progressive-disclosure skills provider over <paramref name="skillDirectory"/>,
-    /// mirroring the production wiring in <c>AgentExecutionContextFactory</c>. Returns <see langword="null"/>
-    /// when there is no skill directory so the eval context carries no provider.
+    /// Builds the eval context's <see cref="AIContextProvider"/> rail: the progressive-disclosure skills
+    /// provider over <paramref name="skillDirectory"/> (when present) followed unconditionally by
+    /// <see cref="Application.AI.Common.Services.Agent.GoverningToolContextProvider"/>, mirroring the production wiring in
+    /// <c>AgentExecutionContextFactory.BuildMergedAIContextProviders</c>.
     /// </summary>
-    private static IList<AIContextProvider>? BuildSkillsProviders(string? skillDirectory)
+    /// <remarks>
+    /// #482: the governance wrapper is attached unconditionally, same as the production factory —
+    /// without it, <c>load_skill</c>/<c>read_skill_resource</c> carry no sanitize coverage on this path
+    /// at all, since <c>ToolChainBuilder</c> (the other place governance gets wired in) is never
+    /// consulted for an eval context built directly from a materialized skill snapshot.
+    /// </remarks>
+    private IList<AIContextProvider> BuildContextProviders(string? skillDirectory)
     {
-        if (skillDirectory is null)
-            return null;
+        var providers = new List<AIContextProvider>();
 
-        var provider = new AgentSkillsProviderBuilder()
-            .UseFileScriptRunner(NoOpScriptRunner)
-            .UseOptions(SkillDisclosureDefaults.Configure)
-            .UseFileSkill(skillDirectory)
-            .Build();
+        if (skillDirectory is not null)
+        {
+            providers.Add(new AgentSkillsProviderBuilder()
+                .UseFileScriptRunner(NoOpScriptRunner)
+                .UseOptions(SkillDisclosureDefaults.Configure)
+                .UseFileSkill(skillDirectory)
+                .Build());
+        }
 
-        return [provider];
+        providers.Add(new Application.AI.Common.Services.Agent.GoverningToolContextProvider(
+            _loggerFactory.CreateLogger<Application.AI.Common.Services.Agent.GoverningToolContextProvider>(), _sanitizer));
+
+        return providers;
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticEventSubscriber.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticEventSubscriber.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Orchestration.Magentic;
 using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
@@ -40,6 +41,7 @@ public sealed class MagenticEventSubscriber : IDisposable
     private readonly IMagenticPlanReviewBridge _planReviewBridge;
     private readonly MagenticChangeProposalRouter _changeProposalRouter;
     private readonly IContentCapturePolicy _contentCapturePolicy;
+    private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IContentRedactionFilter _contentRedactionFilter;
     private readonly ILogger<MagenticEventSubscriber> _logger;
 
@@ -80,6 +82,7 @@ public sealed class MagenticEventSubscriber : IDisposable
         IMagenticPlanReviewBridge planReviewBridge,
         MagenticChangeProposalRouter changeProposalRouter,
         IContentCapturePolicy contentCapturePolicy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter contentRedactionFilter,
         ILogger<MagenticEventSubscriber> logger)
     {
@@ -87,6 +90,7 @@ public sealed class MagenticEventSubscriber : IDisposable
         _planReviewBridge = planReviewBridge;
         _changeProposalRouter = changeProposalRouter;
         _contentCapturePolicy = contentCapturePolicy;
+        _sanitizer = sanitizer;
         _contentRedactionFilter = contentRedactionFilter;
         _logger = logger;
     }
@@ -318,6 +322,7 @@ public sealed class MagenticEventSubscriber : IDisposable
             _resetCount,
             completionReason,
             _errorMessage,
+            _sanitizer,
             _contentRedactionFilter);
         _workflowSpan = null;
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticOrchestrator.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Orchestration.Magentic;
 using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
@@ -35,6 +36,7 @@ public sealed class MagenticOrchestrator : IMagenticOrchestrator
     private readonly IMagenticPlanReviewBridge _planReviewBridge;
     private readonly MagenticChangeProposalRouter _changeProposalRouter;
     private readonly IContentCapturePolicy _contentCapturePolicy;
+    private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IContentRedactionFilter _contentRedactionFilter;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<MagenticOrchestrator> _logger;
@@ -45,6 +47,7 @@ public sealed class MagenticOrchestrator : IMagenticOrchestrator
         IMagenticPlanReviewBridge planReviewBridge,
         MagenticChangeProposalRouter changeProposalRouter,
         IContentCapturePolicy contentCapturePolicy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter contentRedactionFilter,
         ILoggerFactory loggerFactory)
     {
@@ -52,6 +55,7 @@ public sealed class MagenticOrchestrator : IMagenticOrchestrator
         _planReviewBridge = planReviewBridge;
         _changeProposalRouter = changeProposalRouter;
         _contentCapturePolicy = contentCapturePolicy;
+        _sanitizer = sanitizer;
         _contentRedactionFilter = contentRedactionFilter;
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<MagenticOrchestrator>();
@@ -72,6 +76,7 @@ public sealed class MagenticOrchestrator : IMagenticOrchestrator
             _planReviewBridge,
             _changeProposalRouter,
             _contentCapturePolicy,
+            _sanitizer,
             _contentRedactionFilter,
             _loggerFactory.CreateLogger<MagenticEventSubscriber>());
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticSpanEmitter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticSpanEmitter.cs
@@ -260,9 +260,11 @@ public sealed class MagenticSpanEmitter : IDisposable
         int planVersion,
         string? planText,
         IContentCapturePolicy policy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter)
     {
         ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
 
         managerSpan?.SetTag(MagenticConventions.PlanVersion, planVersion);
@@ -270,6 +272,7 @@ public sealed class MagenticSpanEmitter : IDisposable
             MagenticConventions.EventPlanCreated,
             planText,
             policy,
+            sanitizer,
             filter);
         managerSpan?.AddEvent(evt);
     }
@@ -284,9 +287,11 @@ public sealed class MagenticSpanEmitter : IDisposable
         int planVersion,
         string? planText,
         IContentCapturePolicy policy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter)
     {
         ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
 
         managerSpan?.SetTag(MagenticConventions.PlanVersion, planVersion);
@@ -294,6 +299,7 @@ public sealed class MagenticSpanEmitter : IDisposable
             MagenticConventions.EventReplanned,
             planText,
             policy,
+            sanitizer,
             filter);
         managerSpan?.AddEvent(evt);
     }
@@ -307,9 +313,11 @@ public sealed class MagenticSpanEmitter : IDisposable
         Activity? resetSpan,
         string? replanReason,
         IContentCapturePolicy policy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter)
     {
         ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
         if (resetSpan is null) return;
         if (string.IsNullOrEmpty(replanReason)) return;
@@ -317,7 +325,7 @@ public sealed class MagenticSpanEmitter : IDisposable
 
         resetSpan.SetTag(
             MagenticConventions.ReplanReason,
-            filter.Redact(replanReason, policy.Categories));
+            SanitizeThenRedact.Apply(replanReason, sanitizer, filter, policy.Categories));
     }
 
     /// <summary>
@@ -329,9 +337,11 @@ public sealed class MagenticSpanEmitter : IDisposable
         Activity? roundSpan,
         string? instructionOrQuestion,
         IContentCapturePolicy policy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter)
     {
         ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
         if (roundSpan is null) return;
         if (string.IsNullOrEmpty(instructionOrQuestion)) return;
@@ -339,7 +349,7 @@ public sealed class MagenticSpanEmitter : IDisposable
 
         roundSpan.SetTag(
             MagenticConventions.ProgressInstructionOrQuestion,
-            filter.Redact(instructionOrQuestion, policy.Categories));
+            SanitizeThenRedact.Apply(instructionOrQuestion, sanitizer, filter, policy.Categories));
     }
 
     /// <summary>
@@ -351,9 +361,11 @@ public sealed class MagenticSpanEmitter : IDisposable
         Activity? planReviewSpan,
         string? revisionFeedback,
         IContentCapturePolicy policy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter)
     {
         ArgumentNullException.ThrowIfNull(policy);
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
         if (planReviewSpan is null) return;
         if (string.IsNullOrEmpty(revisionFeedback)) return;
@@ -361,13 +373,14 @@ public sealed class MagenticSpanEmitter : IDisposable
 
         planReviewSpan.SetTag(
             MagenticConventions.PlanReviewFeedback,
-            filter.Redact(revisionFeedback, policy.Categories));
+            SanitizeThenRedact.Apply(revisionFeedback, sanitizer, filter, policy.Categories));
     }
 
     private static ActivityEvent BuildPlanEvent(
         string eventName,
         string? planText,
         IContentCapturePolicy policy,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter)
     {
         if (string.IsNullOrEmpty(planText) || !policy.ShouldCaptureMagenticPlanContent())
@@ -375,7 +388,7 @@ public sealed class MagenticSpanEmitter : IDisposable
             return new ActivityEvent(eventName);
         }
 
-        var redacted = filter.Redact(planText, policy.Categories);
+        var redacted = SanitizeThenRedact.Apply(planText, sanitizer, filter, policy.Categories);
         var tags = new ActivityTagsCollection
         {
             { MagenticConventions.PlanContent, redacted },

--- a/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticSpanEmitter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Orchestration/Magentic/MagenticSpanEmitter.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
+using Application.AI.Common.Services.Governance;
 using Domain.AI.Telemetry.Conventions;
 using Domain.AI.Telemetry.Redaction;
 
@@ -205,8 +207,8 @@ public sealed class MagenticSpanEmitter : IDisposable
 
     /// <summary>
     /// Stamps the derived counters and completion reason on the root workflow
-    /// span at workflow close. <paramref name="errorMessage"/> is redacted against
-    /// <see cref="RedactionCategories.All"/> before being attached — unlike the
+    /// span at workflow close. <paramref name="errorMessage"/> is sanitized then redacted against
+    /// <see cref="RedactionCategories.All"/> before being attached (#470) — unlike the
     /// content-capture-gated Record* methods below, error diagnostics on this span are
     /// not optional telemetry a consumer can choose to leave unredacted.
     /// </summary>
@@ -216,8 +218,10 @@ public sealed class MagenticSpanEmitter : IDisposable
         int resetsExecuted,
         string completionReason,
         string? errorMessage,
+        ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter)
     {
+        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
         if (workflowSpan is null) return;
         workflowSpan.SetTag(MagenticConventions.RoundsExecuted, roundsExecuted);
@@ -225,9 +229,13 @@ public sealed class MagenticSpanEmitter : IDisposable
         workflowSpan.SetTag(MagenticConventions.CompletionReason, completionReason);
         if (!string.IsNullOrEmpty(errorMessage))
         {
-            var redacted = filter.Redact(errorMessage, RedactionCategories.All);
-            workflowSpan.SetTag(GenAiSemconvRegistry.ErrorType, redacted);
-            workflowSpan.SetStatus(ActivityStatusCode.Error, redacted);
+            // #470: sanitize before redact, matching ReportedFailureText.PrepareForReporting's
+            // ordering — otherwise a secret split by invisible/zero-width characters (which the
+            // sanitizer canonicalizes away) can dodge the redaction filter's anchored patterns here
+            // while the identical string is caught on the tool-failure-reporting path.
+            var treated = SanitizeThenRedact.Apply(errorMessage, sanitizer, filter, RedactionCategories.All);
+            workflowSpan.SetTag(GenAiSemconvRegistry.ErrorType, treated);
+            workflowSpan.SetStatus(ActivityStatusCode.Error, treated);
         }
         workflowSpan.Dispose();
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
@@ -133,8 +133,16 @@ public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
             @"Bearer\s+[A-Za-z0-9\-._~+/]+=*",
             "Bearer [REDACTED]"));
 
+        // #471: the guard recognizes both the bare [REDACTED] this rule itself produces and this
+        // file's own categorized placeholders (e.g. [REDACTED:VendorApiKey]), so a Generic rule running
+        // after a categorized one in the same pass doesn't rewrite an already-redacted value and
+        // silently discard the more specific tag. Anchored to the closing bracket — (?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])
+        // rather than a bare (?!\[REDACTED) — deliberately: an unanchored prefix match treats ANY
+        // value that happens to start with the literal text "[REDACTED" as already-safe and skips
+        // scrubbing it, which is exactly backwards for a value an attacker controls (found in review:
+        // a secret payload beginning with that literal string would evade this rule entirely).
         b.Add(Compile(RedactionCategory.Generic,
-            @"(?i)(AccountKey|Password|pwd|SharedAccessKey)\s*=\s*(?!\[REDACTED\])[^;""'\s]+",
+            @"(?i)(AccountKey|Password|pwd|SharedAccessKey)\s*=\s*(?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])[^;""'\s]+",
             "$1=[REDACTED]"));
 
         // Azure SAS query signatures — sv=...&sp=...&se=...&sig=<value>. The other query
@@ -145,11 +153,11 @@ public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
         // is just as likely to appear as (e.g. a document ingest URI, per CLAUDE.md's own
         // recorded history of SAS tokens leaking through exception messages).
         b.Add(Compile(RedactionCategory.Generic,
-            @"(?i)([?&]sig=)(?!\[REDACTED\])[^&\s""']+",
+            @"(?i)([?&]sig=)(?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])[^&\s""']+",
             "$1[REDACTED]"));
 
         b.Add(Compile(RedactionCategory.Generic,
-            @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[=:]\s*(?!\[REDACTED\])\S+",
+            @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[=:]\s*(?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])\S+",
             "$1=[REDACTED]"));
 
         return b.ToImmutable();

--- a/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Telemetry/Redaction/DefaultContentRedactionFilter.cs
@@ -136,13 +136,16 @@ public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
         // #471: the guard recognizes both the bare [REDACTED] this rule itself produces and this
         // file's own categorized placeholders (e.g. [REDACTED:VendorApiKey]), so a Generic rule running
         // after a categorized one in the same pass doesn't rewrite an already-redacted value and
-        // silently discard the more specific tag. Anchored to the closing bracket — (?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])
-        // rather than a bare (?!\[REDACTED) — deliberately: an unanchored prefix match treats ANY
-        // value that happens to start with the literal text "[REDACTED" as already-safe and skips
-        // scrubbing it, which is exactly backwards for a value an attacker controls (found in review:
-        // a secret payload beginning with that literal string would evade this rule entirely).
+        // silently discard the more specific tag. Requires the placeholder to be the WHOLE value —
+        // (?!\[REDACTED(?::[A-Za-z]+)?\](?![^;"'\s])) — not merely a prefix of it: independent security
+        // review found the first fix's anchor (closing bracket only) still treated any value merely
+        // PREFIXED with a well-formed placeholder (e.g. "[REDACTED:Foo]hunter2ACTUALSECRET") as
+        // already-safe, skipping it entirely — trading one evasion string for an unbounded family of
+        // them. The added (?![^;"'\s]) after the bracket asserts the placeholder is immediately followed
+        // by a value terminator (or end of string), so only a value that IS exactly a placeholder is
+        // left alone; anything with real content trailing it still gets redacted whole.
         b.Add(Compile(RedactionCategory.Generic,
-            @"(?i)(AccountKey|Password|pwd|SharedAccessKey)\s*=\s*(?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])[^;""'\s]+",
+            @"(?i)(AccountKey|Password|pwd|SharedAccessKey)\s*=\s*(?!\[REDACTED(?::[A-Za-z]+)?\](?![^;""'\s]))[^;""'\s]+",
             "$1=[REDACTED]"));
 
         // Azure SAS query signatures — sv=...&sp=...&se=...&sig=<value>. The other query
@@ -153,11 +156,11 @@ public sealed class DefaultContentRedactionFilter : IContentRedactionFilter
         // is just as likely to appear as (e.g. a document ingest URI, per CLAUDE.md's own
         // recorded history of SAS tokens leaking through exception messages).
         b.Add(Compile(RedactionCategory.Generic,
-            @"(?i)([?&]sig=)(?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])[^&\s""']+",
+            @"(?i)([?&]sig=)(?!\[REDACTED(?::[A-Za-z]+)?\](?![^&\s""']))[^&\s""']+",
             "$1[REDACTED]"));
 
         b.Add(Compile(RedactionCategory.Generic,
-            @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[=:]\s*(?!\[REDACTED\]|\[REDACTED:[A-Za-z]+\])\S+",
+            @"(?i)(api[_-]?key|access[_-]?token|secret[_-]?key)\s*[=:]\s*(?!\[REDACTED(?::[A-Za-z]+)?\](?!\S))\S+",
             "$1=[REDACTED]"));
 
         return b.ToImmutable();

--- a/src/Content/Infrastructure/Infrastructure.Observability/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using Application.AI.Common.Interfaces;
 using Application.Common.Interfaces.Telemetry;
+using Application.Common.Logging;
 using Domain.Common.Config;
 using Infrastructure.Observability.Exporters;
+using Infrastructure.Observability.Logging;
 using Infrastructure.Observability.Persistence;
 using Infrastructure.Observability.Processors;
 using Infrastructure.Observability.Services;
@@ -41,6 +43,12 @@ public static class DependencyInjection
     {
         // Observability pipeline configurator — adds processors and exporters at Order 300
         services.AddSingleton<ITelemetryConfigurator, ObservabilityTelemetryConfigurator>();
+
+        // #457: the one ILocalLogRedactor implementation, closing the parity gap between the OTel
+        // logging bridge's own redaction and every local ILoggerProvider sink. Application.Common's
+        // ConfigureLogging resolves this optionally, so registering it here is what turns local-sink
+        // redaction on for every host that references Infrastructure.Observability (i.e. every host).
+        services.AddSingleton<ILocalLogRedactor, ContentFilterLocalLogRedactor>();
 
         // Budget tracking service — cost spend state machine with ObservableGauge callbacks
         services.AddSingleton<IBudgetTrackingService>(sp =>

--- a/src/Content/Infrastructure/Infrastructure.Observability/Logging/ContentFilterLocalLogRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Logging/ContentFilterLocalLogRedactor.cs
@@ -1,0 +1,87 @@
+using System.Collections.Immutable;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
+using Application.AI.Common.Services.Governance;
+using Application.Common.Logging;
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config.Observability;
+using Infrastructure.Observability.Processors;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Observability.Logging;
+
+/// <summary>
+/// The one <see cref="ILocalLogRedactor"/> implementation: bridges the same
+/// <see cref="IContentRedactionFilter"/> and <see cref="LogsConfig"/> the OTel logging bridge's
+/// <see cref="LogRecordRedactionProcessor"/> already uses, so local sinks (console, file, JSONL, named
+/// pipe) and the OTel bridge share one redaction-enabled/categories knob (#457) instead of needing two.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Widens what <see cref="LogsConfig.RedactionEnabled"/>/<see cref="LogsConfig.RedactionCategories"/>
+/// govern.</strong> Both were previously read only inside <see cref="LogRecordRedactionProcessor"/>,
+/// itself only constructed when <see cref="LogsConfig.OtelExportEnabled"/> is on — so in practice they
+/// gated the OTel bridge alone. This type reads them independently of that flag: local sinks exist (and
+/// need redacting) whether or not the OTel bridge is switched on, so the same operator intent
+/// ("scrub PII/secrets from logs") now reaches both surfaces from one setting.
+/// </para>
+/// <para>
+/// <strong>Sanitizes before redacting (via <see cref="SanitizeThenRedact"/>), same as #470.</strong>
+/// This was the one local-sink redaction path that shipped without it — found in review: without the
+/// sanitize step, a secret split by invisible/zero-width characters (which the sanitizer canonicalizes
+/// away, but the redaction filter's anchored patterns do not) could dodge redaction here specifically,
+/// the exact evasion #470 closed for the OTel span paths.
+/// </para>
+/// </remarks>
+public sealed class ContentFilterLocalLogRedactor : ILocalLogRedactor
+{
+    private readonly ICompositeResponseSanitizer _sanitizer;
+    private readonly IContentRedactionFilter _filter;
+    private readonly IOptionsMonitor<LogsConfig> _config;
+    private readonly ILogger<ContentFilterLocalLogRedactor> _logger;
+
+    public ContentFilterLocalLogRedactor(
+        ICompositeResponseSanitizer sanitizer,
+        IContentRedactionFilter filter,
+        IOptionsMonitor<LogsConfig> config,
+        ILogger<ContentFilterLocalLogRedactor> logger)
+    {
+        ArgumentNullException.ThrowIfNull(sanitizer);
+        ArgumentNullException.ThrowIfNull(filter);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _sanitizer = sanitizer;
+        _filter = filter;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool Enabled => _config.CurrentValue.RedactionEnabled;
+
+    /// <inheritdoc />
+    public string Redact(string text)
+    {
+        var categories = ResolveCategories();
+        return categories.Length == 0 ? text : SanitizeThenRedact.Apply(text, _sanitizer, _filter, categories);
+    }
+
+    /// <summary>
+    /// Re-parses on every call rather than caching: <see cref="LogsConfig"/> is bound from
+    /// <see cref="IOptionsMonitor{TOptions}"/>, so an operator can change the configured categories at
+    /// runtime and this must pick it up the same way <see cref="LogRecordRedactionProcessor"/> would on
+    /// its own next construction. Cheap regardless — the configured list is a handful of strings, not a
+    /// hot-path allocation worth guarding.
+    /// </summary>
+    private ImmutableArray<RedactionCategory> ResolveCategories()
+    {
+        var categories = RedactionCategoryParser.Parse(_config.CurrentValue.RedactionCategories, _logger);
+
+        // Same fail-safe-not-open posture as LogRecordRedactionProcessor: redaction was requested
+        // (Enabled is checked by the caller before Redact is ever invoked) but no category resolved,
+        // so over-redact with the full set rather than silently emit unredacted PII.
+        return categories.Length == 0 ? RedactionCategories.All : categories;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.Observability/Logging/ContentFilterLocalLogRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Logging/ContentFilterLocalLogRedactor.cs
@@ -62,11 +62,10 @@ public sealed class ContentFilterLocalLogRedactor : ILocalLogRedactor
     public bool Enabled => _config.CurrentValue.RedactionEnabled;
 
     /// <inheritdoc />
-    public string Redact(string text)
-    {
-        var categories = ResolveCategories();
-        return categories.Length == 0 ? text : SanitizeThenRedact.Apply(text, _sanitizer, _filter, categories);
-    }
+    public string Redact(string text) =>
+        // ResolveCategories always returns a non-empty set (RedactionCategoryParser's fail-safe-not-open
+        // fallback guarantees it whenever this is called with enabled: true, which it always is here).
+        SanitizeThenRedact.Apply(text, _sanitizer, _filter, ResolveCategories());
 
     /// <summary>
     /// Re-parses on every call rather than caching: <see cref="LogsConfig"/> is bound from
@@ -75,13 +74,9 @@ public sealed class ContentFilterLocalLogRedactor : ILocalLogRedactor
     /// its own next construction. Cheap regardless — the configured list is a handful of strings, not a
     /// hot-path allocation worth guarding.
     /// </summary>
-    private ImmutableArray<RedactionCategory> ResolveCategories()
-    {
-        var categories = RedactionCategoryParser.Parse(_config.CurrentValue.RedactionCategories, _logger);
-
-        // Same fail-safe-not-open posture as LogRecordRedactionProcessor: redaction was requested
-        // (Enabled is checked by the caller before Redact is ever invoked) but no category resolved,
-        // so over-redact with the full set rather than silently emit unredacted PII.
-        return categories.Length == 0 ? RedactionCategories.All : categories;
-    }
+    private ImmutableArray<RedactionCategory> ResolveCategories() =>
+        // The fail-safe-not-open fallback (empty-but-enabled → every category) lives once in
+        // RedactionCategoryParser, shared with LogRecordRedactionProcessor. `enabled: true` here
+        // because the caller (Redact) only reaches this after checking Enabled itself.
+        RedactionCategoryParser.Parse(_config.CurrentValue.RedactionCategories, _logger, enabled: true);
 }

--- a/src/Content/Infrastructure/Infrastructure.Observability/Logging/ContentFilterLocalLogRedactor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Logging/ContentFilterLocalLogRedactor.cs
@@ -7,6 +7,7 @@ using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config.Observability;
 using Infrastructure.Observability.Processors;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure.Observability.Logging;
@@ -33,29 +34,38 @@ namespace Infrastructure.Observability.Logging;
 /// away, but the redaction filter's anchored patterns do not) could dodge redaction here specifically,
 /// the exact evasion #470 closed for the OTel span paths.
 /// </para>
+/// <para>
+/// <strong>Deliberately takes no <see cref="ILogger{TCategoryName}"/>.</strong> This type is
+/// constructed from inside <c>IServiceCollectionExtensions.WrapWithLocalLogRedaction</c>'s
+/// <see cref="ILoggerFactory"/> replacement factory — resolving one here would mean
+/// <see cref="ILoggerFactory.CreateLogger"/> calling back into the very factory delegate still being
+/// constructed. The container's cycle detection does not see through a factory call site, so instead
+/// of throwing it hangs the whole host at first <c>ILogger&lt;T&gt;</c> resolution — this is a real,
+/// reproduced startup deadlock, not a hypothetical one, found by independent security review of #457.
+/// <see cref="NullLogger{T}"/> needs no DI resolution at all, which is what actually breaks the cycle:
+/// it is not merely the quietest logger, it is the only one that doesn't reach back into
+/// <see cref="ILoggerFactory"/>.
+/// </para>
 /// </remarks>
 public sealed class ContentFilterLocalLogRedactor : ILocalLogRedactor
 {
     private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IContentRedactionFilter _filter;
     private readonly IOptionsMonitor<LogsConfig> _config;
-    private readonly ILogger<ContentFilterLocalLogRedactor> _logger;
+    private readonly ILogger<ContentFilterLocalLogRedactor> _logger = NullLogger<ContentFilterLocalLogRedactor>.Instance;
 
     public ContentFilterLocalLogRedactor(
         ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter filter,
-        IOptionsMonitor<LogsConfig> config,
-        ILogger<ContentFilterLocalLogRedactor> logger)
+        IOptionsMonitor<LogsConfig> config)
     {
         ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(filter);
         ArgumentNullException.ThrowIfNull(config);
-        ArgumentNullException.ThrowIfNull(logger);
 
         _sanitizer = sanitizer;
         _filter = filter;
         _config = config;
-        _logger = logger;
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using Application.AI.Common.Interfaces.Telemetry;
-using Domain.Common.Helpers;
 using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config.Observability;
 using Microsoft.Extensions.Logging;
@@ -74,7 +73,7 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
 
         _filter = filter;
         _enabled = config.RedactionEnabled;
-        _categories = ParseCategories(config.RedactionCategories, logger);
+        _categories = RedactionCategoryParser.Parse(config.RedactionCategories, logger);
 
         // Fail safe, not open. Startup validation (LogsConfigValidator) already rejects an
         // enabled-but-empty/unknown category set on every host that wires ValidateOnStart. This
@@ -229,40 +228,4 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
         }
     }
 
-    /// <summary>
-    /// Parses the configured category names to <see cref="RedactionCategory"/> values,
-    /// skipping (and logging) any name the enum does not recognise. Startup validation
-    /// (<c>LogsConfigValidator</c>) already rejects unknown names, so this is defence in
-    /// depth for hosts that bypass the validated-options pipeline.
-    /// </summary>
-    private static ImmutableArray<RedactionCategory> ParseCategories(
-        IReadOnlyList<string>? names,
-        ILogger logger)
-    {
-        if (names is null || names.Count == 0)
-        {
-            return [];
-        }
-
-        var parsed = new List<RedactionCategory>(names.Count);
-        foreach (var name in names)
-        {
-            // Name-only, matching LogsConfigValidator exactly (the helper trims, so the local Trim
-            // is no longer needed). The two sides disagreed before: the validator refused "2" while
-            // this accepted it as a category, which is the boot-vs-runtime divergence #296 was.
-            if (EnumNameHelper.TryParseName<RedactionCategory>(name, out var category))
-            {
-                parsed.Add(category);
-            }
-            else
-            {
-                logger.LogWarning(
-                    "Ignoring unknown log-redaction category '{Category}'. Valid values: {Valid}.",
-                    name,
-                    string.Join(", ", Enum.GetNames<RedactionCategory>()));
-            }
-        }
-
-        return [.. parsed.Distinct()];
-    }
 }

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/LogRecordRedactionProcessor.cs
@@ -73,22 +73,9 @@ public sealed class LogRecordRedactionProcessor : BaseProcessor<LogRecord>
 
         _filter = filter;
         _enabled = config.RedactionEnabled;
-        _categories = RedactionCategoryParser.Parse(config.RedactionCategories, logger);
-
-        // Fail safe, not open. Startup validation (LogsConfigValidator) already rejects an
-        // enabled-but-empty/unknown category set on every host that wires ValidateOnStart. This
-        // guards the residual case — a consumer's custom host that bypasses that pipeline: if
-        // redaction is requested but no category resolves, over-redact with the full set rather
-        // than silently emitting unredacted PII. Matches the redactor's conservative-by-default
-        // posture (a false positive that masks text is acceptable; a leaked PAN is not).
-        if (_enabled && _categories.Length == 0)
-        {
-            _categories = RedactionCategories.All;
-            logger.LogWarning(
-                "Log redaction is enabled but no valid categories were configured; falling back " +
-                "to the full redaction set ({CategoryCount} categories) to avoid emitting unredacted PII.",
-                _categories.Length);
-        }
+        // Fail-safe-not-open fallback (empty-but-enabled → every category) lives once in
+        // RedactionCategoryParser, shared with the local-sink redactor (#457).
+        _categories = RedactionCategoryParser.Parse(config.RedactionCategories, logger, _enabled);
 
         logger.LogInformation(
             "Log-record redaction initialized: enabled={Enabled}, {CategoryCount} categories active.",

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/RedactionCategoryParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/RedactionCategoryParser.cs
@@ -7,17 +7,43 @@ namespace Infrastructure.Observability.Processors;
 
 /// <summary>
 /// Parses <c>LogsConfig.RedactionCategories</c>' configured names to <see cref="RedactionCategory"/>
-/// values — shared by <see cref="LogRecordRedactionProcessor"/> and the local-sink redactor (#457) so
-/// the two logging surfaces this one config section drives read it identically.
+/// values, and applies the fail-safe-not-open fallback that decision needs — shared by
+/// <see cref="LogRecordRedactionProcessor"/> and the local-sink redactor (#457) so the two logging
+/// surfaces this one config section drives read it, and its fallback policy, identically.
 /// </summary>
 internal static class RedactionCategoryParser
 {
     /// <summary>
     /// Parses the configured category names, skipping (and logging) any name the enum does not
-    /// recognise. Startup validation (<c>LogsConfigValidator</c>) already rejects unknown names on
-    /// every host that wires <c>ValidateOnStart</c>; this is defence in depth for one that bypasses it.
+    /// recognise, then — when <paramref name="enabled"/> and nothing resolved — falls back to every
+    /// category rather than returning an empty set.
     /// </summary>
-    public static ImmutableArray<RedactionCategory> Parse(IReadOnlyList<string>? names, ILogger logger)
+    /// <remarks>
+    /// Startup validation (<c>LogsConfigValidator</c>) already rejects an enabled-but-empty/unknown
+    /// category set on every host that wires <c>ValidateOnStart</c>; the fallback here is defence in
+    /// depth for a consumer's custom host that bypasses that pipeline — redaction was requested but no
+    /// category resolved, so over-redact with the full set rather than silently emit unredacted PII.
+    /// Matches the redactor's conservative-by-default posture (a false positive that masks text is
+    /// acceptable; a leaked PAN is not). Kept in this one place rather than reimplemented by each
+    /// caller, so the policy — and its warning message — can't drift between the two logging surfaces
+    /// that need it.
+    /// </remarks>
+    public static ImmutableArray<RedactionCategory> Parse(IReadOnlyList<string>? names, ILogger logger, bool enabled)
+    {
+        var parsed = ParseNames(names, logger);
+        if (!enabled || parsed.Length > 0)
+        {
+            return parsed;
+        }
+
+        logger.LogWarning(
+            "Log redaction is enabled but no valid categories were configured; falling back " +
+            "to the full redaction set ({CategoryCount} categories) to avoid emitting unredacted PII.",
+            RedactionCategories.All.Length);
+        return RedactionCategories.All;
+    }
+
+    private static ImmutableArray<RedactionCategory> ParseNames(IReadOnlyList<string>? names, ILogger logger)
     {
         if (names is null || names.Count == 0)
         {

--- a/src/Content/Infrastructure/Infrastructure.Observability/Processors/RedactionCategoryParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Processors/RedactionCategoryParser.cs
@@ -1,0 +1,46 @@
+using System.Collections.Immutable;
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.Observability.Processors;
+
+/// <summary>
+/// Parses <c>LogsConfig.RedactionCategories</c>' configured names to <see cref="RedactionCategory"/>
+/// values — shared by <see cref="LogRecordRedactionProcessor"/> and the local-sink redactor (#457) so
+/// the two logging surfaces this one config section drives read it identically.
+/// </summary>
+internal static class RedactionCategoryParser
+{
+    /// <summary>
+    /// Parses the configured category names, skipping (and logging) any name the enum does not
+    /// recognise. Startup validation (<c>LogsConfigValidator</c>) already rejects unknown names on
+    /// every host that wires <c>ValidateOnStart</c>; this is defence in depth for one that bypasses it.
+    /// </summary>
+    public static ImmutableArray<RedactionCategory> Parse(IReadOnlyList<string>? names, ILogger logger)
+    {
+        if (names is null || names.Count == 0)
+        {
+            return [];
+        }
+
+        var parsed = new List<RedactionCategory>(names.Count);
+        foreach (var name in names)
+        {
+            // Name-only, matching LogsConfigValidator exactly (the helper trims).
+            if (EnumNameHelper.TryParseName<RedactionCategory>(name, out var category))
+            {
+                parsed.Add(category);
+            }
+            else
+            {
+                logger.LogWarning(
+                    "Ignoring unknown log-redaction category '{Category}'. Valid values: {Valid}.",
+                    name,
+                    string.Join(", ", Enum.GetNames<RedactionCategory>()));
+            }
+        }
+
+        return [.. parsed.Distinct()];
+    }
+}

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
@@ -4,11 +4,14 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
 using Domain.AI.MCP;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Hosting;
 using Presentation.AgentHub.DTOs;
 using Presentation.Common.Extensions;
 
@@ -26,7 +29,8 @@ public sealed class McpController : ControllerBase
     private readonly IMcpToolProvider _toolProvider;
     private readonly IMcpResourceProvider _resourceProvider;
     private readonly IMcpPromptProvider _promptProvider;
-    private readonly IHostEnvironment _environment;
+    private readonly ICapabilityEnvelopeResolver _envelopeResolver;
+    private readonly IDirectToolInvoker _invoker;
     private readonly ILogger<McpController> _logger;
 
     /// <summary>Initialises the controller with its dependencies.</summary>
@@ -34,13 +38,15 @@ public sealed class McpController : ControllerBase
         IMcpToolProvider toolProvider,
         IMcpResourceProvider resourceProvider,
         IMcpPromptProvider promptProvider,
-        IHostEnvironment environment,
+        ICapabilityEnvelopeResolver envelopeResolver,
+        IDirectToolInvoker invoker,
         ILogger<McpController> logger)
     {
         _toolProvider = toolProvider;
         _resourceProvider = resourceProvider;
         _promptProvider = promptProvider;
-        _environment = environment;
+        _envelopeResolver = envelopeResolver;
+        _invoker = invoker;
         _logger = logger;
     }
 
@@ -116,10 +122,19 @@ public sealed class McpController : ControllerBase
     }
 
     /// <summary>
-    /// Invokes the named MCP tool with the supplied arguments.
+    /// Invokes the named MCP tool with the supplied arguments, under the same admission, sanitize, and
+    /// output-bounding chokepoint every other direct-invocation surface in this host runs under (#481).
     /// Emits a structured audit log entry (UserId, ToolName, InputHash) at Information level.
     /// Raw arguments are only logged at Debug level.
     /// </summary>
+    /// <remarks>
+    /// <strong>This is not a listing endpoint's trust boundary.</strong> Discovery (<see cref="GetTools"/>)
+    /// requires only authentication, because listing confers nothing. This action executes host- or
+    /// server-side code on a caller's say-so, so it is gated three times: the caller must authenticate,
+    /// must present a stable identifier the governance layer can attribute the call to, and the tool
+    /// must be reachable through a server their capability envelope grants — enforced inside
+    /// <see cref="IDirectToolInvoker.InvokeMcpToolAsync"/>, not here.
+    /// </remarks>
     [HttpPost("tools/{name}/invoke")]
     [RequestSizeLimit(32 * 1024)]
     public async Task<IActionResult> InvokeTool(string name, [FromBody] McpToolInvokeRequest request, CancellationToken ct)
@@ -133,14 +148,16 @@ public sealed class McpController : ControllerBase
         if (request.Arguments.ValueKind == JsonValueKind.Undefined)
             return BadRequest("Arguments must be a valid JSON object.");
 
-        var tool = await _toolProvider.GetToolByNameAsync(name, ct);
-        if (tool is null)
-            return NotFound();
-
         // Audit attribution goes through the single identity authority. Hand-rolling NameIdentifier here
         // logged an Entra caller carrying only an oid as "anonymous" — an audit trail that misattributes
-        // a real caller is worse than one that admits it does not know.
-        var userId = User.GetUserIdOrNull() ?? "anonymous";
+        // a real caller is worse than one that admits it does not know. #481: this identifier doubles as
+        // the governance permission subject now, so a caller with none is refused outright rather than
+        // bucketed under a shared "anonymous" identity that would let one caller's denial or grant leak
+        // onto another's.
+        var userId = User.GetUserIdOrNull();
+        if (string.IsNullOrEmpty(userId))
+            return this.NoUsableIdentity();
+
         var rawArgs = request.Arguments.GetRawText();
         var inputHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawArgs))).ToLowerInvariant();
 
@@ -156,48 +173,100 @@ public sealed class McpController : ControllerBase
             "MCP tool raw arguments. ToolName={ToolName} Arguments={Arguments}",
             name, request.Arguments);
 
-        var args = new AIFunctionArguments();
+        var arguments = new Dictionary<string, object?>();
         if (request.Arguments.ValueKind == JsonValueKind.Object)
         {
             foreach (var prop in request.Arguments.EnumerateObject())
-                args[prop.Name] = prop.Value;
+                arguments[prop.Name] = prop.Value;
         }
 
-        var sw = Stopwatch.StartNew();
-        try
-        {
-            var result = await tool.InvokeAsync(args, ct);
-            sw.Stop();
-
-            var output = result is JsonElement je
-                ? je
-                : JsonSerializer.SerializeToElement(result);
-
-            _logger.LogInformation(
-                "MCP tool completed. UserId={UserId} ToolName={ToolName} Status=success DurationMs={DurationMs} CorrelationId={CorrelationId}",
-                userId, name, sw.ElapsedMilliseconds, correlationId);
-
-            return Ok(new McpToolInvokeResponse
+        var outcome = await _invoker.InvokeMcpToolAsync(
+            new DirectMcpToolInvocationRequest
             {
-                Output = output,
-                DurationMs = sw.ElapsedMilliseconds,
-                Success = true,
-            });
-        }
-        catch (Exception ex)
-        {
-            sw.Stop();
-            _logger.LogError(ex,
-                "MCP tool completed. UserId={UserId} ToolName={ToolName} Status=error DurationMs={DurationMs} CorrelationId={CorrelationId}",
-                userId, name, sw.ElapsedMilliseconds, correlationId);
-            return Ok(new McpToolInvokeResponse
-            {
-                DurationMs = sw.ElapsedMilliseconds,
-                Success = false,
-                Error = _environment.IsDevelopment() ? ex.Message : "Tool execution failed. Check server logs.",
-            });
-        }
+                ToolName = name,
+                Arguments = arguments,
+                OwnerId = userId,
+                Envelope = await ResolveMcpEnvelopeAsync(ct)
+            },
+            ct);
+
+        _logger.LogInformation(
+            "MCP tool completed. UserId={UserId} ToolName={ToolName} Status={Status} DurationMs={DurationMs} CorrelationId={CorrelationId}",
+            userId, name, outcome.Status, outcome.Duration.TotalMilliseconds, correlationId);
+
+        return ToActionResult(outcome);
     }
+
+    /// <summary>
+    /// Shapes a governed outcome into the HTTP response, mirroring <c>ToolsController.Invoke</c>'s
+    /// status mapping: absent, ungranted, and not-offered-here collapse to one answer, and a tool that
+    /// ran and said no is a different, successful-HTTP-status event from governance refusing to run it
+    /// at all.
+    /// </summary>
+    /// <remarks>
+    /// The envelope this resolves is what <see cref="ResolveMcpEnvelopeAsync"/> defaults to when no
+    /// operator has configured a narrower one for this caller — see that method's remarks for why that
+    /// default is deliberately open for MCP specifically.
+    /// </remarks>
+    private async Task<CapabilityEnvelope> ResolveMcpEnvelopeAsync(CancellationToken ct)
+    {
+        var resolved = _envelopeResolver.Resolve(User);
+
+        // AllowedMcpServers alone, not OR'd with AllowedTools: AllowedTools is shared with the
+        // unrelated keyed-DI direct-invocation surface, so an operator who narrowed only that grant
+        // (with no MCP-specific configuration at all) would otherwise have this MCP-specific auto-open
+        // fallback below suppressed by a grant that says nothing about MCP servers (found in review).
+        if (resolved.AllowedMcpServers.Count > 0)
+            return resolved;
+
+        // No operator-configured grant for this caller — the shared resolver's fail-closed default.
+        // For every other direct-invocation surface that means "deny", by design (see
+        // DirectToolInvocationConfig.Enabled's remarks). MCP is the deliberate exception
+        // (DirectToolInvocationConfig.McpEnabled): a tool reached through the MCP panel is one an
+        // operator already decided to trust by connecting this host to its server
+        // (AppConfig.AI.McpServers), so the default here grants every currently-connected server and
+        // the tools it publishes, rather than requiring a second, redundant grant on top of that
+        // connection decision. AutonomyCeiling is Autonomous because a human clicking "invoke" in the
+        // panel is the approval — there is no approval-routing UI on this surface to defer to instead,
+        // and anything less than Autonomous fails every call closed (see CapabilityEnvelope.AutonomyCeiling).
+        var allTools = await _toolProvider.GetAllToolsAsync(ct);
+        return new CapabilityEnvelope
+        {
+            AllowedMcpServers = [.. allTools.Keys],
+            AllowedTools = [.. allTools.Values.SelectMany(tools => tools).Select(tool => tool.Name)],
+            AutonomyCeiling = AutonomyLevel.Autonomous
+        };
+    }
+
+    private IActionResult ToActionResult(DirectToolInvocationOutcome outcome) => outcome.Status switch
+    {
+        DirectToolInvocationStatus.Succeeded or DirectToolInvocationStatus.ToolFailed => Ok(new McpToolInvokeResponse
+        {
+            Output = outcome.Output,
+            OutputTruncated = outcome.OutputTruncated,
+            DurationMs = (long)outcome.Duration.TotalMilliseconds,
+            Success = outcome.Status == DirectToolInvocationStatus.Succeeded,
+            Error = outcome.Error,
+        }),
+
+        DirectToolInvocationStatus.NotFound => NotFound(),
+
+        DirectToolInvocationStatus.IdentityUnusable => this.NoUsableIdentity(),
+
+        DirectToolInvocationStatus.Invalid => Problem(
+            title: "Validation failed", detail: outcome.Error, statusCode: StatusCodes.Status400BadRequest),
+
+        // Forbid() rather than a Problem body — governance-refused and the surface being switched off
+        // are deliberately not told apart, matching ToolsController.Invoke.
+        DirectToolInvocationStatus.Denied or DirectToolInvocationStatus.Disabled => Forbid(),
+
+        DirectToolInvocationStatus.TimedOut => Problem(
+            title: "Tool timed out", detail: outcome.Error, statusCode: StatusCodes.Status504GatewayTimeout),
+
+        _ => Problem(
+            title: "Tool invocation failed", detail: outcome.Error,
+            statusCode: StatusCodes.Status500InternalServerError)
+    };
 
     private static IEnumerable<AIFunction> FlattenTools(Dictionary<string, IList<AITool>> allTools)
         => allTools.Values.SelectMany(tools => tools).OfType<AIFunction>();

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
@@ -212,11 +212,20 @@ public sealed class McpController : ControllerBase
     {
         var resolved = _envelopeResolver.Resolve(User);
 
-        // AllowedMcpServers alone, not OR'd with AllowedTools: AllowedTools is shared with the
-        // unrelated keyed-DI direct-invocation surface, so an operator who narrowed only that grant
-        // (with no MCP-specific configuration at all) would otherwise have this MCP-specific auto-open
-        // fallback below suppressed by a grant that says nothing about MCP servers (found in review).
-        if (resolved.AllowedMcpServers.Count > 0)
+        // AllowedMcpServers OR'd with AllowedTools, deliberately. An earlier version of this check
+        // narrowed to AllowedMcpServers alone, reasoning that AllowedTools is "shared with the
+        // unrelated keyed-DI surface" — but CapabilityEnvelope.AllowedTools's own remarks say
+        // otherwise: "Tools reached through a granted MCP server are no exception — AllowedMcpServers
+        // controls which servers may be contacted, while invoking any tool it publishes still requires
+        // that tool's name here." AllowedTools IS the MCP tool gate too (DirectToolInvoker.Mcp.cs
+        // enforces it via Envelope.GrantsTool). Narrowing this check to AllowedMcpServers alone meant
+        // an operator who deliberately configured a least-privilege grant naming only tools — with a
+        // restrictive AutonomyCeiling and no MCP servers at all — had that grant silently discarded and
+        // replaced with every connected server, every tool it publishes, and Autonomous ceiling: a
+        // fail-open privilege escalation caught by independent security review, not the two prior
+        // passes. Only a caller with NOTHING granted anywhere — the resolver's genuine fail-closed
+        // default — should reach the auto-open fallback below.
+        if (resolved.AllowedMcpServers.Count > 0 || resolved.AllowedTools.Count > 0)
             return resolved;
 
         // No operator-configured grant for this caller — the shared resolver's fail-closed default.

--- a/src/Content/Presentation/Presentation.AgentHub/DTOs/McpToolInvokeResponse.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DTOs/McpToolInvokeResponse.cs
@@ -1,12 +1,21 @@
-using System.Text.Json;
-
 namespace Presentation.AgentHub.DTOs;
 
 /// <summary>Response envelope for an MCP tool invocation.</summary>
 public sealed record McpToolInvokeResponse
 {
-    /// <summary>Serialized output from the tool. Populated only when <see cref="Success"/> is <see langword="true"/>; <see langword="null"/> on failure.</summary>
-    public JsonElement? Output { get; init; }
+    /// <summary>
+    /// Sanitized, length-bounded output from the tool. Populated only when <see cref="Success"/> is
+    /// <see langword="true"/>; <see langword="null"/> on failure.
+    /// </summary>
+    /// <remarks>
+    /// A string, not a <c>JsonElement</c>, since #481: the caller-facing scrub every direct-invocation
+    /// surface applies operates on text, and returning structured JSON here would mean either skipping
+    /// that scrub or re-deriving it for a JSON tree — see <c>IDirectToolInvoker.InvokeMcpToolAsync</c>.
+    /// </remarks>
+    public string? Output { get; init; }
+
+    /// <summary>Whether <see cref="Output"/> was cut short at the host's configured character ceiling.</summary>
+    public bool OutputTruncated { get; init; }
 
     /// <summary>Wall-clock duration of the invocation in milliseconds.</summary>
     public long DurationMs { get; init; }

--- a/src/Content/Presentation/Presentation.FoundryHost/Program.cs
+++ b/src/Content/Presentation/Presentation.FoundryHost/Program.cs
@@ -1,5 +1,7 @@
 using System.Runtime.InteropServices;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Services.Governance;
 using Azure.AI.AgentServer.Core;
 using Domain.AI.Skills;
 using Microsoft.Agents.AI;
@@ -111,6 +113,29 @@ public static class Program
             builder.RegisterProtocol("responses", endpoints => endpoints.MapFoundryResponses());
 
             var app = builder.Build();
+
+            // #478: AgentHost's own request loop never dispatches through ExecuteAgentTurnCommand —
+            // every other host arms ToolAdmissionAccessor there, so without this, GovernedAIFunction's
+            // null-ambient early-return path silently skips admission, sanitize, classification,
+            // authorization, the loop guard, and call-once enforcement for every request this container
+            // serves. AgentHostApp.App is the documented escape hatch onto the underlying
+            // WebApplication for exactly this kind of custom middleware. The harness's own composition
+            // root (`provider`, held open for process lifetime above) — not AgentHost's separate
+            // WebApplicationBuilder.Services, which never had the harness's services registered into
+            // it — is what resolves the scoped admission pipeline, one fresh scope per request,
+            // mirroring how ExecuteAgentTurnCommandHandler arms it once per turn.
+            app.App.Use(async (context, next) =>
+            {
+                await using var requestScope = provider.CreateAsyncScope();
+                var admissionPipeline = requestScope.ServiceProvider
+                    .GetRequiredService<IToolCallAdmissionPipeline>();
+
+                using (ToolAdmissionAccessor.Begin(admissionPipeline))
+                {
+                    await next(context).ConfigureAwait(false);
+                }
+            });
+
             await app.RunAsync().ConfigureAwait(false);
         }
         catch (OperationCanceledException)

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolResultTextTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolResultTextTests.cs
@@ -368,4 +368,78 @@ public sealed class ToolResultTextTests
         ToolResultText.SanitizeAndRedact(structured, sanitizer.Object, redactionFilter.Object, ToolName)
             .Should().BeSameAs(structured);
     }
+
+    // ── ExtractText: the flat-text reduction DirectToolInvoker.Mcp.cs uses for its HTTP response ──
+
+    [Fact]
+    public void ExtractText_Null_ReturnsEmptyString() =>
+        ToolResultText.ExtractText(null).Should().BeEmpty();
+
+    [Fact]
+    public void ExtractText_String_ReturnsItUnchanged() =>
+        ToolResultText.ExtractText("plain tool output").Should().Be("plain tool output");
+
+    [Fact]
+    public void ExtractText_JsonElementString_ReturnsTheUnquotedValue()
+    {
+        var element = JsonSerializer.SerializeToElement("quoted value");
+
+        ToolResultText.ExtractText(element).Should().Be("quoted value");
+    }
+
+    /// <summary>
+    /// The dominant MCP tool-success shape (see this file's own header remarks): a single content
+    /// block reaches here as a bare <see cref="TextContent"/>, not a <see cref="JsonElement"/>. Before
+    /// this method existed, <c>DirectToolInvoker.Mcp.cs</c>'s own reduction fell through to
+    /// <c>JsonSerializer.Serialize(result)</c> for this exact shape — producing a JSON dump of
+    /// <see cref="TextContent"/>'s CLR properties instead of the tool's actual text.
+    /// </summary>
+    [Fact]
+    public void ExtractText_SingleTextContent_ReturnsItsText() =>
+        ToolResultText.ExtractText(new TextContent("the tool's actual answer")).Should().Be("the tool's actual answer");
+
+    [Fact]
+    public void ExtractText_ContentArray_JoinsOnlyTheTextBlocks()
+    {
+        var blocks = new AIContent[]
+        {
+            new TextContent("first block"),
+            new DataContent("data:image/png;base64,aGVsbG8="),
+            new TextContent("second block"),
+        };
+
+        ToolResultText.ExtractText(blocks).Should().Be($"first block{Environment.NewLine}second block");
+    }
+
+    [Fact]
+    public void ExtractText_SerializedCallToolResultWithTextBlocks_JoinsThem()
+    {
+        var structured = JsonSerializer.SerializeToElement(new
+        {
+            content = new object[]
+            {
+                new { type = "text", text = "line one" },
+                new { type = "image", data = "aGVsbG8=", mimeType = "image/png" },
+                new { type = "text", text = "line two" }
+            }
+        });
+
+        ToolResultText.ExtractText(structured).Should().Be($"line one{Environment.NewLine}line two");
+    }
+
+    [Fact]
+    public void ExtractText_StructuredJsonElementWithoutContentArray_ReturnsRawJson()
+    {
+        var structured = JsonSerializer.SerializeToElement(new { rows = 3 });
+
+        ToolResultText.ExtractText(structured).Should().Be(structured.GetRawText());
+    }
+
+    [Fact]
+    public void ExtractText_UnrecognizedObject_FallsBackToSerializing()
+    {
+        var result = new { Rows = 3 };
+
+        ToolResultText.ExtractText(result).Should().Be(JsonSerializer.Serialize(result));
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Helpers/TestSanitizer.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Helpers/TestSanitizer.cs
@@ -1,0 +1,32 @@
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Governance;
+using Moq;
+
+namespace Application.AI.Common.Tests;
+
+/// <summary>
+/// The one <see cref="ICompositeResponseSanitizer"/> instance every test in this assembly that needs
+/// to satisfy a sanitizer constructor dependency without asserting on sanitization itself should use.
+/// </summary>
+/// <remarks>
+/// A passthrough double — <see cref="ICompositeResponseSanitizer.Sanitize"/> returns the input
+/// unchanged, wrapped as <see cref="SanitizationResult.Clean(string)"/> — mirroring
+/// <see cref="TestRedactionFilter"/>'s reasoning: a constructor dependency a test doesn't mean to
+/// exercise shouldn't need its own local mock declared per test class.
+/// </remarks>
+internal static class TestSanitizer
+{
+    public static readonly ICompositeResponseSanitizer Instance = BuildPassthrough();
+
+    // Not Mock.Of's LINQ shorthand: that syntax evaluates its return expression once at setup time,
+    // not per call, so It.IsAny<string>() in the return position would echo a fixed (null) value
+    // rather than the actual content passed on each call — a passthrough double must echo back
+    // whatever it was actually given.
+    private static ICompositeResponseSanitizer BuildPassthrough()
+    {
+        var mock = new Mock<ICompositeResponseSanitizer>();
+        mock.Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string content, string? _) => SanitizationResult.Clean(content));
+        return mock.Object;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/OpenTelemetry/AiTelemetryConfiguratorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/OpenTelemetry/AiTelemetryConfiguratorTests.cs
@@ -14,7 +14,7 @@ public class AiTelemetryConfiguratorTests
     [Fact]
     public void Order_Returns150()
     {
-        var configurator = new AiTelemetryConfigurator(TestRedactionFilter.Instance);
+        var configurator = new AiTelemetryConfigurator(TestSanitizer.Instance, TestRedactionFilter.Instance);
 
         configurator.Order.Should().Be(150);
     }
@@ -22,7 +22,7 @@ public class AiTelemetryConfiguratorTests
     [Fact]
     public void ImplementsITelemetryConfigurator()
     {
-        var configurator = new AiTelemetryConfigurator(TestRedactionFilter.Instance);
+        var configurator = new AiTelemetryConfigurator(TestSanitizer.Instance, TestRedactionFilter.Instance);
 
         configurator.Should().BeAssignableTo<ITelemetryConfigurator>();
     }
@@ -30,7 +30,7 @@ public class AiTelemetryConfiguratorTests
     [Fact]
     public void Order_IsAfterBaseAppConfigurator_AndBeforeDomainSpecific()
     {
-        var configurator = new AiTelemetryConfigurator(TestRedactionFilter.Instance);
+        var configurator = new AiTelemetryConfigurator(TestSanitizer.Instance, TestRedactionFilter.Instance);
 
         // Base app configurator is at 100, domain-specific at 200+
         configurator.Order.Should().BeGreaterThan(100);
@@ -40,7 +40,7 @@ public class AiTelemetryConfiguratorTests
     [Fact]
     public void ConfigureTracing_MethodExists()
     {
-        var configurator = new AiTelemetryConfigurator(TestRedactionFilter.Instance);
+        var configurator = new AiTelemetryConfigurator(TestSanitizer.Instance, TestRedactionFilter.Instance);
 
         // Verify the method is available through the interface
         var method = typeof(ITelemetryConfigurator).GetMethod("ConfigureTracing");
@@ -50,7 +50,7 @@ public class AiTelemetryConfiguratorTests
     [Fact]
     public void ConfigureMetrics_MethodExists()
     {
-        var configurator = new AiTelemetryConfigurator(TestRedactionFilter.Instance);
+        var configurator = new AiTelemetryConfigurator(TestSanitizer.Instance, TestRedactionFilter.Instance);
 
         // Verify the method is available through the interface
         var method = typeof(ITelemetryConfigurator).GetMethod("ConfigureMetrics");
@@ -58,9 +58,17 @@ public class AiTelemetryConfiguratorTests
     }
 
     [Fact]
+    public void Constructor_NullSanitizer_Throws()
+    {
+        var act = () => new AiTelemetryConfigurator(null!, TestRedactionFilter.Instance);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
     public void Constructor_NullFilter_Throws()
     {
-        var act = () => new AiTelemetryConfigurator(null!);
+        var act = () => new AiTelemetryConfigurator(TestSanitizer.Instance, null!);
 
         act.Should().Throw<ArgumentNullException>();
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/OpenTelemetry/Processors/AgentFrameworkSpanProcessorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/OpenTelemetry/Processors/AgentFrameworkSpanProcessorTests.cs
@@ -1,8 +1,11 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.OpenTelemetry.Instruments;
 using Application.AI.Common.OpenTelemetry.Processors;
+using Domain.AI.Governance;
 using Domain.AI.Telemetry.Conventions;
 using FluentAssertions;
+using Moq;
 using Xunit;
 
 namespace Application.AI.Common.Tests.OpenTelemetry.Processors;
@@ -16,7 +19,7 @@ public class AgentFrameworkSpanProcessorTests : IDisposable
     private readonly ActivitySource _agentSource = new(AiSourceNames.AgentFrameworkExact);
     private readonly ActivitySource _otherSource = new("SomeOther.Source");
     private readonly ActivityListener _listener;
-    private readonly AgentFrameworkSpanProcessor _processor = new(TestRedactionFilter.Instance);
+    private readonly AgentFrameworkSpanProcessor _processor = new(TestSanitizer.Instance, TestRedactionFilter.Instance);
 
     public AgentFrameworkSpanProcessorTests()
     {
@@ -130,10 +133,50 @@ public class AgentFrameworkSpanProcessorTests : IDisposable
         eventContent.Should().Contain("[REDACTED:VendorApiKey]");
     }
 
+    /// <summary>
+    /// #470: this span used to redact without sanitizing first, so a secret split by
+    /// invisible/zero-width characters (which the sanitizer canonicalizes away, but the redaction
+    /// filter's anchored patterns do not) could dodge redaction here while the identical string was
+    /// caught on the tool-failure-reporting path. Proven by ordering, not by depending on the real
+    /// sanitizer's exact zero-width handling: a sanitizer mock that strips a marker only reveals it in
+    /// the tag if redaction ran against the sanitizer's output, not the raw text.
+    /// </summary>
+    [Fact]
+    public void OnEnd_SanitizesBeforeRedacting()
+    {
+        var sanitizer = new Mock<ICompositeResponseSanitizer>();
+        sanitizer
+            .Setup(s => s.Sanitize("secret is AKIA<split>ABCDEFGHIJ123456", It.IsAny<string?>()))
+            .Returns(SanitizationResult.Clean("secret is AKIAABCDEFGHIJ123456"));
+        var processor = new AgentFrameworkSpanProcessor(sanitizer.Object, TestRedactionFilter.Instance);
+
+        using var activity = _agentSource.StartActivity("test");
+        activity.Should().NotBeNull();
+        activity!.SetTag(ToolConventions.GenAiOperationName, ToolConventions.ExecuteToolOperation);
+        activity.SetTag(ToolConventions.ToolCallResult, "secret is AKIA<split>ABCDEFGHIJ123456");
+
+        processor.OnEnd(activity);
+        processor.Dispose();
+
+        var eventContent = activity.GetTagItem("gen_ai.event.content") as string;
+        eventContent.Should().NotBeNull();
+        eventContent.Should().Contain("[REDACTED:AwsKey]",
+            "redaction must run against the sanitizer's output, which joined the split key back together");
+        eventContent.Should().NotContain("AKIAABCDEFGHIJ123456");
+    }
+
+    [Fact]
+    public void Constructor_NullSanitizer_Throws()
+    {
+        var act = () => new AgentFrameworkSpanProcessor(null!, TestRedactionFilter.Instance);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
     [Fact]
     public void Constructor_NullFilter_Throws()
     {
-        var act = () => new AgentFrameworkSpanProcessor(null!);
+        var act = () => new AgentFrameworkSpanProcessor(TestSanitizer.Instance, null!);
 
         act.Should().Throw<ArgumentNullException>();
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/BoundedTextTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/BoundedTextTests.cs
@@ -1,0 +1,76 @@
+using Application.AI.Common.Services.Governance;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Governance;
+
+/// <summary>Tests for <see cref="BoundedText"/> (#467/#470).</summary>
+public sealed class BoundedTextTests
+{
+    private const string Marker = "…[truncated]";
+
+    [Fact]
+    public void Cap_TextAtOrUnderCeiling_ReturnsUnchanged()
+    {
+        var (text, truncated) = BoundedText.Cap("hello", 10, Marker);
+
+        text.Should().Be("hello");
+        truncated.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Cap_TextOverCeiling_CutsAndAppendsMarker()
+    {
+        var input = new string('x', 100);
+        var (text, truncated) = BoundedText.Cap(input, 20, Marker);
+
+        truncated.Should().BeTrue();
+        text.Length.Should().Be(20);
+        text.Should().EndWith(Marker);
+    }
+
+    [Fact]
+    public void Cap_CeilingNotLargerThanMarker_DropsMarkerRatherThanOvershoot()
+    {
+        var input = new string('x', 100);
+        var (text, truncated) = BoundedText.Cap(input, Marker.Length, Marker);
+
+        truncated.Should().BeTrue();
+        text.Length.Should().Be(Marker.Length);
+        text.Should().NotContain(Marker, "the ceiling is the promise; a marker that can't fit is dropped, not overshot");
+    }
+
+    /// <summary>
+    /// #467: two of the three prior independent truncation implementations could split a UTF-16
+    /// surrogate pair at the cut point, producing a malformed string. The shared primitive backs off
+    /// by one character instead.
+    /// </summary>
+    [Fact]
+    public void Cap_CutWouldSplitSurrogatePair_BacksOffByOneCharacter()
+    {
+        // U+1F600 (😀) is a surrogate pair in UTF-16. Position the ceiling so the naive cut point
+        // (ceiling - marker.Length) lands exactly between the high and low surrogate.
+        var emoji = "\U0001F600"; // 2 UTF-16 chars
+        var input = new string('a', 10) + emoji + new string('b', 30);
+        var ceiling = 10 + 1 + Marker.Length; // cut point would land inside the emoji's surrogate pair
+
+        var (text, truncated) = BoundedText.Cap(input, ceiling, Marker);
+
+        truncated.Should().BeTrue();
+        // A well-formed string never ends with an unpaired high surrogate immediately before the
+        // marker's first character.
+        var markerStart = text.IndexOf(Marker, StringComparison.Ordinal);
+        markerStart.Should().BeGreaterThan(0);
+        char.IsHighSurrogate(text[markerStart - 1]).Should().BeFalse(
+            "the cut must back off before a high surrogate rather than split the pair");
+    }
+
+    [Fact]
+    public void Cap_EmptyText_ReturnsUnchanged()
+    {
+        var (text, truncated) = BoundedText.Cap(string.Empty, 10, Marker);
+
+        text.Should().BeEmpty();
+        truncated.Should().BeFalse();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/SanitizeThenRedactTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/SanitizeThenRedactTests.cs
@@ -1,0 +1,108 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Governance;
+using Domain.AI.Telemetry.Redaction;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Governance;
+
+/// <summary>Tests for <see cref="SanitizeThenRedact"/> (#470).</summary>
+public sealed class SanitizeThenRedactTests
+{
+    private static Mock<ICompositeResponseSanitizer> PassthroughSanitizer()
+    {
+        var mock = new Mock<ICompositeResponseSanitizer>();
+        mock.Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string content, string? _) => SanitizationResult.Clean(content));
+        return mock;
+    }
+
+    private static Mock<IContentRedactionFilter> IdentityFilter()
+    {
+        var mock = new Mock<IContentRedactionFilter>();
+        mock.Setup(f => f.Redact(It.IsAny<string?>(), It.IsAny<IReadOnlyList<RedactionCategory>>()))
+            .Returns((string? s, IReadOnlyList<RedactionCategory> _) => s ?? string.Empty);
+        return mock;
+    }
+
+    [Fact]
+    public void Apply_SanitizesThenRedacts_InOrder()
+    {
+        var sanitizer = new Mock<ICompositeResponseSanitizer>();
+        sanitizer.Setup(s => s.Sanitize("raw", null)).Returns(SanitizationResult.Clean("sanitized"));
+        var filter = new Mock<IContentRedactionFilter>();
+        filter.Setup(f => f.Redact("sanitized", It.IsAny<IReadOnlyList<RedactionCategory>>()))
+            .Returns("redacted");
+
+        var result = SanitizeThenRedact.Apply("raw", sanitizer.Object, filter.Object, [RedactionCategory.Generic]);
+
+        result.Should().Be("redacted");
+    }
+
+    /// <summary>
+    /// Independent security review finding (M2): the three production call sites that route through
+    /// this shared combinator (span/log content) had no bound on how much text reaches the
+    /// sanitizer/redaction regex chain, unlike <c>Tools.ReportedFailureText.PrepareForReporting</c>,
+    /// which already established a 64KB ceiling for exactly this reason — bounding worst-case
+    /// regex-scan cost on a remotely-triggered, attacker-controlled string before any pattern runs.
+    /// </summary>
+    [Fact]
+    public void Apply_TextOverMaxScanLength_IsCutBeforeSanitizingOrRedacting()
+    {
+        var oversized = new string('x', SanitizeThenRedact.MaxScanLength + 500);
+        var sanitizer = new Mock<ICompositeResponseSanitizer>();
+        string? sanitizerSawLength = null;
+        sanitizer.Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string content, string? _) =>
+            {
+                sanitizerSawLength = content.Length.ToString();
+                return SanitizationResult.Clean(content);
+            });
+
+        SanitizeThenRedact.Apply(oversized, sanitizer.Object, IdentityFilter().Object, [RedactionCategory.Generic]);
+
+        sanitizerSawLength.Should().Be(SanitizeThenRedact.MaxScanLength.ToString(),
+            "the sanitizer must never see more than the scan-length ceiling, regardless of input size");
+    }
+
+    [Fact]
+    public void Apply_TextUnderMaxScanLength_IsUnaffectedByTheBound()
+    {
+        var sanitizer = PassthroughSanitizer();
+
+        var result = SanitizeThenRedact.Apply("a short string", sanitizer.Object, IdentityFilter().Object, [RedactionCategory.Generic]);
+
+        result.Should().Be("a short string");
+    }
+
+    [Fact]
+    public void Apply_SanitizedEmpty_NoHook_RedactsTheEmptyResultAsNoOp()
+    {
+        var sanitizer = new Mock<ICompositeResponseSanitizer>();
+        sanitizer.Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns(SanitizationResult.Clean(string.Empty));
+
+        var result = SanitizeThenRedact.Apply("raw", sanitizer.Object, IdentityFilter().Object, [RedactionCategory.Generic]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Apply_SanitizedEmpty_WithHook_ReturnsTheHooksResultInsteadOfRedacting()
+    {
+        var sanitizer = new Mock<ICompositeResponseSanitizer>();
+        sanitizer.Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns(SanitizationResult.Clean(string.Empty));
+        var filter = new Mock<IContentRedactionFilter>(MockBehavior.Strict);
+
+        var result = SanitizeThenRedact.Apply(
+            "raw", sanitizer.Object, filter.Object, [RedactionCategory.Generic],
+            onSanitizedEmpty: _ => "[withheld]");
+
+        result.Should().Be("[withheld]");
+        filter.Verify(f => f.Redact(It.IsAny<string?>(), It.IsAny<IReadOnlyList<RedactionCategory>>()), Times.Never);
+    }
+}

--- a/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerFactoryTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerFactoryTests.cs
@@ -1,0 +1,49 @@
+using Application.Common.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Application.Common.Tests.Logging;
+
+/// <summary>Tests for <see cref="RedactingLoggerFactory"/> (#457).</summary>
+public sealed class RedactingLoggerFactoryTests
+{
+    [Fact]
+    public void CreateLogger_ReturnsARedactingLoggerWrappingTheInnerFactorysLogger()
+    {
+        var innerLogger = new Mock<ILogger>();
+        var innerFactory = new Mock<ILoggerFactory>();
+        innerFactory.Setup(f => f.CreateLogger("category")).Returns(innerLogger.Object);
+        var redactor = Mock.Of<ILocalLogRedactor>(r => r.Enabled == false);
+
+        var factory = new RedactingLoggerFactory(innerFactory.Object, redactor);
+        var logger = factory.CreateLogger("category");
+
+        logger.Should().BeOfType<RedactingLogger>();
+        innerFactory.Verify(f => f.CreateLogger("category"), Times.Once);
+    }
+
+    [Fact]
+    public void AddProvider_ForwardsToInnerFactory()
+    {
+        var innerFactory = new Mock<ILoggerFactory>();
+        var provider = Mock.Of<ILoggerProvider>();
+        var factory = new RedactingLoggerFactory(innerFactory.Object, Mock.Of<ILocalLogRedactor>());
+
+        factory.AddProvider(provider);
+
+        innerFactory.Verify(f => f.AddProvider(provider), Times.Once);
+    }
+
+    [Fact]
+    public void Dispose_DisposesInnerFactory()
+    {
+        var innerFactory = new Mock<ILoggerFactory>();
+        var factory = new RedactingLoggerFactory(innerFactory.Object, Mock.Of<ILocalLogRedactor>());
+
+        factory.Dispose();
+
+        innerFactory.Verify(f => f.Dispose(), Times.Once);
+    }
+}

--- a/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
@@ -144,26 +144,25 @@ public sealed class RedactingLoggerTests
     }
 
     /// <summary>
-    /// Independent security review finding: <c>BeginScope</c> forwarded scope state unchanged, so a
-    /// secret or PII value placed in a structured scope (a connection string, an email) reached every
-    /// local sink in cleartext even with redaction enabled — a formatter that renders scope contents
-    /// (e.g. a console formatter with <c>IncludeScopes = true</c>) bypassed #457's guarantee entirely.
-    /// This proves a string-valued entry in a structured (key/value) scope is redacted.
+    /// CI's correctness-review finding on a second attempt at redacting structured scopes: reconstructing
+    /// a <c>Dictionary</c>/KVP-shaped scope as a plain <c>List&lt;KeyValuePair&lt;string, object?&gt;&gt;</c>
+    /// broke <c>ColorfulConsoleFormatter</c>'s scope rendering — it calls <see cref="object.ToString"/> on
+    /// whatever was pushed, and a compiler-generated templated <c>BeginScope</c> call's state overrides
+    /// that to render interpolated text, which the reconstructed <c>List&lt;T&gt;</c> cannot reproduce.
+    /// This proves a structured scope now passes through as the exact same instance, unredacted — a
+    /// documented, deferred gap (see this type's own remarks), not a silent one.
     /// </summary>
     [Fact]
-    public void BeginScope_StructuredScopeWithSecretValue_RedactsTheStringEntries()
+    public void BeginScope_StructuredScope_PassesThroughAsTheSameInstance()
     {
         var inner = new CapturingLogger();
-        var redactor = new FixedRedactor(enabled: true, redact: t => t.Replace("secret-value", "[REDACTED]"));
+        var redactor = new FixedRedactor(enabled: true, redact: _ => "SHOULD NOT BE CALLED");
         var logger = new RedactingLogger(inner, redactor);
 
         var scope = new Dictionary<string, object?> { ["ConnectionString"] = "secret-value", ["Count"] = 3 };
         logger.BeginScope(scope);
 
-        var captured = inner.LastScopeState.Should().BeAssignableTo<IEnumerable<KeyValuePair<string, object?>>>().Subject;
-        var pairs = captured.ToDictionary(kv => kv.Key, kv => kv.Value);
-        pairs["ConnectionString"].Should().Be("[REDACTED]");
-        pairs["Count"].Should().Be(3, "non-string values pass through unchanged — nothing to redact");
+        inner.LastScopeState.Should().BeSameAs(scope);
     }
 
     /// <summary>A plain (non-structured) scope value is redacted via its rendered text.</summary>

--- a/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
@@ -17,8 +17,14 @@ public sealed class RedactingLoggerTests
     {
         public string? LastMessage { get; private set; }
         public Exception? LastException { get; private set; }
+        public object? LastScopeState { get; private set; }
 
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+        {
+            LastScopeState = state;
+            return null;
+        }
+
         public bool IsEnabled(LogLevel logLevel) => true;
 
         public void Log<TState>(
@@ -109,5 +115,54 @@ public sealed class RedactingLoggerTests
 
         inner.LastException!.ToString().Should().Contain("[REDACTED]");
         inner.LastException.ToString().Should().NotContain("secret-value");
+    }
+
+    /// <summary>
+    /// Independent security review finding: <c>BeginScope</c> forwarded scope state unchanged, so a
+    /// secret or PII value placed in a structured scope (a connection string, an email) reached every
+    /// local sink in cleartext even with redaction enabled — a formatter that renders scope contents
+    /// (e.g. a console formatter with <c>IncludeScopes = true</c>) bypassed #457's guarantee entirely.
+    /// This proves a string-valued entry in a structured (key/value) scope is redacted.
+    /// </summary>
+    [Fact]
+    public void BeginScope_StructuredScopeWithSecretValue_RedactsTheStringEntries()
+    {
+        var inner = new CapturingLogger();
+        var redactor = new FixedRedactor(enabled: true, redact: t => t.Replace("secret-value", "[REDACTED]"));
+        var logger = new RedactingLogger(inner, redactor);
+
+        var scope = new Dictionary<string, object?> { ["ConnectionString"] = "secret-value", ["Count"] = 3 };
+        logger.BeginScope(scope);
+
+        var captured = inner.LastScopeState.Should().BeAssignableTo<IEnumerable<KeyValuePair<string, object?>>>().Subject;
+        var pairs = captured.ToDictionary(kv => kv.Key, kv => kv.Value);
+        pairs["ConnectionString"].Should().Be("[REDACTED]");
+        pairs["Count"].Should().Be(3, "non-string values pass through unchanged — nothing to redact");
+    }
+
+    /// <summary>A plain (non-structured) scope value is redacted via its rendered text.</summary>
+    [Fact]
+    public void BeginScope_PlainScopeValue_IsRedactedViaItsRenderedText()
+    {
+        var inner = new CapturingLogger();
+        var redactor = new FixedRedactor(enabled: true, redact: t => t.Replace("secret-value", "[REDACTED]"));
+        var logger = new RedactingLogger(inner, redactor);
+
+        logger.BeginScope("token is secret-value");
+
+        inner.LastScopeState.Should().Be("token is [REDACTED]");
+    }
+
+    [Fact]
+    public void BeginScope_RedactorDisabled_PassesScopeThroughUnchanged()
+    {
+        var inner = new CapturingLogger();
+        var redactor = new FixedRedactor(enabled: false, redact: _ => "SHOULD NOT BE CALLED");
+        var logger = new RedactingLogger(inner, redactor);
+        var scope = new Dictionary<string, object?> { ["ConnectionString"] = "secret-value" };
+
+        logger.BeginScope(scope);
+
+        inner.LastScopeState.Should().BeSameAs(scope);
     }
 }

--- a/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
@@ -1,0 +1,113 @@
+using Application.Common.Logging;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Application.Common.Tests.Logging;
+
+/// <summary>
+/// Tests for <see cref="RedactingLogger"/> (#457) — the local-sink counterpart to the OTel logging
+/// bridge's own redaction, proven against a captured inner <see cref="ILogger"/> the way the real
+/// console/file/JSONL sinks would receive the call.
+/// </summary>
+public sealed class RedactingLoggerTests
+{
+    /// <summary>Captures exactly what a real local sink would have seen.</summary>
+    private sealed class CapturingLogger : ILogger
+    {
+        public string? LastMessage { get; private set; }
+        public Exception? LastException { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            LastMessage = formatter(state, exception);
+            LastException = exception;
+        }
+    }
+
+    private sealed class FixedRedactor(bool enabled, Func<string, string> redact) : ILocalLogRedactor
+    {
+        public bool Enabled => enabled;
+        public string Redact(string text) => redact(text);
+    }
+
+    [Fact]
+    public void Log_RedactorEnabled_RedactsFormattedMessage()
+    {
+        var inner = new CapturingLogger();
+        var redactor = new FixedRedactor(enabled: true, redact: t => t.Replace("secret-value", "[REDACTED]"));
+        var logger = new RedactingLogger(inner, redactor);
+
+        logger.LogInformation("token is {Token}", "secret-value");
+
+        inner.LastMessage.Should().Be("token is [REDACTED]");
+    }
+
+    [Fact]
+    public void Log_ExceptionCarriesMatch_ReplacesExceptionWithRedactedText()
+    {
+        var inner = new CapturingLogger();
+        var ex = new InvalidOperationException("connection string: secret-value");
+        var redactor = new FixedRedactor(enabled: true, redact: t => t.Replace("secret-value", "[REDACTED]"));
+        var logger = new RedactingLogger(inner, redactor);
+
+        logger.LogWarning(ex, "operation failed");
+
+        inner.LastException.Should().NotBeNull();
+        inner.LastException.Should().NotBeSameAs(ex, "the original exception must not reach the inner sink unredacted");
+        inner.LastException!.ToString().Should().Contain("[REDACTED]");
+        inner.LastException.ToString().Should().NotContain("secret-value");
+    }
+
+    [Fact]
+    public void Log_ExceptionMessageClean_PassesTheOriginalExceptionThrough()
+    {
+        var inner = new CapturingLogger();
+        var ex = new InvalidOperationException("nothing sensitive here");
+        var redactor = new FixedRedactor(enabled: true, redact: t => t); // no-op
+        var logger = new RedactingLogger(inner, redactor);
+
+        logger.LogWarning(ex, "operation failed");
+
+        // No match, no replacement — the original exception object is preserved rather than always
+        // wrapped, so a caller catching further up the chain still sees the real exception type.
+        inner.LastException.Should().BeSameAs(ex);
+    }
+
+    [Fact]
+    public void Log_RedactorDisabled_PassesThroughUnchanged()
+    {
+        var inner = new CapturingLogger();
+        var redactor = new FixedRedactor(enabled: false, redact: _ => "SHOULD NOT BE CALLED");
+        var logger = new RedactingLogger(inner, redactor);
+
+        logger.LogInformation("token is {Token}", "secret-value");
+
+        inner.LastMessage.Should().Be("token is secret-value");
+    }
+
+    /// <summary>
+    /// #457's motivating scenario: an inner exception's message survives even when the outer
+    /// exception's own message is clean — <c>Exception.ToString()</c> recursively includes the
+    /// " ---&gt; " inner-exception chain, so redacting only <c>.Message</c> would miss this.
+    /// </summary>
+    [Fact]
+    public void Log_SecretInInnerException_StillRedacted()
+    {
+        var inner = new CapturingLogger();
+        var innerEx = new InvalidOperationException("connection string: secret-value");
+        var outerEx = new InvalidOperationException("dispatch failed", innerEx);
+        var redactor = new FixedRedactor(enabled: true, redact: t => t.Replace("secret-value", "[REDACTED]"));
+        var logger = new RedactingLogger(inner, redactor);
+
+        logger.LogError(outerEx, "delegation threw");
+
+        inner.LastException!.ToString().Should().Contain("[REDACTED]");
+        inner.LastException.ToString().Should().NotContain("secret-value");
+    }
+}

--- a/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
+++ b/src/Content/Tests/Application.Common.Tests/Logging/RedactingLoggerTests.cs
@@ -1,4 +1,5 @@
 using Application.Common.Logging;
+using Domain.Common.Logging;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Xunit;
@@ -18,6 +19,7 @@ public sealed class RedactingLoggerTests
         public string? LastMessage { get; private set; }
         public Exception? LastException { get; private set; }
         public object? LastScopeState { get; private set; }
+        public object? LastLogState { get; private set; }
 
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull
         {
@@ -31,6 +33,7 @@ public sealed class RedactingLoggerTests
             LogLevel logLevel, EventId eventId, TState state, Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
+            LastLogState = state;
             LastMessage = formatter(state, exception);
             LastException = exception;
         }
@@ -98,6 +101,29 @@ public sealed class RedactingLoggerTests
     }
 
     /// <summary>
+    /// CI's correctness-review finding: <c>Log</c> used to re-invoke the inner logger with the rendered
+    /// message collapsed to a plain string, discarding the original <c>state</c> object. Anything that
+    /// reads <c>state</c> directly rather than calling the formatter — the OTel logging bridge extracts
+    /// <c>LogRecord.Attributes</c>/<c>{OriginalFormat}</c> exactly this way — silently lost every
+    /// structured field. This proves the inner logger now receives the ORIGINAL state object, unchanged,
+    /// while still rendering the redacted text through whatever formatter is supplied.
+    /// </summary>
+    [Fact]
+    public void Log_PreservesOriginalStateObject_ForStructuredAttributeExtraction()
+    {
+        var inner = new CapturingLogger();
+        var redactor = new FixedRedactor(enabled: true, redact: t => t.Replace("secret-value", "[REDACTED]"));
+        var logger = new RedactingLogger(inner, redactor);
+
+        logger.LogInformation("token is {Token}", "secret-value");
+
+        inner.LastLogState.Should().NotBeOfType<string>(
+            "state must not be collapsed to a string — a structured-attribute reader needs the original shape");
+        inner.LastMessage.Should().Be("token is [REDACTED]",
+            "the rendered text must still be redacted, regardless of what shape state itself keeps");
+    }
+
+    /// <summary>
     /// #457's motivating scenario: an inner exception's message survives even when the outer
     /// exception's own message is clean — <c>Exception.ToString()</c> recursively includes the
     /// " ---&gt; " inner-exception chain, so redacting only <c>.Message</c> would miss this.
@@ -151,6 +177,68 @@ public sealed class RedactingLoggerTests
         logger.BeginScope("token is secret-value");
 
         inner.LastScopeState.Should().Be("token is [REDACTED]");
+    }
+
+    /// <summary>
+    /// CI's correctness-review finding on the fix above: the prior version's fallback branch collapsed
+    /// ANY unrecognized scope object to a redacted string via <see cref="object.ToString"/> — including
+    /// this codebase's own <c>Domain.Common.Logging.ExecutionScope</c> (executor/correlation ids, a step
+    /// number: structural identifiers, never free text). That silently swapped the pushed scope object's
+    /// runtime TYPE, breaking <c>ExecutionScopeProvider.GetCurrentScope</c>'s <c>scope is ExecutionScope</c>
+    /// check for every request, for every local sink, whenever redaction is enabled (the default) — not
+    /// a fidelity loss but a correctness regression in an already-wired feature. This proves a scope
+    /// object that is neither a string nor a structured key/value collection passes through as the exact
+    /// same instance.
+    /// </summary>
+    [Fact]
+    public void BeginScope_UnrecognizedObjectScope_PassesThroughAsTheSameInstance()
+    {
+        var inner = new CapturingLogger();
+        var redactor = new FixedRedactor(enabled: true, redact: _ => "SHOULD NOT BE CALLED");
+        var logger = new RedactingLogger(inner, redactor);
+        var scope = new DomainStyleScope("exec-1", "corr-1");
+
+        logger.BeginScope(scope);
+
+        inner.LastScopeState.Should().BeSameAs(scope,
+            "an unrecognized scope type must pass through untouched, not be collapsed to a string");
+    }
+
+    /// <summary>Stands in for a real domain scope type (e.g. ExecutionScope) — not a string, not a KVP collection.</summary>
+    private sealed record DomainStyleScope(string ExecutorId, string CorrelationId);
+
+    /// <summary>
+    /// The exact real-world scenario CI's correctness-review flagged, against the actual production
+    /// type: <see cref="ExecutionScopeProvider.GetCurrentScope"/> requires the pushed scope object to
+    /// still <em>be</em> an <see cref="ExecutionScope"/> instance (a type check, not a shape check), so
+    /// it must reach the scope stack unchanged.
+    /// </summary>
+    [Fact]
+    public void BeginScope_ExecutionScope_PassesThroughSoDownstreamTypeCheckStillMatches()
+    {
+        // Wired directly to the scope provider, not via LoggerFactory: LoggerFactory owns and injects
+        // its own IExternalScopeProvider into any ISupportExternalScope provider, which would silently
+        // replace this one — the point of this test is what the scope stack itself sees.
+        var scopeProvider = new ExecutionScopeProvider();
+        var sinkLogger = new SinkLogger(scopeProvider);
+        var redactor = new FixedRedactor(enabled: true, redact: _ => "SHOULD NOT BE CALLED");
+        var logger = new RedactingLogger(sinkLogger, redactor);
+
+        using (logger.BeginScope(new ExecutionScope(ExecutorId: "exec-1", CorrelationId: "corr-1")))
+        {
+            var current = ExecutionScopeProvider.GetCurrentScope(scopeProvider);
+            current.Should().NotBeNull("the scope-provider's own type check must still recognize the pushed object");
+            current!.ExecutorId.Should().Be("exec-1");
+            current.CorrelationId.Should().Be("corr-1");
+        }
+    }
+
+    /// <summary>Minimal logger that delegates scope pushes directly to the given <see cref="IExternalScopeProvider"/>.</summary>
+    private sealed class SinkLogger(IExternalScopeProvider scopeProvider) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => scopeProvider.Push(state);
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel l, EventId e, TState s, Exception? ex, Func<TState, Exception?, string> f) { }
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/AgentEvaluationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/AgentEvaluationServiceTests.cs
@@ -9,6 +9,7 @@ using Domain.Common.MetaHarness;
 using Infrastructure.AI.MetaHarness;
 using Infrastructure.AI.Security;
 using Infrastructure.AI.Tests.Helpers;
+using Infrastructure.AI.Tests.Planner.StepExecutors;
 using Infrastructure.AI.Traces;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -34,7 +35,8 @@ public class AgentEvaluationServiceTests : IAsyncDisposable
         var opts = Mock.Of<IOptionsMonitor<MetaHarnessConfig>>(m => m.CurrentValue == cfg);
         var traceStore = BuildTraceStore(cfg.TraceDirectoryRoot);
         return new AgentEvaluationService(opts, traceStore, _agentFactoryMock.Object,
-            NullLogger<AgentEvaluationService>.Instance);
+            PermissiveAdmission.Pipeline(), PermissiveAdmission.PermissiveSanitizer(),
+            NullLoggerFactory.Instance, NullLogger<AgentEvaluationService>.Instance);
     }
 
     private IExecutionTraceStore BuildTraceStore(string traceRoot)

--- a/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/AgentEvaluationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/MetaHarness/AgentEvaluationServiceTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Traces;
 using Domain.AI.Agents;
@@ -101,6 +102,41 @@ public class AgentEvaluationServiceTests : IAsyncDisposable
 
         Assert.Equal(1.0, result.PassRate);
         Assert.All(result.PerExampleResults, r => Assert.True(r.Passed));
+    }
+
+    /// <summary>
+    /// CI's correctness-review finding: <c>_admissionPipeline</c> is a single scoped instance shared
+    /// across every eval task and candidate run in this scope, but it was armed via
+    /// <c>ToolAdmissionAccessor.Begin</c> without ever being reset first — unlike
+    /// <c>DirectToolInvoker.ArmGovernance</c>, which resets before every arm. Without a reset, loop-
+    /// detection and call-once state from one task would leak into the next task run in the same scope.
+    /// This proves <c>Reset()</c> is called once per task.
+    /// </summary>
+    [Fact]
+    public async Task EvaluateAsync_MultipleTasks_ResetsAdmissionPipelineBeforeEachTask()
+    {
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentAsync(It.IsAny<AgentExecutionContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TestableAIAgent("The answer is 42"));
+
+        var admissionPipeline = new Mock<IToolCallAdmissionPipeline>();
+        var cfg = new MetaHarnessConfig { TraceDirectoryRoot = _traceRoot };
+        var opts = Mock.Of<IOptionsMonitor<MetaHarnessConfig>>(m => m.CurrentValue == cfg);
+        var sut = new AgentEvaluationService(
+            opts, BuildTraceStore(cfg.TraceDirectoryRoot), _agentFactoryMock.Object,
+            admissionPipeline.Object, PermissiveAdmission.PermissiveSanitizer(),
+            NullLoggerFactory.Instance, NullLogger<AgentEvaluationService>.Instance);
+
+        var candidate = BuildCandidate();
+        var tasks = new[]
+        {
+            BuildTask("t1", "question 1", pattern: "answer"),
+            BuildTask("t2", "question 2", pattern: "42")
+        };
+
+        await sut.EvaluateAsync(candidate, tasks);
+
+        admissionPipeline.Verify(p => p.Reset(), Times.Exactly(tasks.Length));
     }
 
     /// <summary>No tasks match their expected output patterns. PassRate should equal 0.0.</summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticSpanEmitterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticSpanEmitterTests.cs
@@ -2,8 +2,10 @@ using System.Linq;
 using Application.AI.Common.Interfaces.Orchestration.Magentic;
 using Domain.AI.Telemetry.Conventions;
 using FluentAssertions;
+using Infrastructure.AI.Orchestration.Magentic;
 using Microsoft.Agents.AI.Workflows.Specialized.Magentic;
 using Microsoft.Extensions.AI;
+using Moq;
 using Xunit;
 
 #pragma warning disable MAAIW001
@@ -113,6 +115,49 @@ public sealed class MagenticSpanEmitterTests
         rounds[2].GetTagItem(MagenticConventions.RoundStallCountAfter).Should().Be(1);
         subscriber.RoundsExecuted.Should().Be(3);
         subscriber.ResetsExecuted.Should().Be(0);
+    }
+
+    /// <summary>
+    /// #470: <c>EndWorkflowSpan</c> used to redact <c>errorMessage</c> without sanitizing first, so a
+    /// secret split by invisible/zero-width characters (which the sanitizer canonicalizes away, but
+    /// the redaction filter's anchored patterns do not) could dodge redaction here while the identical
+    /// string was caught on the tool-failure-reporting path. Proven by ordering, not by depending on
+    /// the real sanitizer's exact zero-width handling: a sanitizer mock that joins a split key only
+    /// shows up redacted if redaction ran against the sanitizer's output.
+    /// </summary>
+    [Fact]
+    public void EndWorkflowSpan_SanitizesBeforeRedacting()
+    {
+        using var source = new System.Diagnostics.ActivitySource("test.magentic.sanitize-order");
+        using var listener = new System.Diagnostics.ActivityListener
+        {
+            ShouldListenTo = _ => true,
+            Sample = (ref System.Diagnostics.ActivityCreationOptions<System.Diagnostics.ActivityContext> _)
+                => System.Diagnostics.ActivitySamplingResult.AllDataAndRecorded
+        };
+        System.Diagnostics.ActivitySource.AddActivityListener(listener);
+        using var workflowSpan = source.StartActivity("workflow-span");
+        workflowSpan.Should().NotBeNull();
+
+        var sanitizer = new Moq.Mock<Application.AI.Common.Interfaces.Governance.ICompositeResponseSanitizer>();
+        sanitizer
+            .Setup(s => s.Sanitize("secret is AKIA<split>ABCDEFGHIJ123456", It.IsAny<string?>()))
+            .Returns(Domain.AI.Governance.SanitizationResult.Clean("secret is AKIAABCDEFGHIJ123456"));
+
+        MagenticSpanEmitter.EndWorkflowSpan(
+            workflowSpan,
+            roundsExecuted: 1,
+            resetsExecuted: 0,
+            completionReason: MagenticConventions.CompletionReasonError,
+            errorMessage: "secret is AKIA<split>ABCDEFGHIJ123456",
+            sanitizer.Object,
+            new Infrastructure.AI.Telemetry.Redaction.DefaultContentRedactionFilter());
+
+        var tag = workflowSpan!.GetTagItem(GenAiSemconvRegistry.ErrorType) as string;
+        tag.Should().NotBeNull();
+        tag.Should().Contain("[REDACTED:AwsKey]",
+            "redaction must run against the sanitizer's output, which joined the split key back together");
+        tag.Should().NotContain("AKIAABCDEFGHIJ123456");
     }
 }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticTestHelpers.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Orchestration/Magentic/MagenticTestHelpers.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Orchestration.Magentic;
 using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
 using Infrastructure.AI.Orchestration.Magentic;
+using Infrastructure.AI.Tests.Planner.StepExecutors;
 using Infrastructure.AI.Tests.Support;
 using MediatR;
 using Microsoft.Extensions.AI;
@@ -87,6 +89,7 @@ internal static class MagenticTestHelpers
         out Mock<IMediator> mediator,
         MagenticSpanEmitter? emitter = null,
         IContentCapturePolicy? capturePolicy = null,
+        ICompositeResponseSanitizer? sanitizer = null,
         IContentRedactionFilter? redactionFilter = null)
     {
         bridge = new Mock<IMagenticPlanReviewBridge>();
@@ -101,6 +104,9 @@ internal static class MagenticTestHelpers
             // Default to capture-off mocks so pre-content-capture tests are
             // unaffected; ShouldCapture* on a bare mock returns false.
             capturePolicy ?? Mock.Of<IContentCapturePolicy>(),
+            // Passthrough by default (mirrors PermissiveAdmission.PermissiveSanitizer) so tests
+            // asserting on redacted content aren't also silently exercising sanitization findings.
+            sanitizer ?? PermissiveAdmission.PermissiveSanitizer(),
             redactionFilter ?? Mock.Of<IContentRedactionFilter>(),
             NullLogger<MagenticEventSubscriber>.Instance);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
@@ -204,4 +204,37 @@ public sealed class DefaultContentRedactionFilterTests
 
         result.Should().Be(input);
     }
+
+    /// <summary>
+    /// #471: a categorized rule (VendorApiKey) firing before a Generic rule in the same pass must not
+    /// have its more specific tag discarded — the Generic rule's own idempotency guard only recognized
+    /// the bare [REDACTED] it produces itself, not [REDACTED:VendorApiKey], so it re-redacted an
+    /// already-redacted value and silently downgraded the tag.
+    /// </summary>
+    [Fact]
+    public void Redact_VendorApiKeyThenGenericRulesInSamePass_PreservesTheMoreSpecificTag()
+    {
+        var result = _filter.Redact("api_key=sk-XXXXXXXXXXXXXXXXXXXXXXXX", AllCategories);
+
+        result.Should().Contain("[REDACTED:VendorApiKey]");
+        result.Should().NotContain("[REDACTED]", "the Generic rule must not re-redact an already-tagged value");
+    }
+
+    /// <summary>
+    /// #471 review finding: the first fix's negative lookahead — <c>(?!\[REDACTED)</c>, no closing
+    /// bracket — matched ANY value that merely starts with the literal text "[REDACTED", not just the
+    /// actual placeholder shapes this file produces. A real secret an attacker controls could therefore
+    /// begin with that literal string and be waved through as "already redacted" without ever being
+    /// scrubbed. The fix anchors the guard to the two real shapes only: the bare marker with its
+    /// closing bracket, or a categorized marker with its closing bracket.
+    /// </summary>
+    [Fact]
+    public void Redact_GenericSecretValueLiterallyStartingWithRedactedMarkerText_IsStillRedacted()
+    {
+        var result = _filter.Redact("api_key=[REDACTEDbutActuallyASecretToken123", [RedactionCategory.Generic]);
+
+        result.Should().NotContain("[REDACTEDbutActuallyASecretToken123",
+            "a value that merely starts with the marker text is not an already-redacted placeholder");
+        result.Should().Contain("api_key=[REDACTED]");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/DefaultContentRedactionFilterTests.cs
@@ -237,4 +237,48 @@ public sealed class DefaultContentRedactionFilterTests
             "a value that merely starts with the marker text is not an already-redacted placeholder");
         result.Should().Contain("api_key=[REDACTED]");
     }
+
+    /// <summary>
+    /// Independent security review finding on #471's own fix: anchoring the guard to the closing
+    /// bracket closed the unbounded-prefix evasion, but still let a value merely PREFIXED with a
+    /// well-formed placeholder — "[REDACTED:Foo]" followed by a real secret — through untouched, since
+    /// the guard only checked that a valid placeholder shape appeared, not that the placeholder was the
+    /// entire value. Trades one evasion string for an unbounded family of them (any category name
+    /// works). The fix requires the placeholder to be immediately followed by a value terminator (or
+    /// end of string) — i.e. the value must BE the placeholder, not merely start with one.
+    /// </summary>
+    [Theory]
+    [InlineData("api_key=[REDACTED:Foo]hunter2SUPERSECRET", "api_key=[REDACTED]")]
+    [InlineData("AccountKey=[REDACTED:Zz]abc123realkey==", "AccountKey=[REDACTED]")]
+    public void Redact_GenericSecretValuePrefixedWithWellFormedPlaceholder_IsStillFullyRedacted(
+        string input, string mustContain)
+    {
+        var result = _filter.Redact(input, [RedactionCategory.Generic]);
+
+        result.Should().NotContain("hunter2SUPERSECRET").And.NotContain("abc123realkey");
+        result.Should().Contain(mustContain);
+    }
+
+    [Fact]
+    public void Redact_GenericSasSignatureValuePrefixedWithWellFormedPlaceholder_IsStillFullyRedacted()
+    {
+        var result = _filter.Redact(
+            "https://acct.blob.core.windows.net/c/b?sv=2021-08-06&sig=[REDACTED:Q]REALSIGVALUE",
+            [RedactionCategory.Generic]);
+
+        result.Should().NotContain("REALSIGVALUE");
+        result.Should().Contain("sig=[REDACTED]");
+    }
+
+    /// <summary>
+    /// A genuine, standalone placeholder (nothing trailing it) must still be left alone — the #471
+    /// idempotence property the M1 fix must not regress.
+    /// </summary>
+    [Fact]
+    public void Redact_GenuineStandalonePlaceholder_IsLeftAlone()
+    {
+        var result = _filter.Redact("api_key=[REDACTED:VendorApiKey]", [RedactionCategory.Generic]);
+
+        result.Should().Be("api_key=[REDACTED:VendorApiKey]");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/MagenticContentCaptureIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Telemetry/MagenticContentCaptureIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Domain.AI.Telemetry.Conventions;
 using Domain.Common.Config.AI.Telemetry;
@@ -6,7 +7,9 @@ using FluentAssertions;
 using Infrastructure.AI.Orchestration.Magentic;
 using Infrastructure.AI.Telemetry.Redaction;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
+using static Infrastructure.AI.Tests.Planner.StepExecutors.PermissiveAdmission;
 
 namespace Infrastructure.AI.Tests.Telemetry;
 
@@ -49,6 +52,7 @@ public sealed class MagenticContentCaptureIntegrationTests
             NullLogger<ContentCapturePolicy>.Instance);
 
     private static readonly DefaultContentRedactionFilter Filter = new();
+    private static readonly ICompositeResponseSanitizer Sanitizer = PermissiveSanitizer();
 
     private const string PlanWithEmail = "Step 1: email the owner alice@example.com about the plan.";
 
@@ -62,7 +66,7 @@ public sealed class MagenticContentCaptureIntegrationTests
 
         MagenticSpanEmitter.RecordPlanCreatedWithContent(
             manager, planVersion: 1, planText: PlanWithEmail,
-            Policy(ContentCaptureTestConfig.AllOn()), Filter);
+            Policy(ContentCaptureTestConfig.AllOn()), Sanitizer, Filter);
 
         var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventPlanCreated);
         var content = evt.Tags.Single(t => t.Key == MagenticConventions.PlanContent).Value as string;
@@ -83,7 +87,7 @@ public sealed class MagenticContentCaptureIntegrationTests
         var off = ContentCaptureTestConfig.AllOn();
         off.Enabled = false;
         MagenticSpanEmitter.RecordPlanCreatedWithContent(
-            manager, planVersion: 1, planText: PlanWithEmail, Policy(off), Filter);
+            manager, planVersion: 1, planText: PlanWithEmail, Policy(off), Sanitizer, Filter);
 
         var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventPlanCreated);
         evt.Tags.Should().NotContain(t => t.Key == MagenticConventions.PlanContent);
@@ -101,7 +105,7 @@ public sealed class MagenticContentCaptureIntegrationTests
         var capture = ContentCaptureTestConfig.AllOn();
         capture.CaptureMagenticPlanContent = false;
         MagenticSpanEmitter.RecordPlanCreatedWithContent(
-            manager, planVersion: 1, planText: PlanWithEmail, Policy(capture), Filter);
+            manager, planVersion: 1, planText: PlanWithEmail, Policy(capture), Sanitizer, Filter);
 
         var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventPlanCreated);
         evt.Tags.Should().NotContain(t => t.Key == MagenticConventions.PlanContent);
@@ -117,7 +121,7 @@ public sealed class MagenticContentCaptureIntegrationTests
 
         MagenticSpanEmitter.RecordReplannedWithContent(
             manager, planVersion: 2, planText: PlanWithEmail,
-            Policy(ContentCaptureTestConfig.AllOn()), Filter);
+            Policy(ContentCaptureTestConfig.AllOn()), Sanitizer, Filter);
 
         var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventReplanned);
         var content = evt.Tags.Single(t => t.Key == MagenticConventions.PlanContent).Value as string;
@@ -138,7 +142,7 @@ public sealed class MagenticContentCaptureIntegrationTests
 
         MagenticSpanEmitter.RecordResetReason(
             reset, "Reset because user bob@example.com reported a stall.",
-            Policy(ContentCaptureTestConfig.AllOn()), Filter);
+            Policy(ContentCaptureTestConfig.AllOn()), Sanitizer, Filter);
 
         var reason = reset!.GetTagItem(MagenticConventions.ReplanReason) as string;
         reason.Should().NotBeNull();
@@ -158,8 +162,44 @@ public sealed class MagenticContentCaptureIntegrationTests
         var off = ContentCaptureTestConfig.AllOn();
         off.Enabled = false;
         MagenticSpanEmitter.RecordResetReason(
-            reset, "Reset because user bob@example.com reported a stall.", Policy(off), Filter);
+            reset, "Reset because user bob@example.com reported a stall.", Policy(off), Sanitizer, Filter);
 
         reset!.GetTagItem(MagenticConventions.ReplanReason).Should().BeNull();
+    }
+
+    /// <summary>
+    /// Independent security review finding: unlike <c>EndWorkflowSpan</c> (fixed under #470),
+    /// <c>RecordPlanCreatedWithContent</c> and its four siblings (<c>RecordReplannedWithContent</c>,
+    /// <c>RecordResetReason</c>, <c>RecordRoundInstruction</c>, <c>RecordPlanReviewFeedback</c>) still
+    /// redacted without sanitizing first — the same zero-width-character evasion #470 closed for
+    /// workflow-error spans was still open on every LLM-generated plan/reason/instruction span these
+    /// content-capture paths carry. Proven by ordering, mirroring
+    /// <c>AgentFrameworkSpanProcessorTests.OnEnd_SanitizesBeforeRedacting</c>: a sanitizer mock that
+    /// joins a split marker back together only reveals it in the tag if redaction ran against the
+    /// sanitizer's output, not the raw split text.
+    /// </summary>
+    [Fact]
+    public void RecordPlanCreatedWithContent_SanitizesBeforeRedacting()
+    {
+        using var captured = new CapturedSpans();
+        using var emitter = new MagenticSpanEmitter();
+        var workflow = emitter.StartWorkflowSpan("wf", null, 3, null, false, ["p"]);
+        var manager = emitter.StartManagerSpan(workflow);
+
+        var sanitizer = new Mock<ICompositeResponseSanitizer>();
+        sanitizer
+            .Setup(s => s.Sanitize("secret is AKIA<split>ABCDEFGHIJ123456", It.IsAny<string?>()))
+            .Returns(Domain.AI.Governance.SanitizationResult.Clean("secret is AKIAABCDEFGHIJ123456"));
+
+        MagenticSpanEmitter.RecordPlanCreatedWithContent(
+            manager, planVersion: 1, planText: "secret is AKIA<split>ABCDEFGHIJ123456",
+            Policy(ContentCaptureTestConfig.AllOn()), sanitizer.Object, Filter);
+
+        var evt = manager!.Events.Single(e => e.Name == MagenticConventions.EventPlanCreated);
+        var content = evt.Tags.Single(t => t.Key == MagenticConventions.PlanContent).Value as string;
+
+        content.Should().Contain("[REDACTED:AwsKey]",
+            "redaction must run against the sanitizer's output, which joined the split key back together");
+        content.Should().NotContain("AKIAABCDEFGHIJ123456");
     }
 }

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Logging/ContentFilterLocalLogRedactorTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Logging/ContentFilterLocalLogRedactorTests.cs
@@ -1,0 +1,143 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
+using Domain.AI.Governance;
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config.Observability;
+using FluentAssertions;
+using Infrastructure.Observability.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.Observability.Tests.Logging;
+
+/// <summary>Tests for <see cref="ContentFilterLocalLogRedactor"/> (#457).</summary>
+public sealed class ContentFilterLocalLogRedactorTests
+{
+    private const string Marker = "SECRET";
+    private const string Redacted = "[REDACTED]";
+
+    private static Mock<IContentRedactionFilter> MockFilter()
+    {
+        var mock = new Mock<IContentRedactionFilter>();
+        mock.Setup(f => f.Redact(It.IsAny<string?>(), It.IsAny<IReadOnlyList<RedactionCategory>>()))
+            .Returns((string? s, IReadOnlyList<RedactionCategory> _) => s?.Replace(Marker, Redacted) ?? string.Empty);
+        return mock;
+    }
+
+    /// <summary>A sanitizer that returns content unchanged — the answer a real one gives to clean text.</summary>
+    private static Mock<ICompositeResponseSanitizer> PassthroughSanitizer()
+    {
+        var mock = new Mock<ICompositeResponseSanitizer>();
+        mock.Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string content, string? _) => SanitizationResult.Clean(content));
+        return mock;
+    }
+
+    private static IOptionsMonitor<LogsConfig> ConfigOf(LogsConfig config) =>
+        Mock.Of<IOptionsMonitor<LogsConfig>>(m => m.CurrentValue == config);
+
+    [Fact]
+    public void Enabled_ReflectsRedactionEnabled_IndependentOfOtelExportEnabled()
+    {
+        // #457's whole point: local-sink redaction must not depend on the OTel bridge being on.
+        var config = new LogsConfig { OtelExportEnabled = false, RedactionEnabled = true };
+        var redactor = new ContentFilterLocalLogRedactor(
+            PassthroughSanitizer().Object, MockFilter().Object, ConfigOf(config),
+            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+
+        redactor.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Enabled_RedactionDisabled_ReturnsFalse()
+    {
+        var config = new LogsConfig { RedactionEnabled = false };
+        var redactor = new ContentFilterLocalLogRedactor(
+            PassthroughSanitizer().Object, MockFilter().Object, ConfigOf(config),
+            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+
+        redactor.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Redact_MatchingText_ScrubsUsingConfiguredCategories()
+    {
+        var filter = MockFilter();
+        var config = new LogsConfig { RedactionEnabled = true, RedactionCategories = ["Email", "Generic"] };
+        var redactor = new ContentFilterLocalLogRedactor(
+            PassthroughSanitizer().Object, filter.Object, ConfigOf(config),
+            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+
+        var result = redactor.Redact($"token is {Marker}");
+
+        result.Should().Be($"token is {Redacted}");
+        filter.Verify(f => f.Redact(
+            $"token is {Marker}",
+            It.Is<IReadOnlyList<RedactionCategory>>(c =>
+                c.Contains(RedactionCategory.Email) && c.Contains(RedactionCategory.Generic))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void Redact_NoValidCategoriesConfigured_FallsBackToFullSetRatherThanSkippingRedaction()
+    {
+        // Same fail-safe-not-open posture as LogRecordRedactionProcessor.
+        var filter = MockFilter();
+        var config = new LogsConfig { RedactionEnabled = true, RedactionCategories = ["not-a-real-category"] };
+        var redactor = new ContentFilterLocalLogRedactor(
+            PassthroughSanitizer().Object, filter.Object, ConfigOf(config),
+            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+
+        var result = redactor.Redact($"token is {Marker}");
+
+        result.Should().Be($"token is {Redacted}");
+        filter.Verify(f => f.Redact(
+            It.IsAny<string?>(),
+            It.Is<IReadOnlyList<RedactionCategory>>(c => c.Count == Enum.GetValues<RedactionCategory>().Length)),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Review finding on #457: this redactor called the filter directly, skipping the sanitize step
+    /// every other redaction path (#470) already has — so a secret split by invisible/zero-width
+    /// characters (which the sanitizer canonicalizes away, but the redaction filter's anchored
+    /// patterns do not) could dodge redaction specifically on local sinks (console, file, JSONL, named
+    /// pipe) while the identical string was caught everywhere else. Proven by ordering: the redaction
+    /// filter mock only sees the marker if it ran against the sanitizer's joined-back-together output,
+    /// not the raw split text.
+    /// </summary>
+    [Fact]
+    public void Redact_SanitizesBeforeRedacting()
+    {
+        const string split = "secret is AKIA<split>ABCDEFGHIJ123456";
+        const string joined = "secret is AKIAABCDEFGHIJ123456";
+
+        var sanitizer = new Mock<ICompositeResponseSanitizer>();
+        sanitizer.Setup(s => s.Sanitize(split, It.IsAny<string?>())).Returns(SanitizationResult.Clean(joined));
+
+        var filter = new Mock<IContentRedactionFilter>();
+        filter.Setup(f => f.Redact(It.IsAny<string?>(), It.IsAny<IReadOnlyList<RedactionCategory>>()))
+            .Returns((string? s, IReadOnlyList<RedactionCategory> _) => s == joined ? "[REDACTED:AwsKey]" : s ?? string.Empty);
+
+        var config = new LogsConfig { RedactionEnabled = true, RedactionCategories = ["AwsKey"] };
+        var redactor = new ContentFilterLocalLogRedactor(
+            sanitizer.Object, filter.Object, ConfigOf(config), NullLogger<ContentFilterLocalLogRedactor>.Instance);
+
+        var result = redactor.Redact(split);
+
+        result.Should().Be("[REDACTED:AwsKey]",
+            "redaction must run against the sanitizer's output, which joined the split key back together");
+    }
+
+    [Fact]
+    public void Constructor_NullSanitizer_Throws()
+    {
+        var config = new LogsConfig();
+        var act = () => new ContentFilterLocalLogRedactor(
+            null!, MockFilter().Object, ConfigOf(config), NullLogger<ContentFilterLocalLogRedactor>.Instance);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Logging/ContentFilterLocalLogRedactorTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Logging/ContentFilterLocalLogRedactorTests.cs
@@ -5,7 +5,6 @@ using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config.Observability;
 using FluentAssertions;
 using Infrastructure.Observability.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -44,8 +43,7 @@ public sealed class ContentFilterLocalLogRedactorTests
         // #457's whole point: local-sink redaction must not depend on the OTel bridge being on.
         var config = new LogsConfig { OtelExportEnabled = false, RedactionEnabled = true };
         var redactor = new ContentFilterLocalLogRedactor(
-            PassthroughSanitizer().Object, MockFilter().Object, ConfigOf(config),
-            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+            PassthroughSanitizer().Object, MockFilter().Object, ConfigOf(config));
 
         redactor.Enabled.Should().BeTrue();
     }
@@ -55,8 +53,7 @@ public sealed class ContentFilterLocalLogRedactorTests
     {
         var config = new LogsConfig { RedactionEnabled = false };
         var redactor = new ContentFilterLocalLogRedactor(
-            PassthroughSanitizer().Object, MockFilter().Object, ConfigOf(config),
-            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+            PassthroughSanitizer().Object, MockFilter().Object, ConfigOf(config));
 
         redactor.Enabled.Should().BeFalse();
     }
@@ -67,8 +64,7 @@ public sealed class ContentFilterLocalLogRedactorTests
         var filter = MockFilter();
         var config = new LogsConfig { RedactionEnabled = true, RedactionCategories = ["Email", "Generic"] };
         var redactor = new ContentFilterLocalLogRedactor(
-            PassthroughSanitizer().Object, filter.Object, ConfigOf(config),
-            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+            PassthroughSanitizer().Object, filter.Object, ConfigOf(config));
 
         var result = redactor.Redact($"token is {Marker}");
 
@@ -87,8 +83,7 @@ public sealed class ContentFilterLocalLogRedactorTests
         var filter = MockFilter();
         var config = new LogsConfig { RedactionEnabled = true, RedactionCategories = ["not-a-real-category"] };
         var redactor = new ContentFilterLocalLogRedactor(
-            PassthroughSanitizer().Object, filter.Object, ConfigOf(config),
-            NullLogger<ContentFilterLocalLogRedactor>.Instance);
+            PassthroughSanitizer().Object, filter.Object, ConfigOf(config));
 
         var result = redactor.Redact($"token is {Marker}");
 
@@ -122,8 +117,7 @@ public sealed class ContentFilterLocalLogRedactorTests
             .Returns((string? s, IReadOnlyList<RedactionCategory> _) => s == joined ? "[REDACTED:AwsKey]" : s ?? string.Empty);
 
         var config = new LogsConfig { RedactionEnabled = true, RedactionCategories = ["AwsKey"] };
-        var redactor = new ContentFilterLocalLogRedactor(
-            sanitizer.Object, filter.Object, ConfigOf(config), NullLogger<ContentFilterLocalLogRedactor>.Instance);
+        var redactor = new ContentFilterLocalLogRedactor(sanitizer.Object, filter.Object, ConfigOf(config));
 
         var result = redactor.Redact(split);
 
@@ -135,8 +129,7 @@ public sealed class ContentFilterLocalLogRedactorTests
     public void Constructor_NullSanitizer_Throws()
     {
         var config = new LogsConfig();
-        var act = () => new ContentFilterLocalLogRedactor(
-            null!, MockFilter().Object, ConfigOf(config), NullLogger<ContentFilterLocalLogRedactor>.Instance);
+        var act = () => new ContentFilterLocalLogRedactor(null!, MockFilter().Object, ConfigOf(config));
 
         act.Should().Throw<ArgumentNullException>();
     }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
@@ -1,16 +1,21 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Governance;
+using Domain.AI.Bundles;
+using Domain.AI.Governance;
 using FluentAssertions;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Presentation.AgentHub.DTOs;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Xunit;
@@ -32,8 +37,21 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Creates a factory variant that registers a fake <see cref="IMcpToolProvider"/>
-    /// and a log-capturing provider, then returns both along with a configured client.
+    /// The fake tool provider's one server key. #481 routes invocation through
+    /// <c>IDirectToolInvoker.InvokeMcpToolAsync</c>, which resolves a tool only by walking the caller's
+    /// <see cref="CapabilityEnvelope.AllowedMcpServers"/> — so the granted envelope built here must name
+    /// this same server, or every invocation test would see a governance-refused tool rather than
+    /// whatever behaviour it means to exercise.
+    /// </summary>
+    private const string TestServerName = "test-server";
+
+    /// <summary>
+    /// Creates a factory variant that registers a fake <see cref="IMcpToolProvider"/>, a log-capturing
+    /// provider, and — #481 — an operator-configured envelope explicitly granting
+    /// <paramref name="toolName"/> through <see cref="TestServerName"/>. Exercises the "operator
+    /// narrowed this caller's grant" path; <see cref="InvokeTool_NoOperatorConfig_StillWorksByDefault"/>
+    /// exercises the unconfigured default instead. <c>DirectToolInvocationConfig.McpEnabled</c> is on
+    /// by default so, unlike the keyed-DI surface, no config override is needed to switch this on.
     /// </summary>
     private (HttpClient client, TestLoggerProvider logs) CreateClientWithFakeTool(
         string toolName,
@@ -52,11 +70,51 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
                         TestAuthHandler.SchemeName, _ => { });
                 services.AddSingleton<IMcpToolProvider>(fakeProvider);
                 services.AddSingleton<ILoggerProvider>(logs);
+                services.Replace(ServiceDescriptor.Singleton<ICapabilityEnvelopeResolver>(
+                    new FixedEnvelopeResolver(new CapabilityEnvelope
+                    {
+                        AllowedTools = [toolName],
+                        AllowedMcpServers = [TestServerName],
+                        // A CapabilityEnvelope grant alone maps to "Ask", not "Autonomous" — see
+                        // CapabilityEnvelope.AutonomyCeiling's remarks. This harness wires no approval
+                        // routing, so anything short of Autonomous fails closed as Denied rather than
+                        // exercising the invocation path these tests mean to cover.
+                        AutonomyCeiling = AutonomyLevel.Autonomous
+                    })));
             });
         });
 
         var client = factory.CreateClient();
         client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "mcp-test-user");
+        return (client, logs);
+    }
+
+    /// <summary>
+    /// Same as <see cref="CreateClientWithFakeTool"/> but leaves <see cref="ICapabilityEnvelopeResolver"/>
+    /// as the host's real, unconfigured default — which resolves to an empty grant — so the request
+    /// exercises <c>McpController.ResolveMcpEnvelopeAsync</c>'s own fallback rather than a test double's
+    /// grant.
+    /// </summary>
+    private (HttpClient client, TestLoggerProvider logs) CreateClientWithFakeToolAndNoEnvelopeOverride(
+        string toolName, Func<ValueTask<object?>>? invokeImpl = null)
+    {
+        var logs = new TestLoggerProvider();
+        var fakeProvider = BuildFakeToolProvider(toolName, invokeImpl, throwOnInvoke: false);
+
+        var factory = _factory.WithWebHostBuilder(b =>
+        {
+            b.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                services.AddSingleton<IMcpToolProvider>(fakeProvider);
+                services.AddSingleton<ILoggerProvider>(logs);
+            });
+        });
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "mcp-test-user-noconfig");
         return (client, logs);
     }
 
@@ -74,14 +132,31 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
         mock.Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<string, IList<AITool>>
             {
-                ["test-server"] = new List<AITool> { fn },
+                [TestServerName] = new List<AITool> { fn },
             });
         mock.Setup(p => p.GetToolByNameAsync(toolName, It.IsAny<CancellationToken>()))
             .ReturnsAsync(fn);
         mock.Setup(p => p.GetToolByNameAsync(
                 It.Is<string>(n => n != toolName), It.IsAny<CancellationToken>()))
             .ReturnsAsync((AIFunction?)null);
+
+        // #481: IDirectToolInvoker.InvokeMcpToolAsync resolves a tool by walking the envelope's granted
+        // servers via GetToolsAsync, never GetToolByNameAsync (which would search every configured
+        // server regardless of grant) — so the fake must answer this call too, not just the one the
+        // controller's old direct-provider path used.
+        mock.Setup(p => p.GetToolsAsync(TestServerName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IList<AITool>)new List<AITool> { fn });
+        mock.Setup(p => p.GetToolsAsync(
+                It.Is<string>(n => n != TestServerName), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IList<AITool>)new List<AITool>());
+
         return mock.Object;
+    }
+
+    /// <summary>A fixed, always-granting <see cref="ICapabilityEnvelopeResolver"/> test double.</summary>
+    private sealed class FixedEnvelopeResolver(CapabilityEnvelope envelope) : ICapabilityEnvelopeResolver
+    {
+        public CapabilityEnvelope Resolve(ClaimsPrincipal? principal) => envelope;
     }
 
     // ── Tests: Tool listing ───────────────────────────────────────────────────
@@ -129,6 +204,80 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
 
     // ── Tests: Tool invocation ────────────────────────────────────────────────
 
+    /// <summary>
+    /// POST /api/mcp/tools/{name}/invoke works with no operator configuration at all — no
+    /// <c>DirectToolInvocationConfig.McpEnabled</c> override, no <see cref="ICapabilityEnvelopeResolver"/>
+    /// grant — because both default open for MCP invocation specifically, unlike the keyed-DI direct
+    /// invocation surface. Guards against a regression to the keyed-DI surface's deny-by-default posture.
+    /// </summary>
+    [Fact]
+    public async Task InvokeTool_NoOperatorConfig_StillWorksByDefault()
+    {
+        var (client, _) = CreateClientWithFakeToolAndNoEnvelopeOverride(
+            "default-open-tool", invokeImpl: () => ValueTask.FromResult<object?>("tool result"));
+
+        var body = new StringContent(
+            JsonSerializer.Serialize(new { Arguments = new { } }),
+            Encoding.UTF8, "application/json");
+
+        using var response = await client.PostAsync("/api/mcp/tools/default-open-tool/invoke", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<McpToolInvokeResponse>();
+        result.Should().NotBeNull();
+        result!.Success.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// Review finding: <c>ResolveMcpEnvelopeAsync</c> used to skip its auto-open fallback whenever
+    /// <c>AllowedTools</c> was non-empty, even if <c>AllowedMcpServers</c> was empty — but
+    /// <c>AllowedTools</c> is shared with the unrelated keyed-DI direct-invocation surface, so an
+    /// operator who narrowed only that grant (naming a tool that has nothing to do with MCP, and
+    /// configuring no MCP servers at all) would have silently suppressed the MCP-specific fallback too.
+    /// This proves the fallback still opens when only <c>AllowedTools</c> is populated.
+    /// </summary>
+    [Fact]
+    public async Task InvokeTool_EnvelopeGrantsOnlyUnrelatedKeyedDiTool_StillFallsBackToAutoOpenForMcp()
+    {
+        var logs = new TestLoggerProvider();
+        var fakeProvider = BuildFakeToolProvider("mcp-only-tool", () => ValueTask.FromResult<object?>("tool result"), throwOnInvoke: false);
+
+        var factory = _factory.WithWebHostBuilder(b =>
+        {
+            b.ConfigureTestServices(services =>
+            {
+                services.AddAuthentication(TestAuthHandler.SchemeName)
+                    .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
+                        TestAuthHandler.SchemeName, _ => { });
+                services.AddSingleton<IMcpToolProvider>(fakeProvider);
+                services.AddSingleton<ILoggerProvider>(logs);
+                services.Replace(ServiceDescriptor.Singleton<ICapabilityEnvelopeResolver>(
+                    new FixedEnvelopeResolver(new CapabilityEnvelope
+                    {
+                        // Names a keyed-DI tool that has nothing to do with MCP; AllowedMcpServers is
+                        // deliberately left empty so this exercises the auto-open fallback condition.
+                        AllowedTools = ["some-unrelated-keyed-di-tool"],
+                        AllowedMcpServers = [],
+                        AutonomyCeiling = AutonomyLevel.Autonomous
+                    })));
+            });
+        });
+
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "mcp-narrowed-keyeddi-user");
+
+        var body = new StringContent(
+            JsonSerializer.Serialize(new { Arguments = new { } }),
+            Encoding.UTF8, "application/json");
+
+        using var response = await client.PostAsync("/api/mcp/tools/mcp-only-tool/invoke", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<McpToolInvokeResponse>();
+        result.Should().NotBeNull();
+        result!.Success.Should().BeTrue();
+    }
+
     /// <summary>POST /api/mcp/tools/{name}/invoke returns 200 with Success=true for a working tool.</summary>
     [Fact]
     public async Task InvokeTool_ValidArgs_Returns200WithOutput()
@@ -163,11 +312,22 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
-    /// <summary>POST /api/mcp/tools/{name}/invoke returns 200 with Success=false when the tool throws.</summary>
+    /// <summary>
+    /// POST /api/mcp/tools/{name}/invoke returns 200 with Success=false when the MCP tool reports a
+    /// protocol-level failure (<c>isError: true</c>) without throwing — the shape
+    /// <see cref="Application.AI.Common.Services.Tools.McpFailureNormalizingAIFunction"/> recognizes
+    /// and DirectToolInvoker's response shaping treats as a completed, "the tool said no" invocation.
+    /// </summary>
     [Fact]
-    public async Task InvokeTool_ToolExecutionFailure_Returns200WithSuccessFalse()
+    public async Task InvokeTool_ToolReportsProtocolFailure_Returns200WithSuccessFalse()
     {
-        var (client, _) = CreateClientWithFakeTool("failing-tool", throwOnInvoke: true);
+        var mcpFailure = JsonSerializer.SerializeToElement(new
+        {
+            isError = true,
+            content = new[] { new { type = "text", text = "Simulated tool failure" } }
+        });
+        var (client, _) = CreateClientWithFakeTool(
+            "failing-tool", invokeImpl: () => ValueTask.FromResult<object?>(mcpFailure));
         var body = new StringContent(
             JsonSerializer.Serialize(new { Arguments = new { } }),
             Encoding.UTF8, "application/json");
@@ -179,6 +339,25 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
         result.Should().NotBeNull();
         result!.Success.Should().BeFalse();
         result.Output.Should().BeNull("error responses must not populate Output");
+        result.Error.Should().Contain("Simulated tool failure");
+    }
+
+    /// <summary>
+    /// POST /api/mcp/tools/{name}/invoke returns 500 when the tool call itself throws — distinct from a
+    /// protocol-level failure, and deliberately does not echo the exception message across the trust
+    /// boundary (matches <c>ToolsController.Invoke</c>'s keyed-DI convention).
+    /// </summary>
+    [Fact]
+    public async Task InvokeTool_ToolThrows_Returns500Faulted()
+    {
+        var (client, _) = CreateClientWithFakeTool("throwing-tool", throwOnInvoke: true);
+        var body = new StringContent(
+            JsonSerializer.Serialize(new { Arguments = new { } }),
+            Encoding.UTF8, "application/json");
+
+        using var response = await client.PostAsync("/api/mcp/tools/throwing-tool/invoke", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
     }
 
     /// <summary>POST /api/mcp/tools/{name}/invoke emits a structured audit log entry with UserId, ToolName, InputHash.</summary>

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
@@ -229,15 +229,19 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
     }
 
     /// <summary>
-    /// Review finding: <c>ResolveMcpEnvelopeAsync</c> used to skip its auto-open fallback whenever
-    /// <c>AllowedTools</c> was non-empty, even if <c>AllowedMcpServers</c> was empty — but
-    /// <c>AllowedTools</c> is shared with the unrelated keyed-DI direct-invocation surface, so an
-    /// operator who narrowed only that grant (naming a tool that has nothing to do with MCP, and
-    /// configuring no MCP servers at all) would have silently suppressed the MCP-specific fallback too.
-    /// This proves the fallback still opens when only <c>AllowedTools</c> is populated.
+    /// Security review finding: an earlier version of <c>ResolveMcpEnvelopeAsync</c> skipped its
+    /// auto-open fallback only when <c>AllowedMcpServers</c> was populated, reasoning that
+    /// <c>AllowedTools</c> is "shared with the unrelated keyed-DI surface" — but
+    /// <see cref="CapabilityEnvelope.AllowedTools"/>'s own remarks say otherwise: it is the MCP tool
+    /// gate too, checked by <c>DirectToolInvoker.Mcp.cs</c>'s <c>Envelope.GrantsTool</c>. That version
+    /// let an operator's deliberate least-privilege grant (a narrow <c>AllowedTools</c> list, no MCP
+    /// servers, a restrictive autonomy ceiling) get silently discarded and replaced with every
+    /// connected server and Autonomous ceiling — a fail-open privilege escalation. This proves the
+    /// fallback stays closed once <em>any</em> grant exists, and that an ungranted tool under that
+    /// grant is still denied rather than auto-opened.
     /// </summary>
     [Fact]
-    public async Task InvokeTool_EnvelopeGrantsOnlyUnrelatedKeyedDiTool_StillFallsBackToAutoOpenForMcp()
+    public async Task InvokeTool_EnvelopeGrantsOnlyAnUnrelatedTool_DoesNotFallBackToAutoOpenForMcp()
     {
         var logs = new TestLoggerProvider();
         var fakeProvider = BuildFakeToolProvider("mcp-only-tool", () => ValueTask.FromResult<object?>("tool result"), throwOnInvoke: false);
@@ -254,17 +258,18 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
                 services.Replace(ServiceDescriptor.Singleton<ICapabilityEnvelopeResolver>(
                     new FixedEnvelopeResolver(new CapabilityEnvelope
                     {
-                        // Names a keyed-DI tool that has nothing to do with MCP; AllowedMcpServers is
-                        // deliberately left empty so this exercises the auto-open fallback condition.
-                        AllowedTools = ["some-unrelated-keyed-di-tool"],
+                        // A deliberate, narrow grant naming a tool unrelated to the one being invoked;
+                        // AllowedMcpServers is empty and the ceiling is restrictive — exactly the
+                        // least-privilege shape the fail-open bug discarded.
+                        AllowedTools = ["some-other-tool"],
                         AllowedMcpServers = [],
-                        AutonomyCeiling = AutonomyLevel.Autonomous
+                        AutonomyCeiling = AutonomyLevel.Restricted
                     })));
             });
         });
 
         var client = factory.CreateClient();
-        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "mcp-narrowed-keyeddi-user");
+        client.DefaultRequestHeaders.Add(TestAuthHandler.UserIdHeader, "mcp-narrow-grant-user");
 
         var body = new StringContent(
             JsonSerializer.Serialize(new { Arguments = new { } }),
@@ -272,10 +277,9 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
 
         using var response = await client.PostAsync("/api/mcp/tools/mcp-only-tool/invoke", body);
 
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        var result = await response.Content.ReadFromJsonAsync<McpToolInvokeResponse>();
-        result.Should().NotBeNull();
-        result!.Success.Should().BeTrue();
+        // The narrow grant is honored as-is: mcp-only-tool isn't in AllowedTools, so it's denied
+        // rather than reached via the every-server-every-tool auto-open fallback.
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     /// <summary>POST /api/mcp/tools/{name}/invoke returns 200 with Success=true for a working tool.</summary>

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Controllers/McpControllerTests.cs
@@ -298,6 +298,35 @@ public sealed class McpControllerTests : IClassFixture<TestWebApplicationFactory
         result!.Success.Should().BeTrue();
     }
 
+    /// <summary>
+    /// The dominant MCP tool-success shape (see <c>ToolResultTextTests</c>'s header remarks, confirmed
+    /// by decompiling <c>ModelContextProtocol.Core</c>'s <c>McpClientTool.InvokeCoreAsync</c>): a
+    /// single-content-block success reaches <see cref="Application.AI.Common.Services.Tools.DirectToolInvoker"/>
+    /// as a bare <see cref="TextContent"/>, not a plain string. Before <c>ToolResultText.ExtractText</c>
+    /// existed, the invoker's own reduction fell through to serializing the whole <see cref="TextContent"/>
+    /// object as JSON instead of extracting its <c>Text</c> — this proves the real end-to-end HTTP path
+    /// returns the tool's actual text for the shape a real MCP tool call is most likely to produce.
+    /// </summary>
+    [Fact]
+    public async Task InvokeTool_ToolReturnsTextContent_ExtractsItsTextRatherThanSerializingTheObject()
+    {
+        var (client, _) = CreateClientWithFakeTool(
+            "text-content-tool",
+            invokeImpl: () => ValueTask.FromResult<object?>(new TextContent("the tool's actual answer")));
+
+        var body = new StringContent(
+            JsonSerializer.Serialize(new { Arguments = new { } }),
+            Encoding.UTF8, "application/json");
+
+        using var response = await client.PostAsync("/api/mcp/tools/text-content-tool/invoke", body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<McpToolInvokeResponse>();
+        result.Should().NotBeNull();
+        result!.Success.Should().BeTrue();
+        result.Output.Should().Be("the tool's actual answer");
+    }
+
     /// <summary>POST /api/mcp/tools/{name}/invoke returns 404 for an unknown tool name.</summary>
     [Fact]
     public async Task InvokeTool_UnknownTool_Returns404()


### PR DESCRIPTION
## Summary
- Closes #470, #471, #472, #457 — the tier-2 sanitize/redact gap cluster (see #478/#481/#482's PR #492 for tier 1).
- #467 investigated and found already fixed by commit e3a2ae37; closed separately, no code change here.
- A `/code-review` pass found and fixed 3 real findings (an unanchored already-redacted regex guard that let attacker-controlled secrets evade redaction, a missing sanitize-before-redact step on the new local-log path, and a fixed `ExtractText` gap that mis-rendered the dominant MCP tool-result shape).
- A `/simplify` pass found and fixed 5 more (dead flag removal, a naming/discoverability fix, two duplicate-fallback-policy consolidations, and the `ExtractText` correctness fix above).
- An independent security review then found and fixed a CRITICAL startup deadlock (a DI cycle introduced by the #457 local-log-redaction wiring — this was the actual cause of every `WebApplicationFactory`-based integration test hanging throughout this PR's development, previously misdiagnosed as machine flakiness) and a HIGH-severity privilege-escalation regression in an earlier commit's own fix to the MCP capability-envelope check, plus 4 MEDIUM/LOW gaps in the redaction guarantees this PR itself establishes.
- Three larger structural-duplication findings and three lower-severity findings were filed as follow-up issues (#493–#498) rather than expanding this PR's blast radius further.

## Test plan
- [x] Full solution builds clean (`dotnet build src/AgenticHarness.slnx`, 0 errors)
- [x] `ValidateOnBuildSweepTests` (composition-root smoke test) — was hanging indefinitely before the DI-cycle fix, now passes in <1s
- [x] `McpControllerTests` — was hanging/crashing before the DI-cycle fix, now 14/14 pass in ~8s, including new regression tests for the TextContent extraction fix and the reverted-then-corrected envelope check
- [x] `Infrastructure.Observability.Tests` — 197/197
- [x] `Application.AI.Common.Tests` — 2268/2268
- [x] `Application.Common.Tests` — 234/234
- [x] `Infrastructure.AI.Tests` (redaction/Magentic-content-capture subset) — 40/40
- [ ] Local `run-gates.sh` (full AI-gated pass) was not run to completion before this push — the code has already been through two independent review passes (`/code-review` + `/simplify`) plus an adversarial security review that found and required fixing a CRITICAL and a HIGH finding; CI's own `correctness-review`/`security-review`/`grader`/OWASP gates are the backstop for anything those missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xxqNNbzacXzssF4kBnaka