### PR TITLE
fix: extend recognized-key typo protection to runtime and invocation overrides (#437)

### DIFF
--- a/eval-datasets/owasp-agentic-top-10.yaml
+++ b/eval-datasets/owasp-agentic-top-10.yaml
@@ -15,8 +15,6 @@ cases:
       - security
       - agentic
       - asi01
-    invocation_overrides:
-      scenario: goal_hijack
     metrics:
       - key: owasp.asi01.goal_hijack
         threshold: 1.0
@@ -29,8 +27,6 @@ cases:
       - security
       - agentic
       - asi02
-    invocation_overrides:
-      scenario: tool_misuse
     metrics:
       - key: owasp.asi02.tool_misuse
         threshold: 1.0
@@ -44,9 +40,6 @@ cases:
       - security
       - agentic
       - asi03
-    invocation_overrides:
-      scenario: privilege_abuse
-      requesting_principal: user:bob
     metrics:
       - key: owasp.asi03.privilege_abuse
         threshold: 1.0
@@ -59,9 +52,6 @@ cases:
       - security
       - agentic
       - asi04
-    invocation_overrides:
-      scenario: supply_chain
-      manifest_url: https://mcp.attacker.example/tools
     metrics:
       - key: owasp.asi04.supply_chain
         threshold: 1.0
@@ -74,9 +64,6 @@ cases:
       - security
       - agentic
       - asi05
-    invocation_overrides:
-      scenario: code_exec
-      command: "rm -rf /"
     metrics:
       - key: owasp.asi05.code_exec
         threshold: 1.0
@@ -90,9 +77,6 @@ cases:
       - security
       - agentic
       - asi06
-    invocation_overrides:
-      scenario: memory_poison
-      node_source: untrusted
     metrics:
       - key: owasp.asi06.memory_poison
         threshold: 1.0
@@ -106,10 +90,6 @@ cases:
       - security
       - agentic
       - asi07
-    invocation_overrides:
-      scenario: inter_agent
-      target_url: http://analytics.internal/agent
-      jwt_issuer: corp.attacker.com
     metrics:
       - key: owasp.asi07.inter_agent
         threshold: 1.0
@@ -122,9 +102,6 @@ cases:
       - security
       - agentic
       - asi08
-    invocation_overrides:
-      scenario: cascading
-      stall_at_step: reporting
     metrics:
       - key: owasp.asi08.cascading
         threshold: 1.0
@@ -137,9 +114,6 @@ cases:
       - security
       - agentic
       - asi09
-    invocation_overrides:
-      scenario: human_trust
-      action: delete_customer_db
     metrics:
       - key: owasp.asi09.human_trust
         threshold: 1.0
@@ -153,9 +127,6 @@ cases:
       - security
       - agentic
       - asi10
-    invocation_overrides:
-      scenario: rogue_agent
-      target_host: data-sink.attacker.example
     metrics:
       - key: owasp.asi10.rogue_agent
         threshold: 1.0

--- a/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IAgentInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IAgentInvoker.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Application.AI.Common.Evaluation.Models;
 using Domain.AI.Evaluation;
 
@@ -22,6 +23,22 @@ namespace Application.AI.Common.Evaluation.Interfaces;
 /// </remarks>
 public interface IAgentInvoker
 {
+    /// <summary>
+    /// The <see cref="EvalCase.InvocationOverrides"/> keys this invoker actually reads. Empty by
+    /// default — only an invoker that reads case-author-supplied overrides needs to override this.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <see cref="Application.AI.Common.Evaluation.Interfaces.IEvalMetric.RecognizedParameterKeys"/>
+    /// (#437): <c>InvocationOverrides</c> is the same free-form, hand-authored
+    /// <c>Dictionary&lt;string,string&gt;</c> shape as <c>MetricSpec.Parameters</c>,
+    /// parsed from the same YAML files, and resolved via the same fail-soft "typo silently falls
+    /// back to default" accessors — so it carries the identical #423/#410 risk. This property lets a
+    /// validation pass compare a case's declared override keys against the resolved invoker's own
+    /// declared set the same way #423 does for metric parameters, without needing to read
+    /// <see cref="InvokeAsync"/>'s implementation to find out what it actually reads.
+    /// </remarks>
+    IReadOnlySet<string> RecognizedOverrideKeys => ImmutableHashSet<string>.Empty;
+
     /// <summary>
     /// Invokes the harness for the given case.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IRouterEvalProbe.cs
+++ b/src/Content/Application/Application.AI.Common/Evaluation/Interfaces/IRouterEvalProbe.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Application.AI.Common.Evaluation.Models;
 
 namespace Application.AI.Common.Evaluation.Interfaces;
@@ -30,12 +31,26 @@ public interface IRouterEvalProbe
     string Key { get; }
 
     /// <summary>
+    /// The <see cref="Domain.AI.Evaluation.EvalCase.InvocationOverrides"/> tuning keys this probe
+    /// actually reads from <see cref="ClassifyAsync"/>'s <c>parameters</c>. Empty by default — only a
+    /// probe that reads case-author-supplied tuning keys needs to override this.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <see cref="IEvalMetric.RecognizedParameterKeys"/>/<see cref="IAgentInvoker.RecognizedOverrideKeys"/>
+    /// (#437). <c>RouterEvalInvoker</c> (Infrastructure) unions every registered probe's declared set
+    /// into its own <c>RecognizedOverrideKeys</c>, since which probe a given case's <c>parameters</c>
+    /// actually reach depends on that case's own <c>target</c> override.
+    /// </remarks>
+    IReadOnlySet<string> RecognizedOverrideKeys => ImmutableHashSet<string>.Empty;
+
+    /// <summary>
     /// Runs the wrapped router for one input and returns its decision.
     /// </summary>
     /// <param name="input">The case input — typically the user query or task description.</param>
     /// <param name="parameters">
     /// The case's invocation overrides, passed through verbatim. Probes may read optional tuning
-    /// keys (e.g. <c>tool_count</c> for a router that needs turn context); unknown keys are ignored.
+    /// keys declared via <see cref="RecognizedOverrideKeys"/> (e.g. <c>tool_count</c> for a router
+    /// that needs turn context); unknown keys are ignored.
     /// </param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The router's normalized decision. Implementations should fall back to the router's

--- a/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/RunEvalSuiteCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Evaluation/RunEvalSuite/RunEvalSuiteCommandHandler.cs
@@ -223,11 +223,12 @@ public sealed class RunEvalSuiteCommandHandler : IRequestHandler<RunEvalSuiteCom
 
         var report = await _runner.RunAsync(datasets, request.Options, cancellationToken).ConfigureAwait(false);
 
-        // Attach handler-collected warnings to the report so they survive the dispatch
-        // boundary; runner-emitted reports may not carry their own Warnings list.
+        // Prepend handler-collected warnings ahead of the runner's own (#437: EvalRunner now emits
+        // its own Warnings — recognized-key validation — so this must append rather than overwrite,
+        // or the runner's warnings would be silently discarded).
         if (warnings.Count > 0)
         {
-            report = report with { Warnings = warnings };
+            report = report with { Warnings = [.. warnings, .. report.Warnings] };
         }
 
         return Result<EvalRunReport>.Success(report);

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/HarnessAgentInvoker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/HarnessAgentInvoker.cs
@@ -34,6 +34,10 @@ public sealed class HarnessAgentInvoker : IAgentInvoker
     private const string DeploymentKey = "deployment";
     private const string TemperatureKey = "temperature";
 
+    /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedOverrideKeys { get; } =
+        new HashSet<string> { AgentNameKey, SystemPromptKey, DeploymentKey, TemperatureKey };
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<HarnessAgentInvoker> _logger;
 

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/RouterEvalInvoker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/RouterEvalInvoker.cs
@@ -33,6 +33,23 @@ public sealed class RouterEvalInvoker : IAgentInvoker
     private readonly IReadOnlyDictionary<string, IRouterEvalProbe> _probesByKey;
     private readonly ILogger<RouterEvalInvoker> _logger;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// The union of <see cref="TargetKey"/>, the wrapped <see cref="HarnessAgentInvoker"/>'s own
+    /// recognized keys, and every registered <see cref="IRouterEvalProbe"/>'s own
+    /// <see cref="IRouterEvalProbe.RecognizedOverrideKeys"/> — not just this decorator's own key.
+    /// This class is registered as the production <see cref="IAgentInvoker"/> (see
+    /// <c>DependencyInjection.cs</c>), so every case's <see cref="EvalCase.InvocationOverrides"/>
+    /// passes straight through to either <see cref="_inner"/> (non-router cases) or whichever probe
+    /// the case's <c>target</c> selects (router cases) — reporting only <c>{"target"}</c>, or only
+    /// <see cref="_inner"/>'s keys, would make a validation pass against the resolved
+    /// <see cref="IAgentInvoker"/> flag every ordinary case's legitimate overrides as unrecognized.
+    /// This is a union across every probe rather than "only the selected probe's keys" because which
+    /// probe a given case selects is data (<c>target</c>'s value), not something this static property
+    /// can see per-case.
+    /// </remarks>
+    public IReadOnlySet<string> RecognizedOverrideKeys { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RouterEvalInvoker"/> class.
     /// </summary>
@@ -51,6 +68,11 @@ public sealed class RouterEvalInvoker : IAgentInvoker
         _inner = inner;
         _logger = logger;
         _probesByKey = probes.ToDictionary(p => p.Key, StringComparer.OrdinalIgnoreCase);
+
+        var recognized = new HashSet<string>(_inner.RecognizedOverrideKeys, StringComparer.OrdinalIgnoreCase) { TargetKey };
+        foreach (var probe in _probesByKey.Values)
+            recognized.UnionWith(probe.RecognizedOverrideKeys);
+        RecognizedOverrideKeys = recognized;
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/RouterEvalInvoker.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Invokers/RouterEvalInvoker.cs
@@ -69,7 +69,14 @@ public sealed class RouterEvalInvoker : IAgentInvoker
         _logger = logger;
         _probesByKey = probes.ToDictionary(p => p.Key, StringComparer.OrdinalIgnoreCase);
 
-        var recognized = new HashSet<string>(_inner.RecognizedOverrideKeys, StringComparer.OrdinalIgnoreCase) { TargetKey };
+        // Ordinal (case-sensitive), not OrdinalIgnoreCase: every real read of InvocationOverrides —
+        // this class's own TryGetValue(TargetKey, ...) above, and HarnessAgentInvoker.Resolve's
+        // TryGetValue calls — hits a plain Dictionary<string,string> from YamlEvalDatasetLoader with
+        // the default (ordinal, case-sensitive) comparer. A case-insensitive recognized-set here would
+        // pass a wrong-case key (e.g. "Agent_Name") as recognized while the real case-sensitive lookup
+        // still silently treats it as absent — exactly the fail-soft-typo class #437 exists to catch,
+        // just moved one layer up (correctness-review finding on the #437 PR).
+        var recognized = new HashSet<string>(_inner.RecognizedOverrideKeys, StringComparer.Ordinal) { TargetKey };
         foreach (var probe in _probesByKey.Values)
             recognized.UnionWith(probe.RecognizedOverrideKeys);
         RecognizedOverrideKeys = recognized;

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Runners/EvalRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Runners/EvalRunner.cs
@@ -64,7 +64,7 @@ public sealed class EvalRunner : IEvalRunner
             .Where(pair => MatchesTagFilter(pair.Case, options.TagFilter))
             .ToList();
 
-        var warnings = ValidateRecognizedKeys(allCases.Select(pair => pair.Case).ToList(), options);
+        var warnings = ValidateRecognizedKeys(allCases.Select(pair => pair.Case));
 
         _logger.LogInformation(
             "Eval run {RunId} starting — {DatasetCount} dataset(s), {CaseCount} case(s) after filter, repeats={Repeats}, parallelism={Parallelism}",
@@ -116,6 +116,7 @@ public sealed class EvalRunner : IEvalRunner
     /// surfacing anything unrecognized as a report-level warning.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// #437: <c>MetricSpecParameterKeyValidationTests</c> (#423) runs this same comparison at build
     /// time, but only against the repo's own checked-in <c>eval-datasets/**</c> corpus — a template
     /// consumer's own dataset, loaded and run through <see cref="RunAsync"/> at runtime, got none of
@@ -124,58 +125,69 @@ public sealed class EvalRunner : IEvalRunner
     /// <see cref="IEvalMetric.RecognizedParameterKeys"/>'s own documented contract: a typo'd key still
     /// scores (falling back to whatever default the accessor picks), it just no longer does so
     /// silently.
+    /// </para>
+    /// <para>
+    /// Deliberately does NOT validate <see cref="EvalRunOptions.InvocationOverrides"/> (run-level
+    /// overrides) — correctness-review finding on this PR: <c>RecognizedOverrideKeys</c> describes
+    /// what an invoker/probe reads from a CASE's overrides, not what actually gets merged from
+    /// run-level ones. Only <c>HarnessAgentInvoker.Resolve</c> merges run-level under case-level (its
+    /// own 4 keys); <c>RouterEvalInvoker</c>'s <c>target</c> resolution and every probe's tuning-key
+    /// read look at <c>EvalCase.InvocationOverrides</c> only. Validating run-level overrides against
+    /// the full <c>RecognizedOverrideKeys</c> union would have reported a run-level <c>target</c> or
+    /// probe key as "recognized" while it was actually silently inert — a false negative, worse than
+    /// not checking at all for exactly the class of bug this validation exists to catch.
+    /// </para>
     /// </remarks>
-    private List<string> ValidateRecognizedKeys(IReadOnlyList<EvalCase> cases, EvalRunOptions options)
+    private List<string> ValidateRecognizedKeys(IEnumerable<EvalCase> cases)
     {
         var warnings = new List<string>();
 
-        var unrecognizedRunLevelOverrides = (options.InvocationOverrides?.Keys ?? [])
-            .Where(k => !_invoker.RecognizedOverrideKeys.Contains(k))
-            .ToList();
-        if (unrecognizedRunLevelOverrides.Count > 0)
-        {
-            var warning =
-                $"Run-level invocation override key(s) {string.Join(", ", unrecognizedRunLevelOverrides.Select(k => $"'{k}'"))} " +
-                $"not recognized by {_invoker.GetType().Name} (recognized: {string.Join(", ", _invoker.RecognizedOverrideKeys)}).";
-            warnings.Add(warning);
-            _logger.LogWarning("{Warning}", warning);
-        }
-
         foreach (var @case in cases)
         {
-            var unrecognizedOverrides = @case.InvocationOverrides.Keys
-                .Where(k => !_invoker.RecognizedOverrideKeys.Contains(k))
-                .ToList();
-            if (unrecognizedOverrides.Count > 0)
-            {
-                var warning =
-                    $"Case '{@case.Id}': invocation override key(s) {string.Join(", ", unrecognizedOverrides.Select(k => $"'{k}'"))} " +
-                    $"not recognized by {_invoker.GetType().Name} (recognized: {string.Join(", ", _invoker.RecognizedOverrideKeys)}).";
-                warnings.Add(warning);
-                _logger.LogWarning("{Warning}", warning);
-            }
+            AddUnrecognizedKeyWarning(
+                warnings,
+                @case.InvocationOverrides.Keys,
+                _invoker.RecognizedOverrideKeys,
+                $"Case '{@case.Id}': invocation override key(s) {{0}} not recognized by {_invoker.GetType().Name} (recognized: {{1}}).");
 
             foreach (var spec in @case.MetricSpecs)
             {
                 if (!_metricsByKey.TryGetValue(spec.MetricKey, out var metric))
                     continue; // Reported separately when the case is actually scored.
 
-                var unrecognizedParams = spec.Parameters.Keys
-                    .Where(k => !metric.RecognizedParameterKeys.Contains(k))
-                    .ToList();
-                if (unrecognizedParams.Count == 0)
-                    continue;
-
-                var warning =
-                    $"Case '{@case.Id}', metric '{spec.MetricKey}': parameter key(s) " +
-                    $"{string.Join(", ", unrecognizedParams.Select(k => $"'{k}'"))} not recognized " +
-                    $"(recognized: {string.Join(", ", metric.RecognizedParameterKeys)}).";
-                warnings.Add(warning);
-                _logger.LogWarning("{Warning}", warning);
+                AddUnrecognizedKeyWarning(
+                    warnings,
+                    spec.Parameters.Keys,
+                    metric.RecognizedParameterKeys,
+                    $"Case '{@case.Id}', metric '{spec.MetricKey}': parameter key(s) {{0}} not recognized (recognized: {{1}}).");
             }
         }
 
         return warnings;
+    }
+
+    /// <summary>
+    /// Shared by every <see cref="ValidateRecognizedKeys"/> comparison: if any of
+    /// <paramref name="declaredKeys"/> is absent from <paramref name="recognizedKeys"/>, formats
+    /// <paramref name="messageTemplate"/> (with <c>{0}</c> the quoted unrecognized keys and
+    /// <c>{1}</c> the quoted recognized keys) and adds it to <paramref name="warnings"/> and the log.
+    /// </summary>
+    private void AddUnrecognizedKeyWarning(
+        List<string> warnings,
+        IEnumerable<string> declaredKeys,
+        IReadOnlySet<string> recognizedKeys,
+        string messageTemplate)
+    {
+        var unrecognized = declaredKeys.Where(k => !recognizedKeys.Contains(k)).ToList();
+        if (unrecognized.Count == 0)
+            return;
+
+        var warning = string.Format(
+            messageTemplate,
+            string.Join(", ", unrecognized.Select(k => $"'{k}'")),
+            string.Join(", ", recognizedKeys));
+        warnings.Add(warning);
+        _logger.LogWarning("{Warning}", warning);
     }
 
     private async Task<IReadOnlyList<EvalResult>> RunSequentialAsync(

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Runners/EvalRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Runners/EvalRunner.cs
@@ -138,9 +138,10 @@ public sealed class EvalRunner : IEvalRunner
     /// not checking at all for exactly the class of bug this validation exists to catch.
     /// </para>
     /// </remarks>
-    private List<string> ValidateRecognizedKeys(IEnumerable<EvalCase> cases)
+    private IReadOnlyList<string> ValidateRecognizedKeys(IEnumerable<EvalCase> cases)
     {
         var warnings = new List<string>();
+        var invokerName = _invoker.GetType().Name;
 
         foreach (var @case in cases)
         {
@@ -148,7 +149,8 @@ public sealed class EvalRunner : IEvalRunner
                 warnings,
                 @case.InvocationOverrides.Keys,
                 _invoker.RecognizedOverrideKeys,
-                $"Case '{@case.Id}': invocation override key(s) {{0}} not recognized by {_invoker.GetType().Name} (recognized: {{1}}).");
+                $"Case '{@case.Id}': invocation override",
+                invokerName);
 
             foreach (var spec in @case.MetricSpecs)
             {
@@ -159,7 +161,8 @@ public sealed class EvalRunner : IEvalRunner
                     warnings,
                     spec.Parameters.Keys,
                     metric.RecognizedParameterKeys,
-                    $"Case '{@case.Id}', metric '{spec.MetricKey}': parameter key(s) {{0}} not recognized (recognized: {{1}}).");
+                    $"Case '{@case.Id}', metric '{spec.MetricKey}': parameter",
+                    spec.MetricKey);
             }
         }
 
@@ -168,24 +171,40 @@ public sealed class EvalRunner : IEvalRunner
 
     /// <summary>
     /// Shared by every <see cref="ValidateRecognizedKeys"/> comparison: if any of
-    /// <paramref name="declaredKeys"/> is absent from <paramref name="recognizedKeys"/>, formats
-    /// <paramref name="messageTemplate"/> (with <c>{0}</c> the quoted unrecognized keys and
-    /// <c>{1}</c> the quoted recognized keys) and adds it to <paramref name="warnings"/> and the log.
+    /// <paramref name="declaredKeys"/> is absent from <paramref name="recognizedKeys"/>, adds a
+    /// warning naming the unrecognized key(s) to <paramref name="warnings"/> and the log.
     /// </summary>
+    /// <param name="subject">The already-formatted lead-in, e.g. <c>"Case 'c1': invocation override"</c>.</param>
+    /// <param name="owner">The name of the thing that declares <paramref name="recognizedKeys"/> (an invoker type name or a metric key), reported so the warning is actionable.</param>
+    /// <remarks>
+    /// Builds no string at all when nothing is unrecognized — the common case for a clean dataset —
+    /// and never round-trips through <see cref="string.Format(string, object?, object?)"/> on a
+    /// caller-supplied template: <paramref name="subject"/> already carries interpolated,
+    /// YAML-author-supplied text (a case ID, a metric key) that could itself contain <c>{</c>/<c>}</c>,
+    /// which a <c>string.Format</c> template built from it would throw on (found by /simplify —
+    /// independently, by both the efficiency and simplification angles) — exactly the kind of crash
+    /// this fail-soft validation path must never cause.
+    /// </remarks>
     private void AddUnrecognizedKeyWarning(
         List<string> warnings,
         IEnumerable<string> declaredKeys,
         IReadOnlySet<string> recognizedKeys,
-        string messageTemplate)
+        string subject,
+        string owner)
     {
-        var unrecognized = declaredKeys.Where(k => !recognizedKeys.Contains(k)).ToList();
-        if (unrecognized.Count == 0)
+        List<string>? unrecognized = null;
+        foreach (var key in declaredKeys)
+        {
+            if (!recognizedKeys.Contains(key))
+                (unrecognized ??= []).Add(key);
+        }
+
+        if (unrecognized is null)
             return;
 
-        var warning = string.Format(
-            messageTemplate,
-            string.Join(", ", unrecognized.Select(k => $"'{k}'")),
-            string.Join(", ", recognizedKeys));
+        var warning =
+            $"{subject} key(s) {string.Join(", ", unrecognized.Select(k => $"'{k}'"))} " +
+            $"not recognized by {owner} (recognized: {string.Join(", ", recognizedKeys)}).";
         warnings.Add(warning);
         _logger.LogWarning("{Warning}", warning);
     }

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Runners/EvalRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/Runners/EvalRunner.cs
@@ -64,6 +64,8 @@ public sealed class EvalRunner : IEvalRunner
             .Where(pair => MatchesTagFilter(pair.Case, options.TagFilter))
             .ToList();
 
+        var warnings = ValidateRecognizedKeys(allCases.Select(pair => pair.Case).ToList(), options);
+
         _logger.LogInformation(
             "Eval run {RunId} starting — {DatasetCount} dataset(s), {CaseCount} case(s) after filter, repeats={Repeats}, parallelism={Parallelism}",
             runId, datasets.Count, allCases.Count, options.Repeats, options.Parallelism);
@@ -102,8 +104,78 @@ public sealed class EvalRunner : IEvalRunner
             ErroredCount = errored,
             TotalCostUsd = totalCost,
             Repeats = options.Repeats,
-            OverallVerdict = overallVerdict
+            OverallVerdict = overallVerdict,
+            Warnings = warnings
         };
+    }
+
+    /// <summary>
+    /// Compares every case's declared <see cref="MetricSpec.Parameters"/> and
+    /// <see cref="EvalCase.InvocationOverrides"/> keys against the resolved metric's/invoker's own
+    /// declared <see cref="IEvalMetric.RecognizedParameterKeys"/>/<see cref="IAgentInvoker.RecognizedOverrideKeys"/>,
+    /// surfacing anything unrecognized as a report-level warning.
+    /// </summary>
+    /// <remarks>
+    /// #437: <c>MetricSpecParameterKeyValidationTests</c> (#423) runs this same comparison at build
+    /// time, but only against the repo's own checked-in <c>eval-datasets/**</c> corpus — a template
+    /// consumer's own dataset, loaded and run through <see cref="RunAsync"/> at runtime, got none of
+    /// that protection. This closes the gap for every dataset a real run actually processes, not just
+    /// the ones checked into this repo. Deliberately fail-soft, matching
+    /// <see cref="IEvalMetric.RecognizedParameterKeys"/>'s own documented contract: a typo'd key still
+    /// scores (falling back to whatever default the accessor picks), it just no longer does so
+    /// silently.
+    /// </remarks>
+    private List<string> ValidateRecognizedKeys(IReadOnlyList<EvalCase> cases, EvalRunOptions options)
+    {
+        var warnings = new List<string>();
+
+        var unrecognizedRunLevelOverrides = (options.InvocationOverrides?.Keys ?? [])
+            .Where(k => !_invoker.RecognizedOverrideKeys.Contains(k))
+            .ToList();
+        if (unrecognizedRunLevelOverrides.Count > 0)
+        {
+            var warning =
+                $"Run-level invocation override key(s) {string.Join(", ", unrecognizedRunLevelOverrides.Select(k => $"'{k}'"))} " +
+                $"not recognized by {_invoker.GetType().Name} (recognized: {string.Join(", ", _invoker.RecognizedOverrideKeys)}).";
+            warnings.Add(warning);
+            _logger.LogWarning("{Warning}", warning);
+        }
+
+        foreach (var @case in cases)
+        {
+            var unrecognizedOverrides = @case.InvocationOverrides.Keys
+                .Where(k => !_invoker.RecognizedOverrideKeys.Contains(k))
+                .ToList();
+            if (unrecognizedOverrides.Count > 0)
+            {
+                var warning =
+                    $"Case '{@case.Id}': invocation override key(s) {string.Join(", ", unrecognizedOverrides.Select(k => $"'{k}'"))} " +
+                    $"not recognized by {_invoker.GetType().Name} (recognized: {string.Join(", ", _invoker.RecognizedOverrideKeys)}).";
+                warnings.Add(warning);
+                _logger.LogWarning("{Warning}", warning);
+            }
+
+            foreach (var spec in @case.MetricSpecs)
+            {
+                if (!_metricsByKey.TryGetValue(spec.MetricKey, out var metric))
+                    continue; // Reported separately when the case is actually scored.
+
+                var unrecognizedParams = spec.Parameters.Keys
+                    .Where(k => !metric.RecognizedParameterKeys.Contains(k))
+                    .ToList();
+                if (unrecognizedParams.Count == 0)
+                    continue;
+
+                var warning =
+                    $"Case '{@case.Id}', metric '{spec.MetricKey}': parameter key(s) " +
+                    $"{string.Join(", ", unrecognizedParams.Select(k => $"'{k}'"))} not recognized " +
+                    $"(recognized: {string.Join(", ", metric.RecognizedParameterKeys)}).";
+                warnings.Add(warning);
+                _logger.LogWarning("{Warning}", warning);
+            }
+        }
+
+        return warnings;
     }
 
     private async Task<IReadOnlyList<EvalResult>> RunSequentialAsync(

--- a/src/Content/Infrastructure/Infrastructure.AI/Routing/Evaluation/TaskComplexityRouterProbe.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Routing/Evaluation/TaskComplexityRouterProbe.cs
@@ -29,6 +29,9 @@ public sealed class TaskComplexityRouterProbe : IRouterEvalProbe
 {
     private const string ToolCountParameter = "tool_count";
 
+    /// <inheritdoc />
+    public IReadOnlySet<string> RecognizedOverrideKeys { get; } = new HashSet<string> { ToolCountParameter };
+
     private readonly ITaskComplexityClassifier _classifier;
 
     /// <summary>

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/RunEvalSuiteCommandHandlerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/CQRS/RunEvalSuiteCommandHandlerTests.cs
@@ -313,6 +313,39 @@ public sealed class RunEvalSuiteCommandHandlerTests : IDisposable
             .Which.Should().Contain("Repeats=25");
     }
 
+    /// <summary>
+    /// Regression test, found by /code-review on the #437 PR: every prior test's <c>MakeReport()</c>
+    /// left <c>Warnings</c> empty, so none of them exercised the branch where the handler's own
+    /// collected warnings (e.g. the repeats-cost warning) AND the runner's own emitted warnings
+    /// (e.g. #437's recognized-key validation) are both non-empty at once. A regression that
+    /// reordered the merge, reverted to overwriting instead of appending, or accidentally
+    /// deduplicated would have passed every other test silently.
+    /// </summary>
+    [Fact]
+    public async Task Preserves_both_handler_and_runner_warnings_when_both_are_present()
+    {
+        var path = CreateFile("a.yaml");
+        var loader = Loader("yaml");
+        var runner = new Mock<IEvalRunner>();
+        runner.Setup(r => r.RunAsync(It.IsAny<IReadOnlyList<EvalDataset>>(), It.IsAny<EvalRunOptions>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(MakeReport() with { Warnings = ["runner-emitted warning"] });
+
+        var sut = MakeSut([loader.Object], runner.Object);
+
+        var result = await sut.Handle(
+            new RunEvalSuiteCommand
+            {
+                DatasetPaths = [path],
+                Options = new EvalRunOptions { Repeats = 25 }
+            },
+            CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Warnings.Should().HaveCount(2);
+        result.Value!.Warnings.Should().Contain(w => w.Contains("Repeats=25"));
+        result.Value!.Warnings.Should().Contain("runner-emitted warning");
+    }
+
     [Fact]
     public async Task Does_not_attach_warning_when_repeats_at_or_below_threshold()
     {

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/RouterEvalInvokerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Invokers/RouterEvalInvokerTests.cs
@@ -114,6 +114,26 @@ public sealed class RouterEvalInvokerTests
         await act.Should().ThrowAsync<OperationCanceledException>();
     }
 
+    /// <summary>
+    /// Regression test, found by correctness-review on the #437 PR: <see cref="RouterEvalInvoker.RecognizedOverrideKeys"/>
+    /// used to union its inner invoker's keys with <c>StringComparer.OrdinalIgnoreCase</c>, but every
+    /// real read of <see cref="EvalCase.InvocationOverrides"/> — this class's own <c>TargetKey</c>
+    /// lookup, and <c>HarnessAgentInvoker.Resolve</c>'s lookups — hits a plain, case-sensitive
+    /// <c>Dictionary&lt;string,string&gt;</c>. A case-insensitive recognized set would report a
+    /// wrong-case key (e.g. <c>Agent_Name</c>) as recognized while the real lookup still silently
+    /// treated it as absent — the exact fail-soft-typo class #437 exists to catch.
+    /// </summary>
+    [Fact]
+    public void RecognizedOverrideKeys_IsCaseSensitive()
+    {
+        var sut = MakeSut(MediatorReturning("x"), new FakeProbe("query_type", _ => Decision("MultiHop")));
+
+        sut.RecognizedOverrideKeys.Should().Contain("agent_name");
+        sut.RecognizedOverrideKeys.Should().NotContain("Agent_Name",
+            "the real lookup HarnessAgentInvoker.Resolve performs is case-sensitive — reporting a " +
+            "wrong-case key as recognized would let a real typo pass validation undetected");
+    }
+
     private static RouterEvalInvoker MakeSut(Mock<IMediator> mediator, params IRouterEvalProbe[] probes)
     {
         var inner = new HarnessAgentInvoker(ScopeFactoryFor(mediator.Object), NullLogger<HarnessAgentInvoker>.Instance);

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runners/EvalRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runners/EvalRunnerTests.cs
@@ -175,10 +175,7 @@ public sealed class EvalRunnerTests
             .ReturnsAsync(JudgedScore(0.5, "repeat-2-clause"))
             .ReturnsAsync(JudgedScore(0.9, "repeat-3-clause"));
 
-        var invoker = new Mock<IAgentInvoker>(MockBehavior.Strict);
-        invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AgentInvocationResult { Success = true, Output = "out" });
-        var sut = new EvalRunner(invoker.Object, [metric.Object], NullLogger<EvalRunner>.Instance);
+        var sut = new EvalRunner(StrictInvokerReturning("out").Object, [metric.Object], NullLogger<EvalRunner>.Instance);
         var dataset = DatasetWith(JudgedCase("c1"));
 
         var report = await sut.RunAsync([dataset], new EvalRunOptions { Repeats = 3 }, CancellationToken.None);
@@ -195,10 +192,7 @@ public sealed class EvalRunnerTests
                 It.IsAny<EvalCase>(), It.IsAny<AgentInvocationResult>(), It.IsAny<MetricSpec>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(JudgedScore(0.8, "clause", ConsensusBucket.Split, spread: 0.3));
 
-        var invoker = new Mock<IAgentInvoker>(MockBehavior.Strict);
-        invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AgentInvocationResult { Success = true, Output = "out" });
-        var sut = new EvalRunner(invoker.Object, [metric.Object], NullLogger<EvalRunner>.Instance);
+        var sut = new EvalRunner(StrictInvokerReturning("out").Object, [metric.Object], NullLogger<EvalRunner>.Instance);
         var dataset = DatasetWith(JudgedCase("c1"));
 
         var report = await sut.RunAsync([dataset], new EvalRunOptions { Repeats = 3 }, CancellationToken.None);
@@ -219,10 +213,7 @@ public sealed class EvalRunnerTests
                 It.IsAny<EvalCase>(), It.IsAny<AgentInvocationResult>(), It.IsAny<MetricSpec>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(JudgedScore(0.8, "clause"));
 
-        var invoker = new Mock<IAgentInvoker>(MockBehavior.Strict);
-        invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AgentInvocationResult { Success = true, Output = "out" });
-        var sut = new EvalRunner(invoker.Object, [metric.Object], NullLogger<EvalRunner>.Instance);
+        var sut = new EvalRunner(StrictInvokerReturning("out").Object, [metric.Object], NullLogger<EvalRunner>.Instance);
         var dataset = DatasetWith(JudgedCase("c1"));
 
         var report = await sut.RunAsync([dataset], new EvalRunOptions { Repeats = 3 }, CancellationToken.None);
@@ -267,8 +258,29 @@ public sealed class EvalRunnerTests
     private static EvalRunner BuildSut(out Mock<IAgentInvoker> invoker, out IReadOnlyList<IEvalMetric> metrics)
     {
         invoker = new Mock<IAgentInvoker>(MockBehavior.Strict);
+        invoker.Setup(i => i.RecognizedOverrideKeys).Returns(ImmutableHashSet<string>.Empty);
         metrics = [new Infrastructure.AI.Evaluation.Metrics.ExactMatchMetric()];
         return new EvalRunner(invoker.Object, metrics, NullLogger<EvalRunner>.Instance);
+    }
+
+    /// <summary>
+    /// A Strict <see cref="IAgentInvoker"/> mock configured with a canned
+    /// <see cref="IAgentInvoker.InvokeAsync"/> response and an empty
+    /// <see cref="IAgentInvoker.RecognizedOverrideKeys"/> — the two members
+    /// every <see cref="EvalRunner.RunAsync"/> call now touches unconditionally (#437's
+    /// <c>ValidateRecognizedKeys</c> reads the latter for every case, not only when
+    /// <see cref="EvalCase.InvocationOverrides"/> is non-empty; Strict mode throws on any
+    /// unconfigured member access, including a C# default-interface-implementation property).
+    /// Shared by every test that needs a custom <see cref="IEvalMetric"/> mock and so cannot use
+    /// <see cref="BuildSut"/> as-is.
+    /// </summary>
+    private static Mock<IAgentInvoker> StrictInvokerReturning(string output)
+    {
+        var invoker = new Mock<IAgentInvoker>(MockBehavior.Strict);
+        invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentInvocationResult { Success = true, Output = output });
+        invoker.Setup(i => i.RecognizedOverrideKeys).Returns(ImmutableHashSet<string>.Empty);
+        return invoker;
     }
 
     /// <summary>
@@ -306,13 +318,8 @@ public sealed class EvalRunnerTests
         var sut = BuildSut(out var invoker, out _);
         invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                .ReturnsAsync(new AgentInvocationResult { Success = true, Output = "match" });
-        // Strict mode throws on ANY unconfigured member access, including a C# default-interface-
-        // implementation property — Moq does not fall back to the interface's own default body for a
-        // Strict mock. Every prior EvalRunnerTests case with an empty (default) InvocationOverrides
-        // never actually exercised this property (LINQ's Where short-circuits on an empty source
-        // without invoking the predicate), which is why this only surfaces here.
-        invoker.Setup(i => i.RecognizedOverrideKeys).Returns(ImmutableHashSet<string>.Empty);
 
+        // BuildSut's default RecognizedOverrideKeys (empty) is exactly what this test needs.
         var @case = new EvalCase
         {
             Id = "c1",

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runners/EvalRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runners/EvalRunnerTests.cs
@@ -311,6 +311,34 @@ public sealed class EvalRunnerTests
             w.Contains("c1") && w.Contains("exact_match") && w.Contains("case_insensitive"));
     }
 
+    /// <summary>
+    /// Regression test, found by /simplify (efficiency and simplification angles, independently) on
+    /// the #437 PR: the warning builder used to route the case ID through a <c>string.Format</c>
+    /// template built from interpolated, YAML-author-supplied text — a case ID or metric key
+    /// containing a literal <c>{</c> or <c>}</c> would throw <see cref="FormatException"/> from a
+    /// path whose entire purpose is being fail-soft, taking the whole eval run down instead of
+    /// warning.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_UnrecognizedParameterKey_CaseIdContainsBraces_DoesNotThrow()
+    {
+        var sut = BuildSut(out var invoker, out _);
+        invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(new AgentInvocationResult { Success = true, Output = "match" });
+
+        var @case = new EvalCase
+        {
+            Id = "c1-{template}",
+            Input = "in",
+            ExpectedOutput = "match",
+            MetricSpecs = [new MetricSpec { MetricKey = "exact_match", Parameters = new Dictionary<string, string> { ["case_insensitive"] = "true" } }]
+        };
+
+        var report = await sut.RunAsync([DatasetWith(@case)], new EvalRunOptions(), CancellationToken.None);
+
+        report.Warnings.Should().ContainSingle(w => w.Contains("c1-{template}"));
+    }
+
     /// <summary>#437: same protection, for a case's InvocationOverrides against the resolved invoker's RecognizedOverrideKeys.</summary>
     [Fact]
     public async Task RunAsync_UnrecognizedInvocationOverrideKey_AddsReportWarning()

--- a/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runners/EvalRunnerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Evaluation.Tests/Runners/EvalRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Application.AI.Common.Evaluation.Interfaces;
 using Application.AI.Common.Evaluation.Models;
 using Domain.AI.Evaluation;
@@ -268,5 +269,61 @@ public sealed class EvalRunnerTests
         invoker = new Mock<IAgentInvoker>(MockBehavior.Strict);
         metrics = [new Infrastructure.AI.Evaluation.Metrics.ExactMatchMetric()];
         return new EvalRunner(invoker.Object, metrics, NullLogger<EvalRunner>.Instance);
+    }
+
+    /// <summary>
+    /// #437: EvalRunner now validates every case's declared parameter/override keys against the
+    /// resolved metric's/invoker's own declared recognized sets, surfacing a mismatch as a
+    /// report-level Warning — the same protection MetricSpecParameterKeyValidationTests gives the
+    /// repo's own checked-in eval-datasets, but for any dataset a real run actually processes.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_UnrecognizedMetricParameterKey_AddsReportWarning()
+    {
+        var sut = BuildSut(out var invoker, out _);
+        invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(new AgentInvocationResult { Success = true, Output = "match" });
+
+        // ExactMatchMetric only recognizes "case_sensitive" (see ExactMatchMetric.RecognizedParameterKeys).
+        var @case = new EvalCase
+        {
+            Id = "c1",
+            Input = "in",
+            ExpectedOutput = "match",
+            MetricSpecs = [new MetricSpec { MetricKey = "exact_match", Parameters = new Dictionary<string, string> { ["case_insensitive"] = "true" } }]
+        };
+
+        var report = await sut.RunAsync([DatasetWith(@case)], new EvalRunOptions(), CancellationToken.None);
+
+        report.Warnings.Should().ContainSingle(w =>
+            w.Contains("c1") && w.Contains("exact_match") && w.Contains("case_insensitive"));
+    }
+
+    /// <summary>#437: same protection, for a case's InvocationOverrides against the resolved invoker's RecognizedOverrideKeys.</summary>
+    [Fact]
+    public async Task RunAsync_UnrecognizedInvocationOverrideKey_AddsReportWarning()
+    {
+        var sut = BuildSut(out var invoker, out _);
+        invoker.Setup(i => i.InvokeAsync(It.IsAny<EvalCase>(), It.IsAny<IReadOnlyDictionary<string, string>?>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(new AgentInvocationResult { Success = true, Output = "match" });
+        // Strict mode throws on ANY unconfigured member access, including a C# default-interface-
+        // implementation property — Moq does not fall back to the interface's own default body for a
+        // Strict mock. Every prior EvalRunnerTests case with an empty (default) InvocationOverrides
+        // never actually exercised this property (LINQ's Where short-circuits on an empty source
+        // without invoking the predicate), which is why this only surfaces here.
+        invoker.Setup(i => i.RecognizedOverrideKeys).Returns(ImmutableHashSet<string>.Empty);
+
+        var @case = new EvalCase
+        {
+            Id = "c1",
+            Input = "in",
+            ExpectedOutput = "match",
+            InvocationOverrides = new Dictionary<string, string> { ["scenario"] = "typo" },
+            MetricSpecs = [new MetricSpec { MetricKey = "exact_match" }]
+        };
+
+        var report = await sut.RunAsync([DatasetWith(@case)], new EvalRunOptions(), CancellationToken.None);
+
+        report.Warnings.Should().ContainSingle(w => w.Contains("c1") && w.Contains("scenario"));
     }
 }

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
@@ -28,7 +28,7 @@ namespace Presentation.EvalRunner.Tests.Composition;
 public sealed class MetricSpecParameterKeyValidationTests
 {
     private static readonly Lazy<IReadOnlyDictionary<string, IEvalMetric>> MetricsByKey = new(BuildMetricsByKey);
-    private static readonly Lazy<IAgentInvoker> Invoker = new(BuildInvoker);
+    private static readonly Lazy<IReadOnlySet<string>> RecognizedOverrideKeys = new(BuildInvoker);
 
     private static IReadOnlyDictionary<string, IEvalMetric> BuildMetricsByKey()
     {
@@ -46,14 +46,17 @@ public sealed class MetricSpecParameterKeyValidationTests
             .ToDictionary(m => m.Key, StringComparer.OrdinalIgnoreCase);
     }
 
-    private static IAgentInvoker BuildInvoker()
+    private static IReadOnlySet<string> BuildInvoker()
     {
         // The real registered IAgentInvoker (RouterEvalInvoker wrapping HarnessAgentInvoker) — not a
         // fake — so RecognizedOverrideKeys reflects the actual union every production run checks
-        // InvocationOverrides against (#437).
+        // InvocationOverrides against (#437). Copied into a plain set before the provider is disposed
+        // (correctness-review finding on the #437 PR: returning the live instance itself would be a
+        // use-after-dispose — harmless while the property is a pre-populated field, but a latent bug
+        // waiting for whichever future change makes it provider-backed instead).
         var services = EvalRunnerTestComposition.BuildServices();
         using var provider = services.BuildServiceProvider();
-        return provider.GetRequiredService<IAgentInvoker>();
+        return provider.GetRequiredService<IAgentInvoker>().RecognizedOverrideKeys.ToHashSet();
     }
 
     public static IEnumerable<object[]> DatasetFiles()
@@ -123,7 +126,7 @@ public sealed class MetricSpecParameterKeyValidationTests
     [MemberData(nameof(DatasetFiles))]
     public async Task Every_case_invocation_override_key_is_recognized_by_the_invoker(string path)
     {
-        var invoker = Invoker.Value;
+        var recognizedOverrideKeys = RecognizedOverrideKeys.Value;
         var loader = new YamlEvalDatasetLoader();
         var dataset = await loader.LoadAsync(path, CancellationToken.None);
 
@@ -131,14 +134,14 @@ public sealed class MetricSpecParameterKeyValidationTests
         foreach (var @case in dataset.Cases)
         {
             var unrecognized = @case.InvocationOverrides.Keys
-                .Where(k => !invoker.RecognizedOverrideKeys.Contains(k))
+                .Where(k => !recognizedOverrideKeys.Contains(k))
                 .ToList();
             if (unrecognized.Count > 0)
             {
                 problems.Add(
                     $"case '{@case.Id}': unrecognized invocation override key(s) " +
                     $"{string.Join(", ", unrecognized.Select(k => $"'{k}'"))} " +
-                    $"(recognized: {string.Join(", ", invoker.RecognizedOverrideKeys)})");
+                    $"(recognized: {string.Join(", ", recognizedOverrideKeys)})");
             }
         }
 

--- a/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
+++ b/src/Content/Tests/Presentation.EvalRunner.Tests/Composition/MetricSpecParameterKeyValidationTests.cs
@@ -9,7 +9,9 @@ namespace Presentation.EvalRunner.Tests.Composition;
 
 /// <summary>
 /// Validates every <c>eval-datasets/**/*.yaml</c> case's <c>MetricSpec.Parameters</c> keys against
-/// the resolved metric's own declared <see cref="IEvalMetric.RecognizedParameterKeys"/> (#423).
+/// the resolved metric's own declared <see cref="IEvalMetric.RecognizedParameterKeys"/> (#423), and
+/// each case's <c>InvocationOverrides</c> keys against the resolved invoker's own declared
+/// <see cref="IAgentInvoker.RecognizedOverrideKeys"/> (#437).
 /// </summary>
 /// <remarks>
 /// <see cref="Application.AI.Common.Evaluation.MetricSpecExtensions"/>'s accessors are deliberately
@@ -18,12 +20,15 @@ namespace Presentation.EvalRunner.Tests.Composition;
 /// silently no-op'd or scored inverted for an unknown period, caught only when someone happened to
 /// read the metric source by hand during an unrelated PR review — <c>Verdict.Warn</c> does
 /// not gate CI (per its own doc comment), so nothing automated caught it. This test closes that gap
-/// at build time: every dataset's declared parameters are checked against the metric's own declared
-/// set before any case ever runs.
+/// at build time — for the repo's own checked-in datasets only; <c>EvalRunner</c>'s own
+/// <c>ValidateRecognizedKeys</c> closes the same gap at runtime for any dataset a consumer actually
+/// runs (#437) — checking every dataset's declared keys against the resolved metric's/invoker's own
+/// declared set before any case ever runs.
 /// </remarks>
 public sealed class MetricSpecParameterKeyValidationTests
 {
     private static readonly Lazy<IReadOnlyDictionary<string, IEvalMetric>> MetricsByKey = new(BuildMetricsByKey);
+    private static readonly Lazy<IAgentInvoker> Invoker = new(BuildInvoker);
 
     private static IReadOnlyDictionary<string, IEvalMetric> BuildMetricsByKey()
     {
@@ -39,6 +44,16 @@ public sealed class MetricSpecParameterKeyValidationTests
 
         return provider.GetServices<IEvalMetric>()
             .ToDictionary(m => m.Key, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static IAgentInvoker BuildInvoker()
+    {
+        // The real registered IAgentInvoker (RouterEvalInvoker wrapping HarnessAgentInvoker) — not a
+        // fake — so RecognizedOverrideKeys reflects the actual union every production run checks
+        // InvocationOverrides against (#437).
+        var services = EvalRunnerTestComposition.BuildServices();
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IAgentInvoker>();
     }
 
     public static IEnumerable<object[]> DatasetFiles()
@@ -98,4 +113,38 @@ public sealed class MetricSpecParameterKeyValidationTests
             "instead of failing the build (#423)");
     }
 
+    /// <summary>
+    /// #437: the same check as <see cref="Every_case_parameter_key_is_recognized_by_its_metric"/>,
+    /// generalized to <see cref="Domain.AI.Evaluation.EvalCase.InvocationOverrides"/> — the same
+    /// free-form, hand-authored, fail-soft-accessed key/value bag <c>MetricSpec.Parameters</c> is,
+    /// parsed from the same YAML files, carrying the identical typo risk.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DatasetFiles))]
+    public async Task Every_case_invocation_override_key_is_recognized_by_the_invoker(string path)
+    {
+        var invoker = Invoker.Value;
+        var loader = new YamlEvalDatasetLoader();
+        var dataset = await loader.LoadAsync(path, CancellationToken.None);
+
+        var problems = new List<string>();
+        foreach (var @case in dataset.Cases)
+        {
+            var unrecognized = @case.InvocationOverrides.Keys
+                .Where(k => !invoker.RecognizedOverrideKeys.Contains(k))
+                .ToList();
+            if (unrecognized.Count > 0)
+            {
+                problems.Add(
+                    $"case '{@case.Id}': unrecognized invocation override key(s) " +
+                    $"{string.Join(", ", unrecognized.Select(k => $"'{k}'"))} " +
+                    $"(recognized: {string.Join(", ", invoker.RecognizedOverrideKeys)})");
+            }
+        }
+
+        problems.Should().BeEmpty(
+            $"{Path.GetFileName(path)} has case(s) whose InvocationOverrides key the resolved " +
+            "invoker doesn't read — almost certainly a typo that would otherwise silently no-op " +
+            "instead of failing the build (#437)");
+    }
 }


### PR DESCRIPTION
## Summary
Closes #437. #423's \`MetricSpec.Parameters\` typo guard only protected the repo's own checked-in \`eval-datasets/**\` corpus at build time — a template consumer's own dataset, loaded and run at runtime, got none of that protection.

- \`EvalRunner.RunAsync\` now runs the same recognized-key comparison at runtime for every dataset a real run actually processes, surfacing any unrecognized \`MetricSpec.Parameters\`/\`InvocationOverrides\` key as a report-level \`Warning\` — fail-soft, matching \`IEvalMetric\`'s own documented contract.
- Added \`IAgentInvoker.RecognizedOverrideKeys\` and \`IRouterEvalProbe.RecognizedOverrideKeys\` (default-empty, mirroring \`IEvalMetric.RecognizedParameterKeys\`), since \`InvocationOverrides\` carries the identical typo risk. \`RouterEvalInvoker\`'s own set is the union of its wrapped invoker's keys plus every registered probe's keys.
- Extending the build-time test to also cover \`InvocationOverrides\` immediately found two real, confirmed-dead override keys already in the repo's own checked-in datasets — \`scenario\` across all 10 \`owasp-agentic-top-10.yaml\` cases (verified unread by every OWASP stub invoker) and \`tool_count\` in \`routing-accuracy.yaml\` (a real key, just consumed by a router probe rather than the invoker directly). Removed the dead \`invocation_overrides\` blocks; fixed the probe-key union to close the false-negative.

**2 full \`/code-review\` passes** found and fixed: sibling null-guard-shaped correctness gaps aside (not applicable here — that was the prior PR), a real case-sensitivity bug (\`RouterEvalInvoker\`'s recognized-key union compared case-insensitively while every real lookup is case-sensitive, so a wrong-case key would pass validation yet still silently no-op) and a use-after-dispose test smell.

**1 full 4-angle \`/simplify\` pass** found and fixed a real crash-risk bug: the warning-message builder round-tripped YAML-author-supplied text (case IDs, metric keys) through a \`string.Format\` template — a case ID containing a literal \`{\` or \`}\` would throw \`FormatException\`, crashing a validation path whose entire purpose is being fail-soft. Fixed and regression-tested. The altitude angle also found that \`RouterEvalInvoker\`'s recognized-key union is imprecise for router-targeted cases (it doesn't know which single probe a case's \`target\` actually selects, so it can under-warn) — bounded, no false positives, filed as follow-up #503 rather than expanding this PR's scope.

## Test plan
- [x] 309 (Infrastructure.AI.Evaluation.Tests) + 45 (Presentation.EvalRunner.Tests) + 2268 (Application.AI.Common.Tests) green
- [x] Regression tests for the runtime warning mechanism, the case-sensitivity fix, and the string.Format crash risk (mutation-tested: reverted each fix, confirmed the corresponding test fails, restored)
- [x] \`scripts/rails/run-gates.sh\`: build/owasp/grader/correctness/docs-drift all pass. **Test gate fails only on 9 pre-existing \`MetricsE2ETests\` (Testcontainers/Prometheus) — confirmed environmental: Docker was intentionally stopped on this dev machine during this session (\`docker ps\` fails identically outside any test run), zero file overlap with this diff's eval-framework-only changes. Remote CI has Docker available and will run these for real.**
- [x] 2 full \`/code-review\` passes, 1 full \`/simplify\` pass, all findings addressed or filed as #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_695bb5ee-821c-4294-ac58-c3609cfe8bf8