### PR TITLE
fix: remove the wall-clock races that made the test suite flaky (#537)

### DIFF
--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DefaultEscalationServiceTests.cs
@@ -133,12 +133,14 @@ public sealed class DefaultEscalationServiceTests : IDisposable
 	/// <see cref="DefaultEscalationService.GetPendingEscalationAsync"/>. A bare
 	/// <c>Task.Delay</c> can lose the race under thread-pool starvation, after which
 	/// <c>SubmitDecisionAsync</c> silently drops the decision and the test stalls for the
-	/// full request timeout. Polling the registration signal removes that race and fails in
-	/// seconds (not minutes) if registration genuinely never happens.
+	/// full request timeout. Polling the registration signal removes that race and gives up well
+	/// before that timeout if registration genuinely never happens — see
+	/// <see cref="EscalationTestDeadlines.BackgroundWork"/> for why the budget is a minute rather
+	/// than the handful of seconds it used to be.
 	/// </remarks>
 	private async Task WaitForRegistrationAsync(Guid escalationId)
 	{
-		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+		using var cts = new CancellationTokenSource(EscalationTestDeadlines.BackgroundWork);
 		while (true)
 		{
 			var pending = await _sut.GetPendingEscalationAsync(escalationId, CancellationToken.None);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationHardeningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationHardeningTests.cs
@@ -329,7 +329,7 @@ public sealed class DurableEscalationHardeningTests : IDisposable
 		var service = CreateService(store);
 		(await service.RehydratePendingEscalationsAsync(CancellationToken.None)).Should().Be(1);
 
-		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+		using var cts = new CancellationTokenSource(EscalationTestDeadlines.BackgroundWork);
 		EscalationOutcome? outcome = null;
 		while (outcome is null)
 		{

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
@@ -143,16 +143,13 @@ public sealed class DurableEscalationServiceTests : IDisposable
 	/// Waits for an outcome the service produces on a background continuation.
 	/// </summary>
 	/// <remarks>
-	/// The budget is generous on purpose (#537). What it waits on is not a fixed amount of work: the
-	/// timeout continuation writes to a SQLite file the sibling store still holds open, then the audit
-	/// mock. Nothing here asserts how long that takes, so a tight budget would be pure race — the same
-	/// shape as the one-second window that made this class flaky in the first place, just further down.
-	/// It stays bounded so a genuinely stuck outcome fails the run instead of hanging it.
+	/// Budgeted by <see cref="EscalationTestDeadlines.BackgroundWork"/>, which carries the reasoning
+	/// for the six loops in this folder that share it (#537).
 	/// </remarks>
 	private static async Task<EscalationOutcome> PollOutcomeAsync(
 		DefaultEscalationService service, Guid escalationId)
 	{
-		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
+		using var cts = new CancellationTokenSource(EscalationTestDeadlines.BackgroundWork);
 		while (true)
 		{
 			var outcome = await service.GetOutcomeAsync(escalationId, CancellationToken.None);
@@ -216,9 +213,10 @@ public sealed class DurableEscalationServiceTests : IDisposable
 		// queued through a service and disposed (#537): that sequence armed a live one-second timer
 		// and then raced Dispose against it. Under suite load the few statements between the two
 		// took longer than the second, so the escalation timed out in-process, left nothing Pending,
-		// and rehydration restored 0. The setup no longer reads the wall clock at all, so that race
-		// is gone; the one remaining wait is PollOutcomeAsync's, and its budget is generous for the
-		// reason given there. The queue-then-restart path this replaced is covered whole by
+		// and rehydration restored 0. The setup still READS the clock, on the next line — what it no
+		// longer does is depend on time PASSING while the test runs, which is where the race lived.
+		// The only remaining wait is PollOutcomeAsync's, bounded by EscalationTestDeadlines. The
+		// queue-then-restart path this replaced is covered whole by
 		// RehydratePendingEscalationsAsync_AfterRestart_RestoresPendingEscalation above.
 		await CreateDurableStore().SavePendingAsync(
 			request, DateTimeOffset.UtcNow.AddSeconds(-10), CancellationToken.None);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
@@ -139,10 +139,20 @@ public sealed class DurableEscalationServiceTests : IDisposable
 			.Setup(a => a.RecordOutcomeAsync(It.IsAny<EscalationOutcome>(), It.IsAny<CancellationToken>()))
 			.Returns(Task.CompletedTask);
 
+	/// <summary>
+	/// Waits for an outcome the service produces on a background continuation.
+	/// </summary>
+	/// <remarks>
+	/// The budget is generous on purpose (#537). What it waits on is not a fixed amount of work: the
+	/// timeout continuation writes to a SQLite file the sibling store still holds open, then the audit
+	/// mock. Nothing here asserts how long that takes, so a tight budget would be pure race — the same
+	/// shape as the one-second window that made this class flaky in the first place, just further down.
+	/// It stays bounded so a genuinely stuck outcome fails the run instead of hanging it.
+	/// </remarks>
 	private static async Task<EscalationOutcome> PollOutcomeAsync(
 		DefaultEscalationService service, Guid escalationId)
 	{
-		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
 		while (true)
 		{
 			var outcome = await service.GetOutcomeAsync(escalationId, CancellationToken.None);
@@ -206,8 +216,9 @@ public sealed class DurableEscalationServiceTests : IDisposable
 		// queued through a service and disposed (#537): that sequence armed a live one-second timer
 		// and then raced Dispose against it. Under suite load the few statements between the two
 		// took longer than the second, so the escalation timed out in-process, left nothing Pending,
-		// and rehydration restored 0. Nothing here reads the wall clock, so there is no race left
-		// to lose — and the queue-then-restart path this replaced is covered whole by
+		// and rehydration restored 0. The setup no longer reads the wall clock at all, so that race
+		// is gone; the one remaining wait is PollOutcomeAsync's, and its budget is generous for the
+		// reason given there. The queue-then-restart path this replaced is covered whole by
 		// RehydratePendingEscalationsAsync_AfterRestart_RestoresPendingEscalation above.
 		await CreateDurableStore().SavePendingAsync(
 			request, DateTimeOffset.UtcNow.AddSeconds(-10), CancellationToken.None);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/DurableEscalationServiceTests.cs
@@ -200,11 +200,17 @@ public sealed class DurableEscalationServiceTests : IDisposable
 	public async Task RehydratePendingEscalationsAsync_TimeoutExpiredDuringDowntime_TimesOutImmediately()
 	{
 		var request = CreateRequest(timeoutSeconds: 1);
-		var first = CreateService(CreateDurableStore());
-		await first.QueueEscalationAsync(request, CancellationToken.None);
-		first.Dispose(); // kills the in-process timeout task; the durable row stays Pending
 
-		await Task.Delay(TimeSpan.FromSeconds(1.5));
+		// A row left Pending by a host that died before its timeout could fire, created far enough
+		// back that its deadline has already passed. Seeded straight into the store rather than
+		// queued through a service and disposed (#537): that sequence armed a live one-second timer
+		// and then raced Dispose against it. Under suite load the few statements between the two
+		// took longer than the second, so the escalation timed out in-process, left nothing Pending,
+		// and rehydration restored 0. Nothing here reads the wall clock, so there is no race left
+		// to lose — and the queue-then-restart path this replaced is covered whole by
+		// RehydratePendingEscalationsAsync_AfterRestart_RestoresPendingEscalation above.
+		await CreateDurableStore().SavePendingAsync(
+			request, DateTimeOffset.UtcNow.AddSeconds(-10), CancellationToken.None);
 
 		var rebooted = CreateService(CreateDurableStore());
 		var restored = await rebooted.RehydratePendingEscalationsAsync(CancellationToken.None);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationReconciliationServiceTests.cs
@@ -260,7 +260,7 @@ public sealed class EscalationReconciliationServiceTests
 
     private async Task WaitForAsync(Func<bool> condition)
     {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        using var cts = new CancellationTokenSource(EscalationTestDeadlines.BackgroundWork);
         while (!condition())
         {
             cts.Token.ThrowIfCancellationRequested();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationResolutionRaceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationResolutionRaceTests.cs
@@ -166,7 +166,7 @@ public sealed class EscalationResolutionRaceTests : IDisposable
 	private async Task<EscalationOutcome> PollOutcomeDrivingClockAsync(
 		DefaultEscalationService service, Guid escalationId)
 	{
-		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+		using var cts = new CancellationTokenSource(EscalationTestDeadlines.BackgroundWork);
 		while (true)
 		{
 			var outcome = await service.GetOutcomeAsync(escalationId, CancellationToken.None);
@@ -325,7 +325,7 @@ public sealed class EscalationResolutionRaceTests : IDisposable
 
 	private static async Task WaitForPendingAsync(DefaultEscalationService service, Guid escalationId)
 	{
-		using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+		using var cts = new CancellationTokenSource(EscalationTestDeadlines.BackgroundWork);
 		while (await service.GetPendingEscalationAsync(escalationId, CancellationToken.None) is null)
 		{
 			cts.Token.ThrowIfCancellationRequested();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationTestDeadlines.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Escalation/EscalationTestDeadlines.cs
@@ -1,0 +1,41 @@
+namespace Infrastructure.AI.Tests.Escalation;
+
+/// <summary>
+/// The budget an escalation test allows for work the service finishes on a background
+/// continuation — a timeout firing, a pending registration landing, a reconciler tick — when the
+/// property under test is <em>that</em> the work happened, never how quickly.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists (#537).</strong> Six polling loops in this folder each waited under a
+/// bare wall-clock literal, and those literals had drifted to 5s, 10s and 20s with no stated reason
+/// for the differences. Every one is the same shape: spin until something non-null appears, give up
+/// at a fixed deadline. None of them asserts a duration. What they actually wait on is a
+/// continuation that writes to a SQLite file a sibling store still holds open and then calls through
+/// to a mock — work whose cost depends on what else the machine is doing, not on the code under
+/// test. Under suite load the short ones lose, and the test fails with a cancellation that reads
+/// like a functional defect rather than the contention it is.
+/// </para>
+/// <para>
+/// A single named budget rather than a shared loop: the six loops genuinely differ — two advance a
+/// fake clock on each iteration, they poll three different accessors, and their delays are tuned
+/// differently. The <em>budget</em> is the only part that had drifted, so the budget is the part
+/// worth naming. Generous enough that contention cannot reach it, bounded so genuinely stuck work
+/// still fails the run instead of hanging it.
+/// </para>
+/// <para>
+/// <strong>Not for a test whose subject is the deadline.</strong>
+/// <c>DefaultEscalationServiceTests.Timeout_CallerCancelled_PropagatesCancellation</c> cancels after
+/// 100ms deliberately — there the short budget is the thing being proved, and it is left alone.
+/// <c>SandboxTestDeadlines.Generous</c> is the same idea for a different mechanism (a real OS
+/// subprocess); the two are kept apart because they are independent decisions that happen to share
+/// a number today, and coupling them would make a change to one silently move the other.
+/// </para>
+/// </remarks>
+internal static class EscalationTestDeadlines
+{
+    /// <summary>
+    /// How long to wait for a background continuation whose duration is incidental to the assertion.
+    /// </summary>
+    public static readonly TimeSpan BackgroundWork = TimeSpan.FromSeconds(60);
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
@@ -145,7 +145,7 @@ public class DockerSandboxSessionFactoryTests
         await using var session = result.Value!;
 
         using var reader = new StreamReader(session.StandardOutput);
-        var output = await reader.ReadToEndAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        var output = await reader.ReadToEndAsync().WaitAsync(SandboxTestDeadlines.Generous);
 
         output.Should().Be("hello world");
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/DockerSandboxSessionFactoryTests.cs
@@ -145,7 +145,7 @@ public class DockerSandboxSessionFactoryTests
         await using var session = result.Value!;
 
         using var reader = new StreamReader(session.StandardOutput);
-        var output = await reader.ReadToEndAsync().WaitAsync(SandboxTestDeadlines.Generous);
+        var output = await reader.ReadToEndAsync().WaitAsync(TimeSpan.FromSeconds(5));
 
         output.Should().Be("hello world");
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxEnvironmentIsolationTests.cs
@@ -245,7 +245,7 @@ public class ProcessSandboxEnvironmentIsolationTests
         },
         Command = "cmd.exe",
         ArgumentList = argumentList,
-        Timeout = TimeSpan.FromSeconds(10)
+        Timeout = SandboxTestDeadlines.Generous
     };
 
     private static ToolExecutionAttestation CreateAttestation(string toolName) => new()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxExecutorTests.cs
@@ -64,7 +64,7 @@ public class ProcessSandboxExecutorTests : IDisposable
 
         var result = await _sut.ExecuteAsync(request, CancellationToken.None);
 
-        result.Success.Should().BeTrue();
+        result.Success.Should().BeTrue("the executor reported: {0}", result.ErrorMessage);
         result.Output.Should().NotBeNullOrEmpty();
         result.Attestation.Should().NotBeNull();
         result.ExitCode.Should().Be(0);
@@ -98,7 +98,7 @@ public class ProcessSandboxExecutorTests : IDisposable
         var result = await _sut.ExecuteAsync(request, CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.ExitCode.Should().Be(1);
+        result.ExitCode.Should().Be(1, "the executor reported: {0}", result.ErrorMessage);
         result.Attestation.Should().NotBeNull();
         result.Attestation!.IsFailureAttestation.Should().BeTrue();
     }
@@ -116,7 +116,7 @@ public class ProcessSandboxExecutorTests : IDisposable
 
         var result = await _sut.ExecuteAsync(request, CancellationToken.None);
 
-        result.Success.Should().BeTrue();
+        result.Success.Should().BeTrue("the executor reported: {0}", result.ErrorMessage);
         result.Output.Should().Contain("key");
         result.Output.Should().Contain("value");
     }
@@ -160,7 +160,7 @@ public class ProcessSandboxExecutorTests : IDisposable
         },
         Command = command,
         ArgumentList = argumentList ?? ["/c", "echo", "test"],
-        Timeout = timeout ?? TimeSpan.FromSeconds(10)
+        Timeout = timeout ?? SandboxTestDeadlines.Generous
     };
 
     private static ToolExecutionAttestation CreateAttestation(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxSessionFactoryTests.cs
@@ -114,11 +114,11 @@ public class ProcessSandboxSessionFactoryTests
         // Two independent round trips over the SAME session/process — the property a one-shot
         // ISandboxExecutor cannot offer (its stdin is written once and closed immediately).
         await writer.WriteLineAsync("first-message");
-        var firstLine = await reader.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        var firstLine = await reader.ReadLineAsync().WaitAsync(SandboxTestDeadlines.Generous);
         firstLine.Should().Be("first-message");
 
         await writer.WriteLineAsync("second-message");
-        var secondLine = await reader.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        var secondLine = await reader.ReadLineAsync().WaitAsync(SandboxTestDeadlines.Generous);
         secondLine.Should().Be("second-message");
 
         session.Completion.IsCompleted.Should().BeFalse(
@@ -145,7 +145,7 @@ public class ProcessSandboxSessionFactoryTests
 
         await session.DisposeAsync();
 
-        await session.Completion.WaitAsync(TimeSpan.FromSeconds(5));
+        await session.Completion.WaitAsync(SandboxTestDeadlines.Generous);
         capturedWorkspace.Should().NotBeNull();
         Directory.Exists(capturedWorkspace!).Should().BeFalse("disposal must clean up the session's workspace");
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxSessionFactoryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/ProcessSandboxSessionFactoryTests.cs
@@ -327,6 +327,6 @@ public class ProcessSandboxSessionFactoryTests
         },
         Command = "cmd.exe",
         ArgumentList = ["/c", "more"],
-        MaxSessionDuration = TimeSpan.FromSeconds(30)
+        MaxSessionDuration = SandboxTestDeadlines.Generous
     };
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxAttestationBindingTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxAttestationBindingTests.cs
@@ -86,13 +86,13 @@ public class SandboxAttestationBindingTests
                 },
                 Command = "cmd.exe",
                 ArgumentList = ["/c", "echo", "crash-stdout-data", "&", "exit", "3"],
-                Timeout = TimeSpan.FromSeconds(10)
+                Timeout = SandboxTestDeadlines.Generous
             };
 
             var result = await _sut.ExecuteAsync(request, CancellationToken.None);
 
             result.Success.Should().BeFalse();
-            result.ExitCode.Should().Be(3);
+            result.ExitCode.Should().Be(3, "the executor reported: {0}", result.ErrorMessage);
             result.Output.Should().Contain("crash-stdout-data");
 
             _attestation.Verify(x => x.SignAsync(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxTestDeadlines.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxTestDeadlines.cs
@@ -22,10 +22,21 @@ namespace Infrastructure.AI.Tests.Sandbox;
 /// <para>
 /// <strong>Why generous rather than tuned.</strong> Nothing here is asserting a duration, so there
 /// is no signal to preserve by keeping the number tight — a slow-but-correct subprocess is still
-/// correct, and this value only decides how long the suite waits before calling a genuinely hung
-/// process hung. It is deliberately far above the observed cost (sub-second) so that scheduling
-/// contention cannot reach it, and still bounded so a real hang fails the run rather than
-/// wedging it.
+/// correct, and this value only decides how long we wait before calling a genuinely hung process
+/// hung. It is deliberately far above the observed cost (sub-second) so that scheduling contention
+/// cannot reach it, and still bounded so a real hang fails the run rather than wedging it.
+/// </para>
+/// <para>
+/// <strong>Where the value actually lands, which is two different places.</strong> In the
+/// session-factory tests it is a test-side <c>WaitAsync</c> — the suite's own patience, invisible to
+/// the code under test. In the executor, isolation, and attestation tests it is assigned to
+/// <c>SandboxExecutionRequest.Timeout</c>, which is the sandbox's <em>production</em> kill budget:
+/// those tests now exercise a 60-second envelope rather than a 10-second one. That weakens nothing,
+/// because each of them asserts what the sandbox produced — environment isolation, an exit code, a
+/// signed attestation — and none asserts how long it took. It is stated here because a comment
+/// describing this purely as "how long the tests wait" would be false at three of its seven call
+/// sites (the other four are the <c>WaitAsync</c> kind), and a reader trusting that description
+/// would mis-size the next one.
 /// </para>
 /// <para>
 /// <strong>Do not use this for a test whose subject IS the deadline.</strong>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxTestDeadlines.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxTestDeadlines.cs
@@ -27,16 +27,27 @@ namespace Infrastructure.AI.Tests.Sandbox;
 /// cannot reach it, and still bounded so a real hang fails the run rather than wedging it.
 /// </para>
 /// <para>
-/// <strong>Where the value actually lands, which is two different places.</strong> In the
-/// session-factory tests it is a test-side <c>WaitAsync</c> — the suite's own patience, invisible to
-/// the code under test. In the executor, isolation, and attestation tests it is assigned to
-/// <c>SandboxExecutionRequest.Timeout</c>, which is the sandbox's <em>production</em> kill budget:
-/// those tests now exercise a 60-second envelope rather than a 10-second one. That weakens nothing,
-/// because each of them asserts what the sandbox produced — environment isolation, an exit code, a
-/// signed attestation — and none asserts how long it took. It is stated here because a comment
-/// describing this purely as "how long the tests wait" would be false at three of its seven call
-/// sites (the other four are the <c>WaitAsync</c> kind), and a reader trusting that description
-/// would mis-size the next one.
+/// <strong>Where the value lands, which is two different places — and why both had to move.</strong>
+/// Three of its seven call sites are a test-side <c>WaitAsync</c>: the suite's own patience, invisible
+/// to the code under test. The other four reach the code under test itself — <c>Timeout</c> on a
+/// <c>SandboxExecutionRequest</c> in the executor, isolation and attestation tests, and
+/// <c>MaxSessionDuration</c> on the session-factory request. Those are the sandbox's own kill budgets,
+/// so those tests now run a 60-second envelope rather than the 10 and 30 seconds they had.
+/// </para>
+/// <para>
+/// The session-factory case is the one worth understanding, because widening only the visible half of
+/// it does nothing. A test there waits on <c>ReadLineAsync</c> or <c>Completion</c>, but
+/// <c>ProcessSandboxSession</c> treats <c>MaxSessionDuration</c> as a hard ceiling and kills the
+/// process at it regardless of how patient the caller is. Raise the <c>WaitAsync</c> alone and the
+/// binding deadline is still the session's own 30 seconds — and the test then fails by reading a
+/// <see langword="null"/> line from a closed stream, which reads like a functional echo bug rather
+/// than the load problem it actually is. A worse diagnostic than the one it replaced. Both halves
+/// move together or neither should.
+/// </para>
+/// <para>
+/// Widening these weakens nothing, because every one of these tests asserts what the sandbox
+/// produced — environment isolation, an exit code, a signed attestation, a cleaned-up workspace —
+/// and none asserts how long it took.
 /// </para>
 /// <para>
 /// <strong>Do not use this for a test whose subject IS the deadline.</strong>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxTestDeadlines.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Sandbox/SandboxTestDeadlines.cs
@@ -1,0 +1,44 @@
+namespace Infrastructure.AI.Tests.Sandbox;
+
+/// <summary>
+/// The deadline a sandbox test gives a real OS subprocess when the property under test is
+/// <em>what</em> the sandbox produced — an exit code, bound output, a signed attestation, a
+/// cleaned-up workspace — rather than how fast it produced it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why this exists (#537).</strong> These tests spawn actual processes and then wait on
+/// them under a fixed wall-clock deadline. Every such deadline was written as a bare literal, and
+/// they had drifted to two different values (10s in the executor and isolation tests, 5s in the
+/// session-factory ones) for no stated reason. Each was comfortable in isolation — the whole
+/// sandbox suite finishes in about three seconds on an idle machine — and each was a race the test
+/// simply expected to win. Run alongside the other ~3,300 tests in this assembly, they lost it
+/// often enough that roughly one full-assembly run in seven failed, on a different member of the
+/// family each time. A run that fails for a reason unrelated to the code under test teaches
+/// whoever hits it to re-run until green, which is precisely the habit that lets a real regression
+/// through — and the local push gate will not write its receipt without a clean pass, so the
+/// flake intermittently blocked the whole review-and-push workflow.
+/// </para>
+/// <para>
+/// <strong>Why generous rather than tuned.</strong> Nothing here is asserting a duration, so there
+/// is no signal to preserve by keeping the number tight — a slow-but-correct subprocess is still
+/// correct, and this value only decides how long the suite waits before calling a genuinely hung
+/// process hung. It is deliberately far above the observed cost (sub-second) so that scheduling
+/// contention cannot reach it, and still bounded so a real hang fails the run rather than
+/// wedging it.
+/// </para>
+/// <para>
+/// <strong>Do not use this for a test whose subject IS the deadline.</strong>
+/// <c>ProcessSandboxExecutorTests.ExecuteAsync_Timeout_KillsProcessAndReturnsFail</c> passes its
+/// own short timeout against a command that runs for a minute; widening that one would delete the
+/// behaviour it exists to prove. The distinction is the whole point: a timeout test asserts the
+/// deadline fires, and every other test here merely needs one that never does.
+/// </para>
+/// </remarks>
+internal static class SandboxTestDeadlines
+{
+    /// <summary>
+    /// Deadline for a subprocess whose duration is incidental to the assertion.
+    /// </summary>
+    public static readonly TimeSpan Generous = TimeSpan.FromSeconds(60);
+}

--- a/src/Content/Tests/Tests.Common/SourceScan.cs
+++ b/src/Content/Tests/Tests.Common/SourceScan.cs
@@ -51,8 +51,16 @@ public static class SourceScan
     /// wrong in a way that cost a measurably flaky suite; that history is recorded there so the
     /// argument is not made again from the same incomplete cost model.
     /// </para>
+    /// <para>
+    /// Returned as <see cref="IReadOnlyList{T}"/> rather than an array <strong>because the instance is
+    /// shared</strong>. Every caller in a run now receives the same object, so one caller sorting or
+    /// assigning into it in place would silently change what every other guard sees — and a guard
+    /// reading a mutated view of the source tree passes vacuously, which is the one failure mode this
+    /// whole class exists to prevent. All three callers are read-only LINQ projections today; this
+    /// makes that a property of the type instead of a property of the current callers.
+    /// </para>
     /// </remarks>
-    public static (string Path, string Code)[] ReadProductionSources(string contentRoot) =>
+    public static IReadOnlyList<(string Path, string Code)> ReadProductionSources(string contentRoot) =>
         Cache.GetOrAdd(contentRoot, root => Directory
             .EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
             .Where(f => !IsExcluded(f, root))

--- a/src/Content/Tests/Tests.Common/SourceScan.cs
+++ b/src/Content/Tests/Tests.Common/SourceScan.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 
 namespace Tests.Common;
@@ -52,20 +53,27 @@ public static class SourceScan
     /// argument is not made again from the same incomplete cost model.
     /// </para>
     /// <para>
-    /// Returned as <see cref="IReadOnlyList{T}"/> rather than an array <strong>because the instance is
-    /// shared</strong>. Every caller in a run now receives the same object, so one caller sorting or
-    /// assigning into it in place would silently change what every other guard sees — and a guard
-    /// reading a mutated view of the source tree passes vacuously, which is the one failure mode this
-    /// whole class exists to prevent. All three callers are read-only LINQ projections today; this
-    /// makes that a property of the type instead of a property of the current callers.
+    /// <strong>Read-only because the instance is shared.</strong> Every caller in a run receives the
+    /// same object, so one caller sorting or assigning into it in place would silently change what
+    /// every other guard sees — and a guard reading a mutated view of the source tree passes
+    /// vacuously, which is the single failure mode this whole class exists to prevent.
+    /// </para>
+    /// <para>
+    /// The wrap is done <strong>once, at the cache boundary</strong>, and the cache stores the wrapper
+    /// rather than the array. Declaring the return type as <see cref="IReadOnlyList{T}"/> while still
+    /// handing back the array would be only a cast: a caller could cast it back and mutate the shared
+    /// instance, and the paragraph above would be asserting an enforcement the code did not provide —
+    /// which is precisely the defect this class is built to catch, committed in its own source. The
+    /// backing array is never reachable after construction, so the guarantee is structural rather than
+    /// a convention the current callers happen to honour.
     /// </para>
     /// </remarks>
     public static IReadOnlyList<(string Path, string Code)> ReadProductionSources(string contentRoot) =>
-        Cache.GetOrAdd(contentRoot, root => Directory
+        Cache.GetOrAdd(contentRoot, root => new ReadOnlyCollection<(string Path, string Code)>(Directory
             .EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
             .Where(f => !IsExcluded(f, root))
             .Select(f => (Path: f, Code: StripCommentsAndStrings(File.ReadAllText(f))))
-            .ToArray());
+            .ToArray()));
 
     /// <summary>
     /// One read of the tree per test assembly. The source is immutable for the lifetime of a run, so
@@ -93,7 +101,8 @@ public static class SourceScan
     /// committed state.
     /// </para>
     /// </remarks>
-    private static readonly ConcurrentDictionary<string, (string Path, string Code)[]> Cache = new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<string, ReadOnlyCollection<(string Path, string Code)>> Cache =
+        new(StringComparer.Ordinal);
 
     /// <summary>
     /// Removes comments and string literals so only compiled code is matched — a doc comment naming

--- a/src/Content/Tests/Tests.Common/SourceScan.cs
+++ b/src/Content/Tests/Tests.Common/SourceScan.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 
 namespace Tests.Common;
@@ -45,22 +46,46 @@ public static class SourceScan
     /// which this class was itself extracted.
     /// </para>
     /// <para>
-    /// <strong>Deliberately not cached.</strong> Each call re-reads the tree — about 3,900 files and
-    /// 19 MB, roughly two seconds. Memoizing it would save a few seconds per test class but hold
-    /// ~38 MB of stripped UTF-16 source resident for the lifetime of the test assembly, where today
-    /// each pass is collectable as soon as its fact ends. Inside a suite that runs for minutes that
-    /// trade is not worth making silently; if a future caller needs it, add the cache here with a
-    /// measurement rather than in one caller.
+    /// <strong>Cached — read <see cref="Cache"/>'s remarks before removing it.</strong> The tree is
+    /// read once per test assembly. An earlier version of this comment argued the opposite and was
+    /// wrong in a way that cost a measurably flaky suite; that history is recorded there so the
+    /// argument is not made again from the same incomplete cost model.
     /// </para>
     /// </remarks>
-    public static (string Path, string Code)[] ReadProductionSources(string contentRoot)
-    {
-        return Directory
-            .EnumerateFiles(contentRoot, "*.cs", SearchOption.AllDirectories)
-            .Where(f => !IsExcluded(f, contentRoot))
+    public static (string Path, string Code)[] ReadProductionSources(string contentRoot) =>
+        Cache.GetOrAdd(contentRoot, root => Directory
+            .EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !IsExcluded(f, root))
             .Select(f => (Path: f, Code: StripCommentsAndStrings(File.ReadAllText(f))))
-            .ToArray();
-    }
+            .ToArray());
+
+    /// <summary>
+    /// One read of the tree per test assembly. The source is immutable for the lifetime of a run, so
+    /// a second read can only ever reproduce the first.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Added because not caching measurably destabilized the suite.</strong> When this helper
+    /// was extracted, the duplicate passes were left in deliberately, on the argument that ~3.5s of
+    /// repeated work was not worth ~38 MB of stripped source held resident. That weighed the wrong
+    /// cost. Widening the validator guard's candidacy took one of its passes from 27 files to all
+    /// ~3,900 (19 MB), three times per run — and <c>ProcessSandboxExecutor</c>'s tests spawn real OS
+    /// processes with timing-sensitive assertions that are starved under that I/O.
+    /// </para>
+    /// <para>
+    /// Measured, same machine, back to back: the commit before that change passed the full solution
+    /// 3 runs out of 3; the commit after passed 1 out of 3, with every failure in the sandbox
+    /// process-executor family. The real cost of the duplicate reads was not seconds, it was whether
+    /// the suite could be trusted — which is not a trade anyone would have taken knowingly.
+    /// </para>
+    /// <para>
+    /// Keyed by root so a caller passing a different tree is not served the wrong one. Never invalidated:
+    /// a test that edits production source mid-run and expects this to notice would be relying on
+    /// behaviour that was never promised, and every current caller reads the tree to reason about the
+    /// committed state.
+    /// </para>
+    /// </remarks>
+    private static readonly ConcurrentDictionary<string, (string Path, string Code)[]> Cache = new(StringComparer.Ordinal);
 
     /// <summary>
     /// Removes comments and string literals so only compiled code is matched — a doc comment naming


### PR DESCRIPTION
Closes #537.

## The filed premise was too narrow

#537 named the sandbox process-executor tests. The flakiness spans at least three unrelated families, and it needs no full-solution run and no synthetic load — the `Infrastructure.AI` assembly alone reproduces it.

| | Result |
|---|---|
| Sandbox tests in isolation (the control) | 3/3 clean, ~3s |
| Whole assembly, before | **2 of 14 runs failed**, a different test each time |
| Whole assembly, after | **0 of 32 runs failed**, every one a full 3321-test pass |

Isolation was the control throughout, and is exactly why this survived: every one of these tests passes every time you run it by itself.

## One cause, three symptoms

Each failing test raced a fixed real-time deadline against work whose duration depends on machine load.

- **Escalation.** Queued a job with a 1-second timer, then had to shut the service down before it fired. Under load the few statements between the two took longer than the second, so the job timed itself out and rehydration found nothing to restore. Now seeds an already-expired row directly — `SavePendingAsync` takes the creation instant as a parameter, so no timer is ever armed. Also ~1.5s faster.
- **Sandbox.** Gave a real Windows subprocess a fixed budget to run `echo hello`. Nothing there asserts a duration. Those deadlines had also drifted to two different values with no stated reason, and now share one documented constant.

`ExecuteAsync_Timeout_KillsProcessAndReturnsFail` deliberately keeps its own short deadline — there the deadline **is** the subject.

## What the review passes changed

Two `/code-review` passes found three real defects in the first cut, all fixed here:

1. **The session-factory fix didn't work.** Widening the test's wait left `MaxSessionDuration` at a 30-second hard kill, so the envelope went 5s → 30s, not → 60s — and the failure degraded to a null read that looks like a functional echo bug rather than load. Both halves now move together.
2. **`IReadOnlyList<T>` was only a cast.** The cache still stored and returned the array, so a caller could cast back and mutate the instance every guard reads — a comment asserting an enforcement the code did not provide, in the file that exists to catch exactly that. Now wrapped once at the cache boundary.
3. **Fixed one instance of a duplicated pattern and stopped.** An identical racy poll sat in a sibling file. Grepping the folder found seven poll budgets drifted across 100ms/5s/5s/10s/20s/60s; six now share one named constant, and the seventh is left short because there the short budget is the property being proved.

Two comment claims were corrected rather than left to quietly stop being true: "no longer reads the wall clock" (the next line reads it — what changed is dependence on time *passing*), and a promise of failure "in seconds, not minutes" whose budget is now a minute.

## Strength of the evidence

32 clean runs against a 14% prior rate is roughly a 1-in-20 outcome if nothing had changed — good evidence, not proof. Three families are fixed because three were observed; the same shape may exist in tests that have not failed yet.

## Test plan

- Full local gate suite green: build, test, OWASP, grader, correctness, security.
- 32 full-assembly runs post-fix, 0 failures; 12 of them against the final post-review code.
- Changes are test-only. No production code, config, or workflow touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj