### PR TITLE
fix: fail closed when a step-config validator cannot be resolved (#526)

### DIFF
--- a/src/Content/Application/Application.Core/Validation/Planner/RetrievalStepConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/Planner/RetrievalStepConfigValidator.cs
@@ -1,0 +1,34 @@
+using Domain.AI.Planner;
+using FluentValidation;
+
+namespace Application.Core.Validation.Planner;
+
+/// <summary>
+/// Validates <see cref="RetrievalStepConfiguration"/>.
+/// </summary>
+/// <remarks>
+/// Added closing #526: <c>PlanValidator.ValidateStepConfigurations</c>'s switch had no arm for this
+/// type at all — not an unregistered validator for a known type, but a step type with no case in the
+/// switch and no validator anywhere in the codebase. Every plan containing a retrieval step reached
+/// the switch's <c>_ =&gt; LogUnknownConfigType</c> fallback and passed unchecked, silently, for as
+/// long as <see cref="Domain.AI.Planner.StepType.Retrieval"/> has existed. Query is the one field
+/// worth a rule: it can carry an upstream-output placeholder that resolves at execution time, so a
+/// literal check for a non-empty string after trimming is the validation this type can meaningfully
+/// do ahead of execution — checking placeholder resolvability would require the upstream step graph,
+/// which is a different concern already covered by <c>ValidateEdgeReferentialIntegrity</c>.
+/// </remarks>
+public sealed class RetrievalStepConfigValidator : AbstractValidator<RetrievalStepConfiguration>
+{
+    /// <summary>Initializes a new instance of the <see cref="RetrievalStepConfigValidator"/> class.</summary>
+    public RetrievalStepConfigValidator()
+    {
+        RuleFor(x => x.Query)
+            .NotEmpty()
+            .WithMessage("RetrievalStepConfiguration.Query must not be empty.");
+
+        RuleFor(x => x.TopK)
+            .GreaterThan(0)
+            .When(x => x.TopK.HasValue)
+            .WithMessage("RetrievalStepConfiguration.TopK, when specified, must be greater than zero.");
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanValidator.cs
@@ -218,6 +218,7 @@ public sealed class PlanValidator : IPlanValidator
                 HumanGateConfig config => await ValidateConfig(config, ct),
                 ConditionalBranchConfig config => await ValidateConfig(config, ct),
                 SubPlanConfig config => await ValidateConfig(config, ct),
+                RetrievalStepConfiguration config => await ValidateConfig(config, ct),
                 _ => LogUnknownConfigType(step)
             };
 
@@ -226,14 +227,60 @@ public sealed class PlanValidator : IPlanValidator
         }
     }
 
+    /// <summary>
+    /// A <see cref="StepConfiguration"/> subtype this switch does not recognize. Fails closed (#526).
+    /// </summary>
+    /// <remarks>
+    /// Until this fix, this branch was NOT purely theoretical — it was live for every retrieval step.
+    /// <see cref="StepConfiguration"/> has six <c>[JsonDerivedType]</c> subtypes, and this switch had
+    /// arms for only five; <see cref="RetrievalStepConfiguration"/> fell through to here for as long
+    /// as <see cref="Domain.AI.Planner.StepType.Retrieval"/> has existed, with no validator anywhere
+    /// in the codebase to catch it even if it hadn't. Failing closed on the general "unrecognized
+    /// subtype" case without first giving that type a switch arm and a validator would have turned
+    /// every retrieval-step plan into a rejection instead of closing the actual gap — so both were
+    /// added in the same change (<see cref="Application.Core.Validation.Planner.RetrievalStepConfigValidator"/>).
+    /// What reaches this branch
+    /// now is only a subtype genuinely absent from the switch — a composition gap from a future
+    /// <see cref="StepConfiguration"/> subtype added without a matching arm, exactly the shape
+    /// <see cref="ValidateConfig{T}"/>'s remarks describe for a missing validator registration.
+    /// </remarks>
     private List<string> LogUnknownConfigType(PlanStep step)
     {
         _logger.LogWarning(
             "No validator registered for StepConfiguration type '{ConfigType}' on step '{StepName}' ({StepId})",
             step.Configuration.GetType().Name, step.Name, step.Id.Value);
-        return [];
+        return [
+            $"No validator is registered for step configuration type '{step.Configuration.GetType().Name}' " +
+            "— this step cannot be validated and the plan is rejected rather than accepted unchecked."
+        ];
     }
 
+    /// <summary>
+    /// Resolves and runs the FluentValidation validator for one step's configuration.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Fails closed when no validator is registered (#526).</strong> All five step-config
+    /// validators reach this method's caller through one mechanism — <c>AddValidatorsFromAssembly</c>
+    /// on the <c>Application.Core</c> assembly, unconditional in every DI composition this repo ships
+    /// (verified: no <c>if</c>/feature flag guards any of the three <c>AddValidatorsFromAssembly</c>
+    /// call sites) — so an unresolvable validator for a known step type is not a host that legitimately
+    /// runs without checking; it is that mechanism having broken. An assembly split, a trimmed publish,
+    /// a refactor that moves the validators' folder out of the scanned assembly, or a consumer who
+    /// composes their own container without this registration would all reach this branch, silently,
+    /// with no test failing.
+    /// </para>
+    /// <para>
+    /// The prior behaviour returned an empty error list on a missing validator — indistinguishable
+    /// from "validated, and clean" to <see cref="ValidateStepConfigurations"/>, which only ever sees
+    /// the returned list, never whether a validator ran. Returning one error instead makes that gap
+    /// visible in exactly the channel a caller is already watching, rather than adding a second
+    /// channel (a distinct result type) that every caller would additionally have to check. Complemented
+    /// by <c>PlannerStepConfigValidatorWiringTests</c>, which resolves all five step-config validators
+    /// from the real composition root so the scan breaking fails CI directly rather than only at the
+    /// point some future plan happens to exercise this fallback.
+    /// </para>
+    /// </remarks>
     private async Task<List<string>> ValidateConfig<T>(T config, CancellationToken ct)
         where T : StepConfiguration
     {
@@ -241,9 +288,13 @@ public sealed class PlanValidator : IPlanValidator
         if (validator is null)
         {
             _logger.LogWarning(
-                "No validator registered for StepConfiguration type '{ConfigType}'; step configurations of this type will pass validation without checking",
+                "No validator registered for StepConfiguration type '{ConfigType}'; the plan is being " +
+                "rejected rather than accepted unchecked",
                 typeof(T).Name);
-            return [];
+            return [
+                $"No validator is registered for step configuration type '{typeof(T).Name}' " +
+                "— this step cannot be validated and the plan is rejected rather than accepted unchecked."
+            ];
         }
 
         var result = await validator.ValidateAsync(config, ct);

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/PlanValidator.cs
@@ -246,21 +246,30 @@ public sealed class PlanValidator : IPlanValidator
     /// </remarks>
     private List<string> LogUnknownConfigType(PlanStep step)
     {
+        var typeName = step.Configuration.GetType().Name;
         _logger.LogWarning(
             "No validator registered for StepConfiguration type '{ConfigType}' on step '{StepName}' ({StepId})",
-            step.Configuration.GetType().Name, step.Name, step.Id.Value);
-        return [
-            $"No validator is registered for step configuration type '{step.Configuration.GetType().Name}' " +
-            "— this step cannot be validated and the plan is rejected rather than accepted unchecked."
-        ];
+            typeName, step.Name, step.Id.Value);
+        return [NoValidatorErrorMessage(typeName)];
     }
+
+    /// <summary>
+    /// The error both fail-closed branches return — <see cref="LogUnknownConfigType"/> for a subtype
+    /// this switch does not recognize, <see cref="ValidateConfig{T}"/> for a known subtype whose
+    /// validator did not resolve. Shared because the two branches report the same fact about the
+    /// caller (this step could not be checked) and a divergent wording between them would read as two
+    /// different situations rather than one.
+    /// </summary>
+    private static string NoValidatorErrorMessage(string configTypeName) =>
+        $"No validator is registered for step configuration type '{configTypeName}' " +
+        "— this step cannot be validated and the plan is rejected rather than accepted unchecked.";
 
     /// <summary>
     /// Resolves and runs the FluentValidation validator for one step's configuration.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// <strong>Fails closed when no validator is registered (#526).</strong> All five step-config
+    /// <strong>Fails closed when no validator is registered (#526).</strong> All six step-config
     /// validators reach this method's caller through one mechanism — <c>AddValidatorsFromAssembly</c>
     /// on the <c>Application.Core</c> assembly, unconditional in every DI composition this repo ships
     /// (verified: no <c>if</c>/feature flag guards any of the three <c>AddValidatorsFromAssembly</c>
@@ -276,7 +285,7 @@ public sealed class PlanValidator : IPlanValidator
     /// the returned list, never whether a validator ran. Returning one error instead makes that gap
     /// visible in exactly the channel a caller is already watching, rather than adding a second
     /// channel (a distinct result type) that every caller would additionally have to check. Complemented
-    /// by <c>PlannerStepConfigValidatorWiringTests</c>, which resolves all five step-config validators
+    /// by <c>PlannerStepConfigValidatorWiringTests</c>, which resolves all six step-config validators
     /// from the real composition root so the scan breaking fails CI directly rather than only at the
     /// point some future plan happens to exercise this fallback.
     /// </para>
@@ -291,10 +300,7 @@ public sealed class PlanValidator : IPlanValidator
                 "No validator registered for StepConfiguration type '{ConfigType}'; the plan is being " +
                 "rejected rather than accepted unchecked",
                 typeof(T).Name);
-            return [
-                $"No validator is registered for step configuration type '{typeof(T).Name}' " +
-                "— this step cannot be validated and the plan is rejected rather than accepted unchecked."
-            ];
+            return [NoValidatorErrorMessage(typeof(T).Name)];
         }
 
         var result = await validator.ValidateAsync(config, ct);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanValidatorTests.cs
@@ -13,6 +13,17 @@ namespace Infrastructure.AI.Tests.Planner;
 
 public sealed class PlanValidatorTests
 {
+    /// <summary>
+    /// A validator whose service provider resolves nothing — every <c>IValidator&lt;T&gt;</c> lookup
+    /// returns null. Since #526 made <c>ValidateConfig&lt;T&gt;</c> fail closed, this now genuinely
+    /// rejects every step it validates; it is the right factory only for tests asserting a plan is
+    /// invalid for a reason that has nothing to do with step-config content (an empty plan, a cycle,
+    /// a dangling edge reference) where that structural check runs, and fails the plan, before step
+    /// config validation would ever matter. A test asserting <c>IsSuccess</c> should be
+    /// <see langword="true"/> needs <see cref="CreateValidatorWithConfigValidators"/> instead — four
+    /// tests here used to reach <c>IsSuccess: true</c> through this factory by relying on the
+    /// pre-#526 fail-open bug rather than through anything that actually validated their steps.
+    /// </summary>
     private static PlanValidator CreateValidator(IServiceProvider? serviceProvider = null)
     {
         return new PlanValidator(
@@ -90,9 +101,59 @@ public sealed class PlanValidatorTests
     }
 
     [Fact]
+    public async Task Validate_StepConfigValidatorCannotBeResolved_RejectsThePlan()
+    {
+        // #526's actual regression coverage. The four tests below prove ValidateConfig<T> works
+        // WHEN a validator resolves; this proves what it does when one does not. Before the fix, a
+        // missing validator returned an empty error list — indistinguishable from "validated, clean"
+        // — and every one of the four tests below would have kept passing regardless, because none
+        // of them exercised this branch. CreateValidator() with no service provider gives the loosest
+        // possible mock: every IValidator<T> lookup returns null, which is the shape a broken
+        // AddValidatorsFromAssembly scan actually produces.
+        var sut = CreateValidator();
+        var step = CreateStep(name: "OnlyStep");
+        var graph = CreateGraph([step]);
+
+        var result = await sut.ValidateAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "a step whose configuration could not be checked must never be reported the same way as " +
+            "one that was checked and passed");
+        result.Errors.Should().Contain(e => e.Contains("No validator is registered"));
+    }
+
+    [Fact]
+    public async Task Validate_UnrecognizedConfigSubtype_RejectsThePlan()
+    {
+        // The second fail-open path #526 closed — LogUnknownConfigType, reached when a
+        // StepConfiguration subtype has no arm in ValidateStepConfigurations' switch at all (not
+        // just no registered validator for a known one). RetrievalStepConfiguration lived here for
+        // real, silently, before this fix added it a switch arm and a validator; this test proves the
+        // fallback for whatever the NEXT unlisted subtype turns out to be.
+        var sut = CreateValidatorWithConfigValidators();
+        var step = CreateStep(name: "OnlyStep", config: new UnrecognizedTestConfig());
+        var graph = CreateGraph([step]);
+
+        var result = await sut.ValidateAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse(
+            "a step configuration type this switch does not recognize must never be reported the " +
+            "same way as one that was checked and passed");
+        result.Errors.Should().Contain(e => e.Contains("No validator is registered"));
+    }
+
+    /// <summary>
+    /// A <see cref="StepConfiguration"/> subtype deliberately absent from
+    /// <c>PlanValidator.ValidateStepConfigurations</c>'s switch, so a test can exercise the
+    /// <c>_ =&gt; LogUnknownConfigType(step)</c> fallback without depending on a real subtype someday
+    /// gaining an arm and silently retiring the coverage.
+    /// </summary>
+    private sealed record UnrecognizedTestConfig : StepConfiguration;
+
+    [Fact]
     public async Task Validate_SingleStepGraph_ReturnsSuccess()
     {
-        var sut = CreateValidator();
+        var sut = CreateValidatorWithConfigValidators();
         var step = CreateStep(name: "OnlyStep");
         var graph = CreateGraph([step]);
 
@@ -105,7 +166,7 @@ public sealed class PlanValidatorTests
     [Fact]
     public async Task Validate_AcyclicGraph_ReturnsSuccess()
     {
-        var sut = CreateValidator();
+        var sut = CreateValidatorWithConfigValidators();
         var a = CreateStep(name: "A");
         var b = CreateStep(name: "B");
         var c = CreateStep(name: "C");
@@ -270,7 +331,7 @@ public sealed class PlanValidatorTests
     [Fact]
     public async Task Validate_ConditionalBranch_BothEdgesPresent_ReturnsSuccess()
     {
-        var sut = CreateValidator();
+        var sut = CreateValidatorWithConfigValidators();
         var root = CreateStep(name: "Root");
         var trueTarget = CreateStep(name: "TrueTarget");
         var falseTarget = CreateStep(name: "FalseTarget");
@@ -443,12 +504,37 @@ public sealed class PlanValidatorTests
         result.Errors.Should().Contain(e => e.Contains("ModelDeploymentKey"));
     }
 
+    [Fact]
+    public async Task Validate_InvalidRetrievalStepConfig_WithRealDiContainer_ReturnsFail()
+    {
+        // Same shape as Validate_InvalidLlmCallConfig_WithRealDiContainer_ReturnsFail, for the
+        // validator #526 added. Proves the real container resolves RetrievalStepConfigValidator AND
+        // that its rule actually fires — PlannerStepConfigValidatorWiringTests only proves resolution.
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddApplicationCoreDependencies();
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        var sut = new PlanValidator(scope.ServiceProvider, NullLogger<PlanValidator>.Instance);
+        var step = CreateStep(
+            name: "BadRetrieval",
+            type: StepType.Retrieval,
+            config: new RetrievalStepConfiguration { Query = "   " });
+        var graph = CreateGraph([step]);
+
+        var result = await sut.ValidateAsync(graph, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("Query"));
+    }
+
     // --- Resource Estimation ---
 
     [Fact]
     public async Task Validate_ResourceEstimation_ReturnsCriticalPathDuration()
     {
-        var sut = CreateValidator();
+        var sut = CreateValidatorWithConfigValidators();
         var a = CreateStep(name: "A", timeout: TimeSpan.FromSeconds(10));
         var b = CreateStep(name: "B", timeout: TimeSpan.FromSeconds(20));
         var c = CreateStep(name: "C", timeout: TimeSpan.FromSeconds(5));

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerStepConfigValidatorWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerStepConfigValidatorWiringTests.cs
@@ -1,0 +1,56 @@
+using Application.Core;
+using Domain.AI.Planner;
+using FluentAssertions;
+using FluentValidation;
+using Infrastructure.AI.Planner;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Resolves every step-config validator <see cref="PlanValidator" /> depends on from a real,
+/// production-shaped container — not a mock — so an assembly-scan break fails this test instead of
+/// degrading <c>PlanValidator.ValidateConfig</c> to its fail-closed fallback silently in a real host.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is option 3 from #526. All six step-config validators reach the container through one
+/// mechanism, <c>AddValidatorsFromAssembly</c> on the <c>Application.Core</c> assembly — there is no
+/// per-type registration to verify individually, only whether the scan itself still reaches them. An
+/// assembly split, a trimmed publish, or a refactor that moves the
+/// <c>Application.Core/Validation/Planner</c> folder out of the scanned assembly would silently break
+/// every one of them at once; this test is what turns that into a loud CI failure instead of a
+/// warning log nobody reads until a plan they expected to be checked was not.
+/// </para>
+/// <para>
+/// <c>PlanValidatorTests</c> exercises <c>PlanValidator.ValidateConfig&lt;T&gt;</c>'s behavior
+/// against a <em>mocked</em> <c>IServiceProvider</c> that hands back canned validators — it proves the
+/// method's logic, not that a real container actually resolves anything. This test proves the other
+/// half: that <c>services.AddApplicationCoreDependencies()</c>, run exactly as the composition root
+/// runs it, really does make every <c>IValidator&lt;T&gt;</c> for every known
+/// <see cref="StepConfiguration" /> subtype resolvable.
+/// </para>
+/// </remarks>
+public sealed class PlannerStepConfigValidatorWiringTests
+{
+    [Fact]
+    public void RealContainer_ResolvesAValidatorForEveryKnownStepConfigurationType()
+    {
+        var services = new ServiceCollection();
+        services.AddApplicationCoreDependencies();
+        var provider = services.BuildServiceProvider();
+
+        provider.GetService<IValidator<LlmCallConfig>>().Should().NotBeNull(
+            "PlanValidator dispatches LlmCallConfig to ValidateConfig<T>, which fails the whole " +
+            "plan closed if this cannot be resolved (#526)");
+        provider.GetService<IValidator<ToolUseConfig>>().Should().NotBeNull();
+        provider.GetService<IValidator<HumanGateConfig>>().Should().NotBeNull();
+        provider.GetService<IValidator<ConditionalBranchConfig>>().Should().NotBeNull();
+        provider.GetService<IValidator<SubPlanConfig>>().Should().NotBeNull();
+        provider.GetService<IValidator<RetrievalStepConfiguration>>().Should().NotBeNull(
+            "added alongside this test (#526) — until now RetrievalStepConfiguration had no switch " +
+            "arm in PlanValidator and no validator anywhere, so every retrieval-step plan passed " +
+            "unchecked regardless of what this test would have found");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -278,7 +278,7 @@ public sealed class SecurityControlHasACallerTests
     /// assumed but asserted by <see cref="MediatRValidationBehavior_IsRegisteredAsAnOpenGenericPipelineBehavior"/>,
     /// because it is the claim 58 exemptions rest on. Third, a consumer resolves
     /// <c>IValidator&lt;T&gt;</c> itself and applies it, in which case the validator's own name appears
-    /// in no wiring file while it runs on every call. The five planner step-config validators are the
+    /// in no wiring file while it runs on every call. The six planner step-config validators are the
     /// third shape:
     /// <c>PlanValidator.ValidateStepConfigurations</c> resolves and applies each one against every
     /// step of every plan. <c>PlanValidatorTests</c> proves the dispatch for three
@@ -747,18 +747,22 @@ public sealed class SecurityControlHasACallerTests
     /// withdrawn on the claim that it "could not fail", which was false: withdrawing it removed
     /// real detection for four of five, including <c>ConditionalBranchConfig</c>, which no other
     /// test guards. The restored check anchors on the dispatch-arm shape
-    /// (<c>{Type} config =&gt; await ValidateConfig(</c>), which matches exactly the five arms and
-    /// nothing else — verified — and its mutation test deletes the <c>SubPlanConfig</c> arm
-    /// specifically, because that is the type with a second mention. The rest of the limits are
+    /// (<c>{Type} config =&gt; await ValidateConfig(</c>) rather than on the type's name, which
+    /// currently matches exactly six arms and nothing else — verified — and its mutation test
+    /// deletes the <c>SubPlanConfig</c> arm specifically, because that is the type with a second
+    /// mention. The regex originally required its captured type name to end in "Config"; #526
+    /// dropped that requirement after finding it blind to <c>RetrievalStepConfiguration</c>, whose
+    /// name ends in "Configuration" — a live blind spot in the same family this file's history is
+    /// otherwise all about, found by adding a type rather than by review. The rest of the limits are
     /// tracked as #528.
     /// </para>
     /// <para>
-    /// What the exemption does not prove is that the five are <em>registered</em>.
-    /// <c>PlanValidator.ValidateConfig</c>
-    /// fails open when no <c>IValidator&lt;T&gt;</c> resolves (#526), and their only registration
-    /// is <c>AddValidatorsFromAssembly</c> on Application.Core; real-container resolution is tested
-    /// for two of the five. The exemption says a consumer <em>would call</em> each one — not that
-    /// one exists to be called.
+    /// <c>PlanValidator.ValidateConfig</c> used to fail open when no <c>IValidator&lt;T&gt;</c>
+    /// resolved; #526 made that fail closed, and
+    /// <c>PlannerStepConfigValidatorWiringTests.RealContainer_ResolvesAValidatorForEveryKnownStepConfigurationType</c>
+    /// now resolves all six from a real container built the way the composition root builds it — not
+    /// mocked, not partial — so this exemption list and that test together prove both halves: a
+    /// consumer would call each one, and each one exists to be called.
     /// </para>
     /// <para>
     /// One limit remains, tracked in #528: entries are unqualified type names, so a second
@@ -770,12 +774,15 @@ public sealed class SecurityControlHasACallerTests
     /// </remarks>
     private static readonly string[] ConsumerResolvedValidatedTypes =
     [
-        // All five: PlanValidator.ValidateStepConfigurations dispatches each to ValidateConfig<T>.
+        // All six: PlanValidator.ValidateStepConfigurations dispatches each to ValidateConfig<T>.
+        // RetrievalStepConfiguration added by #526 — it had no switch arm and no validator at all
+        // before that fix, which is the reason the anchor below no longer requires a "Config" suffix.
         "LlmCallConfig",
         "ToolUseConfig",
         "HumanGateConfig",
         "ConditionalBranchConfig",
-        "SubPlanConfig"
+        "SubPlanConfig",
+        "RetrievalStepConfiguration"
     ];
 
     /// <summary>
@@ -797,7 +804,15 @@ public sealed class SecurityControlHasACallerTests
         File.Exists(planValidator).Should().BeTrue("the consumer that justifies every exemption must exist");
 
         var source = SourceScan.StripCommentsAndStrings(File.ReadAllText(planValidator));
-        var dispatched = Regex.Matches(source, @"\b(\w+Config)\s+\w+\s*=>\s*await\s+ValidateConfig\(")
+
+        // Deliberately NOT anchored on a "Config" type-name suffix. #526 added
+        // RetrievalStepConfiguration, whose name ends in "Configuration" — a suffix-anchored version
+        // of this pattern would have been silently blind to it in exactly the way the file's own
+        // remarks describe for the pre-2026-08-26 candidacy rule elsewhere in this suite: the guard
+        // would report nothing wrong while a real arm went unwatched. The dispatch SHAPE
+        // ({Type} config => await ValidateConfig() is what identifies an arm; the type's name is not
+        // load-bearing and must never be part of the anchor again.
+        var dispatched = Regex.Matches(source, @"\b(\w+)\s+\w+\s*=>\s*await\s+ValidateConfig\(")
             .Select(m => m.Groups[1].Value)
             .ToHashSet(StringComparer.Ordinal);
 


### PR DESCRIPTION
Closes #526.

## The gap

`PlanValidator.ValidateConfig<T>` resolved `IValidator<T>` from the container and, when nothing was registered, logged a warning and returned an empty error list — indistinguishable from "checked, and clean" to the caller. `LogUnknownConfigType` had the same shape for a `StepConfiguration` subtype the switch does not recognize.

No shipped host runs without these validators — all reach the container through one mechanism, `AddValidatorsFromAssembly` on `Application.Core`, unconditional at every call site — so an unresolvable validator for a known type is not a legitimate configuration, it's that mechanism having broken (an assembly split, a trimmed publish, a folder move). Both branches now reject the plan instead.

## Verifying the premise found a bigger defect

`StepConfiguration` has **six** `[JsonDerivedType]` subtypes, not five. `RetrievalStepConfiguration` had no switch arm in `ValidateStepConfigurations` **at all** — not an unregistered validator for a known type, a step type with no case in the switch and no validator anywhere in the codebase. Every retrieval-step plan has passed unchecked, silently, for as long as `StepType.Retrieval` has existed.

Failing closed on the general "unrecognized subtype" branch without first closing that gap would have rejected every retrieval-step plan instead of fixing the actual defect. Both landed together: a switch arm, a new `RetrievalStepConfigValidator` (Query non-empty, TopK positive when set), and a real-container test proving it resolves.

## Option 3 from the issue

`PlannerStepConfigValidatorWiringTests` resolves all six step-config validators from a real container built the way the composition root builds it — not mocked — so a scan break fails CI directly instead of degrading to a warning log nobody reads.

## A blind spot in the guard itself

`SecurityControlHasACallerTests`' dispatch-arm anchor required its captured type name to end in `"Config"`. `RetrievalStepConfiguration` ends in `"Configuration"` and would have been silently invisible to it — the exact blind-spot shape that guard's own history is otherwise about, found by adding a type rather than by review. The anchor is now on the dispatch shape alone, with no naming assumption.

## Verified with mutation, not just passing tests

- Reverted each of the two fail-closed branches independently; a dedicated regression test catches each on its own.
- Four pre-existing `PlanValidatorTests` were found relying on the old fail-open bug incidentally — asserting graph structure (acyclicity, critical-path duration) while accidentally skipping step-config validation entirely via a loose mock. Fixed to supply real validators.
- The new validator's `Query` rule is mutation-tested the same way.

## Test plan

- Full local gate suite green twice (once before a `/simplify` pass deduped the two branches' error message, once after): build, test, OWASP, grader, correctness, security.
- 39 tests across `PlanValidatorTests`, `PlannerStepConfigValidatorWiringTests`, and the guard suite; every new/changed assertion mutation-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj