### PR TITLE
fix: bound, isolate and normalize replayed tool-call history (#508, #509, #510)

### DIFF
--- a/documentation/onboarding/10-observability.html
+++ b/documentation/onboarding/10-observability.html
@@ -332,6 +332,21 @@ docker run -d --name jaeger \
                         behind.
                     </p>
                     <p>
+                        Two further settings bound growth the size-tier alone does not reach, because it caps each
+                        payload individually and nothing caps how many of them accumulate.
+                        <code>MaxCallsPerTurn</code> (default 32) limits how many tool calls a single turn persists —
+                        nothing upstream does, since the framework's per-request iteration limit caps tool-calling
+                        <em>rounds</em>, not the calls issued in parallel within one round.
+                        <code>MaxReplayedChars</code> (default 65536, roughly 16k tokens) limits the total treated text
+                        one replayed window sends back to the model, and is the only real ceiling on a resumed
+                        conversation's per-turn prompt cost: the store's dispatch window is capped in <em>rows</em>, and
+                        each row expands into two chat messages per tool call it carries, so a row cap stops bounding
+                        the prompt once turns are tool-heavy. Both trim from the same end — newest kept, oldest
+                        dropped — so they compose into one coherent policy rather than a slice from the middle of a
+                        turn. The two are validated against each other at startup: a window budget smaller than a
+                        single maximum-size call would drop not just that call but every older one behind it.
+                    </p>
+                    <p>
                         Operators can disable replay entirely with
                         <code>AI:Conversations:ToolCallReplay:Enabled</code>. That switch gates both writing new tool
                         payloads <em>and</em> replaying already-persisted ones — but note it does not

--- a/src/Content/Application/Application.AI.Common/Interfaces/IToolCallReplayTreatment.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IToolCallReplayTreatment.cs
@@ -27,7 +27,10 @@ public interface IToolCallReplayTreatment
     /// <summary>
     /// The most tool calls one turn may persist for replay
     /// (<c>AppConfig:AI:Conversations:ToolCallReplay:MaxCallsPerTurn</c>). A caller building a turn's
-    /// records keeps the earliest this many by round ordinal and drops the rest, logging how many.
+    /// records keeps the <strong>newest</strong> this many by round ordinal and drops the rest, logging
+    /// how many — the same end <see cref="MaxReplayedChars"/> trims from on replay. The shared direction
+    /// is load-bearing: trimming opposite ends would compose into a middle slice that is neither the
+    /// turn's opening reasoning nor its conclusions.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/src/Content/Application/Application.AI.Common/Interfaces/IToolCallReplayTreatment.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/IToolCallReplayTreatment.cs
@@ -25,6 +25,41 @@ public interface IToolCallReplayTreatment
     bool Enabled { get; }
 
     /// <summary>
+    /// The most tool calls one turn may persist for replay
+    /// (<c>AppConfig:AI:Conversations:ToolCallReplay:MaxCallsPerTurn</c>). A caller building a turn's
+    /// records keeps the earliest this many by round ordinal and drops the rest, logging how many.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Bounds storage growth driven by model output. Nothing else does: the framework's per-request
+    /// iteration limit caps tool-calling rounds, not the calls issued in parallel inside one round.
+    /// </para>
+    /// <para>
+    /// <strong>Stub this explicitly when mocking this interface.</strong> Zero is a meaningful value
+    /// here — it drops every tool call, it does not mean "unlimited" — and a mocking framework leaves
+    /// an unconfigured <see langword="int"/> member at zero. A test that stubs only
+    /// <see cref="Enabled"/> therefore turns the whole feature off while still appearing to exercise
+    /// it, which is exactly how this member's introduction broke an end-to-end replay test that had
+    /// been passing.
+    /// </para>
+    /// </remarks>
+    int MaxCallsPerTurn { get; }
+
+    /// <summary>
+    /// The most treated tool-call text, in characters, one replayed window may send back to the model
+    /// across every row in it (<c>AppConfig:AI:Conversations:ToolCallReplay:MaxReplayedChars</c>).
+    /// </summary>
+    /// <remarks>
+    /// The read-side counterpart to <see cref="MaxCallsPerTurn"/>, and the only one of the two that
+    /// bounds per-turn prompt cost. It applies to rows already in the store, so it also bounds
+    /// conversations persisted before any write-side cap existed — which a write-side cap alone, by
+    /// construction, never can. The same
+    /// <strong>stub this explicitly when mocking</strong> warning on <see cref="MaxCallsPerTurn"/>
+    /// applies here, and bites harder: a zero read budget silently empties every replayed window.
+    /// </remarks>
+    int MaxReplayedChars { get; }
+
+    /// <summary>
     /// Treats raw text — a tool call's arguments or a tool result — for safe, bounded, model-facing
     /// replay: sanitize, then redact, then size-tier the result (verbatim under the configured
     /// ceiling, truncated with a visible marker above it, withheld outright above the hard

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -104,22 +104,34 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
     private async Task AppendFunctionResultTracesAsync(IEnumerable<ChatMessage> messages, CancellationToken ct)
     {
         var alreadyReplayed = Services.ReplayedToolCallScope.Current;
-        var functionResults = messages
-            .SelectMany(m => m.Contents)
-            .OfType<FunctionResultContent>()
-            .Where(r => alreadyReplayed is null || string.IsNullOrEmpty(r.CallId) || !alreadyReplayed.Contains(r.CallId))
-            .ToList();
+
+        // Claim-as-you-select, in one pass, rather than filtering the list and then marking the
+        // survivors: the question is never "is this id known?" on its own but "is it known, and if
+        // not, take it," and splitting those into two steps leaves a gap two concurrent callers can
+        // both pass through — producing exactly the duplicate trace record this scope exists to
+        // prevent. ReplayedToolCallSet.TryClaim tests and takes under one lock, so the id is marked
+        // known the moment it is picked up for recording rather than after the trace write succeeds;
+        // a later round's scan of the same (still-growing) inbound message list therefore skips it
+        // even if the write below fails. See ReplayedToolCallScope's remarks: this is what closes the
+        // intra-turn duplicate-recording case a read-only, dispatch-time snapshot alone cannot.
+        //
+        // A result with no CallId cannot be deduplicated at all, and a null scope means no turn armed
+        // one (a test constructing this middleware directly) — both are recorded rather than dropped.
+        var functionResults = new List<FunctionResultContent>();
+        foreach (var candidate in messages.SelectMany(m => m.Contents).OfType<FunctionResultContent>())
+        {
+            if (alreadyReplayed is not null
+                && !string.IsNullOrEmpty(candidate.CallId)
+                && !alreadyReplayed.TryClaim(candidate.CallId))
+            {
+                continue;
+            }
+
+            functionResults.Add(candidate);
+        }
 
         foreach (var result in functionResults)
         {
-            // Mark this call id known the moment it's picked up for recording — not after the trace
-            // write succeeds — so a later round's scan of the same (still-growing) inbound message
-            // list skips it even if the trace write below fails. See ReplayedToolCallScope's remarks:
-            // this is what closes the intra-turn duplicate-recording case a read-only, dispatch-time
-            // snapshot alone cannot.
-            if (!string.IsNullOrEmpty(result.CallId))
-                alreadyReplayed?.Add(result.CallId);
-
             // A failed call's Result already carries the raw exception message baked in by
             // IncludeDetailedErrors (see ExecuteAgentTurnCommandHandler.RedactedResultForStreaming) — this
             // trace record feeds the dashboard's per-invocation page via ToolInvocationDetailDto,

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessage.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessage.cs
@@ -21,12 +21,39 @@ public sealed record ConversationMessage(
     WidgetSpec? Widget = null)
 {
     /// <summary>
-    /// This turn's tool calls, or <see langword="null"/> when it made none. Normalized to
-    /// <see langword="null"/> for an empty (but non-null) list at construction, so every producer of a
-    /// <see cref="ConversationMessage"/> gets the same guarantee for free instead of each one having to
-    /// remember the ternary itself — an empty non-null list would otherwise serialize to a non-null
-    /// <c>"[]"</c> JSON column, which <c>EfCoreConversationStore</c>'s dispatch-window filter reads as
-    /// "this row has tool calls" (it tests the column for non-null, not for non-empty).
+    /// Backing field for <see cref="ToolCalls"/>. The initializer normalizes the primary constructor's
+    /// argument; the property's <c>init</c> accessor normalizes every other way a value can arrive.
     /// </summary>
-    public IReadOnlyList<ToolCallRecord>? ToolCalls { get; init; } = ToolCalls is { Count: > 0 } ? ToolCalls : null;
+    /// <remarks>
+    /// Both are needed, and neither is redundant. A field/property <em>initializer</em> runs only in the
+    /// primary constructor — a record's compiler-generated copy constructor copies backing fields
+    /// directly and does not re-run it — so an initializer alone leaves <c>with { ToolCalls = [] }</c>
+    /// holding a non-null empty list. An <c>init</c> accessor alone would not compile the positional
+    /// parameter away (the compiler does not auto-assign a positional parameter to a member the type
+    /// declares itself; that is what <c>CS8907</c> reports), so the initializer is what consumes it.
+    /// </remarks>
+    private readonly IReadOnlyList<ToolCallRecord>? _toolCalls = ToolCalls is { Count: > 0 } ? ToolCalls : null;
+
+    /// <summary>
+    /// This turn's tool calls, or <see langword="null"/> when it made none. An empty (but non-null)
+    /// list normalizes to <see langword="null"/> however it arrives — the primary constructor, an
+    /// object initializer, or a <c>with</c> expression — so every producer of a
+    /// <see cref="ConversationMessage"/> gets the same guarantee for free instead of each one having to
+    /// remember the ternary itself.
+    /// </summary>
+    /// <remarks>
+    /// The guarantee is load-bearing rather than cosmetic, and two call sites cite it as their reason
+    /// for not normalizing themselves (<c>ConversationEntityMapper.ToEntity</c> and the store's own
+    /// dispatch-window filter). An empty non-null list serializes to a non-null <c>"[]"</c> JSON column,
+    /// which <c>EfCoreConversationStore</c>'s filter would read as "this row is model-relevant" — that
+    /// filter tests the column for non-null — admitting an empty-content widget row into the prompt
+    /// window that <c>FileSystemConversationStore</c>'s DTO-level filter correctly drops. That store
+    /// filter now also excludes <c>"[]"</c> explicitly, so the two are belt and braces: this closes the
+    /// hole at the source, and the filter stays correct for any row persisted while it was open.
+    /// </remarks>
+    public IReadOnlyList<ToolCallRecord>? ToolCalls
+    {
+        get => _toolCalls;
+        init => _toolCalls = value is { Count: > 0 } ? value : null;
+    }
 }

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Models.Conversations;
 
@@ -75,10 +76,35 @@ public static class ConversationMessageMapping
     /// deliberately not built ahead of a case nothing today produces.
     /// </para>
     /// </remarks>
+    /// <param name="maxReplayedChars">
+    /// Total budget, in characters of treated tool-call text, for the whole window. Callers must source
+    /// this from <c>IToolCallReplayTreatment.MaxReplayedChars</c> rather than default it, for the same
+    /// reason as <paramref name="replayToolCalls"/>: this is the only bound on what a resumed
+    /// conversation costs per turn. The store's dispatch window is capped in <em>rows</em>, and one row
+    /// expands here into two chat messages per tool call it carries, so once turns are tool-heavy that
+    /// row cap stops bounding the prompt at all. Defaults to <see cref="int.MaxValue"/> only so this
+    /// method's own unit tests, which are about expansion correctness and not about the budget, don't
+    /// have to pass it.
+    /// </param>
+    /// <param name="logger">
+    /// Optional, for reporting what the budget dropped. Matching <c>ToolCallTranscriptExtractor.Extract</c>,
+    /// which takes a logger the same way and for the same reason — silently shrinking a model's memory
+    /// is exactly the kind of change that must leave a trace.
+    /// </param>
     public static IReadOnlyList<ChatMessage> ToChatMessages(
-        IReadOnlyList<ConversationMessage> messages, bool replayToolCalls = true)
+        IReadOnlyList<ConversationMessage> messages,
+        bool replayToolCalls = true,
+        int maxReplayedChars = int.MaxValue,
+        ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(messages);
+
+        // Computed up front, over the whole window, because the budget is a property of the window and
+        // not of any one row: which of a row's calls survive depends on how much every LATER row
+        // already spent, which a single forward pass cannot know when it reaches that row.
+        var admittedByRow = replayToolCalls
+            ? SelectCallsWithinBudget(messages, maxReplayedChars, logger)
+            : null;
 
         var result = new List<ChatMessage>();
 
@@ -92,17 +118,23 @@ public static class ConversationMessageMapping
         // with no recovery short of deleting the conversation.
         var usedCallIds = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var message in messages)
+        for (var i = 0; i < messages.Count; i++)
         {
+            var message = messages[i];
+
             if (!replayToolCalls
                 || message.Role != MessageRole.Assistant
-                || message.ToolCalls is not { Count: > 0 } toolCalls)
+                || message.ToolCalls is not { Count: > 0 })
             {
                 result.Add(new ChatMessage(ToChatRole(message.Role), message.Content));
                 continue;
             }
 
-            AppendToolCallRounds(result, toolCalls, usedCallIds);
+            // May be empty when the budget dropped every one of this row's calls. The row then behaves
+            // exactly like a tool-only turn whose calls were never persisted: its narrated text (if any)
+            // still replays below, so the model keeps the prose account of what happened even where it
+            // has lost the literal call/result pairs.
+            AppendToolCallRounds(result, admittedByRow![i], usedCallIds);
 
             if (!string.IsNullOrEmpty(message.Content))
             {
@@ -114,22 +146,109 @@ public static class ConversationMessageMapping
     }
 
     /// <summary>
-    /// Appends one assistant/tool message pair per call, oldest <see cref="ToolCallRecord.RoundOrdinal"/>
-    /// first, so a resumed conversation replays tool activity in the sequence it actually happened.
+    /// Decides, for every row in the window, which of its tool calls fit inside
+    /// <paramref name="maxReplayedChars"/> — newest first, dropping the oldest until the remainder
+    /// fits — and returns them per row in ascending <see cref="ToolCallRecord.RoundOrdinal"/> order.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Newest-first is the admission order because a replayed window is context, not an audit log: the
+    /// tool activity the current turn is most likely to reason about is the most recent. Admission
+    /// <em>latches</em> shut at the first call that does not fit rather than continuing to look for a
+    /// smaller one further back — that keeps the surviving set a contiguous newest tail, where
+    /// skip-and-continue would punch holes through the middle of the history and replay a sequence
+    /// that never happened.
+    /// </para>
+    /// <para>
+    /// A budget smaller than the single newest call admits nothing. That is the honest reading of a
+    /// ceiling rather than an oversight: the alternative — always keeping one call — would mean the
+    /// bound can be exceeded by an unbounded amount, which is not a bound. The rows' own text still
+    /// replays either way.
+    /// </para>
+    /// <para>
+    /// Cost is measured on <see cref="ToolCallRecord.Input"/> plus <see cref="ToolCallRecord.Output"/>
+    /// — the treated text that actually reaches the model. The tool name and the synthesized call id
+    /// ride along uncounted; both are tens of characters against a budget in the tens of thousands, and
+    /// including them would imply a precision this is not trying to claim.
+    /// </para>
+    /// </remarks>
+    private static IReadOnlyList<ToolCallRecord>[] SelectCallsWithinBudget(
+        IReadOnlyList<ConversationMessage> messages,
+        int maxReplayedChars,
+        ILogger? logger)
+    {
+        var admittedByRow = new IReadOnlyList<ToolCallRecord>[messages.Count];
+        var spent = 0;
+        var dropped = 0;
+        var budgetExhausted = false;
+
+        for (var i = messages.Count - 1; i >= 0; i--)
+        {
+            var message = messages[i];
+            if (message.Role != MessageRole.Assistant || message.ToolCalls is not { Count: > 0 } calls)
+            {
+                admittedByRow[i] = [];
+                continue;
+            }
+
+            // Defensive sort, not a no-op: ToolCallTranscriptExtractor always builds this list in
+            // ascending-ordinal order, but a persisted record read back from storage is data this code
+            // doesn't control the shape of. Done here rather than at append time so the budget walks
+            // the calls in the same order the model will see them.
+            var ordered = calls
+                .Select((call, index) => (call, ordinal: call.RoundOrdinal ?? index))
+                .OrderBy(x => x.ordinal)
+                .Select(x => x.call)
+                .ToList();
+
+            var admitted = new List<ToolCallRecord>(ordered.Count);
+            for (var j = ordered.Count - 1; j >= 0; j--)
+            {
+                var cost = (ordered[j].Input?.Length ?? 0) + (ordered[j].Output?.Length ?? 0);
+
+                if (budgetExhausted || spent + cost > maxReplayedChars)
+                {
+                    budgetExhausted = true;
+                    dropped++;
+                    continue;
+                }
+
+                spent += cost;
+                admitted.Add(ordered[j]);
+            }
+
+            admitted.Reverse();
+            admittedByRow[i] = admitted;
+        }
+
+        if (dropped > 0)
+        {
+            logger?.LogWarning(
+                "[ToolCallReplay] Replayed tool-call history exceeded the {Budget}-char window budget; " +
+                "dropped the {Dropped} oldest call(s), replaying {Spent} chars.",
+                maxReplayedChars, dropped, spent);
+        }
+
+        return admittedByRow;
+    }
+
+    /// <summary>
+    /// Appends one assistant/tool message pair per call, so a resumed conversation replays tool
+    /// activity in the sequence it actually happened.
+    /// </summary>
+    /// <param name="result">The projection being built.</param>
+    /// <param name="toolCalls">
+    /// This row's admitted calls, already sorted by <see cref="ToolCallRecord.RoundOrdinal"/> and
+    /// already filtered against the window budget by <see cref="SelectCallsWithinBudget"/>. Empty when
+    /// the budget dropped all of them, in which case this appends nothing.
+    /// </param>
+    /// <param name="usedCallIds">Call ids already emitted anywhere in this window.</param>
     private static void AppendToolCallRounds(
         List<ChatMessage> result,
         IReadOnlyList<ToolCallRecord> toolCalls,
         HashSet<string> usedCallIds)
     {
-        // Defensive sort, not a no-op: ToolCallTranscriptExtractor always builds this list in
-        // ascending-ordinal order, but a persisted record read back from storage is data this code
-        // doesn't control the shape of.
-        var ordered = toolCalls
-            .Select((call, index) => (call, ordinal: call.RoundOrdinal ?? index))
-            .OrderBy(x => x.ordinal);
-
-        foreach (var (call, _) in ordered)
+        foreach (var call in toolCalls)
         {
             var callId = ResolveUniqueCallId(call.CallId, usedCallIds);
 

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -171,10 +171,13 @@ public static class ConversationMessageMapping
     /// replays either way.
     /// </para>
     /// <para>
-    /// Cost is measured on <see cref="ToolCallRecord.Input"/> plus <see cref="ToolCallRecord.Output"/>
-    /// — the treated text that actually reaches the model. The tool name and the synthesized call id
-    /// ride along uncounted; both are tens of characters against a budget in the tens of thousands, and
-    /// including them would imply a precision this is not trying to claim.
+    /// Cost counts every part of a record that actually reaches the model:
+    /// <see cref="ToolCallRecord.Input"/>, <see cref="ToolCallRecord.Output"/>,
+    /// <see cref="ToolCallRecord.ToolName"/> and <see cref="ToolCallRecord.CallId"/>. The last two are
+    /// normally tens of characters and were originally left out on those grounds — but both are
+    /// model-supplied strings that no treatment pass bounds, so "normally small" is an assumption about
+    /// untrusted input rather than a property of it. Counting them costs one addition and removes a way
+    /// for a budget to be quietly exceeded.
     /// </para>
     /// </remarks>
     private static (IReadOnlyList<ToolCallRecord>[] AdmittedByRow, int AdmittedCalls) SelectCallsWithinBudget(
@@ -224,7 +227,7 @@ public static class ConversationMessageMapping
             var cut = ordered.Count;
             while (cut > 0)
             {
-                var cost = (ordered[cut - 1].Input?.Length ?? 0) + (ordered[cut - 1].Output?.Length ?? 0);
+                var cost = CostOf(ordered[cut - 1]);
 
                 if (spent + cost > maxReplayedChars)
                 {
@@ -251,6 +254,21 @@ public static class ConversationMessageMapping
 
         return (admittedByRow, admittedCalls);
     }
+
+    /// <summary>
+    /// What one record costs against the window budget: every part of it that reaches the model.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ToolCallRecord.ToolName"/> and <see cref="ToolCallRecord.CallId"/> are counted even
+    /// though they are normally short, because neither is bounded by
+    /// <c>IToolCallReplayTreatment.Treat</c> — they come from the model or an MCP server and are
+    /// persisted verbatim, so their size is not this code's to assume.
+    /// </remarks>
+    private static int CostOf(ToolCallRecord call) =>
+        (call.Input?.Length ?? 0)
+        + (call.Output?.Length ?? 0)
+        + (call.ToolName?.Length ?? 0)
+        + (call.CallId?.Length ?? 0);
 
     /// <summary>
     /// Appends one assistant/tool message pair per call, so a resumed conversation replays tool

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -47,14 +47,13 @@ public static class ConversationMessageMapping
     /// <param name="replayToolCalls">
     /// Whether an assistant row's <see cref="ConversationMessage.ToolCalls"/> should expand into real
     /// call/result content (see the remarks below) or be skipped in favor of the row's narrated text
-    /// only. Callers must source this from <c>IToolCallReplayTreatment.Enabled</c>, not default it —
-    /// an operator's kill switch for this feature (<c>AppConfig:AI:Conversations:ToolCallReplay:Enabled</c>)
-    /// has to stop replaying <em>already-persisted</em> tool payloads, not just stop writing new ones:
-    /// gating only the write side (as <c>ExecuteAgentTurnCommandHandler.BuildTreatedToolCallRecords</c>
-    /// already does) would leave every conversation with tool history from before the flag was flipped
-    /// still shipping that content to the model on every later turn. Defaults to
-    /// <see langword="true"/> only so this method's own unit tests, which are about expansion
-    /// correctness and not about the gate, don't have to pass it.
+    /// only. Source it from <c>IToolCallReplayTreatment.Enabled</c> — an operator's kill switch for this
+    /// feature (<c>AppConfig:AI:Conversations:ToolCallReplay:Enabled</c>) has to stop replaying
+    /// <em>already-persisted</em> tool payloads, not just stop writing new ones: gating only the write
+    /// side (as <c>ExecuteAgentTurnCommandHandler.BuildTreatedToolCallRecords</c> already does) would
+    /// leave every conversation with tool history from before the flag was flipped still shipping that
+    /// content to the model on every later turn. Deliberately has no default, for the same reason as
+    /// <paramref name="maxReplayedChars"/>.
     /// </param>
     /// <remarks>
     /// <para>
@@ -77,14 +76,13 @@ public static class ConversationMessageMapping
     /// </para>
     /// </remarks>
     /// <param name="maxReplayedChars">
-    /// Total budget, in characters of treated tool-call text, for the whole window. Callers must source
-    /// this from <c>IToolCallReplayTreatment.MaxReplayedChars</c> rather than default it, for the same
-    /// reason as <paramref name="replayToolCalls"/>: this is the only bound on what a resumed
+    /// Total budget, in characters of treated tool-call text, for the whole window. Source it from
+    /// <c>IToolCallReplayTreatment.MaxReplayedChars</c>: this is the only bound on what a resumed
     /// conversation costs per turn. The store's dispatch window is capped in <em>rows</em>, and one row
     /// expands here into two chat messages per tool call it carries, so once turns are tool-heavy that
-    /// row cap stops bounding the prompt at all. Defaults to <see cref="int.MaxValue"/> only so this
-    /// method's own unit tests, which are about expansion correctness and not about the budget, don't
-    /// have to pass it.
+    /// row cap stops bounding the prompt at all. Deliberately has no default — an omitted budget would
+    /// mean an unbounded prompt on every resumed turn, with nothing failing to say so, and a required
+    /// parameter is the only form of that rule the compiler can enforce.
     /// </param>
     /// <param name="logger">
     /// Optional, for reporting what the budget dropped. Matching <c>ToolCallTranscriptExtractor.Extract</c>,
@@ -93,20 +91,29 @@ public static class ConversationMessageMapping
     /// </param>
     public static IReadOnlyList<ChatMessage> ToChatMessages(
         IReadOnlyList<ConversationMessage> messages,
-        bool replayToolCalls = true,
-        int maxReplayedChars = int.MaxValue,
+        bool replayToolCalls,
+        int maxReplayedChars,
         ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(messages);
 
+        // Handled up front rather than as a clause inside the loop below. Keeping it here means the
+        // budget array is never null, so the loop needs no null-forgiving index and no second check of
+        // this same flag twelve lines apart — a coupling that was safe only by inspection.
+        if (!replayToolCalls)
+        {
+            return [.. messages.Select(m => new ChatMessage(ToChatRole(m.Role), m.Content))];
+        }
+
         // Computed up front, over the whole window, because the budget is a property of the window and
         // not of any one row: which of a row's calls survive depends on how much every LATER row
         // already spent, which a single forward pass cannot know when it reaches that row.
-        var admittedByRow = replayToolCalls
-            ? SelectCallsWithinBudget(messages, maxReplayedChars, logger)
-            : null;
+        var (admittedByRow, admittedCalls) = SelectCallsWithinBudget(messages, maxReplayedChars, logger);
 
-        var result = new List<ChatMessage>();
+        // Sized exactly: one message per row, plus the call/result pair each admitted call expands into.
+        // The count is already in hand from the pass above, so this costs nothing and saves the handful
+        // of doubling reallocations a tool-heavy window would otherwise walk through.
+        var result = new List<ChatMessage>(messages.Count + (2 * admittedCalls));
 
         // Scoped to the WHOLE window, not to one row: ToolCallTranscriptExtractor dedupes call ids
         // within a turn, but nothing dedupes across turns, and some provider connectors number call
@@ -122,9 +129,7 @@ public static class ConversationMessageMapping
         {
             var message = messages[i];
 
-            if (!replayToolCalls
-                || message.Role != MessageRole.Assistant
-                || message.ToolCalls is not { Count: > 0 })
+            if (message.Role != MessageRole.Assistant || message.ToolCalls is not { Count: > 0 })
             {
                 result.Add(new ChatMessage(ToChatRole(message.Role), message.Content));
                 continue;
@@ -172,7 +177,7 @@ public static class ConversationMessageMapping
     /// including them would imply a precision this is not trying to claim.
     /// </para>
     /// </remarks>
-    private static IReadOnlyList<ToolCallRecord>[] SelectCallsWithinBudget(
+    private static (IReadOnlyList<ToolCallRecord>[] AdmittedByRow, int AdmittedCalls) SelectCallsWithinBudget(
         IReadOnlyList<ConversationMessage> messages,
         int maxReplayedChars,
         ILogger? logger)
@@ -180,6 +185,7 @@ public static class ConversationMessageMapping
         var admittedByRow = new IReadOnlyList<ToolCallRecord>[messages.Count];
         var spent = 0;
         var dropped = 0;
+        var admittedCalls = 0;
         var budgetExhausted = false;
 
         for (var i = messages.Count - 1; i >= 0; i--)
@@ -187,6 +193,15 @@ public static class ConversationMessageMapping
             var message = messages[i];
             if (message.Role != MessageRole.Assistant || message.ToolCalls is not { Count: > 0 } calls)
             {
+                admittedByRow[i] = [];
+                continue;
+            }
+
+            // Once the budget has latched shut, every older row is dropped wholesale — no sort, no
+            // per-call arithmetic, since nothing behind the latch can be admitted by definition.
+            if (budgetExhausted)
+            {
+                dropped += calls.Count;
                 admittedByRow[i] = [];
                 continue;
             }
@@ -201,24 +216,29 @@ public static class ConversationMessageMapping
                 .Select(x => x.call)
                 .ToList();
 
-            var admitted = new List<ToolCallRecord>(ordered.Count);
-            for (var j = ordered.Count - 1; j >= 0; j--)
+            // What survives is a suffix of `ordered`, so the result is one index rather than a second
+            // list built backwards and reversed: `cut` walks down from the end while calls still fit and
+            // ends as the position of the oldest admitted call. That makes the contiguous-newest-tail
+            // guarantee structural — it is what a suffix IS — instead of something that has to be
+            // inferred from a latch, a reverse walk and a final Reverse() agreeing with each other.
+            var cut = ordered.Count;
+            while (cut > 0)
             {
-                var cost = (ordered[j].Input?.Length ?? 0) + (ordered[j].Output?.Length ?? 0);
+                var cost = (ordered[cut - 1].Input?.Length ?? 0) + (ordered[cut - 1].Output?.Length ?? 0);
 
-                if (budgetExhausted || spent + cost > maxReplayedChars)
+                if (spent + cost > maxReplayedChars)
                 {
                     budgetExhausted = true;
-                    dropped++;
-                    continue;
+                    break;
                 }
 
                 spent += cost;
-                admitted.Add(ordered[j]);
+                cut--;
             }
 
-            admitted.Reverse();
-            admittedByRow[i] = admitted;
+            dropped += cut;
+            admittedCalls += ordered.Count - cut;
+            admittedByRow[i] = cut == 0 ? ordered : ordered.GetRange(cut, ordered.Count - cut);
         }
 
         if (dropped > 0)
@@ -229,7 +249,7 @@ public static class ConversationMessageMapping
                 maxReplayedChars, dropped, spent);
         }
 
-        return admittedByRow;
+        return (admittedByRow, admittedCalls);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/ReplayedToolCallScope.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ReplayedToolCallScope.cs
@@ -1,10 +1,11 @@
 namespace Application.AI.Common.Services;
 
 /// <summary>
-/// Ambient (<see cref="AsyncLocal{T}"/>), mutable set of tool-call ids already known to
-/// <c>ToolDiagnosticsMiddleware.AppendFunctionResultTracesAsync</c> for the current turn — seeded with
-/// ids replayed from earlier conversation history, then grown as the middleware itself records each
-/// genuinely new result.
+/// Ambient (<see cref="AsyncLocal{T}"/>) holder for the current turn's
+/// <see cref="ReplayedToolCallSet"/> — the mutable set of tool-call ids already known to
+/// <c>ToolDiagnosticsMiddleware.AppendFunctionResultTracesAsync</c>, seeded with ids replayed from
+/// earlier conversation history, then grown as the middleware itself records each genuinely new
+/// result.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -34,10 +35,18 @@ namespace Application.AI.Common.Services;
 /// <c>finally</c> block, for the same reason: leaving a stale value armed would apply one turn's seed
 /// set to a later, unrelated turn sharing the same async-local flow.
 /// </para>
+/// <para>
+/// The value is a <see cref="ReplayedToolCallSet"/> rather than a bare <see cref="HashSet{T}"/>
+/// because an ambient value is not guaranteed to be reached by one thread at a time: a tool that
+/// drives an <see cref="Microsoft.Extensions.AI.IChatClient"/> through the same middleware without
+/// going through the turn handler inherits its parent flow's instance by reference instead of
+/// rebinding its own. See that type for the concurrency contract and why the operation it exposes is
+/// a single claim rather than a separate test and add.
+/// </para>
 /// </remarks>
 public static class ReplayedToolCallScope
 {
-    private static readonly AsyncLocal<HashSet<string>?> s_current = new();
+    private static readonly AsyncLocal<ReplayedToolCallSet?> s_current = new();
 
     /// <summary>
     /// The current turn's known-call-id set — seeded with replayed history, then grown in place as
@@ -45,7 +54,7 @@ public static class ReplayedToolCallScope
     /// test constructing the middleware directly). Callers must treat a <see langword="null"/> scope
     /// as "nothing is known yet," not as an error.
     /// </summary>
-    public static HashSet<string>? Current
+    public static ReplayedToolCallSet? Current
     {
         get => s_current.Value;
         set => s_current.Value = value;

--- a/src/Content/Application/Application.AI.Common/Services/ReplayedToolCallSet.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ReplayedToolCallSet.cs
@@ -1,0 +1,114 @@
+namespace Application.AI.Common.Services;
+
+/// <summary>
+/// The turn-scoped, mutable set of tool-call ids behind <see cref="ReplayedToolCallScope"/> — seeded
+/// with ids replayed from earlier conversation history, then grown as
+/// <c>ToolDiagnosticsMiddleware.AppendFunctionResultTracesAsync</c> records each genuinely new result.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A dedicated type rather than a bare <see cref="HashSet{T}"/> for two reasons, both about
+/// concurrency. <see cref="HashSet{T}"/> is not thread-safe, and this instance is reachable from more
+/// than one thread: a tool that drives an <see cref="Microsoft.Extensions.AI.IChatClient"/> through
+/// the same middleware pipeline <em>without</em> going through <c>ExecuteAgentTurnCommandHandler</c>
+/// inherits its parent flow's instance by reference rather than rebinding its own, and the chat client
+/// is built with <c>AllowConcurrentInvocation = true</c>, so two such tools can call in at once. This
+/// mirrors the locking <see cref="LlmUsageCapture"/> — the sibling turn-scoped ambient capture with
+/// the identical lifetime, invoked on the very next line of that same middleware method — has always
+/// applied.
+/// </para>
+/// <para>
+/// <strong><see cref="TryClaim"/> is the whole point, and a lock alone would not have been enough.</strong>
+/// The caller's question is never "is this id present?" on its own — it is "is this id present, and if
+/// not, take it," so that exactly one caller records the result. Locking a separate
+/// <c>Contains</c> and a separate <c>Add</c> makes each one atomic while leaving the gap between them
+/// wide open: two threads both read "absent," both add, and both record — producing precisely the
+/// duplicate trace record this scope exists to prevent. Claiming and testing in a single locked
+/// operation is what actually closes it, so no <c>Add</c> is exposed at all.
+/// </para>
+/// </remarks>
+public sealed class ReplayedToolCallSet
+{
+    private readonly HashSet<string> _callIds;
+    private readonly Lock _lock = new();
+
+    /// <summary>Initializes an empty set.</summary>
+    public ReplayedToolCallSet()
+        : this([])
+    {
+    }
+
+    /// <summary>
+    /// Initializes the set with the call ids already known before this turn dispatched.
+    /// </summary>
+    /// <param name="seedCallIds">
+    /// The replayed history's call ids. Empty and duplicate entries are absorbed rather than rejected —
+    /// this is seeded from persisted conversation rows, whose shape the seeding code does not control.
+    /// </param>
+    /// <remarks>
+    /// Ordinal comparison, matching every other place a provider-issued call id is compared in this
+    /// codebase (<c>ConversationMessageMapping</c>'s own uniqueness set is explicitly
+    /// <see cref="StringComparer.Ordinal"/>). A call id is an opaque provider token, not human text:
+    /// case-insensitive matching would collapse two genuinely distinct ids.
+    /// </remarks>
+    public ReplayedToolCallSet(IEnumerable<string> seedCallIds)
+    {
+        ArgumentNullException.ThrowIfNull(seedCallIds);
+
+        _callIds = new HashSet<string>(
+            seedCallIds.Where(id => !string.IsNullOrEmpty(id)),
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Atomically claims <paramref name="callId"/> for the caller, returning <see langword="true"/>
+    /// when this caller is the first to claim it and <see langword="false"/> when it was already
+    /// known — either from replayed history seeded before dispatch, or from an earlier round of this
+    /// same turn.
+    /// </summary>
+    /// <param name="callId">The provider-issued call id. An empty id is never claimable.</param>
+    /// <returns><see langword="true"/> if the caller should record this result; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// An empty id returns <see langword="false"/> rather than throwing: a result with no id cannot be
+    /// deduplicated at all, so the caller has to decide what to do with it, and that decision is not
+    /// this type's to make. Callers guard for the empty case before calling.
+    /// </remarks>
+    public bool TryClaim(string? callId) =>
+        !string.IsNullOrEmpty(callId) && ClaimCore(callId);
+
+    /// <summary>
+    /// Whether <paramref name="callId"/> is already known. For assertions and diagnostics — callers on
+    /// the recording path want <see cref="TryClaim"/>, whose test-and-take is a single atomic step.
+    /// </summary>
+    /// <param name="callId">The provider-issued call id.</param>
+    public bool Contains(string? callId)
+    {
+        if (string.IsNullOrEmpty(callId))
+            return false;
+
+        lock (_lock)
+        {
+            return _callIds.Contains(callId);
+        }
+    }
+
+    /// <summary>How many distinct call ids are currently known.</summary>
+    public int Count
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _callIds.Count;
+            }
+        }
+    }
+
+    private bool ClaimCore(string callId)
+    {
+        lock (_lock)
+        {
+            return _callIds.Add(callId);
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/ToolCallReplayTreatment.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ToolCallReplayTreatment.cs
@@ -70,9 +70,25 @@ public sealed class ToolCallReplayTreatment : IToolCallReplayTreatment
         get
         {
             var configured = Math.Max(0, _appConfig.CurrentValue.AI.Conversations.ToolCallReplay.MaxReplayedChars);
-            var floor = Math.Min(int.MaxValue, (long)ResolveMaxVerbatimChars() * 2);
+            var floor = (int)Math.Min(int.MaxValue, (long)ResolveMaxVerbatimChars() * 2);
 
-            return configured >= floor ? configured : (int)floor;
+            if (configured >= floor)
+                return configured;
+
+            // Logged, not silent, because this raise moves a cost ceiling UPWARD past what an operator
+            // asked for — the one direction that deserves to be noticed. An operator lowering this as a
+            // deliberate mitigation would otherwise get a larger budget than they set with nothing to
+            // tell them. (The honest kill switch remains Enabled=false, which the read path also
+            // honours, so this is a floor on a cost knob rather than a way around an off switch.)
+            // Same clamp-and-say-so shape ResolveMaxVerbatimChars uses.
+            _logger.LogWarning(
+                "[ToolCallReplayTreatment] Configured MaxReplayedChars={Configured} is below the " +
+                "{Floor}-char floor (twice MaxVerbatimChars) and was raised to it. Below that floor a " +
+                "single maximum-size tool call cannot fit, and admission latches shut — every replayed " +
+                "tool call would be dropped, not just the oversized one.",
+                configured, floor);
+
+            return floor;
         }
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/ToolCallReplayTreatment.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ToolCallReplayTreatment.cs
@@ -50,9 +50,31 @@ public sealed class ToolCallReplayTreatment : IToolCallReplayTreatment
         Math.Max(0, _appConfig.CurrentValue.AI.Conversations.ToolCallReplay.MaxCallsPerTurn);
 
     /// <inheritdoc />
-    /// <remarks>Floored at 0 for the same reason as <see cref="MaxCallsPerTurn"/>.</remarks>
-    public int MaxReplayedChars =>
-        Math.Max(0, _appConfig.CurrentValue.AI.Conversations.ToolCallReplay.MaxReplayedChars);
+    /// <remarks>
+    /// <para>Floored at 0 for the same reason as <see cref="MaxCallsPerTurn"/>.</para>
+    /// <para>
+    /// Also floored at twice the effective per-payload ceiling, which is the invariant
+    /// <c>ToolCallReplayConfigValidator</c> enforces at startup — repeated here because startup is not
+    /// the only way this value changes. A reloaded config file reaches
+    /// <see cref="IOptionsMonitor{TOptions}"/> without going back through validation, and below that
+    /// floor the window budget cannot fit even one maximum-size call: admission latches shut at the
+    /// first call that does not fit, so every older call goes too and the conversation loses its whole
+    /// replayed tool history rather than just the oversized entry. Raising the value silently is the
+    /// safe direction here — the alternative is honouring a budget that empties the window — and it is
+    /// the same defense-in-depth shape <see cref="ResolveMaxVerbatimChars"/> already applies where a
+    /// reload could otherwise cross a bound that matters.
+    /// </para>
+    /// </remarks>
+    public int MaxReplayedChars
+    {
+        get
+        {
+            var configured = Math.Max(0, _appConfig.CurrentValue.AI.Conversations.ToolCallReplay.MaxReplayedChars);
+            var floor = Math.Min(int.MaxValue, (long)ResolveMaxVerbatimChars() * 2);
+
+            return configured >= floor ? configured : (int)floor;
+        }
+    }
 
     /// <inheritdoc />
     public string NoResultPlaceholder =>

--- a/src/Content/Application/Application.AI.Common/Services/ToolCallReplayTreatment.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ToolCallReplayTreatment.cs
@@ -38,6 +38,23 @@ public sealed class ToolCallReplayTreatment : IToolCallReplayTreatment
     public bool Enabled => _appConfig.CurrentValue.AI.Conversations.ToolCallReplay.Enabled;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Floored at 0 for the same reason <see cref="ResolveMaxVerbatimChars"/> clamps: an
+    /// <see cref="IOptionsMonitor{TOptions}"/> value can change at runtime from a reloaded config file
+    /// without going back through <c>ToolCallReplayConfigValidator</c>, and a negative limit read by a
+    /// caller taking "the first N" would disable the bound rather than tighten it. Unlike that method
+    /// this needs no upper clamp and logs nothing — it is a cost ceiling, not a security one, so a
+    /// large value is a deployment's own trade to make and not worth a warning on every turn.
+    /// </remarks>
+    public int MaxCallsPerTurn =>
+        Math.Max(0, _appConfig.CurrentValue.AI.Conversations.ToolCallReplay.MaxCallsPerTurn);
+
+    /// <inheritdoc />
+    /// <remarks>Floored at 0 for the same reason as <see cref="MaxCallsPerTurn"/>.</remarks>
+    public int MaxReplayedChars =>
+        Math.Max(0, _appConfig.CurrentValue.AI.Conversations.ToolCallReplay.MaxReplayedChars);
+
+    /// <inheritdoc />
     public string NoResultPlaceholder =>
         "[no result recorded: this tool call did not complete.]";
 

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -147,12 +147,11 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			// scope to skip re-recording the former while still recording the latter. Seeded once,
 			// before dispatch, then grown in place by that middleware: see ReplayedToolCallScope's
 			// remarks for why the seed is taken here rather than re-derived mid-turn.
-			ReplayedToolCallScope.Current = messages
-				.SelectMany(m => m.Contents)
-				.OfType<FunctionResultContent>()
-				.Select(r => r.CallId)
-				.Where(id => !string.IsNullOrEmpty(id))
-				.ToHashSet();
+			ReplayedToolCallScope.Current = new ReplayedToolCallSet(
+				messages
+					.SelectMany(m => m.Contents)
+					.OfType<FunctionResultContent>()
+					.Select(r => r.CallId));
 
 			object? response;
 			IReadOnlyList<ToolExchange> toolExchanges;
@@ -811,14 +810,43 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// this method exists to gate, and would leave a caller-visible difference between "opted out" and
 	/// "genuinely made no tool calls" only in the log, never in what gets persisted.
 	/// </para>
+	/// <para>
+	/// Caps the turn at <see cref="IToolCallReplayTreatment.MaxCallsPerTurn"/> records for the same
+	/// before-any-work reason, and logs how many it dropped. This is the write-side half of the bound;
+	/// it cannot be the whole of it, because it does nothing for rows persisted before the cap existed
+	/// — <c>ConversationMessageMapping.ToChatMessages</c> enforces the read-side character budget that
+	/// covers those.
+	/// </para>
 	/// </remarks>
 	private IReadOnlyList<ToolCallRecord> BuildTreatedToolCallRecords(IReadOnlyList<ToolExchange> exchanges)
 	{
 		if (exchanges.Count == 0 || !_toolCallReplayTreatment.Enabled)
 			return [];
 
-		var records = new List<ToolCallRecord>(exchanges.Count);
-		foreach (var exchange in exchanges)
+		// Bound what one turn persists before treating anything, for the same reason the Enabled check
+		// above comes first: treating a payload and then discarding it would still have run the
+		// sanitize/redact pass this cap exists to avoid paying for. Nothing upstream bounds this — the
+		// framework's per-request iteration limit caps tool-calling ROUNDS, while the chat client is
+		// built with concurrent invocation allowed, so one round's parallel calls are unbounded.
+		// Earliest-first: the turn's own prose refers back to what it did first, so truncating the tail
+		// keeps the record coherent where truncating the head would not.
+		var admitted = exchanges;
+		if (exchanges.Count > _toolCallReplayTreatment.MaxCallsPerTurn)
+		{
+			var dropped = exchanges.Count - _toolCallReplayTreatment.MaxCallsPerTurn;
+			_logger.LogWarning(
+				"[ToolCallReplay] Turn produced {Total} tool calls, above the {Cap} persisted per turn; " +
+				"dropping the {Dropped} latest from replay history.",
+				exchanges.Count, _toolCallReplayTreatment.MaxCallsPerTurn, dropped);
+
+			admitted = exchanges
+				.OrderBy(e => e.RoundOrdinal)
+				.Take(_toolCallReplayTreatment.MaxCallsPerTurn)
+				.ToList();
+		}
+
+		var records = new List<ToolCallRecord>(admitted.Count);
+		foreach (var exchange in admitted)
 		{
 			var treatedInput = string.IsNullOrEmpty(exchange.ArgsJson)
 				? null

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -812,10 +812,11 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 	/// </para>
 	/// <para>
 	/// Caps the turn at <see cref="IToolCallReplayTreatment.MaxCallsPerTurn"/> records for the same
-	/// before-any-work reason, and logs how many it dropped. This is the write-side half of the bound;
-	/// it cannot be the whole of it, because it does nothing for rows persisted before the cap existed
-	/// — <c>ConversationMessageMapping.ToChatMessages</c> enforces the read-side character budget that
-	/// covers those.
+	/// before-any-work reason, keeping the newest and logging how many it dropped. This is the
+	/// write-side half of the bound; it cannot be the whole of it, because it does nothing for rows
+	/// persisted before the cap existed — <c>ConversationMessageMapping.ToChatMessages</c> enforces the
+	/// read-side character budget that covers those, and trims from the same end so the two compose
+	/// into one coherent policy rather than a middle slice.
 	/// </para>
 	/// </remarks>
 	private IReadOnlyList<ToolCallRecord> BuildTreatedToolCallRecords(IReadOnlyList<ToolExchange> exchanges)
@@ -823,25 +824,38 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 		if (exchanges.Count == 0 || !_toolCallReplayTreatment.Enabled)
 			return [];
 
+		// Read once into a local, not four times off IOptionsMonitor.CurrentValue: a hot config reload
+		// between the comparison and the Take would apply one limit while reporting another, or skip the
+		// cap entirely. Same reason DurableTranscript snapshots its own budget at construction — half a
+		// policy applied mid-decision is worse than either whole one.
+		var maxCallsPerTurn = _toolCallReplayTreatment.MaxCallsPerTurn;
+
 		// Bound what one turn persists before treating anything, for the same reason the Enabled check
 		// above comes first: treating a payload and then discarding it would still have run the
 		// sanitize/redact pass this cap exists to avoid paying for. Nothing upstream bounds this — the
 		// framework's per-request iteration limit caps tool-calling ROUNDS, while the chat client is
 		// built with concurrent invocation allowed, so one round's parallel calls are unbounded.
-		// Earliest-first: the turn's own prose refers back to what it did first, so truncating the tail
-		// keeps the record coherent where truncating the head would not.
+		//
+		// Newest-first, matching ConversationMessageMapping's read-side budget exactly. The two halves
+		// of one policy must trim from the same end: keeping the earliest here and the newest there
+		// would compose into a middle slice — neither the beginning of the turn's reasoning nor its
+		// conclusions — and would make the read side's contiguous-newest-tail guarantee false of the
+		// system even though it holds of that method. Newest is the right shared direction because this
+		// is a memory, not an audit log: a later turn reasons about what the agent last found, and the
+		// assistant prose persisted beside these records summarizes the outcome rather than the opening
+		// moves.
 		var admitted = exchanges;
-		if (exchanges.Count > _toolCallReplayTreatment.MaxCallsPerTurn)
+		if (exchanges.Count > maxCallsPerTurn)
 		{
-			var dropped = exchanges.Count - _toolCallReplayTreatment.MaxCallsPerTurn;
+			var dropped = exchanges.Count - maxCallsPerTurn;
 			_logger.LogWarning(
 				"[ToolCallReplay] Turn produced {Total} tool calls, above the {Cap} persisted per turn; " +
-				"dropping the {Dropped} latest from replay history.",
-				exchanges.Count, _toolCallReplayTreatment.MaxCallsPerTurn, dropped);
+				"dropping the {Dropped} earliest from replay history.",
+				exchanges.Count, maxCallsPerTurn, dropped);
 
 			admitted = exchanges
 				.OrderBy(e => e.RoundOrdinal)
-				.Take(_toolCallReplayTreatment.MaxCallsPerTurn)
+				.TakeLast(maxCallsPerTurn)
 				.ToList();
 		}
 

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Models.Conversations;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
 
 namespace Application.Core.CQRS.Agents.RunConversation;
 
@@ -28,6 +29,8 @@ internal sealed class DurableTranscript
     private readonly string _conversationId;
     private readonly string _ownerId;
     private readonly bool _replayToolCalls;
+    private readonly int _maxReplayedChars;
+    private readonly ILogger? _logger;
 
     /// <summary>Binds a transcript to the conversation and caller a run is executing for.</summary>
     /// <param name="store">The transcript store. Enforces ownership on every call made here.</param>
@@ -38,7 +41,23 @@ internal sealed class DurableTranscript
     /// was opened — see <see cref="LoadHistoryAsync"/>. Read once, at construction, deliberately: it
     /// gates one run's dispatch, not a value re-checked mid-run.
     /// </param>
-    public DurableTranscript(IConversationStore store, string conversationId, string ownerId, bool replayToolCalls)
+    /// <param name="maxReplayedChars">
+    /// The deployment's <c>IToolCallReplayTreatment.MaxReplayedChars</c> budget, snapshotted at the same
+    /// moment and for the same reason as <paramref name="replayToolCalls"/> — the two settings gate one
+    /// run's dispatch together, and reading one live while the other is fixed would let a mid-run config
+    /// reload apply half a policy.
+    /// </param>
+    /// <param name="logger">
+    /// Optional, for reporting tool-call history the budget dropped. Absent in tests that construct a
+    /// transcript directly.
+    /// </param>
+    public DurableTranscript(
+        IConversationStore store,
+        string conversationId,
+        string ownerId,
+        bool replayToolCalls,
+        int maxReplayedChars,
+        ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
@@ -48,6 +67,8 @@ internal sealed class DurableTranscript
         _conversationId = conversationId;
         _ownerId = ownerId;
         _replayToolCalls = replayToolCalls;
+        _maxReplayedChars = maxReplayedChars;
+        _logger = logger;
     }
 
     /// <summary>
@@ -112,7 +133,8 @@ internal sealed class DurableTranscript
         if (messages is null || messages.Count == 0)
             return [];
 
-        return ConversationMessageMapping.ToChatMessages(messages, _replayToolCalls);
+        return ConversationMessageMapping.ToChatMessages(
+            messages, _replayToolCalls, _maxReplayedChars, _logger);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -148,7 +148,12 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 			cancellationToken, lease.LeaseLost);
 
 		var transcript = new DurableTranscript(
-			_conversationStore, request.ConversationId, ownerId, _toolCallReplayTreatment.Enabled);
+			_conversationStore,
+			request.ConversationId,
+			ownerId,
+			_toolCallReplayTreatment.Enabled,
+			_toolCallReplayTreatment.MaxReplayedChars,
+			_logger);
 
 		return await RunAsync(request, transcript, turnCts.Token);
 	}

--- a/src/Content/Application/Application.Core/Validation/ToolCallReplayConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ToolCallReplayConfigValidator.cs
@@ -52,11 +52,15 @@ public sealed class ToolCallReplayConfigValidator : AbstractValidator<ToolCallRe
         // fit); reachable the moment an operator raises the per-payload ceiling for a large-context
         // model and leaves the window budget alone, which is exactly the plausible mistake. Validating
         // the relationship is what makes that a startup error instead of silent amnesia.
+        // (long) rather than int arithmetic: MaxVerbatimChars is range-checked above, but rules are
+        // evaluated independently, so a nonsense value still reaches this one. At int width the
+        // doubling overflows negative above ~1.07 billion, which would make this rule pass vacuously
+        // and report a negative threshold in its own failure message.
         RuleFor(x => x.MaxReplayedChars)
-            .GreaterThanOrEqualTo(x => x.MaxVerbatimChars * 2)
+            .Must((config, maxReplayedChars) => maxReplayedChars >= (long)config.MaxVerbatimChars * 2)
             .WithMessage(x =>
                 $"MaxReplayedChars ({x.MaxReplayedChars}) must be at least twice MaxVerbatimChars " +
-                $"({x.MaxVerbatimChars}), i.e. {x.MaxVerbatimChars * 2}, so at least one " +
+                $"({x.MaxVerbatimChars}), i.e. {(long)x.MaxVerbatimChars * 2}, so at least one " +
                 "maximum-size tool call always fits in a replayed window. A smaller budget silently " +
                 "drops every replayed tool call rather than just the oversized one.");
     }

--- a/src/Content/Application/Application.Core/Validation/ToolCallReplayConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ToolCallReplayConfigValidator.cs
@@ -40,5 +40,24 @@ public sealed class ToolCallReplayConfigValidator : AbstractValidator<ToolCallRe
         RuleFor(x => x.MaxReplayedChars)
             .GreaterThanOrEqualTo(0)
             .WithMessage("MaxReplayedChars must be zero or greater.");
+
+        // Cross-field, because these two settings are not independent even though each is individually
+        // sensible. One replayed call costs up to 2 * MaxVerbatimChars (arguments and result are capped
+        // separately), and the window budget admits newest-first and then latches shut at the first
+        // call that does not fit — so a window budget smaller than one maximum-size call drops not just
+        // that call but EVERY older one behind it, emptying the whole conversation's replayed tool
+        // history for as long as that one oversized call stays in the window.
+        //
+        // Unreachable at the shipped defaults (8192 and 65536, where at least four full-size calls
+        // fit); reachable the moment an operator raises the per-payload ceiling for a large-context
+        // model and leaves the window budget alone, which is exactly the plausible mistake. Validating
+        // the relationship is what makes that a startup error instead of silent amnesia.
+        RuleFor(x => x.MaxReplayedChars)
+            .GreaterThanOrEqualTo(x => x.MaxVerbatimChars * 2)
+            .WithMessage(x =>
+                $"MaxReplayedChars ({x.MaxReplayedChars}) must be at least twice MaxVerbatimChars " +
+                $"({x.MaxVerbatimChars}), i.e. {x.MaxVerbatimChars * 2}, so at least one " +
+                "maximum-size tool call always fits in a replayed window. A smaller budget silently " +
+                "drops every replayed tool call rather than just the oversized one.");
     }
 }

--- a/src/Content/Application/Application.Core/Validation/ToolCallReplayConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ToolCallReplayConfigValidator.cs
@@ -28,5 +28,17 @@ public sealed class ToolCallReplayConfigValidator : AbstractValidator<ToolCallRe
                 $"MaxVerbatimChars must be between 0 and {ToolCallReplayTreatment.WithholdCeilingChars} " +
                 "(the size above which the structural secret-redaction pass falls back to a regex-only " +
                 "scan and cannot be trusted to replay verbatim).");
+
+        // Non-negative only, with no upper bound: unlike MaxVerbatimChars these are cost ceilings, not
+        // security ones — every payload they count has already been sanitized, redacted and size-capped
+        // individually. A deployment on a very large context window raising either one is a legitimate
+        // trade it can make for itself; a negative value is just nonsense that would disable the bound.
+        RuleFor(x => x.MaxCallsPerTurn)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("MaxCallsPerTurn must be zero or greater.");
+
+        RuleFor(x => x.MaxReplayedChars)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("MaxReplayedChars must be zero or greater.");
     }
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Conversations/ToolCallReplayConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Conversations/ToolCallReplayConfig.cs
@@ -43,10 +43,11 @@ public sealed class ToolCallReplayConfig
     public int MaxVerbatimChars { get; set; } = 8192;
 
     /// <summary>
-    /// The most tool calls a single turn persists for replay. Calls beyond this many are dropped, with
-    /// a warning naming how many. Defaults to 32.
+    /// The most tool calls a single turn persists for replay. The <strong>newest</strong> this many are
+    /// kept and the rest dropped, with a warning naming how many. Defaults to 32.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Bounds model-output-driven storage growth, which nothing else does: the agent framework's
     /// per-request iteration limit caps tool-calling <em>rounds</em>, not the calls issued in parallel
     /// within one round, and the chat client permits concurrent invocation. 32 is generous against real
@@ -54,6 +55,14 @@ public sealed class ToolCallReplayConfig
     /// than legitimate work — while staying well clear of the point where one turn's history would
     /// dominate a resumed conversation. Set to 0 to persist no tool calls at all, though
     /// <see cref="Enabled"/> is the honest way to express that.
+    /// </para>
+    /// <para>
+    /// Newest-kept is the same end <see cref="MaxReplayedChars"/> trims from on replay, and that
+    /// agreement is load-bearing rather than incidental: the two settings are one policy enforced at two
+    /// points, so trimming opposite ends would compose into a middle slice — neither the turn's opening
+    /// reasoning nor its conclusions — and would break the contiguous-newest-tail property each half
+    /// otherwise guarantees on its own.
+    /// </para>
     /// </remarks>
     public int MaxCallsPerTurn { get; set; } = 32;
 
@@ -74,6 +83,15 @@ public sealed class ToolCallReplayConfig
     /// <c>tool_calls</c> entry with no matching result message is a malformed conversation a provider
     /// rejects outright, and because the window is rebuilt from persisted rows every turn, that
     /// rejection would recur permanently.
+    /// </para>
+    /// <para>
+    /// <strong>Must be at least twice <see cref="MaxVerbatimChars"/>, and startup validation enforces
+    /// that.</strong> One call costs up to two full payloads (arguments and result are capped
+    /// separately), and admission latches shut at the first call that does not fit — so a window budget
+    /// smaller than a single maximum-size call drops not merely that call but every older one behind
+    /// it, emptying the conversation's whole replayed tool history for as long as the oversized call
+    /// stays in the window. Raising <see cref="MaxVerbatimChars"/> for a large-context model without
+    /// raising this in step is the mistake that rule exists to catch.
     /// </para>
     /// </remarks>
     public int MaxReplayedChars { get; set; } = 65536;

--- a/src/Content/Domain/Domain.Common/Config/AI/Conversations/ToolCallReplayConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Conversations/ToolCallReplayConfig.cs
@@ -6,12 +6,23 @@ namespace Domain.Common.Config.AI.Conversations;
 /// <c>AppConfig:AI:Conversations:ToolCallReplay</c>.
 /// </summary>
 /// <remarks>
-/// Only <see cref="MaxVerbatimChars"/> is configurable here. The size above which a payload is
-/// withheld rather than truncated is a hard constant, not exposed through config — above that
-/// ceiling the structural secret-redaction pass falls back to a regex-only scan that cannot see
-/// through escaped-nested-JSON secrets (#391), so letting a deployment raise it would let that
-/// deployment silently opt into replaying unredactable content to the model. See the treatment
-/// service this config feeds for that constant and the three-tier rule it implements.
+/// <para>
+/// The size above which a single payload is withheld rather than truncated is a hard constant, not
+/// exposed through config — above that ceiling the structural secret-redaction pass falls back to a
+/// regex-only scan that cannot see through escaped-nested-JSON secrets (#391), so letting a
+/// deployment raise it would let that deployment silently opt into replaying unredactable content to
+/// the model. See the treatment service this config feeds for that constant and the three-tier rule
+/// it implements.
+/// </para>
+/// <para>
+/// The three settings bound three different quantities and none substitutes for another.
+/// <see cref="MaxVerbatimChars"/> bounds <em>one</em> payload. <see cref="MaxCallsPerTurn"/> bounds
+/// how many payloads a single turn <em>persists</em>. <see cref="MaxReplayedChars"/> bounds the total
+/// a whole replayed window <em>sends to the model</em>. Only the last is a true ceiling on per-turn
+/// prompt cost: the store's dispatch window is capped in rows, and one row expands into two chat
+/// messages per tool call it carries, so a row cap alone stops bounding the prompt as soon as turns
+/// are tool-heavy.
+/// </para>
 /// </remarks>
 public sealed class ToolCallReplayConfig
 {
@@ -30,4 +41,40 @@ public sealed class ToolCallReplayConfig
     /// it is used, defense-in-depth alongside the equivalent startup validation.
     /// </summary>
     public int MaxVerbatimChars { get; set; } = 8192;
+
+    /// <summary>
+    /// The most tool calls a single turn persists for replay. Calls beyond this many are dropped, with
+    /// a warning naming how many. Defaults to 32.
+    /// </summary>
+    /// <remarks>
+    /// Bounds model-output-driven storage growth, which nothing else does: the agent framework's
+    /// per-request iteration limit caps tool-calling <em>rounds</em>, not the calls issued in parallel
+    /// within one round, and the chat client permits concurrent invocation. 32 is generous against real
+    /// agent behaviour — a turn issuing more parallel calls than that is far more likely a runaway loop
+    /// than legitimate work — while staying well clear of the point where one turn's history would
+    /// dominate a resumed conversation. Set to 0 to persist no tool calls at all, though
+    /// <see cref="Enabled"/> is the honest way to express that.
+    /// </remarks>
+    public int MaxCallsPerTurn { get; set; } = 32;
+
+    /// <summary>
+    /// The most treated tool-call text, in characters, that one replayed window sends back to the
+    /// model across every row in it. Once exceeded, the oldest calls are dropped until the remainder
+    /// fits, with a warning naming how many. Defaults to 65536 (roughly 16,000 tokens).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the only setting that bounds what a resumed conversation actually costs per turn.
+    /// Oldest-first is the drop order because a replayed window is context, not an audit log: the most
+    /// recent tool activity is what the current turn is most likely to reason about, and dropping from
+    /// the old end leaves a contiguous, coherent tail rather than holes through the middle.
+    /// </para>
+    /// <para>
+    /// A call is dropped as a whole call/result pair, never half of one — a persisted assistant
+    /// <c>tool_calls</c> entry with no matching result message is a malformed conversation a provider
+    /// rejects outright, and because the window is rebuilt from persisted rows every turn, that
+    /// rejection would recur permanently.
+    /// </para>
+    /// </remarks>
+    public int MaxReplayedChars { get; set; } = 65536;
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
@@ -539,6 +539,14 @@ public sealed class EfCoreConversationStore : IConversationStore
         // more; excluding it here as well keeps this query correct for rows persisted before that
         // normalization covered the `with`-expression path, and for any future producer that writes
         // this column without going through the DTO.
+        //
+        // RETIREMENT CONDITION, so this does not become permanent by default: the record type is the
+        // real seam, and this clause exists only for already-written rows. Once a backfill has run
+        // (`UPDATE ConversationMessages SET ToolCallsJson = NULL WHERE ToolCallsJson = '[]'`) across
+        // every deployment that could hold them, drop the `!= "[]"` and the test that pins it. Until
+        // then it stays, with the caveat that the literal encodes a System.Text.Json rendering detail —
+        // it would silently stop matching if the serializer emitted whitespace or the column moved to
+        // a native JSON type, which is another reason not to leave it here indefinitely.
         var tail = await context.ConversationMessages
             .AsNoTracking()
             .Where(m => m.ConversationId == conversationId

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/EfCoreConversationStore.cs
@@ -530,9 +530,19 @@ public sealed class EfCoreConversationStore : IConversationStore
         // reads a negative LIMIT as no limit at all — so passing the value through would answer a
         // request for no messages with the entire transcript, unbounded, straight into the model's
         // context. The file-backed store returns nothing for the same input.
+        //
+        // Testing the column for non-null is not sufficient on its own: an empty tool-call list
+        // serializes to a non-null "[]", which this filter would read as "this row is model-relevant"
+        // and admit an empty-content widget row into the prompt window — the row the file-backed
+        // store's DTO-level `ToolCalls is { Count: > 0 }` filter correctly drops. ConversationMessage
+        // now normalizes an empty list to null however it arrives, so nothing should write "[]" any
+        // more; excluding it here as well keeps this query correct for rows persisted before that
+        // normalization covered the `with`-expression path, and for any future producer that writes
+        // this column without going through the DTO.
         var tail = await context.ConversationMessages
             .AsNoTracking()
-            .Where(m => m.ConversationId == conversationId && (m.Content != "" || m.ToolCallsJson != null))
+            .Where(m => m.ConversationId == conversationId
+                && (m.Content != "" || (m.ToolCallsJson != null && m.ToolCallsJson != "[]")))
             .OrderByDescending(m => m.Ordinal)
             .Take(Math.Max(0, maxMessages))
             .ToListAsync(ct);

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -477,7 +477,11 @@ public sealed class AgUiRunHandler
     // tool-call expansion on the live IToolCallReplayTreatment.Enabled value so an operator's kill
     // switch stops replaying already-persisted tool payloads, not just stop writing new ones.
     private IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        ConversationMessageMapping.ToChatMessages(messages, _toolCallReplayTreatment.Enabled);
+        ConversationMessageMapping.ToChatMessages(
+            messages,
+            _toolCallReplayTreatment.Enabled,
+            _toolCallReplayTreatment.MaxReplayedChars,
+            _logger);
 
     private static async Task TryWriteErrorAsync(IAgUiEventWriter writer, string message, CancellationToken ct)
     {

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -688,5 +688,9 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
     // gates tool-call expansion on the live IToolCallReplayTreatment.Enabled value so an operator's
     // kill switch stops replaying already-persisted tool payloads, not just stop writing new ones.
     private IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        ConversationMessageMapping.ToChatMessages(messages, _toolCallReplayTreatment.Enabled);
+        ConversationMessageMapping.ToChatMessages(
+            messages,
+            _toolCallReplayTreatment.Enabled,
+            _toolCallReplayTreatment.MaxReplayedChars,
+            _logger);
 }

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -219,6 +219,21 @@ public static class IServiceCollectionExtensions
             .ValidateFluentValidation<ContentCaptureConfig, ContentCaptureConfigValidator>()
             .ValidateOnStart();
 
+        // Tool-call replay bounds. ToolCallReplayConfigValidator existed and was fully tested but was
+        // never bound here, so none of its rules ran at startup and three XML doc comments asserted a
+        // control that did not exist — the sixth instance of this codebase's "a security control has a
+        // caller" pattern. Two rules depend on this registration: MaxVerbatimChars must not exceed the
+        // size above which structural secret redaction stops being trustworthy (a confidentiality
+        // bound, previously defended only by the runtime clamp in ToolCallReplayTreatment), and
+        // MaxReplayedChars must be at least twice MaxVerbatimChars, without which one oversized tool
+        // result silently empties a conversation's entire replayed tool history.
+        services.AddOptions<Domain.Common.Config.AI.Conversations.ToolCallReplayConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:Conversations:ToolCallReplay"))
+            .ValidateFluentValidation<
+                Domain.Common.Config.AI.Conversations.ToolCallReplayConfig,
+                ToolCallReplayConfigValidator>()
+            .ValidateOnStart();
+
         services.AddOptions<Domain.Common.Config.AI.ContextManagement.PromptCompositionConfig>()
             .Bind(configuration.GetSection("AppConfig:AI:ContextManagement:PromptComposition"))
             .ValidateFluentValidation<

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
@@ -232,7 +232,7 @@ public sealed class ToolDiagnosticsMiddlewareTests
             new(ChatRole.Tool, [new FunctionResultContent("call-1", "42 results")])
         };
 
-        ReplayedToolCallScope.Current = new HashSet<string> { "call-1" };
+        ReplayedToolCallScope.Current = new ReplayedToolCallSet(["call-1"]);
         try
         {
             await middleware.GetResponseAsync(messages, null, CancellationToken.None);
@@ -258,7 +258,7 @@ public sealed class ToolDiagnosticsMiddlewareTests
             new(ChatRole.Tool, [new FunctionResultContent("call-2", "42 results")])
         };
 
-        ReplayedToolCallScope.Current = new HashSet<string> { "call-1" };
+        ReplayedToolCallScope.Current = new ReplayedToolCallSet(["call-1"]);
         try
         {
             await middleware.GetResponseAsync(messages, null, CancellationToken.None);
@@ -293,7 +293,7 @@ public sealed class ToolDiagnosticsMiddlewareTests
             new(ChatRole.Tool, [new FunctionResultContent("call-2", "second result")])
         };
 
-        ReplayedToolCallScope.Current = [];
+        ReplayedToolCallScope.Current = new ReplayedToolCallSet();
         try
         {
             await middleware.GetResponseAsync(roundOneMessages, null, CancellationToken.None);

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
@@ -51,7 +51,7 @@ public sealed class ConversationMessageMappingBudgetTests
             AssistantRow("second", Call("call-2", 0, 100)),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 1000);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 1000);
 
         ReplayedCallIds(replayed).Should().Equal("call-1", "call-2");
     }
@@ -67,7 +67,7 @@ public sealed class ConversationMessageMappingBudgetTests
         };
 
         // Room for two of the three.
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 250);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 250);
 
         ReplayedCallIds(replayed).Should().Equal(
             ["call-2", "call-3"],
@@ -84,7 +84,7 @@ public sealed class ConversationMessageMappingBudgetTests
             AssistantRow("second", Call("call-2", 0, 100)),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 100);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 100);
 
         ReplayedCallIds(replayed).Should().Equal("call-2");
         replayed.Select(m => m.Text).Should().Contain("I searched and found nothing",
@@ -99,7 +99,7 @@ public sealed class ConversationMessageMappingBudgetTests
             AssistantRow("only", Call("call-1", 0, 100)),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 10);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 10);
 
         ReplayedCallIds(replayed).Should().BeEmpty(
             "always keeping one call would mean the bound can be exceeded by an unbounded amount, " +
@@ -115,7 +115,7 @@ public sealed class ConversationMessageMappingBudgetTests
             AssistantRow("narration", Call("call-1", 0, 100)),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 0);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 0);
 
         ReplayedCallIds(replayed).Should().BeEmpty();
         replayed.Should().ContainSingle().Which.Text.Should().Be("narration");
@@ -133,7 +133,7 @@ public sealed class ConversationMessageMappingBudgetTests
                 Call("call-3", 2, 100)),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 250);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 250);
 
         ReplayedCallIds(replayed).Should().Equal(
             ["call-2", "call-3"],
@@ -153,7 +153,7 @@ public sealed class ConversationMessageMappingBudgetTests
         // call-3 (100) fits. call-2 (400) does not. call-1 (10) would fit in what remains, but
         // admitting it would replay a sequence that never happened — call-1 then call-3, with the
         // call-2 that came between them silently gone.
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 200);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 200);
 
         ReplayedCallIds(replayed).Should().Equal(
             ["call-3"],
@@ -169,7 +169,7 @@ public sealed class ConversationMessageMappingBudgetTests
             AssistantRow("second", Call("call-2", 0, 100)),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 100);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 100);
 
         var results = replayed
             .SelectMany(m => m.Contents)

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
@@ -22,15 +22,31 @@ namespace Application.AI.Common.Tests.Models.Conversations;
 /// </remarks>
 public sealed class ConversationMessageMappingBudgetTests
 {
-    /// <summary>A call whose Input + Output cost exactly <paramref name="cost"/> characters.</summary>
-    private static ToolCallRecord Call(string id, int ordinal, int cost) =>
-        new(
-            "search",
-            new string('i', cost / 2),
-            new string('o', cost - (cost / 2)),
+    private const string ToolName = "search";
+
+    /// <summary>
+    /// A call whose <em>total</em> budget cost is exactly <paramref name="cost"/> characters.
+    /// </summary>
+    /// <remarks>
+    /// The payload is sized down by the tool name and call id, because those count against the budget
+    /// too — they reach the model and no treatment pass bounds them. Sizing the payload alone would
+    /// leave every arithmetic assertion below quietly off by the length of two strings, which is
+    /// exactly the kind of drift that makes a budget test stop testing the budget.
+    /// </remarks>
+    private static ToolCallRecord Call(string id, int ordinal, int cost)
+    {
+        var payload = cost - ToolName.Length - id.Length;
+        if (payload < 0)
+            throw new ArgumentOutOfRangeException(nameof(cost), cost, "Cost must cover the name and id.");
+
+        return new ToolCallRecord(
+            ToolName,
+            new string('i', payload / 2),
+            new string('o', payload - (payload / 2)),
             DurationMs: 0,
             CallId: id,
             RoundOrdinal: ordinal);
+    }
 
     private static ConversationMessage AssistantRow(string text, params ToolCallRecord[] calls) =>
         new(Guid.NewGuid(), MessageRole.Assistant, text, DateTimeOffset.UtcNow, ToolCalls: calls);
@@ -145,12 +161,12 @@ public sealed class ConversationMessageMappingBudgetTests
     {
         var transcript = new List<ConversationMessage>
         {
-            AssistantRow("tiny and old", Call("call-1", 0, 10)),
+            AssistantRow("tiny and old", Call("call-1", 0, 20)),
             AssistantRow("huge", Call("call-2", 0, 400)),
             AssistantRow("newest", Call("call-3", 0, 100)),
         };
 
-        // call-3 (100) fits. call-2 (400) does not. call-1 (10) would fit in what remains, but
+        // call-3 (100) fits. call-2 (400) does not. call-1 (20) would fit in the 100 that remains, but
         // admitting it would replay a sequence that never happened — call-1 then call-3, with the
         // call-2 that came between them silently gone.
         var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: 200);

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
@@ -1,0 +1,199 @@
+using Application.AI.Common.Models.Conversations;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Tests.Models.Conversations;
+
+/// <summary>
+/// Proves the read-side half of #508: <see cref="ConversationMessageMapping.ToChatMessages"/> bounds
+/// the total treated tool-call text one replayed window sends to the model, dropping oldest-first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Why a read-side bound is needed at all, given the write-side per-turn cap exists too: the store's
+/// dispatch window is capped in <em>rows</em>, and each row expands here into two chat messages per
+/// tool call it carries, so a 50-row window of tool-heavy turns expands without bound. The write-side
+/// cap cannot cover rows persisted before that cap existed; this one can, because it applies at replay.
+/// </para>
+/// <para>
+/// Separate file from <see cref="ConversationMessageMappingTests"/>, which is about expansion
+/// correctness and deliberately leaves the budget at its <see cref="int.MaxValue"/> default.
+/// </para>
+/// </remarks>
+public sealed class ConversationMessageMappingBudgetTests
+{
+    /// <summary>A call whose Input + Output cost exactly <paramref name="cost"/> characters.</summary>
+    private static ToolCallRecord Call(string id, int ordinal, int cost) =>
+        new(
+            "search",
+            new string('i', cost / 2),
+            new string('o', cost - (cost / 2)),
+            DurationMs: 0,
+            CallId: id,
+            RoundOrdinal: ordinal);
+
+    private static ConversationMessage AssistantRow(string text, params ToolCallRecord[] calls) =>
+        new(Guid.NewGuid(), MessageRole.Assistant, text, DateTimeOffset.UtcNow, ToolCalls: calls);
+
+    private static IReadOnlyList<string> ReplayedCallIds(IReadOnlyList<ChatMessage> replayed) =>
+        replayed
+            .SelectMany(m => m.Contents)
+            .OfType<FunctionCallContent>()
+            .Select(c => c.CallId)
+            .ToList();
+
+    [Fact]
+    public void ToChatMessages_TotalUnderBudget_ReplaysEveryCall()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("first", Call("call-1", 0, 100)),
+            AssistantRow("second", Call("call-2", 0, 100)),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 1000);
+
+        ReplayedCallIds(replayed).Should().Equal("call-1", "call-2");
+    }
+
+    [Fact]
+    public void ToChatMessages_TotalOverBudget_DropsOldestAndKeepsNewest()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("first", Call("call-1", 0, 100)),
+            AssistantRow("second", Call("call-2", 0, 100)),
+            AssistantRow("third", Call("call-3", 0, 100)),
+        };
+
+        // Room for two of the three.
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 250);
+
+        ReplayedCallIds(replayed).Should().Equal(
+            ["call-2", "call-3"],
+            "a replayed window is context, not an audit log — the most recent tool activity is what " +
+            "the current turn is most likely to reason about");
+    }
+
+    [Fact]
+    public void ToChatMessages_DroppedRowStillReplaysItsNarratedText()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("I searched and found nothing", Call("call-1", 0, 100)),
+            AssistantRow("second", Call("call-2", 0, 100)),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 100);
+
+        ReplayedCallIds(replayed).Should().Equal("call-2");
+        replayed.Select(m => m.Text).Should().Contain("I searched and found nothing",
+            "losing the literal call/result pair must not also lose the prose account of what happened");
+    }
+
+    [Fact]
+    public void ToChatMessages_BudgetSmallerThanNewestCall_AdmitsNothing()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("only", Call("call-1", 0, 100)),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 10);
+
+        ReplayedCallIds(replayed).Should().BeEmpty(
+            "always keeping one call would mean the bound can be exceeded by an unbounded amount, " +
+            "which is not a bound");
+        replayed.Should().ContainSingle().Which.Text.Should().Be("only");
+    }
+
+    [Fact]
+    public void ToChatMessages_ZeroBudget_ReplaysTextOnly()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("narration", Call("call-1", 0, 100)),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 0);
+
+        ReplayedCallIds(replayed).Should().BeEmpty();
+        replayed.Should().ContainSingle().Which.Text.Should().Be("narration");
+    }
+
+    [Fact]
+    public void ToChatMessages_PartialRow_DropsOldestCallsWithinThatRow()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow(
+                "one turn, three parallel calls",
+                Call("call-1", 0, 100),
+                Call("call-2", 1, 100),
+                Call("call-3", 2, 100)),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 250);
+
+        ReplayedCallIds(replayed).Should().Equal(
+            ["call-2", "call-3"],
+            "the budget cuts within a row as readily as across rows");
+    }
+
+    [Fact]
+    public void ToChatMessages_AdmissionLatchesShut_RatherThanSkippingToASmallerOlderCall()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("tiny and old", Call("call-1", 0, 10)),
+            AssistantRow("huge", Call("call-2", 0, 400)),
+            AssistantRow("newest", Call("call-3", 0, 100)),
+        };
+
+        // call-3 (100) fits. call-2 (400) does not. call-1 (10) would fit in what remains, but
+        // admitting it would replay a sequence that never happened — call-1 then call-3, with the
+        // call-2 that came between them silently gone.
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 200);
+
+        ReplayedCallIds(replayed).Should().Equal(
+            ["call-3"],
+            "the surviving set must be a contiguous newest tail, not holes punched through history");
+    }
+
+    [Fact]
+    public void ToChatMessages_EveryDroppedCallLosesItsResultToo()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("first", Call("call-1", 0, 100)),
+            AssistantRow("second", Call("call-2", 0, 100)),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, maxReplayedChars: 100);
+
+        var results = replayed
+            .SelectMany(m => m.Contents)
+            .OfType<FunctionResultContent>()
+            .Select(r => r.CallId)
+            .ToList();
+
+        results.Should().Equal(
+            ["call-2"],
+            "a call is dropped as a whole call/result pair — an assistant tool_calls entry with no " +
+            "matching result is a malformed conversation a provider rejects outright");
+    }
+
+    [Fact]
+    public void ToChatMessages_ReplayDisabled_IgnoresBudgetAndReplaysTextOnly()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            AssistantRow("narration", Call("call-1", 0, 100)),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(
+            transcript, replayToolCalls: false, maxReplayedChars: 0);
+
+        replayed.Should().ContainSingle().Which.Text.Should().Be("narration");
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingTests.cs
@@ -38,7 +38,7 @@ public sealed class ConversationMessageMappingTests
                 ToolCalls: [toolCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         replayed.Should().HaveCount(4);
         replayed[0].Role.Should().Be(ChatRole.User);
@@ -72,7 +72,7 @@ public sealed class ConversationMessageMappingTests
                 ToolCalls: [second, first]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         replayed.Should().HaveCount(5);
         ((FunctionCallContent)replayed[0].Contents.Single()).CallId.Should().Be("call-1");
@@ -92,7 +92,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, string.Empty, DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         replayed.Should().HaveCount(2, "an empty final Content must not produce a trailing empty assistant message");
     }
@@ -107,7 +107,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, "done", DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         ((FunctionCallContent)replayed[0].Contents.Single()).Arguments.Should().BeNull();
     }
@@ -123,7 +123,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, "done", DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         var call = (FunctionCallContent)replayed[0].Contents.Single();
         call.Arguments.Should().ContainKey("_raw").WhoseValue.Should()
@@ -140,7 +140,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, "done", DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         ((FunctionResultContent)replayed[1].Contents.Single()).Result.Should().BeNull();
     }
@@ -155,7 +155,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, "done", DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         var callId = ((FunctionCallContent)replayed[0].Contents.Single()).CallId;
         callId.Should().NotBeNullOrEmpty();
@@ -179,7 +179,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, "turn two", DateTimeOffset.UtcNow, ToolCalls: [turnTwoCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         var callIds = replayed.SelectMany(m => m.Contents).OfType<FunctionCallContent>()
             .Select(c => c.CallId).ToList();
@@ -208,7 +208,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, "turn two", DateTimeOffset.UtcNow, ToolCalls: [turnTwoCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         replayed.SelectMany(m => m.Contents).OfType<FunctionCallContent>()
             .Select(c => c.CallId).Should().Equal("call_a", "call_b");
@@ -226,7 +226,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.Assistant, "it's sunny", DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: false);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: false, maxReplayedChars: int.MaxValue);
 
         replayed.Should().ContainSingle();
         replayed[0].Text.Should().Be("it's sunny");
@@ -243,7 +243,7 @@ public sealed class ConversationMessageMappingTests
             new(Guid.NewGuid(), MessageRole.System, "be nice", DateTimeOffset.UtcNow),
         };
 
-        var replayed = ConversationMessageMapping.ToChatMessages(transcript);
+        var replayed = ConversationMessageMapping.ToChatMessages(transcript, replayToolCalls: true, maxReplayedChars: int.MaxValue);
 
         replayed.Should().HaveCount(3);
         replayed.SelectMany(m => m.Contents).Should().AllBeOfType<TextContent>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageTests.cs
@@ -1,0 +1,105 @@
+using Application.AI.Common.Models.Conversations;
+using FluentAssertions;
+
+namespace Application.AI.Common.Tests.Models.Conversations;
+
+/// <summary>
+/// Pins <see cref="ConversationMessage.ToolCalls"/>' empty-to-null normalization across every way a
+/// value can reach it (#510).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The guarantee is load-bearing, not cosmetic. Two call sites cite it as their reason for not
+/// normalizing themselves — <c>ConversationEntityMapper.ToEntity</c> and
+/// <c>EfCoreConversationStore.GetHistoryForDispatch</c>'s dispatch-window filter — because an empty
+/// non-null list serializes to a non-null <c>"[]"</c> column that filter would read as "this row is
+/// model-relevant," admitting an empty-content widget row into the prompt window.
+/// </para>
+/// <para>
+/// The <c>with</c>-expression case is the one that was actually broken: a property <em>initializer</em>
+/// runs only in the primary constructor, and a record's compiler-generated copy constructor copies
+/// backing fields directly without re-running it. The fix moved the normalization into the property's
+/// <c>init</c> accessor, which every assignment path goes through.
+/// </para>
+/// <para>
+/// <see cref="Construction_NonEmptyList_IsPreserved"/> is not padding either: the fix depends on the
+/// backing field's initializer binding to the primary constructor <em>parameter</em> rather than to the
+/// property of the same name. Binding the other way would compile and silently null every tool-call
+/// list in the system, so it is pinned rather than assumed.
+/// </para>
+/// </remarks>
+public sealed class ConversationMessageTests
+{
+    private static ToolCallRecord AnyCall() => new("file_read", "{}", "ok", DurationMs: 0);
+
+    private static ConversationMessage Message(IReadOnlyList<ToolCallRecord>? toolCalls) =>
+        new(Guid.NewGuid(), MessageRole.Assistant, "text", DateTimeOffset.UtcNow, toolCalls);
+
+    [Fact]
+    public void Construction_NonEmptyList_IsPreserved()
+    {
+        var call = AnyCall();
+
+        Message([call]).ToolCalls.Should().ContainSingle().Which.Should().BeSameAs(call);
+    }
+
+    [Fact]
+    public void Construction_EmptyList_NormalizesToNull()
+    {
+        Message([]).ToolCalls.Should().BeNull();
+    }
+
+    [Fact]
+    public void Construction_Null_StaysNull()
+    {
+        Message(null).ToolCalls.Should().BeNull();
+    }
+
+    [Fact]
+    public void WithExpression_EmptyList_NormalizesToNull()
+    {
+        var original = Message([AnyCall()]);
+
+        var copied = original with { ToolCalls = [] };
+
+        copied.ToolCalls.Should().BeNull(
+            "a 'with' expression assigns through the init accessor, which must normalize the same way " +
+            "the primary constructor does — otherwise the empty list serializes to a non-null \"[]\" " +
+            "column that the dispatch-window filter reads as a model-relevant row");
+    }
+
+    [Fact]
+    public void WithExpression_NonEmptyList_IsPreserved()
+    {
+        var replacement = AnyCall();
+
+        var copied = Message(null) with { ToolCalls = [replacement] };
+
+        copied.ToolCalls.Should().ContainSingle().Which.Should().BeSameAs(replacement);
+    }
+
+    [Fact]
+    public void WithExpression_UnrelatedProperty_CarriesToolCallsThrough()
+    {
+        var call = AnyCall();
+        var original = Message([call]);
+
+        var copied = original with { Content = "edited" };
+
+        copied.ToolCalls.Should().ContainSingle().Which.Should().BeSameAs(call,
+            "the copy constructor copies the backing field, so a copy that doesn't touch ToolCalls " +
+            "must keep them");
+    }
+
+    [Fact]
+    public void ObjectInitializer_EmptyList_NormalizesToNull()
+    {
+        var message = new ConversationMessage(
+            Guid.NewGuid(), MessageRole.Assistant, "text", DateTimeOffset.UtcNow)
+        {
+            ToolCalls = [],
+        };
+
+        message.ToolCalls.Should().BeNull();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ReplayedToolCallSetTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ReplayedToolCallSetTests.cs
@@ -1,0 +1,156 @@
+using Application.AI.Common.Services;
+using FluentAssertions;
+
+namespace Application.AI.Common.Tests.Services;
+
+/// <summary>
+/// Tests for <see cref="ReplayedToolCallSet"/> (#509).
+/// </summary>
+/// <remarks>
+/// The invariant that matters is <em>exactly-once claiming under concurrency</em>, not merely that the
+/// underlying collection survives being touched by two threads. The set exists so
+/// <c>ToolDiagnosticsMiddleware</c> records each tool result once; if two concurrent callers could both
+/// be told they were first, the middleware would write the duplicate trace record the set exists to
+/// prevent — which a lock around a separate <c>Contains</c> and <c>Add</c> would not have stopped.
+/// </remarks>
+public sealed class ReplayedToolCallSetTests
+{
+    [Fact]
+    public void TryClaim_UnknownId_ReturnsTrueAndBecomesKnown()
+    {
+        var set = new ReplayedToolCallSet();
+
+        set.TryClaim("call-1").Should().BeTrue();
+        set.Contains("call-1").Should().BeTrue();
+        set.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryClaim_SameIdTwice_SecondCallerIsRefused()
+    {
+        var set = new ReplayedToolCallSet();
+
+        set.TryClaim("call-1").Should().BeTrue();
+        set.TryClaim("call-1").Should().BeFalse();
+        set.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void TryClaim_IdSeededFromReplayedHistory_IsRefused()
+    {
+        var set = new ReplayedToolCallSet(["call-1", "call-2"]);
+
+        set.TryClaim("call-1").Should().BeFalse();
+        set.TryClaim("call-3").Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void TryClaim_EmptyId_IsNeverClaimable(string? callId)
+    {
+        var set = new ReplayedToolCallSet();
+
+        set.TryClaim(callId).Should().BeFalse(
+            "a result with no id cannot be deduplicated, so the caller — not this type — decides what " +
+            "to do with it");
+        set.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Constructor_SeedWithEmptyAndDuplicateEntries_AbsorbsThem()
+    {
+        var set = new ReplayedToolCallSet(["call-1", "call-1", "", "call-2"]);
+
+        set.Count.Should().Be(2,
+            "the seed comes from persisted conversation rows, whose shape the seeding code does not " +
+            "control");
+    }
+
+    [Fact]
+    public void Contains_IsOrdinal_SoCasingDistinguishesIds()
+    {
+        var set = new ReplayedToolCallSet(["Call-1"]);
+
+        set.Contains("call-1").Should().BeFalse(
+            "a call id is an opaque provider token; case-insensitive matching would collapse two " +
+            "genuinely distinct ids");
+        set.TryClaim("call-1").Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryClaim_ManyThreadsRacingOnOneId_ExactlyOneWins()
+    {
+        // The defect this closes: two tools driving the same middleware pipeline concurrently share one
+        // set by reference (the chat client is built with AllowConcurrentInvocation = true). A separate
+        // Contains-then-Add — even with each half individually locked — lets both read "absent," both
+        // add, and both record the same tool result.
+        //
+        // A Barrier repeated over many rounds, rather than one thread-start stampede: the window a
+        // check-then-act leaves open is nanoseconds wide, and starting N threads once almost never
+        // lands inside it — a version of this test built that way passed against a deliberately
+        // check-then-act implementation three runs in a row, proving nothing. The barrier releases
+        // every thread within the same scheduling quantum, and doing that thousands of times turns a
+        // rare interleaving into a near-certain one.
+        const int racers = 8;
+        const int rounds = 5000;
+
+        var set = new ReplayedToolCallSet();
+        var ids = Enumerable.Range(0, rounds).Select(r => $"contended-{r}").ToArray();
+        var winsPerThread = new int[racers];
+        using var barrier = new Barrier(racers);
+
+        var threads = Enumerable.Range(0, racers)
+            .Select(index => new Thread(() =>
+            {
+                for (var round = 0; round < rounds; round++)
+                {
+                    barrier.SignalAndWait();
+                    if (set.TryClaim(ids[round]))
+                        winsPerThread[index]++;
+                }
+            }))
+            .ToList();
+
+        foreach (var thread in threads)
+            thread.Start();
+
+        foreach (var thread in threads)
+            thread.Join();
+
+        winsPerThread.Sum().Should().Be(rounds,
+            "exactly one caller per id may be told it is the first to claim it — no more, no fewer");
+        set.Count.Should().Be(rounds);
+    }
+
+    [Fact]
+    public void TryClaim_ManyThreadsClaimingDistinctIds_AllSucceedAndNoneAreLost()
+    {
+        // The other half of the hazard: HashSet<T> is not thread-safe, so concurrent Add calls can lose
+        // an update or corrupt a bucket chain outright. Distinct ids means every claim must succeed.
+        const int racers = 64;
+        var set = new ReplayedToolCallSet();
+        var winners = 0;
+        using var startGate = new ManualResetEventSlim(false);
+
+        var threads = Enumerable.Range(0, racers)
+            .Select(i => new Thread(() =>
+            {
+                startGate.Wait();
+                if (set.TryClaim($"call-{i}"))
+                    Interlocked.Increment(ref winners);
+            }))
+            .ToList();
+
+        foreach (var thread in threads)
+            thread.Start();
+
+        startGate.Set();
+
+        foreach (var thread in threads)
+            thread.Join();
+
+        winners.Should().Be(racers);
+        set.Count.Should().Be(racers);
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -126,6 +126,10 @@ public class AgentPipelineIntegrationTests
             .Setup(t => t.Treat(It.IsAny<string>(), It.IsAny<string?>()))
             .Returns((string rawText, string? _) => rawText);
         toolCallReplayTreatmentMock.Setup(t => t.NoResultPlaceholder).Returns("[no result recorded]");
+        // Explicit, because an unconfigured Moq int property returns 0 — and a zero limit here is not
+        // "no limit", it drops every tool call.
+        toolCallReplayTreatmentMock.Setup(t => t.MaxCallsPerTurn).Returns(32);
+        toolCallReplayTreatmentMock.Setup(t => t.MaxReplayedChars).Returns(65536);
         services.AddScoped(_ => toolCallReplayTreatmentMock.Object);
 
         // The REAL admission chain over the five permissive gates above, not a mock of it, built the

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -242,6 +242,61 @@ public class ExecuteAgentTurnCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_TurnExceedsMaxCallsPerTurn_PersistsOnlyTheEarliestAndTreatsNoMore()
+    {
+        // Arrange — #508's write side. Nothing upstream bounds how many tool calls one turn can make:
+        // the framework's per-request iteration limit caps tool-calling ROUNDS, while the chat client
+        // permits concurrent invocation, so a single round's parallel calls are unbounded. Six calls
+        // against a cap of two.
+        var messages = new List<ChatMessage>();
+        for (var i = 0; i < 6; i++)
+        {
+            messages.Add(new ChatMessage(ChatRole.Assistant,
+                [new FunctionCallContent($"call-{i}", "search",
+                    new Dictionary<string, object?> { ["q"] = $"query-{i}" })]));
+            messages.Add(new ChatMessage(ChatRole.Tool,
+                [new FunctionResultContent($"call-{i}", $"result-{i}")]));
+        }
+        messages.Add(new ChatMessage(ChatRole.Assistant, "done"));
+
+        var agent = new TestableAIAgent(_ => new AgentResponse(messages));
+        _agentCache
+            .Setup(c => c.GetOrCreateAsync(
+                It.IsAny<string>(),
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<SkillAgentOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agent);
+
+        var cappedTreatment = new PassthroughToolCallReplayTreatment { MaxCallsPerTurn = 2 };
+        var handler = new ExecuteAgentTurnCommandHandler(
+            _agentCache.Object,
+            Mock.Of<Application.AI.Common.Interfaces.Governance.IToolCallAdmissionPipeline>(
+                p => p.GetTrace() == Domain.AI.Governance.GovernanceTrace.Empty),
+            _agentRegistry.Object,
+            new Mock<ISkillMetadataRegistry>().Object,
+            new Application.AI.Common.Services.Context.ConversationRegistrationTracker(),
+            new Mock<IObservabilityStore>().Object,
+            Mock.Of<ILlmUsageCapture>(c => c.TakeSnapshot() == new LlmUsageSnapshot(0, 0, 0, 0, null, 0m, 0m, Array.Empty<string>())),
+            new DefaultContextSnapshotComputer(),
+            new NullContextSnapshotNotifier(),
+            TimeProvider.System,
+            NullLogger<ExecuteAgentTurnCommandHandler>.Instance,
+            cappedTreatment);
+
+        // Act
+        var result = await handler.Handle(CreateCommand(), CancellationToken.None);
+
+        // Assert — the turn still succeeds and still narrates its answer; only the surplus structured
+        // tool-call memory is dropped, earliest kept, so the turn's own prose still refers to records
+        // that are present.
+        result.Success.Should().BeTrue();
+        result.Response.Should().Be("done");
+        result.ToolCalls.Should().HaveCount(2);
+        result.ToolCalls.Select(c => c.CallId).Should().Equal(["call-0", "call-1"]);
+    }
+
+    [Fact]
     public async Task Handle_ActiveStreamSink_StreamsDeltasAndReturnsConcatenatedText()
     {
         // Arrange — multi-chunk streaming agent + an attached sink.

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandlerTests.cs
@@ -242,7 +242,7 @@ public class ExecuteAgentTurnCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_TurnExceedsMaxCallsPerTurn_PersistsOnlyTheEarliestAndTreatsNoMore()
+    public async Task Handle_TurnExceedsMaxCallsPerTurn_PersistsOnlyTheNewestAndTreatsNoMore()
     {
         // Arrange — #508's write side. Nothing upstream bounds how many tool calls one turn can make:
         // the framework's per-request iteration limit caps tool-calling ROUNDS, while the chat client
@@ -288,12 +288,15 @@ public class ExecuteAgentTurnCommandHandlerTests
         var result = await handler.Handle(CreateCommand(), CancellationToken.None);
 
         // Assert — the turn still succeeds and still narrates its answer; only the surplus structured
-        // tool-call memory is dropped, earliest kept, so the turn's own prose still refers to records
-        // that are present.
+        // tool-call memory is dropped. NEWEST kept, matching the direction ConversationMessageMapping's
+        // read-side budget trims from: the two halves of one policy must cut from the same end, or they
+        // compose into a middle slice that is neither the turn's opening reasoning nor its conclusions.
+        // Newest is the shared direction because this is a memory rather than an audit log — the prose
+        // persisted beside these records summarizes what the agent last found.
         result.Success.Should().BeTrue();
         result.Response.Should().Be("done");
         result.ToolCalls.Should().HaveCount(2);
-        result.ToolCalls.Select(c => c.CallId).Should().Equal(["call-0", "call-1"]);
+        result.ToolCalls.Select(c => c.CallId).Should().Equal(["call-4", "call-5"]);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerSolutionReviewFixTests.cs
@@ -62,7 +62,10 @@ public class RunConversationCommandHandlerSolutionReviewFixTests
             Options.Create(new ConversationsConfig()),
             // Never read: these tests run only the self-contained path, which never opens a
             // DurableTranscript (the only consumer of Enabled).
-            new Mock<IToolCallReplayTreatment>().Object,
+            // See RunConversationCommandHandlerTests: the limits are stubbed even though replay is off
+            // here, so an unconfigured Moq zero can never masquerade as "unlimited".
+            Mock.Of<IToolCallReplayTreatment>(t =>
+                t.MaxCallsPerTurn == 32 && t.MaxReplayedChars == 65536),
             NullLogger<RunConversationCommandHandler>.Instance);
     }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationCommandHandlerTests.cs
@@ -48,7 +48,11 @@ public class RunConversationCommandHandlerTests
             Options.Create(new ConversationsConfig()),
             // Never read: these tests run only the self-contained path, which never opens a
             // DurableTranscript (the only consumer of Enabled).
-            new Mock<IToolCallReplayTreatment>().Object,
+            // Replay is off here (Enabled defaults to false on an unconfigured mock) so the limits do
+            // not bite, but they are stubbed anyway: a later test flipping Enabled on would otherwise
+            // get a silent zero budget and see no tool calls replayed at all.
+            Mock.Of<IToolCallReplayTreatment>(t =>
+                t.MaxCallsPerTurn == 32 && t.MaxReplayedChars == 65536),
             NullLogger<RunConversationCommandHandler>.Instance);
     }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/RunConversationDurableTests.cs
@@ -81,7 +81,10 @@ public sealed class RunConversationDurableTests
             _store,
             _lease,
             Options.Create(new ConversationsConfig { MaxHistoryMessages = maxHistoryMessages }),
-            Mock.Of<IToolCallReplayTreatment>(t => t.Enabled == true),
+            // The two limits are stubbed explicitly: an unconfigured Moq int property returns 0, and a
+            // zero limit drops every replayed tool call rather than meaning "unlimited".
+            Mock.Of<IToolCallReplayTreatment>(t =>
+                t.Enabled == true && t.MaxCallsPerTurn == 32 && t.MaxReplayedChars == 65536),
             NullLogger<RunConversationCommandHandler>.Instance);
 
     private static RunConversationCommand SelfContained(params string[] messages) => new()

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ToolCallReplayTrimDirectionCompositionTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ToolCallReplayTrimDirectionCompositionTests.cs
@@ -31,15 +31,26 @@ namespace Application.Core.Tests.CQRS;
 public sealed class ToolCallReplayTrimDirectionCompositionTests
 {
     private const int CostPerCall = 100;
+    private const string ToolName = "search";
 
-    private static ToolCallRecord Call(int ordinal) =>
-        new(
-            "search",
-            new string('i', CostPerCall / 2),
-            new string('o', CostPerCall / 2),
+    /// <summary>
+    /// A call whose <em>total</em> budget cost is exactly <see cref="CostPerCall"/>, so the budgets
+    /// below can be expressed as a plain multiple of it. The payload is sized down by the tool name and
+    /// call id, which count against the budget too.
+    /// </summary>
+    private static ToolCallRecord Call(int ordinal)
+    {
+        var callId = $"call-{ordinal}";
+        var payload = CostPerCall - ToolName.Length - callId.Length;
+
+        return new ToolCallRecord(
+            ToolName,
+            new string('i', payload / 2),
+            new string('o', payload - (payload / 2)),
             DurationMs: 0,
-            CallId: $"call-{ordinal}",
+            CallId: callId,
             RoundOrdinal: ordinal);
+    }
 
     /// <summary>Mirrors <c>BuildTreatedToolCallRecords</c>' cap: keep the newest N by round ordinal.</summary>
     private static IReadOnlyList<ToolCallRecord> ApplyWriteSideCap(

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ToolCallReplayTrimDirectionCompositionTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ToolCallReplayTrimDirectionCompositionTests.cs
@@ -1,0 +1,117 @@
+using Application.AI.Common.Models.Conversations;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Application.Core.Tests.CQRS;
+
+/// <summary>
+/// Pins the one property neither half of the tool-call replay bound can prove on its own: that the
+/// write-side per-turn cap and the read-side window budget trim from the <em>same</em> end, so the two
+/// compose into a contiguous newest tail rather than a middle slice (#508).
+/// </summary>
+/// <remarks>
+/// <para>
+/// This test exists because the invariant was created and violated inside a single working session.
+/// The write cap originally kept the earliest calls while the read budget kept the newest, each with a
+/// comment justifying its own direction, and both halves had green tests — because each test only ever
+/// exercised its own half. Composed, they produced a slice from the middle of a turn: neither the
+/// reasoning that opened it nor the conclusions that closed it, while the assistant prose persisted
+/// alongside referred to results that were no longer there.
+/// </para>
+/// <para>
+/// Deliberately reproduces the write side by construction rather than by driving the real handler: the
+/// handler needs an agent, an admission pipeline and a usage capture wired up, none of which bear on
+/// the question here. What matters is that the two trims are applied in sequence, the way production
+/// applies them — persistence first, then replay — and that the survivors are a suffix of what the turn
+/// actually did. <c>ExecuteAgentTurnCommandHandlerTests</c> pins that the handler really does trim this
+/// direction; this pins what that direction composes to.
+/// </para>
+/// </remarks>
+public sealed class ToolCallReplayTrimDirectionCompositionTests
+{
+    private const int CostPerCall = 100;
+
+    private static ToolCallRecord Call(int ordinal) =>
+        new(
+            "search",
+            new string('i', CostPerCall / 2),
+            new string('o', CostPerCall / 2),
+            DurationMs: 0,
+            CallId: $"call-{ordinal}",
+            RoundOrdinal: ordinal);
+
+    /// <summary>Mirrors <c>BuildTreatedToolCallRecords</c>' cap: keep the newest N by round ordinal.</summary>
+    private static IReadOnlyList<ToolCallRecord> ApplyWriteSideCap(
+        IReadOnlyList<ToolCallRecord> calls, int maxCallsPerTurn) =>
+        calls.Count <= maxCallsPerTurn
+            ? calls
+            : calls.OrderBy(c => c.RoundOrdinal).TakeLast(maxCallsPerTurn).ToList();
+
+    private static IReadOnlyList<string> ReplayedCallIds(IReadOnlyList<ChatMessage> replayed) =>
+        replayed
+            .SelectMany(m => m.Contents)
+            .OfType<FunctionCallContent>()
+            .Select(c => c.CallId)
+            .ToList();
+
+    [Fact]
+    public void WriteCapThenReadBudget_SurvivorsAreAContiguousNewestTailOfTheOriginalTurn()
+    {
+        // A turn makes 10 calls. The write cap persists 6. The read budget then affords 3.
+        var allCalls = Enumerable.Range(0, 10).Select(Call).ToList();
+
+        var persisted = ApplyWriteSideCap(allCalls, maxCallsPerTurn: 6);
+        persisted.Select(c => c.CallId).Should().Equal(
+            ["call-4", "call-5", "call-6", "call-7", "call-8", "call-9"],
+            "the write cap keeps the newest calls the turn made");
+
+        var transcript = new List<ConversationMessage>
+        {
+            new(Guid.NewGuid(), MessageRole.Assistant, "done", DateTimeOffset.UtcNow, ToolCalls: persisted),
+        };
+
+        var replayed = ConversationMessageMapping.ToChatMessages(
+            transcript, replayToolCalls: true, maxReplayedChars: 3 * CostPerCall);
+
+        ReplayedCallIds(replayed).Should().Equal(
+            ["call-7", "call-8", "call-9"],
+            "trimming the same end twice leaves a suffix of the original turn — the composition a " +
+            "middle slice would not be");
+    }
+
+    [Fact]
+    public void WriteCapThenReadBudget_SurvivorsAreNeverDiscontiguous()
+    {
+        // The property stated generally, across every pairing of the two limits: whatever survives must
+        // be a CONTIGUOUS run ending at the turn's last call. A middle slice — the failure this guards —
+        // would satisfy neither clause.
+        var allCalls = Enumerable.Range(0, 10).Select(Call).ToList();
+
+        for (var cap = 1; cap <= 10; cap++)
+        {
+            for (var affordable = 1; affordable <= 10; affordable++)
+            {
+                var persisted = ApplyWriteSideCap(allCalls, cap);
+                var transcript = new List<ConversationMessage>
+                {
+                    new(Guid.NewGuid(), MessageRole.Assistant, "done", DateTimeOffset.UtcNow,
+                        ToolCalls: persisted),
+                };
+
+                var survivors = ReplayedCallIds(ConversationMessageMapping.ToChatMessages(
+                    transcript, replayToolCalls: true, maxReplayedChars: affordable * CostPerCall));
+
+                var expectedCount = Math.Min(cap, affordable);
+                var expected = allCalls
+                    .TakeLast(expectedCount)
+                    .Select(c => c.CallId)
+                    .ToList();
+
+                survivors.Should().Equal(expected,
+                    $"cap={cap}, affordable={affordable}: the survivors must be the newest " +
+                    $"{expectedCount} calls of the turn, contiguous and ending at the last one");
+            }
+        }
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Fakes/PassthroughToolCallReplayTreatment.cs
+++ b/src/Content/Tests/Application.Core.Tests/Fakes/PassthroughToolCallReplayTreatment.cs
@@ -12,6 +12,18 @@ internal sealed class PassthroughToolCallReplayTreatment : IToolCallReplayTreatm
 {
     public bool Enabled => true;
 
+    /// <summary>
+    /// Settable so a test about the per-turn cap can tighten it. Defaults to the same 32 the real
+    /// config does, so every test that is not about the cap sees production behaviour.
+    /// </summary>
+    public int MaxCallsPerTurn { get; set; } = 32;
+
+    /// <summary>
+    /// Settable for the same reason as <see cref="MaxCallsPerTurn"/>, defaulting to the config's own
+    /// 65536.
+    /// </summary>
+    public int MaxReplayedChars { get; set; } = 65536;
+
     public string NoResultPlaceholder => "[no result recorded]";
 
     public string Treat(string rawText, string? toolName) => rawText;

--- a/src/Content/Tests/Application.Core.Tests/Validation/ToolCallReplayConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/ToolCallReplayConfigValidatorTests.cs
@@ -35,8 +35,45 @@ public sealed class ToolCallReplayConfigValidatorTests
     [Fact]
     public async Task Validate_MaxVerbatimCharsAtWithholdCeiling_IsValid()
     {
-        var result = await _validator.ValidateAsync(
-            new ToolCallReplayConfig { MaxVerbatimChars = ToolCallReplayTreatment.WithholdCeilingChars });
+        // MaxReplayedChars has to move with it. A per-payload ceiling this high means one call can cost
+        // twice it, and a window budget smaller than a single call empties the entire replayed history
+        // rather than dropping just that call — which is what the cross-field rule below refuses.
+        var result = await _validator.ValidateAsync(new ToolCallReplayConfig
+        {
+            MaxVerbatimChars = ToolCallReplayTreatment.WithholdCeilingChars,
+            MaxReplayedChars = ToolCallReplayTreatment.WithholdCeilingChars * 2,
+        });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_WindowBudgetSmallerThanOneMaximumSizeCall_HasError()
+    {
+        // The plausible operator mistake this rule exists for: raise the per-payload ceiling for a
+        // large-context model, leave the window budget at its default. One 40k-char tool result then
+        // silently drops EVERY replayed tool call behind it — the budget admits newest-first and
+        // latches shut at the first call that does not fit — so the conversation loses its whole tool
+        // memory with only a per-turn warning. A startup error beats silent amnesia.
+        var result = await _validator.ValidateAsync(new ToolCallReplayConfig
+        {
+            MaxVerbatimChars = 40000,
+            MaxReplayedChars = 65536,
+        });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "MaxReplayedChars");
+    }
+
+    [Fact]
+    public async Task Validate_WindowBudgetExactlyOneMaximumSizeCall_IsValid()
+    {
+        // The boundary the rule draws: exactly one full-size call must fit, and does.
+        var result = await _validator.ValidateAsync(new ToolCallReplayConfig
+        {
+            MaxVerbatimChars = 20000,
+            MaxReplayedChars = 40000,
+        });
 
         result.IsValid.Should().BeTrue();
     }

--- a/src/Content/Tests/Application.Core.Tests/Validation/ToolCallReplayConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/ToolCallReplayConfigValidatorTests.cs
@@ -61,6 +61,50 @@ public sealed class ToolCallReplayConfigValidatorTests
     }
 
     [Fact]
+    public async Task Validate_MaxCallsPerTurnNegative_HasError()
+    {
+        // A negative "limit" read by a caller taking the first N would disable the bound rather than
+        // tighten it — the opposite of what a limit is for (#508).
+        var result = await _validator.ValidateAsync(new ToolCallReplayConfig { MaxCallsPerTurn = -1 });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "MaxCallsPerTurn");
+    }
+
+    [Fact]
+    public async Task Validate_MaxReplayedCharsNegative_HasError()
+    {
+        var result = await _validator.ValidateAsync(new ToolCallReplayConfig { MaxReplayedChars = -1 });
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "MaxReplayedChars");
+    }
+
+    [Fact]
+    public async Task Validate_LargeCostCeilings_AreAllowed()
+    {
+        // Unlike MaxVerbatimChars these are cost ceilings, not security ones — every payload they
+        // count has already been sanitized, redacted and individually size-capped, so a deployment on
+        // a very large context window may legitimately raise them.
+        var result = await _validator.ValidateAsync(
+            new ToolCallReplayConfig { MaxCallsPerTurn = 4096, MaxReplayedChars = 8_000_000 });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void DefaultCostCeilings_AreBoundedAndNonZero()
+    {
+        // Regression guard for the defaults themselves: shipping either at 0 would silently disable
+        // tool-call replay for every consumer of this template, and shipping either unbounded would
+        // reintroduce the very gap #508 closed.
+        var config = new ToolCallReplayConfig();
+
+        config.MaxCallsPerTurn.Should().BeInRange(1, 1024);
+        config.MaxReplayedChars.Should().BeInRange(1, 1_048_576);
+    }
+
+    [Fact]
     public void DefaultValue_IsWellUnderTheWithholdCeiling()
     {
         // Regression guard for the default itself, not just the validator: if a future edit raises

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationStoreContractTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/ConversationStoreContractTests.cs
@@ -1040,6 +1040,33 @@ public abstract class ConversationStoreContractTests
         history[1].ToolCalls.Should().ContainSingle().Which.CallId.Should().Be("call-1");
     }
 
+    [Fact]
+    public async Task GetHistoryForDispatch_ExcludesEmptyContentRowWithAnEmptyToolCallList()
+    {
+        // #510. An empty-but-non-null tool-call list is not tool activity — it is a widget-only row
+        // wearing the wrong shape. ConversationMessage normalizes an empty list to null however it
+        // arrives, so the DTO should never carry one here; this pins the behaviour at the STORE, which
+        // is what actually decides model-relevance, and which for the EF-backed store reads a
+        // serialized "[]" column rather than the DTO. Both stores must agree, or a conversation's
+        // replayed window differs by which backend a deployment happens to run.
+        var record = await Store.CreateAsync("agent", Owner);
+        await Store.AppendMessageAsync(record.Id, Owner, UserMessage("real question"));
+        await Store.AppendMessageAsync(
+            record.Id,
+            Owner,
+            new ConversationMessage(
+                Guid.NewGuid(), MessageRole.Assistant, string.Empty, DateTimeOffset.UtcNow,
+                ToolCalls: [],
+                Widget: new WidgetSpec("render_table", JsonDocument.Parse("{}").RootElement)));
+        await Store.AppendMessageAsync(record.Id, Owner, AssistantMessage("real answer"));
+
+        var history = await Store.GetHistoryForDispatch(record.Id, Owner, maxMessages: 10);
+
+        history!.Select(m => m.Content).Should().Equal(
+            ["real question", "real answer"],
+            "a row with no text and no actual tool calls carries nothing the model can read");
+    }
+
     // -- Helpers --
 
     /// <summary>Builds a user message with a fresh id and the current timestamp.</summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/DurableConversationContinuityTests.cs
@@ -335,6 +335,11 @@ public sealed class DurableConversationContinuityTests : IDisposable
 
         var toolCallReplayTreatment = new Mock<IToolCallReplayTreatment>();
         toolCallReplayTreatment.Setup(t => t.Enabled).Returns(replayToolCallsEnabled);
+        // Both limits must be stubbed explicitly. An unconfigured Moq int property returns 0, and a
+        // zero budget drops every replayed tool call — which would silently turn this whole file's
+        // subject off while every assertion about it still looked like it was being exercised.
+        toolCallReplayTreatment.Setup(t => t.MaxCallsPerTurn).Returns(32);
+        toolCallReplayTreatment.Setup(t => t.MaxReplayedChars).Returns(65536);
 
         return new RunConversationCommandHandler(
             mediator.Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/EfCoreConversationStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/EfCoreConversationStoreTests.cs
@@ -1,7 +1,9 @@
 using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Models.Conversations;
 using FluentAssertions;
 using Infrastructure.AI.Conversations;
 using Infrastructure.AI.Persistence;
+using Infrastructure.AI.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
@@ -142,6 +144,43 @@ public sealed class EfCoreConversationStoreTests : ConversationStoreContractTest
 
         Convert.ToString(command.ExecuteScalar())
             .Should().BeEquivalentTo("wal");
+    }
+
+    [Fact]
+    public async Task GetHistoryForDispatch_LegacyRowWithLiteralEmptyToolCallsJson_IsExcluded()
+    {
+        // #510's other half, and the only test that actually exercises it. ConversationMessage now
+        // normalizes an empty tool-call list to null however it arrives, so nothing writes "[]" through
+        // the DTO any more — which means a DTO-level test cannot reach this filter at all. The rows
+        // that matter are ones persisted while the `with`-expression hole was open, so this writes the
+        // column directly, the way those rows exist in a real deployment's database today.
+        //
+        // Without the != "[]" clause this row reads as model-relevant, and an empty-content widget row
+        // is admitted into the prompt window — the row the file-backed store's DTO-level filter drops,
+        // making a conversation's replayed history differ by which backend a deployment happens to run.
+        var record = await Store.CreateAsync("agent", Owner);
+        await Store.AppendMessageAsync(record.Id, Owner, UserMessage("real question"));
+        await Store.AppendMessageAsync(record.Id, Owner, AssistantMessage("real answer"));
+
+        await using (var context = _contextFactory.CreateDbContext())
+        {
+            context.ConversationMessages.Add(new ConversationMessageEntity
+            {
+                ConversationId = record.Id,
+                MessageId = Guid.NewGuid(),
+                Role = MessageRole.Assistant,
+                Content = string.Empty,
+                Timestamp = Clock.GetUtcNow(),
+                ToolCallsJson = "[]",
+            });
+            await context.SaveChangesAsync();
+        }
+
+        var history = await Store.GetHistoryForDispatch(record.Id, Owner, maxMessages: 10);
+
+        history!.Select(m => m.Content).Should().Equal(
+            ["real question", "real answer"],
+            "a literal \"[]\" column is an empty list, not tool activity");
     }
 
     private EfCoreConversationStore BuildStore() =>

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
@@ -444,7 +444,10 @@ public sealed class AgUiRunHandlerTests
             turnLease ?? new InProcessConversationTurnLease(),
             new AgUiEventWriterAccessor(),
             budget.Object,
-            Mock.Of<IToolCallReplayTreatment>(t => t.Enabled == true),
+            // The two limits are stubbed explicitly: an unconfigured Moq int property returns 0, and a
+            // zero limit drops every replayed tool call rather than meaning "unlimited".
+            Mock.Of<IToolCallReplayTreatment>(t =>
+                t.Enabled == true && t.MaxCallsPerTurn == 32 && t.MaxReplayedChars == 65536),
             environment.Object,
             logger ?? NullLogger<AgUiRunHandler>.Instance);
     }

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -53,6 +53,10 @@ public class ConversationOrchestratorTests
 
         // Enabled by default — most tests don't exercise the tool-call replay kill switch.
         _toolCallReplayTreatment.Setup(t => t.Enabled).Returns(true);
+        // Explicit, because an unconfigured Moq int property returns 0 — and a zero limit is not "no
+        // limit", it drops every replayed tool call.
+        _toolCallReplayTreatment.Setup(t => t.MaxCallsPerTurn).Returns(32);
+        _toolCallReplayTreatment.Setup(t => t.MaxReplayedChars).Returns(65536);
     }
 
     private ConversationOrchestrator CreateOrchestrator(string environmentName = "Development")

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -245,6 +245,117 @@ public sealed class SecurityControlHasACallerTests
     }
 
     /// <summary>
+    /// Every <c>*ConfigValidator</c> must be bound into the options pipeline, because a validator that
+    /// nothing binds runs nowhere and enforces nothing.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>The defect this exists to catch, in the shape it actually shipped.</strong>
+    /// <c>ToolCallReplayConfigValidator</c> was written, fully unit-tested, and documented in three
+    /// separate XML comments as the startup enforcement for two bounds — one of them the
+    /// confidentiality ceiling above which structural secret redaction stops being trustworthy. It was
+    /// never added to <c>RegisterValidatedConfigSections</c>, so none of its rules ever ran in any
+    /// host. Its own doc comment said "auto-discovered via <c>AddValidatorsFromAssembly</c> — no manual
+    /// registration required", which is true of the DI registration and irrelevant to whether anything
+    /// resolves it: nothing validates a config POCO unless an <c>AddOptions</c> chain asks it to.
+    /// </para>
+    /// <para>
+    /// <strong>Why the existing guards missed it.</strong> The validator's own tests pass — they
+    /// construct it directly. <c>ValidateOnBuildSweepTests</c> passes — an unregistered validator
+    /// breaks no service graph. The interface scan above passes — a validator implements no guarded
+    /// contract. Every signal available said the control was fine, because each one measured something
+    /// other than "does this ever run in a host".
+    /// </para>
+    /// <para>
+    /// Written over every validator rather than the one that broke, so the next config class cannot
+    /// land unregistered either — the specific fix would have left the mechanism just as forgettable.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void EveryConfigValidator_IsBoundIntoTheOptionsPipeline()
+    {
+        var contentRoot = Path.Combine(RepoRoot.Path, "src", "Content");
+
+        var validatorNames = Directory
+            .EnumerateFiles(contentRoot, "*ConfigValidator.cs", SearchOption.AllDirectories)
+            .Where(f => !SourceScan.IsExcluded(f, contentRoot))
+            .Where(f => !f.Contains(Path.DirectorySeparatorChar + "Tests" + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Select(n => n!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        // Control: a scan that found no validators would pass while reading nothing — the blind-guard
+        // failure this file's own remarks warn about.
+        validatorNames.Should().NotBeEmpty("the validators this reads must exist for its verdict to mean anything");
+
+        // The composition root is the only place an options binding can live, so its text is the
+        // authority on what actually runs. Read as source rather than resolved through DI because an
+        // unbound validator is still perfectly resolvable — that is precisely what made it invisible.
+        var compositionRoot = File.ReadAllText(Path.Combine(
+            contentRoot, "Presentation", "Presentation.Common", "Extensions", "IServiceCollectionExtensions.cs"));
+        var wiring = SourceScan.StripCommentsAndStrings(compositionRoot);
+
+        // Control: the needle must match a binding known to be present, or "no offenders" would be
+        // satisfied by a scan that cannot see any binding at all.
+        wiring.Should().Contain("GovernanceConfigValidator",
+            "control: a known-bound validator must be visible to this scan");
+
+        var unbound = validatorNames
+            .Where(name => !wiring.Contains(name, StringComparison.Ordinal))
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+
+        var unexpected = unbound.Except(KnownUnboundConfigValidators, StringComparer.Ordinal).ToArray();
+
+        unexpected.Should().BeEmpty(
+            "a config validator that no AddOptions chain binds never runs, however thoroughly it is "
+            + "tested and however confidently its doc comment says otherwise — AddValidatorsFromAssembly "
+            + "registers it for resolution, it does not cause anything to resolve it. Either bind it in "
+            + "RegisterValidatedConfigSections or delete it with the documentation claiming it enforces. "
+            + "Unbound: " + string.Join(", ", unexpected));
+
+        // The ratchet half: the allowlist may only ever shrink. Without this, working an entry off the
+        // list leaves a stale name that would silently re-admit a regression under the same type name.
+        KnownUnboundConfigValidators
+            .Except(unbound, StringComparer.Ordinal)
+            .Should().BeEmpty(
+                "these validators are now bound — remove them from KnownUnboundConfigValidators so the "
+                + "list keeps meaning 'known debt' rather than 'permanently excused'");
+    }
+
+    /// <summary>
+    /// Config validators that exist, are tested, and are bound nowhere — pre-existing debt this guard
+    /// found rather than caused. Tracked so the list can only shrink.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These are <strong>not</strong> exemptions in the sense this file's remarks forbid. Each is a
+    /// real instance of the same defect the test above describes, several with doc comments asserting
+    /// they refuse to boot on invalid config — which they do not, because nothing binds them. They are
+    /// listed rather than fixed here because binding a validator changes host behaviour: a deployment
+    /// whose configuration is already invalid stops booting. That is the correct outcome and it is a
+    /// per-subsystem change with its own verification, not something to bundle into an unrelated PR.
+    /// </para>
+    /// <para>
+    /// The entry that motivated this guard — <c>ToolCallReplayConfigValidator</c> — is deliberately
+    /// absent: it was bound in the same change, which is why the list is seven names and not eight.
+    /// </para>
+    /// </remarks>
+    private static readonly string[] KnownUnboundConfigValidators =
+    [
+        "AutonomyConfigValidator",
+        "ConditionalBranchConfigValidator",
+        "HumanGateConfigValidator",
+        "LlmCallConfigValidator",
+        "SubPlanConfigValidator",
+        "ToolAuthorizationConfigValidator",
+        "ToolUseConfigValidator",
+    ];
+
+    /// <summary>
     /// Finds every public interface declared under a guarded folder, returning its name and the file
     /// that declares it.
     /// </summary>

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -276,11 +276,20 @@ public sealed class SecurityControlHasACallerTests
     {
         var contentRoot = Path.Combine(RepoRoot.Path, "src", "Content");
 
+        // Only FluentValidation validators. A name ending in ConfigValidator is not enough: the repo
+        // also validates config from IHostedService implementations, which self-register through
+        // AddHostedService in their own subsystem and need no options binding at all. Matching on the
+        // name alone reported two live controls (ToolAuthorizationConfigValidator,
+        // AutonomyConfigValidator) as unbound debt — a guard against inert machinery that was itself
+        // producing false alarms, which is the fastest way to make one get ignored.
         var validatorNames = Directory
             .EnumerateFiles(contentRoot, "*ConfigValidator.cs", SearchOption.AllDirectories)
             .Where(f => !SourceScan.IsExcluded(f, contentRoot))
             .Where(f => !f.Contains(Path.DirectorySeparatorChar + "Tests" + Path.DirectorySeparatorChar,
                 StringComparison.OrdinalIgnoreCase))
+            .Where(f => Regex.IsMatch(
+                SourceScan.StripCommentsAndStrings(File.ReadAllText(f)),
+                @":\s*AbstractValidator\s*<"))
             .Select(Path.GetFileNameWithoutExtension)
             .Where(n => !string.IsNullOrEmpty(n))
             .Select(n => n!)
@@ -291,12 +300,29 @@ public sealed class SecurityControlHasACallerTests
         // failure this file's own remarks warn about.
         validatorNames.Should().NotBeEmpty("the validators this reads must exist for its verdict to mean anything");
 
-        // The composition root is the only place an options binding can live, so its text is the
-        // authority on what actually runs. Read as source rather than resolved through DI because an
-        // unbound validator is still perfectly resolvable — that is precisely what made it invisible.
-        var compositionRoot = File.ReadAllText(Path.Combine(
-            contentRoot, "Presentation", "Presentation.Common", "Extensions", "IServiceCollectionExtensions.cs"));
-        var wiring = SourceScan.StripCommentsAndStrings(compositionRoot);
+        // Control: the AbstractValidator filter must actually exclude the other shape, or it is doing
+        // nothing and the false alarms come straight back.
+        validatorNames.Should().NotContain("ToolAuthorizationConfigValidator",
+            "control: an IHostedService validator must not be treated as needing an options binding");
+
+        // Every DI file, not just the composition root: a binding is equally real in a subsystem's own
+        // DependencyInjection partial, and reading one file reported anything registered elsewhere as
+        // unbound. Source text rather than a resolved container, because an unbound validator is still
+        // perfectly resolvable — that is exactly what made the original defect invisible.
+        var wiringFiles = Directory
+            .EnumerateFiles(contentRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !SourceScan.IsExcluded(f, contentRoot))
+            .Where(f => !f.Contains(Path.DirectorySeparatorChar + "Tests" + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(f => Path.GetFileName(f).StartsWith("DependencyInjection", StringComparison.Ordinal)
+                || Path.GetFileName(f).Equals("IServiceCollectionExtensions.cs", StringComparison.Ordinal))
+            .ToArray();
+
+        wiringFiles.Should().NotBeEmpty("the wiring files this reads must exist for its verdict to mean anything");
+
+        var wiring = string.Join(
+            "\n",
+            wiringFiles.Select(f => SourceScan.StripCommentsAndStrings(File.ReadAllText(f))));
 
         // Control: the needle must match a binding known to be present, or "no offenders" would be
         // satisfied by a scan that cannot see any binding at all.
@@ -333,25 +359,32 @@ public sealed class SecurityControlHasACallerTests
     /// <remarks>
     /// <para>
     /// These are <strong>not</strong> exemptions in the sense this file's remarks forbid. Each is a
-    /// real instance of the same defect the test above describes, several with doc comments asserting
-    /// they refuse to boot on invalid config — which they do not, because nothing binds them. They are
-    /// listed rather than fixed here because binding a validator changes host behaviour: a deployment
-    /// whose configuration is already invalid stops booting. That is the correct outcome and it is a
-    /// per-subsystem change with its own verification, not something to bundle into an unrelated PR.
+    /// real instance of the same defect the test above describes. They are listed rather than fixed
+    /// here because binding a validator changes host behaviour: a deployment whose configuration is
+    /// already invalid stops booting. That is the correct outcome and it is a per-subsystem change with
+    /// its own verification, not something to bundle into an unrelated PR. Tracked as #514.
+    /// </para>
+    /// <para>
+    /// All five are the planner's step-config validators, and it is worth confirming per validator
+    /// whether each is meant to be bound directly or invoked as a child validator from a parent's
+    /// <c>SetValidator</c> — nothing references them at all today, so they are inert either way, but
+    /// the fix differs.
     /// </para>
     /// <para>
     /// The entry that motivated this guard — <c>ToolCallReplayConfigValidator</c> — is deliberately
-    /// absent: it was bound in the same change, which is why the list is seven names and not eight.
+    /// absent: it was bound in the same change. Two names that appeared in this list on its first
+    /// draft, <c>ToolAuthorizationConfigValidator</c> and <c>AutonomyConfigValidator</c>, are absent
+    /// for a different reason: they are <see cref="Microsoft.Extensions.Hosting.IHostedService"/>
+    /// startup validators registered in their own subsystems and were never in scope for this check.
+    /// The scan above now excludes that shape rather than relying on this list to remember it.
     /// </para>
     /// </remarks>
     private static readonly string[] KnownUnboundConfigValidators =
     [
-        "AutonomyConfigValidator",
         "ConditionalBranchConfigValidator",
         "HumanGateConfigValidator",
         "LlmCallConfigValidator",
         "SubPlanConfigValidator",
-        "ToolAuthorizationConfigValidator",
         "ToolUseConfigValidator",
     ];
 


### PR DESCRIPTION
Closes #508. Closes #509. Closes #510.

Three follow-ups filed against #511's tool-call replay feature — persisting an agent turn's tool calls and replaying them into the model's context on later turns. All three are small; the reviews that followed them were not, and the largest finding was pre-existing.

## The three issues

**#508 — replayed history had no ceiling.** The dispatch window is capped in *rows*, but one row expands into two chat messages per tool call it carries, so a tool-heavy conversation grew without bound in both storage and per-turn prompt cost. Adds a write-side per-turn call cap and, more importantly, a read-side character budget across the whole window. Only the read side can bound rows persisted before any cap existed. Admission latches shut at the first call that does not fit, so survivors are a contiguous newest tail rather than holes punched through history, and a call is always dropped as a whole call/result pair — a `tool_calls` entry with no matching result is a malformed conversation a provider rejects permanently.

**#509 — a shared set was mutated without synchronization.** The turn-scoped set of known tool-call ids was a bare `HashSet` behind an `AsyncLocal`, diverging from the locking `LlmUsageCapture` invoked on the next line of the same method. Replaced with `ReplayedToolCallSet`, exposing a single atomic `TryClaim` rather than a separate `Contains` and `Add` — locking each half individually would have left the gap between them open, and that gap is exactly what produces the duplicate trace record the scope exists to prevent.

**#510 — empty-list normalization had a hole.** `ConversationMessage.ToolCalls` normalized via a property initializer, which runs only in the primary constructor; a record's copy constructor copies the backing field instead, so `with { ToolCalls = [] }` yielded a non-null empty list that serialized to a `"[]"` column the dispatch filter read as model-relevant. Normalization moved into the `init` accessor, which every assignment path goes through, plus a tightened store filter for rows persisted while the hole was open.

## What the reviews found

**A validator that had never run.** `ToolCallReplayConfigValidator` was written, unit-tested, and named in three doc comments as the startup enforcement for two bounds — including the size ceiling above which structural secret redaction stops being trustworthy. Nothing bound it into the options pipeline, so none of its rules had ever executed in any host. Its own tests passed (they construct it directly), `ValidateOnBuild` passed (an unbound validator breaks no service graph), and the interface-consumer scan passed (a validator implements no guarded contract) — every available signal measured something other than whether it runs.

That is the sixth instance of this repo's documented "a security control has a caller" pattern, so the fix is not just the missing registration: a general guard now asserts every FluentValidation config validator is bound. It found five more, all planner step-configs, tracked as a shrink-only ratchet under #514 rather than fixed here — binding a validator turns a currently-booting host into a failing one, which is correct but is a per-subsystem change with its own verification.

**The two halves of the cap trimmed from opposite ends.** Persisting kept the earliest calls; replaying kept the newest. Each half had a comment justifying its own direction and green tests covering only itself. Composed, they carved a slice from the middle of a turn while the assistant's own summary referred to results no longer present. Both now trim newest, with a composition test over every pairing of the two limits — a property provable of each half and of neither the system.

**The two limits were not independent.** One call costs up to twice the per-payload ceiling, and admission latches shut at the first call that does not fit, so a window budget smaller than one maximum-size call drops every older call behind it — emptying a conversation's whole tool memory with only a per-turn warning. Unreachable at shipped defaults; reachable the moment an operator raises the per-payload ceiling for a large-context model and leaves the window budget alone. Now a cross-field startup error, enforced at runtime too since a config reload bypasses startup validation.

Also: a limit read four times mid-decision, an integer overflow that would have made the cross-field rule pass vacuously, two parameters whose "do not default these" rule lived in prose and now lives in the compiler, and the budget now counts tool name and call id — model-supplied strings no treatment pass bounds, previously excluded on a "they're usually short" assumption about untrusted input.

## Verification

Every fix is mutation-tested. Two of those probes found my own tests were vacuous and both were rebuilt until they failed against the bug: a store test could not reach the filter it was written for, and a concurrency test passed three runs against a deliberately check-then-act implementation before being rebuilt on a repeated barrier that catches it every time.

The final local gate run — build, test, OWASP, docs-links, grader, correctness, security, docs-drift — passed with zero findings, the first of three runs to come back clean. Full solution: **11,568 tests, 0 failures.**

## Deliberately not done

Filed rather than half-done: #512 (a colliding call id can suppress a genuine tool result from the trace store — observability only, no authorization decision reads it), #513 (tool names persisted and replayed unsanitized), #514 (the five unbound planner validators), #515 (the replay window policy has no owner; three call sites re-derive it — the severe half is closed by making the parameters required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj