### PR TITLE
fix: bound tool output at the admission chokepoint every path calls (#532)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -151,8 +151,28 @@ public interface IToolCallAdmissionPipeline
     /// calling this method — caller discipline standing in for a guarantee that now lives here instead
     /// (#479).
     /// </remarks>
+    /// <param name="wasTruncated">
+    /// <see langword="true"/> when this method <em>itself</em> cut <paramref name="content"/> to fit
+    /// the tool-output ceiling (#532). Callers that publish a "was this cut short?" signal across a
+    /// boundary must OR this into it.
+    /// <para>
+    /// It is an out-parameter rather than something a caller can infer, because inferring it requires
+    /// the caller to already know this pipeline's ceiling and to assume its own is not larger. The
+    /// Execution API assumed exactly that and was wrong on shipped defaults: its ceiling is 262,144
+    /// characters, the pipeline's is 50,000, so for every output between those two numbers its own
+    /// before-and-after measurements both saw nothing to cut while the middle step had already
+    /// removed four fifths of the body — and it answered <c>OutputTruncated = false</c> on a prefix.
+    /// A caller that cannot tell a complete result from a prefix parses the prefix as complete.
+    /// Reporting the fact alongside the value is what makes that unrepresentable; two components
+    /// agreeing on a number is not, because either can change its number alone.
+    /// </para>
+    /// </param>
     bool TryApplyTextOutputPolicy(
-        ToolCallAdmission admission, string toolName, string? content, out string? result);
+        ToolCallAdmission admission,
+        string toolName,
+        string? content,
+        out string? result,
+        out bool wasTruncated);
 
     /// <summary>
     /// Reports what happened when a call this pipeline approved was actually carried out, closing

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -305,9 +305,18 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
 
     /// <inheritdoc />
     public bool TryApplyTextOutputPolicy(
-        ToolCallAdmission admission, string toolName, string? content, out string? result)
+        ToolCallAdmission admission,
+        string toolName,
+        string? content,
+        out string? result,
+        out bool wasTruncated)
     {
         ArgumentNullException.ThrowIfNull(admission);
+
+        // Every early return below leaves nothing to report; only the one branch that actually cuts
+        // overwrites this. Set once here so no future branch can forget it and silently answer "not
+        // truncated" — which is the exact failure this out-parameter exists to make impossible.
+        wasTruncated = false;
 
         // #479: sanitize unconditionally on both branches, the same guarantee ApplyOutputPolicy carries
         // (#469) — this method used to sanitize only when a redaction was required, leaving the
@@ -328,9 +337,17 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         if (processed is string text)
         {
             // #532: bound after sanitize/redact — see ApplyOutputPolicy for why the order is fixed.
-            // This is the plan path's only cut. The Execution API's DirectToolInvoker pre-cuts before
-            // calling in and cuts again after, so it is unaffected while its ceiling is no larger.
-            result = BoundedText.Cap(text, OutputCeiling, OutputTruncationMarker).Text;
+            // This is the plan path's only cut. It is NOT the Execution API's only cut, and an earlier
+            // version of this comment claimed the API was "unaffected while its ceiling is no larger"
+            // — a precondition that does not hold on shipped defaults (its 262,144 against this
+            // 50,000), so its own before-and-after checks both saw an unchanged string while this step
+            // had already removed most of the body. Rather than restore that assumption by aligning
+            // the two numbers, the cut now reports itself and the caller ORs it into whatever
+            // truncation signal it publishes: a fact that travels with the value cannot drift apart
+            // the way two independently-owned ceilings can.
+            var (bounded, truncated) = BoundedText.Cap(text, OutputCeiling, OutputTruncationMarker);
+            result = bounded;
+            wasTruncated = truncated;
             return true;
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -6,7 +6,9 @@ using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
+using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Application.AI.Common.Services.Governance;
 
@@ -57,6 +59,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     private readonly IApprovalExecutionReporter _executionReporter;
     private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IContentRedactionFilter _redactionFilter;
+    private readonly IOptionsMonitor<AppConfig> _options;
     private readonly ILogger<ToolCallAdmissionPipeline> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="ToolCallAdmissionPipeline"/> class.</summary>
@@ -79,6 +82,12 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// <param name="callOnceGate">
     /// Stage 6 — durable call-once enforcement, after the loop guard for the same reason: it too
     /// only makes sense to ask about a call that has cleared every access question already.
+    /// </param>
+    /// <param name="options">
+    /// Supplies the tool-output ceiling — see <see cref="OutputCeiling"/> for why it reuses the
+    /// existing per-result limit rather than adding a setting of its own. Read per call through
+    /// <see cref="IOptionsMonitor{TOptions}.CurrentValue"/> rather than captured, so a hot-reloaded
+    /// ceiling takes effect on the next tool result instead of at the next process start.
     /// </param>
     /// <param name="trace">The turn's governance trail, which the stages write to and this type snapshots.</param>
     /// <param name="executionReporter">
@@ -105,8 +114,11 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         IApprovalExecutionReporter executionReporter,
         ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter redactionFilter,
+        IOptionsMonitor<AppConfig> options,
         ILogger<ToolCallAdmissionPipeline> logger)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        _options = options;
         ArgumentNullException.ThrowIfNull(authorizationGate);
         ArgumentNullException.ThrowIfNull(governor);
         ArgumentNullException.ThrowIfNull(classificationGate);
@@ -246,6 +258,32 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         return decision.ApprovedCall is { } call ? admission.WithApproval(call) : admission;
     }
 
+    /// <summary>
+    /// Appended where a tool result is cut to <see cref="OutputCeiling"/>, so a truncation is visible
+    /// to the model rather than reading as the tool having returned exactly that much.
+    /// </summary>
+    public const string OutputTruncationMarker = "\n[tool output truncated]";
+
+    /// <summary>
+    /// The maximum characters of free text a single tool result may contribute to the context window.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Reuses <c>AI.ContextManagement.ToolResultStorage.PerResultCharLimit</c> rather than introducing
+    /// a second number. That setting already means "the size above which a single tool result is too
+    /// large to keep inline", which is the same question asked here; two settings for one question is
+    /// how the values drift apart and one of them silently stops matching what anyone believes.
+    /// </para>
+    /// <para>
+    /// Deliberately <strong>not</strong> gated on <c>GovernanceConfig.Enabled</c>. Bounding is
+    /// resource management, not a policy verdict — an unbounded tool result exhausts the context
+    /// window whether or not a consumer has armed governance, exactly as the unconditional sanitize
+    /// beside it applies regardless of any gate's verdict (#469).
+    /// </para>
+    /// </remarks>
+    private int OutputCeiling =>
+        _options.CurrentValue.AI.ContextManagement.ToolResultStorage.PerResultCharLimit;
+
     /// <inheritdoc />
     public object? ApplyOutputPolicy(ToolCallAdmission admission, string toolName, object? result)
     {
@@ -253,9 +291,16 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
 
         // #469: the sanitize pass below is unconditional — see the interface remarks for why. It stays
         // in shape-preserving lockstep with RedactResult below via the shared ToolResultText.Sanitize.
-        return admission.RedactsOutput
+        var treated = admission.RedactsOutput
             ? _classificationGate.RedactResult(toolName, result)
             : ToolResultText.Sanitize(result, _sanitizer, toolName);
+
+        // #532: bound AFTER sanitize and redact, never before. Cutting first would hand the scrubbers
+        // a truncated string — a secret split across the cut survives, and an injection payload whose
+        // tail was removed can still carry its head. It also mirrors ReportExecutionAsync, which has
+        // always sanitized, redacted, and THEN bounded tool failure text at this same pipeline (#460);
+        // success output simply never got the third step.
+        return ToolResultText.Bound(treated, OutputCeiling, OutputTruncationMarker);
     }
 
     /// <inheritdoc />
@@ -282,7 +327,10 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
 
         if (processed is string text)
         {
-            result = text;
+            // #532: bound after sanitize/redact — see ApplyOutputPolicy for why the order is fixed.
+            // This is the plan path's only cut. The Execution API's DirectToolInvoker pre-cuts before
+            // calling in and cuts again after, so it is unaffected while its ceiling is no larger.
+            result = BoundedText.Cap(text, OutputCeiling, OutputTruncationMarker).Text;
             return true;
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
@@ -75,6 +75,54 @@ internal static class ToolResultText
         Transform(result, text => redactionFilter.Redact(SanitizeText(text, sanitizer, toolName), RedactionCategories.All));
 
     /// <summary>
+    /// Cuts the free text carried by <paramref name="result"/> so that its <strong>total</strong>
+    /// across every text-carrying block is at most <paramref name="ceiling"/> characters, preserving
+    /// shape exactly as <see cref="Sanitize"/> does.
+    /// </summary>
+    /// <param name="result">The tool result to bound.</param>
+    /// <param name="ceiling">Maximum total characters of free text, inclusive of the marker.</param>
+    /// <param name="marker">Appended where the cut lands, so the cut is visible to the model.</param>
+    /// <remarks>
+    /// <para>
+    /// <strong>The budget spans blocks; it is not applied per block.</strong> A multi-content-block
+    /// result — what an MCP tool returns — would otherwise admit <c>ceiling x blockCount</c>
+    /// characters, which bounds nothing on the shape that most needs bounding. Blocks are walked in
+    /// order and each takes what remains; once the budget is spent, later blocks come back empty. The
+    /// marker sits at the cut, so the model is told the output was truncated exactly once rather than
+    /// once per block.
+    /// </para>
+    /// <para>
+    /// Delegates to <see cref="BoundedText.Cap"/> rather than slicing, so this inherits the
+    /// surrogate-pair guarantee every other trust-boundary truncation site in the repo relies on
+    /// (#467/#470) — a cut that would land inside a surrogate pair backs off by one instead.
+    /// </para>
+    /// <para>
+    /// Structured values are untouched for the same reason <see cref="Sanitize"/> leaves them alone:
+    /// a serialized result's <c>structuredContent</c> is typed JSON, not free text, and cutting it
+    /// mid-value produces something the model mis-parses rather than something it reads as truncated.
+    /// Bounding a result whose size lives entirely in structured content is therefore out of scope
+    /// here and belongs to whatever budgets a whole turn (#522).
+    /// </para>
+    /// </remarks>
+    public static object? Bound(object? result, int ceiling, string marker)
+    {
+        var remaining = ceiling;
+
+        return Transform(result, text =>
+        {
+            if (text.Length <= remaining)
+            {
+                remaining -= text.Length;
+                return text;
+            }
+
+            var (bounded, _) = BoundedText.Cap(text, remaining, marker);
+            remaining = 0;
+            return bounded;
+        });
+    }
+
+    /// <summary>
     /// Applies <paramref name="transform"/> to the free text carried by <paramref name="result"/>,
     /// preserving whichever of the five recognized shapes it arrived in, and returns
     /// <paramref name="result"/> itself — not a reconstructed equivalent — whenever the transform left

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -277,7 +277,10 @@ public sealed partial class DirectToolInvoker
         if (failureText is not null)
         {
             var (preCutError, _) = PreCutForScrub(failureText, ceiling);
-            if (!admissionPipeline.TryApplyTextOutputPolicy(admission, toolName, preCutError, out var admittedError))
+            // Truncation discarded: the outcome carries no ErrorTruncated field to report it on,
+            // exactly as the ScrubAndBound below discards its own.
+            if (!admissionPipeline.TryApplyTextOutputPolicy(
+                    admission, toolName, preCutError, out var admittedError, out _))
             {
                 return DirectToolInvocationOutcome.Refused(
                     DirectToolInvocationStatus.Denied, GovernanceDenials.NotPermitted(toolName), duration);
@@ -295,14 +298,18 @@ public sealed partial class DirectToolInvoker
         var raw = ToolResultText.ExtractText(rawResult);
         var (preCut, droppedByPreCut) = PreCutForScrub(raw, ceiling);
 
-        if (!admissionPipeline.TryApplyTextOutputPolicy(admission, toolName, preCut, out var admitted))
+        if (!admissionPipeline.TryApplyTextOutputPolicy(
+                admission, toolName, preCut, out var admitted, out var truncatedByPipeline))
         {
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.Denied, GovernanceDenials.NotPermitted(toolName), duration);
         }
 
         var (output, truncatedByOwnScrub) = ScrubAndBound(admitted ?? string.Empty, ceiling, toolName);
-        var truncated = droppedByPreCut || truncatedByOwnScrub;
+
+        // truncatedByPipeline is the third term - see the sibling in DirectToolInvoker.Response.cs
+        // for why the other two cannot see the admission pipeline's own, smaller cut (#532).
+        var truncated = droppedByPreCut || truncatedByPipeline || truncatedByOwnScrub;
 
         return new DirectToolInvocationOutcome
         {

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
@@ -70,7 +70,10 @@ public sealed partial class DirectToolInvoker
             // can succeed with it in its output — code review on the PR that added #479/#484's
             // guarantees to the success path below caught that this branch never picked them up.
             var (preCutError, _) = PreCutForScrub(rawError, ceiling);
-            if (!armed.AdmissionPipeline.TryApplyTextOutputPolicy(admission, armed.ToolName, preCutError, out var admittedError))
+            // Truncation discarded here for the same reason the ScrubAndBound below discards its own:
+            // the outcome carries no ErrorTruncated field to report it on.
+            if (!armed.AdmissionPipeline.TryApplyTextOutputPolicy(
+                    admission, armed.ToolName, preCutError, out var admittedError, out _))
             {
                 return DirectToolInvocationOutcome.Refused(
                     DirectToolInvocationStatus.Denied,
@@ -106,7 +109,8 @@ public sealed partial class DirectToolInvoker
         // Fails closed: when a redaction was required and could not be applied, the chain returns
         // false and the original must be withheld rather than emitted. See the chain's own remarks
         // for why falling back to the raw content is the trap.
-        if (!armed.AdmissionPipeline.TryApplyTextOutputPolicy(admission, armed.ToolName, preCut, out var admitted))
+        if (!armed.AdmissionPipeline.TryApplyTextOutputPolicy(
+                admission, armed.ToolName, preCut, out var admitted, out var truncatedByPipeline))
         {
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.Denied,
@@ -118,7 +122,16 @@ public sealed partial class DirectToolInvoker
         // failure branch above applies to result.Error, and independent of whatever the admission
         // pipeline's sanitizer already did above.
         var (output, truncatedByOwnScrub) = ScrubAndBound(admitted ?? string.Empty, ceiling, armed.ToolName);
-        var truncated = droppedByPreCut || truncatedByOwnScrub;
+
+        // truncatedByPipeline is the third term, and without it the other two are not enough (#532).
+        // Both of them measure against THIS class's ceiling; the admission pipeline cuts to its own,
+        // which on shipped defaults is roughly five times smaller. For any output between the two,
+        // the pre-cut found nothing to drop, the pipeline removed most of the body, and the scrub
+        // then saw a string already well inside the ceiling and also found nothing to drop — so the
+        // response carried a prefix while reporting OutputTruncated = false. The DTO's own remarks
+        // name that harm exactly: a caller that cannot tell a complete result from a prefix parses
+        // the prefix as complete.
+        var truncated = droppedByPreCut || truncatedByPipeline || truncatedByOwnScrub;
 
         return new DirectToolInvocationOutcome
         {

--- a/src/Content/Application/Application.Core/Validation/ToolResultStorageConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ToolResultStorageConfigValidator.cs
@@ -1,0 +1,69 @@
+using Domain.Common.Config.AI.ContextManagement;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="ToolResultStorageConfig"/> — the large-tool-result persistence settings
+/// bound from <c>AppConfig:AI:ContextManagement:ToolResultStorage</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wired into the options pipeline with <c>ValidateOnStart()</c> in the composition root, so an
+/// invalid section fails the host at boot rather than at first use.
+/// </para>
+/// <para>
+/// <strong>Why this section needs a validator now (#532).</strong>
+/// <see cref="ToolResultStorageConfig.PerResultCharLimit"/> used to decide only whether a large
+/// result was spilled to disk and previewed, so a nonsensical value degraded storage behaviour and
+/// nothing else. It is now also the ceiling
+/// <c>ToolCallAdmissionPipeline</c> cuts every tool result to before the model sees it. At zero or
+/// below, that cut takes <em>everything</em>: each result reaches the model as an empty string, the
+/// agent behaves as though every tool it calls returns nothing, and no error is raised anywhere.
+/// A setting that was merely suboptimal became silently destructive, which is exactly the class of
+/// misconfiguration that should stop a host from booting rather than be discovered from behaviour.
+/// </para>
+/// <para>
+/// The two cross-field rules encode coherence the class cannot express on its own. A preview larger
+/// than the limit that triggers previewing, or an aggregate per-message budget smaller than what a
+/// single result may occupy, are not tunings — they are contradictions, and both would otherwise be
+/// accepted and then quietly resolved in whichever direction the reading code happens to check
+/// first. The shipped defaults (50,000 / 200,000 / 2,000) satisfy every rule, so a host that omits
+/// the section — which is every host today — keeps booting unchanged.
+/// </para>
+/// </remarks>
+public sealed class ToolResultStorageConfigValidator : AbstractValidator<ToolResultStorageConfig>
+{
+    /// <summary>Initializes a new instance of the <see cref="ToolResultStorageConfigValidator"/> class.</summary>
+    public ToolResultStorageConfigValidator()
+    {
+        RuleFor(x => x.PerResultCharLimit)
+            .GreaterThan(0)
+            .WithMessage(
+                "ToolResultStorage.PerResultCharLimit must be greater than zero — it is the ceiling "
+                + "every tool result is cut to before the model sees it, so a non-positive value "
+                + "silently replaces every tool result with an empty string.");
+
+        RuleFor(x => x.PreviewSizeChars)
+            .GreaterThan(0)
+            .WithMessage("ToolResultStorage.PreviewSizeChars must be greater than zero.");
+
+        RuleFor(x => x.PreviewSizeChars)
+            .LessThanOrEqualTo(x => x.PerResultCharLimit)
+            .WithMessage(
+                "ToolResultStorage.PreviewSizeChars must not exceed PerResultCharLimit — the preview "
+                + "is what is kept in context when a result is too large to keep inline, so a preview "
+                + "bigger than that threshold is a contradiction.");
+
+        RuleFor(x => x.AggregatePerMessageCharLimit)
+            .GreaterThanOrEqualTo(x => x.PerResultCharLimit)
+            .WithMessage(
+                "ToolResultStorage.AggregatePerMessageCharLimit must be at least PerResultCharLimit — "
+                + "an aggregate budget smaller than what one result may occupy cannot be satisfied by "
+                + "a single result.");
+
+        RuleFor(x => x.StoragePath)
+            .NotEmpty()
+            .WithMessage("ToolResultStorage.StoragePath must not be empty.");
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -233,8 +233,13 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         // reports itself as safe. #479: this call now sanitizes unconditionally on both the redact and
         // plain-allow branches — the separate unconditional Sanitize() call this method used to make
         // immediately afterward is gone, not just moved; making it again here would scrub twice.
+        // Truncation discarded here, unlike in the Execution API (#532). This is the plan path's only
+        // cut — there is no second, wider ceiling whose own measurement would contradict it — and a
+        // step result has no truncation field to publish it on. The marker the cut leaves in the text
+        // is what a later step or a reader sees. If StepExecutionResult ever gains such a field, this
+        // is the value it takes.
         if (!_admissionPipeline.TryApplyTextOutputPolicy(
-                admission, config.ToolName, sandboxResult.Output, out var content))
+                admission, config.ToolName, sandboxResult.Output, out var content, out _))
         {
             await ReportExecutionAsync(
                 admission, EscalationExecutionStatus.Failed, GovernanceDenials.NotPermitted(config.ToolName),

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -241,6 +241,16 @@ public static class IServiceCollectionExtensions
                 PromptCompositionConfigValidator>()
             .ValidateOnStart();
 
+        // PerResultCharLimit is now the ceiling every tool result is cut to before the model sees it
+        // (#532), not just the spill-to-disk threshold it used to be. At zero or below that cut takes
+        // everything, so every tool would return an empty string to the model with nothing logged.
+        services.AddOptions<Domain.Common.Config.AI.ContextManagement.ToolResultStorageConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:ContextManagement:ToolResultStorage"))
+            .ValidateFluentValidation<
+                Domain.Common.Config.AI.ContextManagement.ToolResultStorageConfig,
+                ToolResultStorageConfigValidator>()
+            .ValidateOnStart();
+
         // Bundle-execution knobs (archive limits, handle/run/stream TTLs, cleanup interval, per-caller
         // stream cap). All rules are unconditional positivity checks and the class defaults are all
         // positive, so hosts that omit the section (every host except the bundle API) keep booting on

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Governance;
+using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -32,7 +33,8 @@ internal static class AdmissionHarness
         IAgentToolAuthorizationGate? authorizationGate = null,
         ICallOnceGate? callOnceGate = null,
         IGovernanceTraceRecorder? trace = null,
-        ICompositeResponseSanitizer? sanitizer = null) =>
+        ICompositeResponseSanitizer? sanitizer = null,
+        int? outputCeiling = null) =>
         new(authorizationGate ?? PermissiveAuthorizationGate(),
             governor ?? PermissiveGovernor(),
             classificationGate ?? PermissiveClassificationGate(),
@@ -43,7 +45,27 @@ internal static class AdmissionHarness
             Mock.Of<IApprovalExecutionReporter>(),
             sanitizer ?? PermissiveSanitizer(),
             PermissiveRedactionFilter(),
+            Config(outputCeiling),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
+
+    /// <summary>
+    /// Config carrying the tool-output ceiling (#532), defaulting to the shipped
+    /// <c>PerResultCharLimit</c> so a test that does not care about bounding is unaffected by it.
+    /// </summary>
+    /// <remarks>
+    /// A test that DOES care passes a small ceiling rather than building a 50,000-character result:
+    /// the property under test is that the budget is enforced, not the size of the default.
+    /// </remarks>
+    public static IOptionsMonitor<AppConfig> Config(int? outputCeiling = null)
+    {
+        var config = new AppConfig();
+        if (outputCeiling is { } ceiling)
+            config.AI.ContextManagement.ToolResultStorage.PerResultCharLimit = ceiling;
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.SetupGet(m => m.CurrentValue).Returns(config);
+        return monitor.Object;
+    }
 
     /// <summary>A sanitizer that returns content unchanged — the answer a real one gives to clean text.</summary>
     public static ICompositeResponseSanitizer PermissiveSanitizer()

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -6,6 +6,7 @@ using Application.AI.Common.Services.Governance;
 using Domain.AI.Changes;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using FluentAssertions;
 using Moq;
@@ -334,6 +335,79 @@ public sealed class ToolCallAdmissionPipelineTests
         result.Should().BeNull();
     }
 
+    // ===== #532: tool output is bounded, not just sanitized =====
+    //
+    // The asymmetry these close: tool FAILURE text is already bounded — ReportExecutionAsync
+    // "sanitizes, redacts, and bounds it exactly once, at the one chokepoint every reporting path
+    // funnels through" (#460), and GovernedAIFunction's remarks depend on that. Tool SUCCESS output
+    // was not bounded at the sibling methods beside it, on either path that reaches them:
+    // GovernedAIFunction hands ApplyOutputPolicy's value straight to the model, and
+    // ToolUseStepExecutor.HandleSuccessAsync puts TryApplyTextOutputPolicy's value into the step
+    // result. A tool's error message was capped; the same tool's 20 MB payload was not.
+    //
+    // The Execution API path is deliberately NOT covered here — DirectToolInvoker already bounds
+    // with PreCutForScrub before this call and ScrubAndBound/FinalCut after it.
+
+    [Fact]
+    public void ApplyOutputPolicy_OversizedText_IsBoundedAndMarked()
+    {
+        var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
+
+        var result = pipeline.ApplyOutputPolicy(ToolCallAdmission.Allow(), Tool, new string('x', 5000));
+
+        result.Should().BeOfType<string>().Which.Length.Should().BeLessThanOrEqualTo(100,
+            "the ceiling is the promise a caller sizing the context window relies on — the marker "
+            + "counts against it rather than overshooting it");
+        result.As<string>().Should().EndWith(ToolCallAdmissionPipeline.OutputTruncationMarker,
+            "a silent cut reads to the model as the tool having returned exactly this much");
+    }
+
+    [Fact]
+    public void TryApplyTextOutputPolicy_OversizedText_IsBoundedAndMarked()
+    {
+        var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
+
+        var ok = pipeline.TryApplyTextOutputPolicy(
+            ToolCallAdmission.Allow(), Tool, new string('x', 5000), out var result);
+
+        ok.Should().BeTrue("bounding is not a policy denial — the result is admitted, just cut");
+        result!.Length.Should().BeLessThanOrEqualTo(100);
+        result.Should().EndWith(ToolCallAdmissionPipeline.OutputTruncationMarker);
+    }
+
+    [Fact]
+    public void ApplyOutputPolicy_TextWithinTheCeiling_IsReturnedWhole()
+    {
+        // Control. Without this, a bound that cut EVERYTHING would satisfy the two tests above while
+        // destroying every tool result in the harness.
+        var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
+
+        pipeline.ApplyOutputPolicy(ToolCallAdmission.Allow(), Tool, "a short result")
+            .Should().Be("a short result", "text under the ceiling must not be touched or marked");
+    }
+
+    [Fact]
+    public void ApplyOutputPolicy_MultipleTextBlocks_BoundsTheTOTALNotEachBlock()
+    {
+        // The one that is easy to get wrong. Capping each block at N yields N x blockCount, which
+        // bounds nothing on a result with many blocks — exactly the shape an MCP tool returns.
+        var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
+
+        var blocks = new AIContent[]
+        {
+            new TextContent(new string('a', 500)),
+            new TextContent(new string('b', 500)),
+            new TextContent(new string('c', 500))
+        };
+
+        var result = pipeline.ApplyOutputPolicy(ToolCallAdmission.Allow(), Tool, blocks);
+
+        result.Should().BeOfType<AIContent[]>()
+            .Which.OfType<TextContent>().Sum(b => b.Text.Length)
+            .Should().BeLessThanOrEqualTo(100,
+                "the budget spans the blocks — a per-block cap would admit 300 characters here");
+    }
+
     [Fact]
     public void TryApplyTextOutputPolicy_PlainAllow_NullContent_PassesThroughWithoutSanitizing()
     {
@@ -518,6 +592,7 @@ public sealed class ToolCallAdmissionPipelineTests
             progress.Object, callOnceGate.Object, AdmissionHarness.TraceRecorder(),
             new Mock<IApprovalExecutionReporter>().Object,
             AdmissionHarness.PermissiveSanitizer(), AdmissionHarness.PermissiveRedactionFilter(),
+            AdmissionHarness.Config(),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
     }
 
@@ -531,7 +606,8 @@ public sealed class ToolCallAdmissionPipelineTests
         Mock.Of<IToolClassificationGate>(), Mock.Of<IToolCallObserverChain>(), Mock.Of<IProgressEvaluator>(),
         Mock.Of<ICallOnceGate>(), AdmissionHarness.TraceRecorder(), reporter.Object,
         sanitizer ?? AdmissionHarness.PermissiveSanitizer(), redactionFilter ?? AdmissionHarness.PermissiveRedactionFilter(),
-        NullLogger<ToolCallAdmissionPipeline>.Instance);
+        AdmissionHarness.Config(),
+            NullLogger<ToolCallAdmissionPipeline>.Instance);
 
     private static ApprovedCall Call() =>
         new(Guid.NewGuid(), new ApprovalFailureKey("conv-1", "agent-1", Tool));

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -297,7 +297,7 @@ public sealed class ToolCallAdmissionPipelineTests
             classificationGate: gate.Object,
             sanitizer: AdmissionHarness.SubstitutingSanitizer("secret", "[SCRUBBED]"));
 
-        var ok = pipeline.TryApplyTextOutputPolicy(ToolCallAdmission.Allow(), Tool, "a secret value", out var result);
+        var ok = pipeline.TryApplyTextOutputPolicy(ToolCallAdmission.Allow(), Tool, "a secret value", out var result, out _);
 
         ok.Should().BeTrue();
         result.Should().Be("a [SCRUBBED] value");
@@ -312,7 +312,7 @@ public sealed class ToolCallAdmissionPipelineTests
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
         var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", out var result);
+            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", out var result, out _);
 
         ok.Should().BeTrue();
         result.Should().Be("[redacted]");
@@ -329,7 +329,7 @@ public sealed class ToolCallAdmissionPipelineTests
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
         var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", out var result);
+            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", out var result, out _);
 
         ok.Should().BeFalse();
         result.Should().BeNull();
@@ -368,7 +368,7 @@ public sealed class ToolCallAdmissionPipelineTests
         var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
 
         var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.Allow(), Tool, new string('x', 5000), out var result);
+            ToolCallAdmission.Allow(), Tool, new string('x', 5000), out var result, out _);
 
         ok.Should().BeTrue("bounding is not a policy denial — the result is admitted, just cut");
         result!.Length.Should().BeLessThanOrEqualTo(100);
@@ -414,7 +414,7 @@ public sealed class ToolCallAdmissionPipelineTests
         var sanitizer = new Mock<ICompositeResponseSanitizer>(MockBehavior.Strict);
         var pipeline = AdmissionHarness.Pipeline(sanitizer: sanitizer.Object);
 
-        var ok = pipeline.TryApplyTextOutputPolicy(ToolCallAdmission.Allow(), Tool, null, out var result);
+        var ok = pipeline.TryApplyTextOutputPolicy(ToolCallAdmission.Allow(), Tool, null, out var result, out _);
 
         ok.Should().BeTrue("there is nothing to sanitize in an absent result");
         result.Should().BeNull();
@@ -434,7 +434,7 @@ public sealed class ToolCallAdmissionPipelineTests
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
         var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.AllowWithOutputRedaction(), Tool, null, out var result);
+            ToolCallAdmission.AllowWithOutputRedaction(), Tool, null, out var result, out _);
 
         ok.Should().BeFalse("a redact-required call must never report success just because there was nothing to redact yet");
         result.Should().BeNull();

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -62,6 +62,7 @@ public sealed class DirectToolInvokerTests
     private readonly GovernorRecord _governor = new();
     private readonly RecordingSanitizer _sanitizer = new();
     private readonly DirectToolInvocationConfig _config = new() { Enabled = true };
+    private int? _pipelineOutputCeiling;
     private readonly Mock<IApprovalExecutionReporter> _executionReporter = new();
     private FakeClassificationGate? _classificationGate;
     private FakeObserverChain? _observerChain;
@@ -515,6 +516,33 @@ public sealed class DirectToolInvokerTests
         outcome.OutputTruncated.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task Reports_truncation_the_admission_pipeline_applied_even_when_the_invokers_own_ceiling_never_fires()
+    {
+        // #532's actual defect, reproduced at the ratio production ships with rather than the inverse
+        // ratio most fixtures in this file use: the invoker's own ceiling (MaxOutputCharacters, real
+        // default 262,144) is far LARGER than the admission pipeline's (PerResultCharLimit, real
+        // default 50,000). An output landing strictly between the two passes both of the invoker's own
+        // pre-cut and post-scrub checks untouched — neither ever sees anything to drop — while the
+        // pipeline in between removes most of the body. Before the fix, OutputTruncated was computed
+        // only from the invoker's own two checks and came back false on a response that was, in fact,
+        // a prefix.
+        _config.MaxOutputCharacters = 1000;
+        _pipelineOutputCeiling = 100;
+        _sanitizer.PassThrough = true;
+        var tool = Tool("alpha", result: ToolResult.Ok(new string('a', 500)));
+
+        var outcome = await Invoke(Request("alpha"), tool);
+
+        outcome.Output!.Length.Should().BeLessThanOrEqualTo(1000,
+            "the invoker's own ceiling is the outer bound the response must respect regardless of "
+            + "which stage did the cutting");
+        outcome.OutputTruncated.Should().BeTrue(
+            "the admission pipeline cut this response to 100 characters before the invoker's own " +
+            "1000-character checks ever ran, so the response IS a prefix even though neither of the " +
+            "invoker's own measurements found anything to drop");
+    }
+
     // ---- data classification --------------------------------------------------------------------
 
     [Fact]
@@ -843,13 +871,21 @@ public sealed class DirectToolInvokerTests
 
         // #532: the chain now bounds tool output and reads its ceiling from AppConfig, so it requires
         // one — registered here for the same reason as every gate above, and stated the same way: an
-        // absent registration is a composition that cannot exist in production. Shipped defaults, so
-        // the pipeline's 50,000-character ceiling sits far above the small per-test ceilings this
-        // fixture gives DirectToolInvoker itself; the invoker's own cut is what these tests observe,
-        // and the pipeline's is a no-op at this size. That separation is deliberate: if the two ever
-        // interfered, the truncation tests below would be asserting against the wrong cut.
+        // absent registration is a composition that cannot exist in production. Most tests leave
+        // _pipelineOutputCeiling unset, which binds the shipped 50,000-character default — far above
+        // the small per-test ceilings this fixture gives DirectToolInvoker itself, so the invoker's own
+        // cut is what those tests observe and the pipeline's is a no-op at that size.
+        //
+        // A prior version of this comment stated that separation as though it always held. It does
+        // not: on real shipped defaults the invoker's ceiling (262,144) is roughly five times LARGER
+        // than the pipeline's (50,000), the inverse of what most tests here set up — which is exactly
+        // why the family below needs _pipelineOutputCeiling set below the invoker's ceiling rather than
+        // above it, to reproduce the ratio production actually ships with.
+        var pipelineConfig = new Domain.Common.Config.AppConfig();
+        if (_pipelineOutputCeiling is { } ceiling)
+            pipelineConfig.AI.ContextManagement.ToolResultStorage.PerResultCharLimit = ceiling;
         services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
-            new StaticOptionsMonitor<Domain.Common.Config.AppConfig>(new Domain.Common.Config.AppConfig()));
+            new StaticOptionsMonitor<Domain.Common.Config.AppConfig>(pipelineConfig));
 
         // The real chain, not a mock of it, built the same way the production root builds it. This
         // suite's whole subject is what the Execution API does before, during and after a tool call,

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -841,6 +841,16 @@ public sealed class DirectToolInvokerTests
         services.AddSingleton(AdmissionHarness.PermissiveSanitizer());
         services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
 
+        // #532: the chain now bounds tool output and reads its ceiling from AppConfig, so it requires
+        // one — registered here for the same reason as every gate above, and stated the same way: an
+        // absent registration is a composition that cannot exist in production. Shipped defaults, so
+        // the pipeline's 50,000-character ceiling sits far above the small per-test ceilings this
+        // fixture gives DirectToolInvoker itself; the invoker's own cut is what these tests observe,
+        // and the pipeline's is a no-op at this size. That separation is deliberate: if the two ever
+        // interfered, the truncation tests below would be asserting against the wrong cut.
+        services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+            new StaticOptionsMonitor<Domain.Common.Config.AppConfig>(new Domain.Common.Config.AppConfig()));
+
         // The real chain, not a mock of it, built the same way the production root builds it. This
         // suite's whole subject is what the Execution API does before, during and after a tool call,
         // and that is now the chain's behaviour plus this type's response shaping — mocking the chain

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -22,6 +22,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
+using Microsoft.Extensions.Options;
+
 namespace Application.Core.Tests.CQRS;
 
 /// <summary>
@@ -136,6 +138,14 @@ public class AgentPipelineIntegrationTests
         // same way the production root builds it. The handler depends only on the chain now, and
         // registering the real one keeps this an end-to-end proof that the five gates are reachable
         // from the turn — a mocked chain would prove nothing about whether they are wired at all.
+        // #532: the admission chain bounds tool output and reads its ceiling from AppConfig,
+        // so it requires one. Registered rather than defaulted inside AddToolCallAdmissionChain:
+        // a host that forgets to bind AppConfig should fail loudly at container build, which is
+        // what ValidateOnBuildSweepTests exists to catch — a TryAdd default there would make that
+        // guard structurally unable to see it.
+        services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+            Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+                m => m.CurrentValue == new Domain.Common.Config.AppConfig()));
         services.AddToolCallAdmissionChain();
 
         // Conversation-lifetime budget — not under test here; permissive mock (disabled) so the

--- a/src/Content/Tests/Application.Core.Tests/Validation/ToolResultStorageConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/ToolResultStorageConfigValidatorTests.cs
@@ -1,0 +1,109 @@
+using Application.Core.Validation;
+using Domain.Common.Config.AI.ContextManagement;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.Core.Tests.Validation;
+
+/// <summary>
+/// Tests for <see cref="ToolResultStorageConfigValidator"/>.
+/// Pattern: the class defaults are the valid baseline; each test mutates one field and asserts the
+/// contradiction is rejected. Every rule is unconditional — this section has no <c>Enabled</c> flag,
+/// and the ceiling it carries applies to every tool result regardless of any other setting.
+/// </summary>
+public class ToolResultStorageConfigValidatorTests
+{
+    private readonly ToolResultStorageConfigValidator _validator = new();
+
+    [Fact]
+    public async Task Validate_DefaultConfig_NoErrors()
+    {
+        // Every host today omits this section and binds these defaults. If this test ever fails, the
+        // validator has made a shipped configuration unbootable.
+        var config = new ToolResultStorageConfig();
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public async Task Validate_NonPositivePerResultCharLimit_HasError(int limit)
+    {
+        // The reason this validator exists (#532). PerResultCharLimit is the ceiling every tool result
+        // is cut to before the model sees it, so at zero the cut takes everything: each result arrives
+        // as an empty string, the agent behaves as though every tool returns nothing, and nothing is
+        // logged. Previously this value only chose when to spill a result to disk, where a bad number
+        // was merely suboptimal.
+        var config = new ToolResultStorageConfig { PerResultCharLimit = limit, PreviewSizeChars = 1 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(ToolResultStorageConfig.PerResultCharLimit));
+    }
+
+    [Fact]
+    public async Task Validate_PreviewLargerThanPerResultLimit_HasError()
+    {
+        // A preview is what survives in context when a result is too large to keep inline. A preview
+        // bigger than the threshold that triggers previewing is not a tuning, it is a contradiction.
+        var config = new ToolResultStorageConfig { PerResultCharLimit = 1_000, PreviewSizeChars = 2_000 };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(ToolResultStorageConfig.PreviewSizeChars));
+    }
+
+    [Fact]
+    public async Task Validate_PreviewEqualToPerResultLimit_NoErrors()
+    {
+        // Boundary control. Without this the rule could be written as a strict inequality and the two
+        // "rejects a bad value" tests above would still pass while a legitimate config stopped booting.
+        var config = new ToolResultStorageConfig
+        {
+            PerResultCharLimit = 1_000,
+            PreviewSizeChars = 1_000,
+            AggregatePerMessageCharLimit = 1_000
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Validate_AggregateBelowPerResultLimit_HasError()
+    {
+        // An aggregate per-message budget smaller than what a single result may occupy cannot be
+        // satisfied by one result, so the two limits would disagree on every oversized call.
+        var config = new ToolResultStorageConfig
+        {
+            PerResultCharLimit = 50_000,
+            AggregatePerMessageCharLimit = 10_000
+        };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == nameof(ToolResultStorageConfig.AggregatePerMessageCharLimit));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Validate_EmptyStoragePath_HasError(string path)
+    {
+        var config = new ToolResultStorageConfig { StoragePath = path };
+
+        var result = await _validator.ValidateAsync(config);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(ToolResultStorageConfig.StoragePath));
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
@@ -88,6 +88,10 @@ internal static class PermissiveAdmission
             Mock.Of<IApprovalExecutionReporter>(),
             sanitizer.Object,
             redactionFilter.Object,
+            // #532: the shipped PerResultCharLimit, so these orchestration tests see the real default
+            // ceiling rather than an artificial one.
+            Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+                m => m.CurrentValue == new Domain.Common.Config.AppConfig()),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
@@ -164,6 +164,14 @@ public sealed class PlanRunLlmCallScopeTests
         // composition which forgets it fails at resolution instead of running unguarded. The real
         // chain over the gates above, built the same way the production root builds it — a mock of
         // the chain would not exercise the code an enveloped run actually goes through.
+        // #532: the admission chain bounds tool output and reads its ceiling from AppConfig,
+        // so it requires one. Registered rather than defaulted inside AddToolCallAdmissionChain:
+        // a host that forgets to bind AppConfig should fail loudly at container build, which is
+        // what ValidateOnBuildSweepTests exists to catch — a TryAdd default there would make that
+        // guard structurally unable to see it.
+        services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+            Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+                m => m.CurrentValue == new Domain.Common.Config.AppConfig()));
         services.AddToolCallAdmissionChain();
         services.AddSingleton(Mock.Of<IPlanProgressNotifier>());
         services.AddScoped(_ => new PlanExecutionContext());

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
@@ -59,6 +59,8 @@ internal static class PermissiveAdmission
             Mock.Of<IApprovalExecutionReporter>(),
             PermissiveSanitizer(),
             PermissiveRedactionFilter(),
+            Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+                m => m.CurrentValue == new Domain.Common.Config.AppConfig()),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
 
     /// <summary>A sanitizer that returns content unchanged — the answer a real one gives to clean text.</summary>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -13,6 +13,7 @@ using Domain.AI.Sandbox;
 using Infrastructure.AI.Planner.StepExecutors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -510,6 +511,8 @@ public sealed class ToolUseStepExecutorTests
             _executionReporter.Object,
             _responseSanitizer.Object,
             PermissiveAdmission.PermissiveRedactionFilter(),
+            Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
+                m => m.CurrentValue == new Domain.Common.Config.AppConfig()),
             NullLogger<ToolCallAdmissionPipeline>.Instance);
 
     /// <summary>


### PR DESCRIPTION
Closes #532.

## The gap

`ToolCallAdmissionPipeline` already sanitizes and redacts every tool result before it reaches the model, at the one chokepoint every dispatch path calls. It never bounded the *size* of a successful result — only tool **failure** text was ever capped there. A tool that returned 20 MB of output handed all 20 MB to the model with nothing to stop it.

## The fix

`ApplyOutputPolicy` and `TryApplyTextOutputPolicy` now cut to `AI.ContextManagement.ToolResultStorage.PerResultCharLimit` (shipped default 50,000 chars), after sanitize/redact so a secret split across the cut can't survive and an injection payload's head can't slip through with its tail removed. For a multi-block MCP result the budget spans all blocks, not per block — a per-block cap admits `ceiling × blockCount`, which bounds nothing on the shape that most needs bounding.

## Two defects found reviewing this before it reached CI

**A destructive setting with no guard.** The same char limit used to decide only whether a result got spilled to disk with a preview — a bad value degraded storage behavior. This branch also makes it the ceiling that survives to the model. At zero or below, the cut takes *everything*: every tool call returns an empty string, silently, with nothing logged. Added `ToolResultStorageConfigValidator`, bound with `ValidateOnStart` so a bad value stops the host at boot. Verified bound, not just written: deleting its wiring makes the repo's own `SecurityControlHasACallerTests` guard name it explicitly as unbound.

**A truncation flag that could read false on a truncated result.** Caught by the local gate's correctness reviewer, not by my own pass. The Execution API already had two truncation checks of its own — a pre-cut and a post-scrub — both measured against its own, *larger* ceiling (real default 262,144 vs. the pipeline's 50,000). For any output landing between the two numbers, both of the API's own checks saw a string already inside their ceiling and reported nothing dropped, while the pipeline's cut in between had already removed most of the body. `OutputTruncated: false` on a response that was, in fact, a prefix — and the DTO's own docs name exactly this harm: a caller that can't tell a complete result from a prefix parses the prefix as complete.

Fixed by having the pipeline report whether *it* cut, via a new out-parameter every caller now consults, rather than aligning two independently-owned numbers — that fixes today's values and breaks again the next time either one changes alone, which is how this drifted apart in the first place. A regression test reproduces the real ratio (API ceiling larger than the pipeline's) rather than the inverted ratio every existing fixture used, which is why none of them had caught it; reverting the fix locally turns that one test red.

## Test plan

- Full local gate suite green: build, test, OWASP, grader, correctness, security (correctness blocked once, on the truncation-flag defect above — fixed, re-ran clean).
- New validator: 8 tests, every rule mutation-tested (deleting a rule fails a test; deleting the DI binding makes the binding guard name it unbound).
- New regression test for the truncation-flag defect, confirmed red against the pre-fix code.
- Changes span Application and Infrastructure only; no config surface added beyond the one section that already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj