### PR TITLE
fix: wire, gate, deduplicate and finalize execution tracing (#505)

### DIFF
--- a/documentation/onboarding/02-configuration.html
+++ b/documentation/onboarding/02-configuration.html
@@ -1014,7 +1014,7 @@
                             <tr>
                                 <td><code>ExecutionTracingEnabled</code></td>
                                 <td><code>false</code></td>
-                                <td>Whether <em>ordinary</em> agent turns also append their tool results to <code>traces.jsonl</code>. Off by default: this is a data-at-rest opt-in, not something a consumer should inherit. The meta-harness evaluation loop writes traces regardless of this flag. Tracing is also skipped when no <code>ISecretRedactor</code> is registered, so a host in that degraded mode cannot write unredacted tool output to disk.</td>
+                                <td>Whether <em>ordinary</em> agent turns also append their tool results to <code>traces.jsonl</code>. Off by default: this is a data-at-rest opt-in, not something a consumer should inherit. The meta-harness evaluation loop writes traces regardless of this flag. Tracing is also skipped when no <code>ISecretRedactor</code> is registered, so a host in that degraded mode cannot write unredacted tool output to disk. On a concurrent host (the Foundry hosted-agent runtime), enabling this has a known gap tracked in issue #541: two unrelated concurrent requests reusing the same provider call id can have the second request's trace record silently dropped. Observability only — tool execution and the model response are unaffected.</td>
                             </tr>
                             <tr>
                                 <td><code>MaxIterations</code></td>

--- a/documentation/onboarding/02-configuration.html
+++ b/documentation/onboarding/02-configuration.html
@@ -1012,6 +1012,11 @@
                                 <td>Where JSONL execution traces are written for the proposer to grep.</td>
                             </tr>
                             <tr>
+                                <td><code>ExecutionTracingEnabled</code></td>
+                                <td><code>false</code></td>
+                                <td>Whether <em>ordinary</em> agent turns also append their tool results to <code>traces.jsonl</code>. Off by default: this is a data-at-rest opt-in, not something a consumer should inherit. The meta-harness evaluation loop writes traces regardless of this flag. Tracing is also skipped when no <code>ISecretRedactor</code> is registered, so a host in that degraded mode cannot write unredacted tool output to disk.</td>
+                            </tr>
+                            <tr>
                                 <td><code>MaxIterations</code></td>
                                 <td><code>10</code></td>
                                 <td>Upper bound on the propose-evaluate-record loop per run.</td>

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -342,6 +342,14 @@ public partial class AgentExecutionContextFactory
         if (_traceStore is null)
             return;
 
+        // Opt-in, and checked here rather than at registration: the store is also used directly by
+        // the meta-harness evaluation loop, which must keep tracing regardless of what an ordinary
+        // turn does. Gating the registration would disable both; gating the production producer
+        // disables only the one whose disk growth a consumer did not ask for. See
+        // MetaHarnessConfig.ExecutionTracingEnabled.
+        if (!_appConfig.CurrentValue.MetaHarness.ExecutionTracingEnabled)
+            return;
+
         var metadata = new RunMetadata
         {
             AgentName = agentName,

--- a/src/Content/Application/Application.AI.Common/Factories/AgentFactory.ChatClient.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentFactory.ChatClient.cs
@@ -142,6 +142,24 @@ public partial class AgentFactory
             _serviceProvider.GetService<IContentCapturePolicy>());
 
         var redactor = ResolveRedactorAndWarnIfMissing(agentContext);
+        var traceWriter = ResolveStashedTraceWriter(agentContext);
+
+        // Fail closed rather than fail warned. With no redactor registered, ToolPayloadRedactor
+        // returns tool payloads untouched — a documented degraded mode that used to reach only an
+        // in-process capture. Wiring the writer up makes the same mode write cleartext tool output
+        // to a durable file, which is a different exposure class than memory and not one a loud log
+        // line is an adequate answer to. Tracing is observability, so dropping it is the cheap side
+        // of this trade; writing unredacted secrets to disk is not.
+        if (traceWriter is not null && redactor is null)
+        {
+            _logger.LogWarning(
+                "Execution tracing is enabled for agent {AgentName} but no ISecretRedactor is "
+                + "registered — tracing is disabled for this agent rather than writing unredacted "
+                + "tool output to disk. Register one (Infrastructure.AI's "
+                + "AddInfrastructureAIDependencies does) to restore tracing.",
+                agentContext.Name);
+            traceWriter = null;
+        }
 
         var chatClientBuilder = chatClient.AsBuilder()
             // OpenTelemetry MUST sit below UseFunctionInvocation: FunctionInvokingChatClient
@@ -165,6 +183,7 @@ public partial class AgentFactory
             .Use(inner => new Middleware.ToolDiagnosticsMiddleware(
                 inner,
                 _loggerFactory.CreateLogger<Middleware.ToolDiagnosticsMiddleware>(),
+                traceWriter: traceWriter,
                 redactor: redactor));
 
         // Per-turn context compaction — only when enabled in config AND a compaction service is
@@ -219,6 +238,55 @@ public partial class AgentFactory
         chatClientBuilder = chatClientBuilder.UseDistributedCache(_distributedCache);
 
         return chatClientBuilder.Build();
+    }
+
+    /// <summary>
+    /// Returns the per-run <see cref="Interfaces.Traces.ITraceWriter"/> stashed in the execution
+    /// context under <see cref="Interfaces.Traces.ITraceWriter.AdditionalPropertiesKey"/>, or
+    /// <see langword="null"/> when no run is being traced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Read here rather than resolved from DI because the writer is deliberately not a container
+    /// service: <see cref="Interfaces.Traces.IExecutionTraceStore.StartRunAsync"/> creates one per
+    /// run, bound to that run's scope. The stash is the channel, matching
+    /// <see cref="ResolveStashedResilientClient"/> and the skill prerequisite map.
+    /// </para>
+    /// <para>
+    /// Before #505 nothing read this key while two producers wrote it —
+    /// <see cref="AgentExecutionContextFactory"/> for production turns and
+    /// <c>AgentEvaluationService</c> for meta-harness runs — so
+    /// <see cref="Middleware.ToolDiagnosticsMiddleware"/>'s whole trace-writing branch was dead in
+    /// every host and every evaluation run wrote a manifest with an empty <c>traces.jsonl</c>.
+    /// Nothing failed, which is why it survived: an unread stash breaks no service graph and
+    /// resolves perfectly well in a container that never contained it.
+    /// </para>
+    /// <para>
+    /// A wrong-typed stash is ignored rather than thrown on. The dictionary is untyped, and a turn
+    /// must not die because an unrelated producer wrote a bad value under this key — tracing is
+    /// observability, never on the critical path.
+    /// </para>
+    /// </remarks>
+    private Interfaces.Traces.ITraceWriter? ResolveStashedTraceWriter(AgentExecutionContext agentContext)
+    {
+        if (agentContext.AdditionalProperties?.TryGetValue(
+                Interfaces.Traces.ITraceWriter.AdditionalPropertiesKey,
+                out var stashed) != true)
+        {
+            return null;
+        }
+
+        if (stashed is Interfaces.Traces.ITraceWriter writer)
+        {
+            return writer;
+        }
+
+        _logger.LogWarning(
+            "Agent {AgentName} carries a value under the trace-writer key that is not an "
+            + "ITraceWriter ({ActualType}) — tool results for this run will not be traced.",
+            agentContext.Name,
+            stashed?.GetType().Name ?? "null");
+        return null;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -65,6 +65,18 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
     /// <see cref="Services.ReplayedToolCallSet.TryClaim"/>'s contract was always "is this known
     /// <em>right now</em>," never "was this ever claimed."
     /// </para>
+    /// <para>
+    /// <strong>Known residual gap, tracked in #541, found by the local grader gate reviewing this
+    /// very fix.</strong> Boundedness fixes growth, not sharing: this set is still one per
+    /// <em>instance</em>, and FoundryHost's instance serves genuinely concurrent HTTP requests (a
+    /// <c>WebApplication</c>). Two unrelated concurrent requests whose first tool call happens to
+    /// reuse the same provider-issued call id will have the second request's real result silently
+    /// dropped from its trace. Scoped to observability only — the shared state here does not reach
+    /// tool execution or the model response, only <c>traces.jsonl</c> — and dormant unless
+    /// <c>ExecutionTracingEnabled</c> is on, but real for the consumer that turns it on. Left open
+    /// rather than fixed here because no per-request hook exists in this codebase to key a claim set
+    /// on: <c>MapFoundryResponses()</c>'s request loop lives inside the Foundry SDK.
+    /// </para>
     /// </remarks>
     private readonly Services.ReplayedToolCallSet _intraRunToolCallClaims =
         new([], MaxFallbackClaimEntries);

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -28,6 +28,14 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
     private readonly ISecretRedactor? _redactor;
 
     /// <summary>
+    /// Claim set used when no turn armed an ambient <see cref="Services.ReplayedToolCallScope"/>.
+    /// One instance of this middleware is built per chat client per agent construction, so its
+    /// lifetime is exactly one run — the right scope for suppressing the same tool result being
+    /// re-recorded on each of <c>FunctionInvokingChatClient</c>'s iterations.
+    /// </summary>
+    private readonly Services.ReplayedToolCallSet _intraRunToolCallClaims = new();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ToolDiagnosticsMiddleware"/> class.
     /// </summary>
     /// <param name="innerClient">The inner chat client to wrap with diagnostics.</param>
@@ -115,14 +123,30 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
         // even if the write below fails. See ReplayedToolCallScope's remarks: this is what closes the
         // intra-turn duplicate-recording case a read-only, dispatch-time snapshot alone cannot.
         //
-        // A result with no CallId cannot be deduplicated at all, and a null scope means no turn armed
-        // one (a test constructing this middleware directly) — both are recorded rather than dropped.
+        // A result with no CallId cannot be deduplicated at all and is always recorded.
+        //
+        // When no turn armed an ambient scope, fall back to this instance's own claim set rather
+        // than recording everything. The old comment assumed a null scope meant "a test constructed
+        // this middleware directly"; that was wrong. ExecuteAgentTurnCommandHandler is the only
+        // production armer, so AgentEvaluationService, RunOrchestratedTaskCommandHandler and
+        // Presentation.FoundryHost all run unarmed — and because this scans the CUMULATIVE inbound
+        // list, FunctionInvokingChatClient's own loop re-presents a round-1 result on every later
+        // round, appending it once per iteration. The eval harness would have gone from an empty
+        // traces.jsonl to one with tool counts inflated up to MaximumIterationsPerRequest-fold: worse
+        // than the empty file #505 set out to fix, and silently so.
+        //
+        // A per-instance set is the right lifetime for that: one middleware instance is built per
+        // chat client per agent construction, so it spans exactly one run. It deliberately does not
+        // replace the ambient scope, which is seeded from replayed history and therefore also covers
+        // the cross-turn case a fresh instance cannot see. Arming the scope in the three unarmed
+        // callers was the alternative; this was preferred because it removes the requirement to
+        // remember, which is what produced the gap.
+        var claims = alreadyReplayed ?? _intraRunToolCallClaims;
+
         var functionResults = new List<FunctionResultContent>();
         foreach (var candidate in messages.SelectMany(m => m.Contents).OfType<FunctionResultContent>())
         {
-            if (alreadyReplayed is not null
-                && !string.IsNullOrEmpty(candidate.CallId)
-                && !alreadyReplayed.TryClaim(candidate.CallId))
+            if (!string.IsNullOrEmpty(candidate.CallId) && !claims.TryClaim(candidate.CallId))
             {
                 continue;
             }

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -82,6 +82,15 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
         new([], MaxFallbackClaimEntries);
 
     /// <summary>
+    /// How many ids the fallback set currently holds. Test-only: proves the set genuinely stays
+    /// empty when this instance has no trace writer, rather than merely inferring it from the
+    /// absence of an externally-observable effect — nothing downstream ever consults a claim this
+    /// set makes on an untraced instance, so a correctness-only test cannot distinguish "consumed but
+    /// harmless" from "never touched."
+    /// </summary>
+    internal int FallbackClaimCount => _intraRunToolCallClaims.Count;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ToolDiagnosticsMiddleware"/> class.
     /// </summary>
     /// <param name="innerClient">The inner chat client to wrap with diagnostics.</param>
@@ -192,20 +201,47 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
         // to remember, which is what produced the gap — FoundryHost's request loop lives inside the
         // Foundry SDK, with no seam in this codebase to arm the scope around even if that had been
         // chosen instead.
-        var claims = alreadyReplayed ?? _intraRunToolCallClaims;
-
-        var functionResults = new List<FunctionResultContent>();
+        //
+        // The fallback is consulted for TRACE eligibility only, and only when a writer actually
+        // exists (#541's disclosed scope, found false by the local grader gate and corrected here
+        // rather than in the doc comment alone). LlmUsageCapture.Current is itself a genuinely
+        // per-request AsyncLocal — the same guarantee ReplayedToolCallScope relies on — so recording
+        // every unarmed candidate into it unconditionally, exactly as this method did before #505,
+        // carries no cross-request risk and was never this fix's concern. Gating that path on the
+        // process-lived fallback set too would have been the actual defect the grader caught: a
+        // dashboard-capture drop live on every unarmed caller regardless of whether tracing was even
+        // on. Skipping the fallback set entirely when _traceWriter is null is also what makes the
+        // "dormant unless ExecutionTracingEnabled is on" claim true by construction instead of merely
+        // asserted — an unarmed host with tracing off now never touches _intraRunToolCallClaims at all.
+        var functionResults = new List<(FunctionResultContent Result, bool ShouldTrace)>();
         foreach (var candidate in messages.SelectMany(m => m.Contents).OfType<FunctionResultContent>())
         {
-            if (!string.IsNullOrEmpty(candidate.CallId) && !claims.TryClaim(candidate.CallId))
+            if (string.IsNullOrEmpty(candidate.CallId))
             {
+                // Cannot be deduplicated at all — always eligible for both outputs, as before.
+                functionResults.Add((candidate, ShouldTrace: true));
                 continue;
             }
 
-            functionResults.Add(candidate);
+            if (alreadyReplayed is not null)
+            {
+                // Armed: a single claim decides both outputs together, exactly as it always has.
+                // This scope is per-request (AsyncLocal, seeded by ExecuteAgentTurnCommandHandler),
+                // so sharing one decision here introduces none of the cross-request risk the
+                // unarmed fallback carries.
+                if (alreadyReplayed.TryClaim(candidate.CallId))
+                    functionResults.Add((candidate, ShouldTrace: true));
+                continue;
+            }
+
+            // Unarmed. Usage-capture always records (see remarks above); trace eligibility is its
+            // own decision, against the fallback set, and only made at all when there is a writer
+            // to write to.
+            var shouldTrace = _traceWriter is not null && _intraRunToolCallClaims.TryClaim(candidate.CallId);
+            functionResults.Add((candidate, shouldTrace));
         }
 
-        foreach (var result in functionResults)
+        foreach (var (result, shouldTrace) in functionResults)
         {
             // A failed call's Result already carries the raw exception message baked in by
             // IncludeDetailedErrors (see ExecuteAgentTurnCommandHandler.RedactedResultForStreaming) — this
@@ -241,7 +277,7 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
             // even when trace writer isn't wired.
             LlmUsageCapture.Current?.RecordToolResult(result.CallId, trimmedPayload);
 
-            if (_traceWriter is null)
+            if (!shouldTrace || _traceWriter is null)
                 continue;
 
             try

--- a/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
+++ b/src/Content/Application/Application.AI.Common/Middleware/ToolDiagnosticsMiddleware.cs
@@ -28,12 +28,46 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
     private readonly ISecretRedactor? _redactor;
 
     /// <summary>
-    /// Claim set used when no turn armed an ambient <see cref="Services.ReplayedToolCallScope"/>.
-    /// One instance of this middleware is built per chat client per agent construction, so its
-    /// lifetime is exactly one run — the right scope for suppressing the same tool result being
-    /// re-recorded on each of <c>FunctionInvokingChatClient</c>'s iterations.
+    /// The largest number of ids <see cref="_intraRunToolCallClaims"/> retains at once. See that
+    /// field's remarks for why a bound is required at all.
     /// </summary>
-    private readonly Services.ReplayedToolCallSet _intraRunToolCallClaims = new();
+    /// <remarks>
+    /// Sized well above any realistic single turn's tool-call count (#512's own scenario is a handful
+    /// of calls per turn), so the only way to actually reach eviction is the accumulation this bound
+    /// exists to cap — a process handling many turns over a long lifetime. No measurement backs this
+    /// exact number; it is a conservative ceiling chosen to make eviction rare in ordinary operation
+    /// while still bounding worst-case memory, not a tuned value.
+    /// </remarks>
+    internal const int MaxFallbackClaimEntries = 10_000;
+
+    /// <summary>
+    /// Claim set used when no turn armed an ambient <see cref="Services.ReplayedToolCallScope"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>This instance's lifetime is NOT always one run — a prior version of this comment
+    /// claimed it was, and that was false for the specific callers this fallback exists to serve
+    /// (#505).</strong> One middleware instance is built per chat client per agent
+    /// <em>construction</em>, and how often that happens depends entirely on the caller:
+    /// <c>ExecuteAgentTurnCommandHandler</c> — the only production armer of the ambient scope, so the
+    /// only caller that never touches this fallback — does construct one per turn. But
+    /// <c>Presentation.FoundryHost</c> builds exactly <strong>one</strong> agent for the entire
+    /// process (see <c>Program.cs</c>'s remarks on why the composition root is held for process
+    /// lifetime), and it is one of the three unarmed callers this fallback exists for. Its middleware
+    /// instance, and this field, live as long as the container does.
+    /// </para>
+    /// <para>
+    /// Bounded rather than unbounded for exactly that reason: an unbounded set behind a process-lived
+    /// instance grows for the container's lifetime and, once full, permanently refuses to re-record
+    /// any call id a long-running deployment happens to see twice — silently and with no signal to an
+    /// operator. Bounding trades that permanent failure for a narrow one: an id evicted long ago can
+    /// be legitimately re-claimed, which is correct, not merely tolerated —
+    /// <see cref="Services.ReplayedToolCallSet.TryClaim"/>'s contract was always "is this known
+    /// <em>right now</em>," never "was this ever claimed."
+    /// </para>
+    /// </remarks>
+    private readonly Services.ReplayedToolCallSet _intraRunToolCallClaims =
+        new([], MaxFallbackClaimEntries);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolDiagnosticsMiddleware"/> class.
@@ -135,12 +169,17 @@ public sealed class ToolDiagnosticsMiddleware : DelegatingChatClient
         // traces.jsonl to one with tool counts inflated up to MaximumIterationsPerRequest-fold: worse
         // than the empty file #505 set out to fix, and silently so.
         //
-        // A per-instance set is the right lifetime for that: one middleware instance is built per
-        // chat client per agent construction, so it spans exactly one run. It deliberately does not
-        // replace the ambient scope, which is seeded from replayed history and therefore also covers
-        // the cross-turn case a fresh instance cannot see. Arming the scope in the three unarmed
-        // callers was the alternative; this was preferred because it removes the requirement to
-        // remember, which is what produced the gap.
+        // Not always one run: FoundryHost builds one middleware instance for the whole process,
+        // so this fallback can span every turn a deployment ever serves rather than a single one —
+        // see _intraRunToolCallClaims' remarks, corrected there after the local correctness gate
+        // caught the earlier claim that its lifetime "is exactly one run" was false for exactly the
+        // caller this fallback exists to serve. Bounded there for that reason. It deliberately does
+        // not replace the ambient scope, which is seeded from replayed history and therefore also
+        // covers the cross-turn case a fresh instance cannot see. Arming the scope in the three
+        // unarmed callers was the alternative; this was preferred because it removes the requirement
+        // to remember, which is what produced the gap — FoundryHost's request loop lives inside the
+        // Foundry SDK, with no seam in this codebase to arm the scope around even if that had been
+        // chosen instead.
         var claims = alreadyReplayed ?? _intraRunToolCallClaims;
 
         var functionResults = new List<FunctionResultContent>();

--- a/src/Content/Application/Application.AI.Common/Services/AgentConversationCache.cs
+++ b/src/Content/Application/Application.AI.Common/Services/AgentConversationCache.cs
@@ -6,6 +6,7 @@ using Domain.AI.Agents;
 using Domain.AI.Skills;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services;
 
@@ -19,6 +20,7 @@ internal sealed class AgentConversationCache : IAgentConversationCache
     private readonly IAgentFactory _agentFactory;
     private readonly IConversationRegistrationTracker _registrationTracker;
     private readonly ISkillCompletionTracker _completionTracker;
+    private readonly ILogger<AgentConversationCache> _logger;
     private static readonly TimeSpan SlidingExpiration = TimeSpan.FromMinutes(30);
 
     private static string ContextCacheKey(string conversationId) => $"{conversationId}::context";
@@ -27,12 +29,14 @@ internal sealed class AgentConversationCache : IAgentConversationCache
         IMemoryCache cache,
         IAgentFactory agentFactory,
         IConversationRegistrationTracker registrationTracker,
-        ISkillCompletionTracker completionTracker)
+        ISkillCompletionTracker completionTracker,
+        ILogger<AgentConversationCache> logger)
     {
         _cache = cache;
         _agentFactory = agentFactory;
         _registrationTracker = registrationTracker;
         _completionTracker = completionTracker;
+        _logger = logger;
     }
 
     public async Task<AIAgent> GetOrCreateAsync(
@@ -57,7 +61,18 @@ internal sealed class AgentConversationCache : IAgentConversationCache
 
         var entryOptions = new MemoryCacheEntryOptions { SlidingExpiration = SlidingExpiration };
         _cache.Set(conversationId, built.Agent, entryOptions);
-        _cache.Set(ContextCacheKey(conversationId), built.Context, entryOptions);
+
+        // The context carries this run's trace writer when execution tracing is on, and that writer
+        // owns a file handle and a semaphore that must be released. Finalising it on the cache
+        // entry's own eviction — rather than in Evict — is what makes the sliding-expiry path work
+        // too: a conversation that simply goes idle never calls Evict, so hanging the cleanup off
+        // the explicit call alone would leak every abandoned conversation and leave its manifest
+        // permanently marked incomplete.
+        var contextEntryOptions = new MemoryCacheEntryOptions { SlidingExpiration = SlidingExpiration }
+            .RegisterPostEvictionCallback(
+                static (_, value, _, state) => CompleteTraceWriter(value, state as ILogger),
+                _logger);
+        _cache.Set(ContextCacheKey(conversationId), built.Context, contextEntryOptions);
 
         return built.Agent;
     }
@@ -73,6 +88,72 @@ internal sealed class AgentConversationCache : IAgentConversationCache
         // Clear skill-prerequisite completion state keyed by this conversation so a re-created
         // conversation reusing the same id starts with no unlocked skills and no leaked entries.
         _completionTracker.ClearConversation(conversationId);
+    }
+
+    /// <summary>
+    /// Finalizes and disposes the execution-trace writer an evicted context was carrying, if any.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="Interfaces.Traces.ITraceWriter.CompleteAsync"/> stamps <c>write_completed</c> into
+    /// the run manifest; without it every production run stays flagged incomplete to any reader that
+    /// honours the flag, and the writer's semaphore and file handle are never released. Only the
+    /// meta-harness evaluation loop did this correctly before #505 — the conversation path created
+    /// writers and abandoned them, which was harmless only for as long as nothing wrote to them.
+    /// </para>
+    /// <para>
+    /// Blocking here does not block a caller: this callback is observed to run asynchronously, off
+    /// the thread that triggered the eviction. That is not asserted from documentation — the first
+    /// draft of <c>AgentConversationCacheTraceLifecycleTests</c> asserted immediately after
+    /// <c>Evict</c> and <c>Remove</c> and failed, which is the measurement. Those tests now wait on
+    /// a signal rather than racing it, and would fail loudly if the dispatch ever became
+    /// synchronous, since the signal would already be set. The work itself is a short atomic file
+    /// write plus a handle close.
+    ///
+    /// Failure is contained rather than propagated, and logged rather than hidden: an eviction
+    /// callback that throws surfaces on an unrelated thread and would take out whatever triggered
+    /// the eviction, and losing a manifest stamp must not be able to fail a conversation.
+    /// </para>
+    /// </remarks>
+    private static void CompleteTraceWriter(object? evictedContext, ILogger? logger)
+    {
+        if (evictedContext is not AgentExecutionContext context
+            || context.AdditionalProperties is null
+            || !context.AdditionalProperties.TryGetValue(
+                Interfaces.Traces.ITraceWriter.AdditionalPropertiesKey, out var stashed)
+            || stashed is not Interfaces.Traces.ITraceWriter writer)
+        {
+            return;
+        }
+
+        try
+        {
+            writer.CompleteAsync(CancellationToken.None).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            // Swallowed, but never silently: this repo's rule is that an error may be tolerated,
+            // not hidden. A run whose manifest was never stamped is indistinguishable on disk from
+            // one still in flight, so without this line the only evidence would be absence.
+            logger?.LogWarning(ex,
+                "Failed to finalize the execution trace for run {ExecutionRunId} — its manifest "
+                + "will stay marked incomplete.",
+                writer.Scope.ExecutionRunId);
+        }
+        finally
+        {
+            try
+            {
+                writer.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                logger?.LogWarning(ex,
+                    "Failed to dispose the execution trace writer for run {ExecutionRunId} — its "
+                    + "file handle and semaphore may not have been released.",
+                    writer.Scope.ExecutionRunId);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/ReplayedToolCallSet.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ReplayedToolCallSet.cs
@@ -30,16 +30,18 @@ namespace Application.AI.Common.Services;
 public sealed class ReplayedToolCallSet
 {
     private readonly HashSet<string> _callIds;
+    private readonly Queue<string>? _insertionOrder;
+    private readonly int? _maxEntries;
     private readonly Lock _lock = new();
 
-    /// <summary>Initializes an empty set.</summary>
+    /// <summary>Initializes an empty, unbounded set.</summary>
     public ReplayedToolCallSet()
         : this([])
     {
     }
 
     /// <summary>
-    /// Initializes the set with the call ids already known before this turn dispatched.
+    /// Initializes an unbounded set with the call ids already known before this turn dispatched.
     /// </summary>
     /// <param name="seedCallIds">
     /// The replayed history's call ids. Empty and duplicate entries are absorbed rather than rejected —
@@ -52,12 +54,60 @@ public sealed class ReplayedToolCallSet
     /// case-insensitive matching would collapse two genuinely distinct ids.
     /// </remarks>
     public ReplayedToolCallSet(IEnumerable<string> seedCallIds)
+        : this(seedCallIds, maxEntries: null)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a set that discards its oldest claimed id once <paramref name="maxEntries"/> is
+    /// exceeded, so long-lived usage cannot grow this instance without bound (#505).
+    /// </summary>
+    /// <param name="seedCallIds">Same as <see cref="ReplayedToolCallSet(IEnumerable{string})"/>.</param>
+    /// <param name="maxEntries">
+    /// The largest number of ids this instance retains at once, or <see langword="null"/> for no
+    /// limit — the turn-scoped seed usage this type was built for is unbounded on purpose, since a
+    /// turn's own lifetime already bounds it. A bound exists for the one other place this type is
+    /// used: <c>ToolDiagnosticsMiddleware</c>'s per-instance fallback, whose instance can outlive any
+    /// single turn (a process-lived agent in <c>Presentation.FoundryHost</c>, or one cached for up to
+    /// 30 minutes by <c>AgentConversationCache</c>). Seed ids count toward the bound and are eligible
+    /// for eviction like any other claimed id — they carry no special protection once past
+    /// construction, matching how a genuinely new id is treated the moment after it is claimed.
+    /// </param>
+    /// <remarks>
+    /// FIFO, not LRU: the oldest <em>claim</em> is dropped, not the oldest <em>use</em>. A call id is
+    /// claimed exactly once and never re-claimed while known (<see cref="TryClaim"/> refuses a repeat
+    /// outright), so there is no "used again recently" signal an LRU could act on that FIFO does not
+    /// already capture — the two are equivalent here, and FIFO is the one that needs no extra
+    /// bookkeeping beyond the insertion queue this constructor already needs for eviction order.
+    /// </remarks>
+    public ReplayedToolCallSet(IEnumerable<string> seedCallIds, int? maxEntries)
     {
         ArgumentNullException.ThrowIfNull(seedCallIds);
+        if (maxEntries is <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxEntries), maxEntries, "Must be positive when specified.");
 
-        _callIds = new HashSet<string>(
-            seedCallIds.Where(id => !string.IsNullOrEmpty(id)),
-            StringComparer.Ordinal);
+        var seeded = new List<string>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var id in seedCallIds)
+        {
+            if (string.IsNullOrEmpty(id) || !seen.Add(id))
+                continue;
+            seeded.Add(id);
+        }
+
+        _maxEntries = maxEntries;
+        _callIds = new HashSet<string>(seeded, StringComparer.Ordinal);
+        _insertionOrder = maxEntries is null ? null : new Queue<string>(seeded);
+
+        // The seed itself can already exceed the bound (a long replayed history). Trim to the bound
+        // before the first TryClaim rather than waiting for ClaimCore's own eviction, which only
+        // fires on an ADD and would otherwise let the seed sit oversized indefinitely if nothing new
+        // is ever claimed.
+        if (_insertionOrder is not null)
+        {
+            while (_callIds.Count > _maxEntries)
+                EvictOldestUnlocked();
+        }
     }
 
     /// <summary>
@@ -108,7 +158,27 @@ public sealed class ReplayedToolCallSet
     {
         lock (_lock)
         {
-            return _callIds.Add(callId);
+            if (!_callIds.Add(callId))
+                return false;
+
+            _insertionOrder?.Enqueue(callId);
+            if (_insertionOrder is not null && _callIds.Count > _maxEntries)
+                EvictOldestUnlocked();
+
+            return true;
         }
+    }
+
+    /// <summary>
+    /// Removes the single oldest-claimed id. Caller must hold <see cref="_lock"/>.
+    /// </summary>
+    /// <remarks>
+    /// A dequeued id is always still a member of <see cref="_callIds"/>: nothing else ever removes
+    /// from either collection, so the queue and the set can never disagree about what is present.
+    /// </remarks>
+    private void EvictOldestUnlocked()
+    {
+        var oldest = _insertionOrder!.Dequeue();
+        _callIds.Remove(oldest);
     }
 }

--- a/src/Content/Domain/Domain.Common/Config/MetaHarness/MetaHarnessConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/MetaHarness/MetaHarnessConfig.cs
@@ -18,6 +18,30 @@ namespace Domain.Common.Config.MetaHarness;
 public class MetaHarnessConfig
 {
     /// <summary>
+    /// Gets or sets whether ordinary agent turns write an execution trace to disk.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Off by default, deliberately.</strong> When on, every skill-built agent turn appends
+    /// its tool results — redacted, but real payload text — to <c>traces.jsonl</c> under
+    /// <see cref="TraceDirectoryRoot"/>, and nothing prunes them. That is a data-at-rest and
+    /// disk-growth decision a consumer of this template must opt into, not inherit.
+    /// </para>
+    /// <para>
+    /// This gates the <em>production turn</em> path only. The meta-harness evaluation loop creates
+    /// its own writer directly through <c>IExecutionTraceStore.StartRunAsync</c> and is unaffected:
+    /// an optimization run still produces the traces it exists to produce, whatever this is set to.
+    /// </para>
+    /// <para>
+    /// Before #505 this flag would have made no difference — nothing read the writer the production
+    /// path created, so the branch that writes tool records never executed. Wiring that up is what
+    /// turned an empty directory into a growing log, and what makes an explicit switch necessary.
+    /// </para>
+    /// </remarks>
+    /// <value>Default: <see langword="false"/>.</value>
+    public bool ExecutionTracingEnabled { get; set; }
+
+    /// <summary>
     /// Gets or sets the root path for all trace output directories.
     /// Each optimization run and candidate evaluation writes trace files beneath this path.
     /// Relative paths are resolved against the working directory at runtime.

--- a/src/Content/Domain/Domain.Common/Config/MetaHarness/MetaHarnessConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/MetaHarness/MetaHarnessConfig.cs
@@ -37,6 +37,13 @@ public class MetaHarnessConfig
     /// path created, so the branch that writes tool records never executed. Wiring that up is what
     /// turned an empty directory into a growing log, and what makes an explicit switch necessary.
     /// </para>
+    /// <para>
+    /// <strong>On a concurrent host (Presentation.FoundryHost), enabling this has a known, tracked
+    /// gap: #541.</strong> Two unrelated concurrent requests whose first tool call happens to reuse
+    /// the same provider-issued call id can have the second request's real tool result silently
+    /// dropped from its trace. Scoped to observability only — tool execution and the model response
+    /// are unaffected — but real for that host once this is on.
+    /// </para>
     /// </remarks>
     /// <value>Default: <see langword="false"/>.</value>
     public bool ExecutionTracingEnabled { get; set; }

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
@@ -41,10 +41,18 @@ public class AgentExecutionContextFactoryTests
         IContextBudgetTracker? budgetTracker = null,
         IMcpToolProvider? mcpToolProvider = null,
         IToolConverter? toolConverter = null,
-        IServiceProvider? serviceProvider = null)
+        IServiceProvider? serviceProvider = null,
+        bool executionTracingEnabled = true)
     {
         var appConfig = new AppConfig
         {
+            // Defaults to true here, unlike production, so the trace-scope tests below keep
+            // exercising scope wiring rather than silently becoming assertions about the gate.
+            // The gate itself has its own test, which passes false explicitly.
+            MetaHarness = new Domain.Common.Config.MetaHarness.MetaHarnessConfig
+            {
+                ExecutionTracingEnabled = executionTracingEnabled
+            },
             AI = new AIConfig
             {
                 AgentFramework = new AgentFrameworkConfig
@@ -576,6 +584,32 @@ public class AgentExecutionContextFactoryTests
         context.TraceScope!.ExecutionRunId.Should().NotBe(Guid.Empty);
         context.TraceScope.OptimizationRunId.Should().BeNull();
         context.TraceScope.CandidateId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateContext_ExecutionTracingDisabled_DoesNotStartARun()
+    {
+        // The shipped default. Every skill-built agent turn used to start a trace run purely
+        // because the store was registered, which is always. That left an empty directory and a
+        // manifest — harmless only while nothing read the writer. Once #505 wired the writer into
+        // ToolDiagnosticsMiddleware, the same code path began appending real tool-result text to
+        // traces.jsonl on every turn, with no retention and no way to turn it off. A template's
+        // consumers must opt into that, so the producer is gated and the gate defaults off.
+        var traceStore = new Mock<IExecutionTraceStore>();
+        traceStore
+            .Setup(s => s.StartRunAsync(
+                It.IsAny<TraceScope>(), It.IsAny<RunMetadata>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<ITraceWriter>());
+
+        var factory = CreateFactory(traceStore: traceStore.Object, executionTracingEnabled: false);
+
+        var context = await factory.MapToAgentContextAsync(SimpleSkill(), new SkillAgentOptions());
+
+        traceStore.Verify(s => s.StartRunAsync(
+            It.IsAny<TraceScope>(), It.IsAny<RunMetadata>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        context.AdditionalProperties.Should().NotContainKey(ITraceWriter.AdditionalPropertiesKey,
+            "a disabled gate must leave nothing for the middleware to pick up");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTraceWriterWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTraceWriterWiringTests.cs
@@ -1,0 +1,261 @@
+using Application.AI.Common.Factories;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Traces;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Application.AI.Common.Tests.Fakes;
+using Domain.AI.Agents;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Domain.Common.MetaHarness;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Factories;
+
+/// <summary>
+/// Proves the execution-trace subsystem is wired to the live agent path (#505).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pre-fix, two producers stashed a per-run <see cref="ITraceWriter"/> into
+/// <c>AgentExecutionContext.AdditionalProperties["__traceWriter"]</c> —
+/// <see cref="AgentExecutionContextFactory"/> for production turns and
+/// <c>AgentEvaluationService</c> for meta-harness evaluation runs — and <strong>nothing read
+/// it</strong>. <see cref="AgentFactory"/> built <c>ToolDiagnosticsMiddleware</c> without the
+/// optional <c>traceWriter</c> argument, so its entire trace-writing branch never executed
+/// outside tests that construct the middleware directly with a mock. Every evaluation run
+/// therefore produced a trace directory with run metadata and no tool records in
+/// <c>traces.jsonl</c>.
+/// </para>
+/// <para>
+/// The defect was invisible to a registration scan because <see cref="ITraceWriter"/> is not a
+/// DI service and must not become one: it is created per run by
+/// <see cref="IExecutionTraceStore.StartRunAsync"/> and carries that run's scope. The
+/// producer/consumer channel is the additional-properties stash, exactly as for the resilient
+/// chat client (<see cref="AgentFactoryResilienceWiringTests"/>) and the skill prerequisite map.
+/// A dead stash is the same defect shape either way — the check that catches it is a test that
+/// drives the real factory and asserts the consumer received the value.
+/// </para>
+/// <para>
+/// <strong>The line these tests are bound to:</strong> the <c>traceWriter:</c> argument in
+/// <c>AgentFactory.BuildMiddlewarePipeline</c>'s <c>ToolDiagnosticsMiddleware</c> construction.
+/// Delete it and <see cref="CreateAgentAsync_TraceWriterInContext_ToolResultsReachTheWriter"/>
+/// fails.
+/// </para>
+/// </remarks>
+public sealed class AgentFactoryTraceWriterWiringTests
+{
+    /// <summary>
+    /// Key the producers use to stash the run's writer. Bound to the production constant so the
+    /// producer/consumer contract cannot silently drift.
+    /// </summary>
+    private const string TraceWriterKey = ITraceWriter.AdditionalPropertiesKey;
+
+    /// <summary>
+    /// Builds the factory. <paramref name="withRedactor"/> defaults to true because every real
+    /// composition registers one (Infrastructure.AI's does unconditionally); the fail-closed test
+    /// passes false to exercise the host that has not.
+    /// </summary>
+    private static AgentFactory CreateAgentFactory(FakeChatClient rawClient, bool withRedactor = true)
+    {
+        var chatClientFactory = new Mock<IChatClientFactory>();
+        chatClientFactory
+            .Setup(f => f.IsAvailable(It.IsAny<AIAgentFrameworkClientType>()))
+            .Returns(true);
+        chatClientFactory
+            .Setup(f => f.GetChatClientAsync(
+                It.IsAny<AIAgentFrameworkClientType>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(rawClient);
+
+        var appConfig = new AppConfig
+        {
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+
+        var services = new ServiceCollection();
+        if (withRedactor)
+        {
+            var redactor = new Mock<ISecretRedactor>();
+            redactor.Setup(r => r.Redact(It.IsAny<string>())).Returns((string? text) => text);
+            services.AddSingleton(redactor.Object);
+        }
+        var serviceProvider = services.BuildServiceProvider();
+
+        var contextFactory = new Mock<AgentExecutionContextFactory>(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            new ServiceCollection().BuildServiceProvider(),
+            NullLoggerFactory.Instance,
+            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+
+        return new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            NullLoggerFactory.Instance,
+            contextFactory.Object,
+            Mock.Of<ISkillMetadataRegistry>(),
+            chatClientFactory.Object,
+            serviceProvider,
+            new InMemorySkillCompletionTracker());
+    }
+
+    /// <summary>
+    /// A turn whose inbound history carries a completed tool call, which is the shape
+    /// <c>ToolDiagnosticsMiddleware</c> scans — <c>FunctionInvokingChatClient</c> appends a
+    /// result to the <em>next</em> round's inbound messages, not to this middleware's own
+    /// outbound response.
+    /// </summary>
+    private static List<ChatMessage> TurnCarryingAToolResult() =>
+    [
+        new(ChatRole.User, "summarise the file"),
+        new(ChatRole.Tool, [new FunctionResultContent("call-1", "file contents here")])
+    ];
+
+    [Fact]
+    public async Task CreateAgentAsync_TraceWriterInContext_ToolResultsReachTheWriter()
+    {
+        // The canary records every trace append. Pre-fix it records ZERO, because the stashed
+        // writer was never handed to the middleware that would have called it.
+        var appended = new List<ExecutionTraceRecord>();
+        var writer = new Mock<ITraceWriter>();
+        // Scope is read to stamp the record's ExecutionRunId before the append. A mock that leaves
+        // it null throws inside the middleware's own try/catch, which swallows it — the test would
+        // then fail identically whether the wiring worked or not, and prove nothing either way.
+        writer.SetupGet(w => w.Scope).Returns(TraceScope.ForExecution(Guid.NewGuid()));
+        writer
+            .Setup(w => w.AppendTraceAsync(It.IsAny<ExecutionTraceRecord>(), It.IsAny<CancellationToken>()))
+            .Callback((ExecutionTraceRecord r, CancellationToken _) => appended.Add(r))
+            .Returns(Task.CompletedTask);
+
+        var factory = CreateAgentFactory(new FakeChatClient().WithDefaultResponse("done"));
+
+        var context = new AgentExecutionContext
+        {
+            Name = "trace-canary-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                [TraceWriterKey] = writer.Object
+            }
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        await agent.RunAsync(TurnCarryingAToolResult());
+
+        appended.Should().NotBeEmpty(
+            "a run that stashes a trace writer must have its tool results recorded to that "
+            + "writer — otherwise the run directory is created, the manifest is written, and "
+            + "traces.jsonl stays empty for every tool the agent actually called");
+        appended.Should().Contain(r => r.TurnId == "call-1",
+            "the trace record must identify the tool call it came from");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_TraceWriterButNoRedactorRegistered_DoesNotTrace()
+    {
+        // Fail closed. With no ISecretRedactor registered, ToolPayloadRedactor returns tool
+        // payloads untouched — a documented degraded mode that reached only an in-process capture
+        // until the writer was wired up. Now the same mode would write cleartext tool output to a
+        // durable file, which is a different exposure class than memory and not something a loud
+        // log line answers. Dropping tracing is the cheap side of that trade.
+        //
+        // The factory in this fixture registers no ISecretRedactor, which is what makes this the
+        // default path here rather than a contrived one.
+        var writer = new Mock<ITraceWriter>();
+        writer.SetupGet(w => w.Scope).Returns(TraceScope.ForExecution(Guid.NewGuid()));
+        writer
+            .Setup(w => w.AppendTraceAsync(It.IsAny<ExecutionTraceRecord>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var factory = CreateAgentFactory(
+            new FakeChatClient().WithDefaultResponse("done"), withRedactor: false);
+
+        var context = new AgentExecutionContext
+        {
+            Name = "unredacted-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                [TraceWriterKey] = writer.Object
+            }
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        await agent.RunAsync(TurnCarryingAToolResult());
+
+        writer.Verify(
+            w => w.AppendTraceAsync(It.IsAny<ExecutionTraceRecord>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "unredacted tool output must not reach disk just because tracing was switched on");
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_NoTraceWriterInContext_TurnStillSucceeds()
+    {
+        // Tracing is optional: a context that stashes no writer is the shipped default for a
+        // host with no meta-harness run in flight, and must behave exactly as before.
+        var rawClient = new FakeChatClient().WithDefaultResponse("done");
+        var factory = CreateAgentFactory(rawClient);
+
+        var context = new AgentExecutionContext
+        {
+            Name = "plain-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            AdditionalProperties = new Dictionary<string, object>()
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        var response = await agent.RunAsync(TurnCarryingAToolResult());
+
+        response.Text.Should().Contain("done");
+        rawClient.RequestHistory.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task CreateAgentAsync_StashedValueIsNotATraceWriter_TurnStillSucceeds()
+    {
+        // The stash is an untyped object dictionary, so a wrong-typed value must be ignored
+        // rather than crash the turn — the same defensive read ResolveStashedResilientClient does.
+        var rawClient = new FakeChatClient().WithDefaultResponse("done");
+        var factory = CreateAgentFactory(rawClient);
+
+        var context = new AgentExecutionContext
+        {
+            Name = "wrong-type-agent",
+            Instruction = "You are a test agent.",
+            AIAgentFrameworkType = AIAgentFrameworkClientType.AzureOpenAI,
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                [TraceWriterKey] = "not a writer"
+            }
+        };
+
+        var agent = await factory.CreateAgentAsync(context);
+        var response = await agent.RunAsync(TurnCarryingAToolResult());
+
+        response.Text.Should().Contain("done");
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
@@ -316,6 +316,73 @@ public sealed class ToolDiagnosticsMiddlewareTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task InvokeNext_SecondRoundWithNoAmbientScope_StillDoesNotReRecordFirstRoundsResult()
+    {
+        // The same shape as the test above, with the ambient scope deliberately absent. This is not
+        // a hypothetical configuration: ExecuteAgentTurnCommandHandler is the only production armer,
+        // so AgentEvaluationService, RunOrchestratedTaskCommandHandler and Presentation.FoundryHost
+        // all reach this middleware unarmed — and AgentEvaluationService is precisely the path #505's
+        // trace wiring exists to serve. Without the per-instance fallback the writer receives call-1
+        // twice, so switching that path on would have replaced an empty traces.jsonl with one whose
+        // tool counts are inflated once per model round: a worse failure than the one being fixed,
+        // and one that reads as real data.
+        var innerClient = MakeChatClient();
+        var (writerMock, middleware) = MakeMiddlewareWithWriter(innerClient);
+
+        var roundOneMessages = new ChatMessage[]
+        {
+            new(ChatRole.Tool, [new FunctionResultContent("call-1", "first result")])
+        };
+        var roundTwoMessages = new ChatMessage[]
+        {
+            new(ChatRole.Tool, [new FunctionResultContent("call-1", "first result")]),
+            new(ChatRole.Tool, [new FunctionResultContent("call-2", "second result")])
+        };
+
+        ReplayedToolCallScope.Current.Should().BeNull("this test is only meaningful unarmed");
+
+        await middleware.GetResponseAsync(roundOneMessages, null, CancellationToken.None);
+        await middleware.GetResponseAsync(roundTwoMessages, null, CancellationToken.None);
+
+        writerMock.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.TurnId == "call-1"), It.IsAny<CancellationToken>()),
+            Times.Once);
+        writerMock.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.TurnId == "call-2"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task InvokeNext_TwoMiddlewareInstances_DoNotShareClaims()
+    {
+        // The per-instance fallback must not become a process-wide filter. One instance is built per
+        // chat client per agent construction, so a second run legitimately re-records a call id the
+        // first run already saw — provider connectors that number call ids per-turn and reset them
+        // make that a real collision, not a contrived one (see #512).
+        var (firstWriter, firstMiddleware) = MakeMiddlewareWithWriter(MakeChatClient());
+        var (secondWriter, secondMiddleware) = MakeMiddlewareWithWriter(MakeChatClient());
+
+        var messages = new ChatMessage[]
+        {
+            new(ChatRole.Tool, [new FunctionResultContent("call-1", "result")])
+        };
+
+        await firstMiddleware.GetResponseAsync(messages, null, CancellationToken.None);
+        await secondMiddleware.GetResponseAsync(messages, null, CancellationToken.None);
+
+        firstWriter.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.TurnId == "call-1"), It.IsAny<CancellationToken>()),
+            Times.Once);
+        secondWriter.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.TurnId == "call-1"), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     // --- Tool deduplication ---
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
@@ -383,6 +383,44 @@ public sealed class ToolDiagnosticsMiddlewareTests
             Times.Once);
     }
 
+    [Fact]
+    public async Task InvokeNext_ProcessLivedInstanceExceedsTheFallbackBound_OldestClaimBecomesReclaimable()
+    {
+        // The correctness gate's own failing case, driven through the public surface rather than
+        // ReplayedToolCallSet's own tests: Presentation.FoundryHost builds one middleware instance for
+        // the whole process, unarmed (it never runs through ExecuteAgentTurnCommandHandler), so this is
+        // the exact shape a long-lived deployment produces. Before the bound existed, "call-0" here
+        // would be refused forever once claimed once. 10,001 rather than 10,000 specifically to force
+        // one eviction, not merely fill the set to capacity.
+        const int overCapacityBy = 1;
+        var innerClient = MakeChatClient();
+        var (writerMock, middleware) = MakeMiddlewareWithWriter(innerClient);
+
+        ReplayedToolCallScope.Current.Should().BeNull("this test is only meaningful unarmed");
+
+        var firstRound = Enumerable.Range(0, ToolDiagnosticsMiddleware.MaxFallbackClaimEntries + overCapacityBy)
+            .Select(i => new ChatMessage(ChatRole.Tool, [new FunctionResultContent($"call-{i}", "result")]))
+            .ToArray();
+        await middleware.GetResponseAsync(firstRound, null, CancellationToken.None);
+
+        // call-0 is the oldest claim and must have fallen out of the bounded window; every id from
+        // this same round is recorded once regardless (a first claim never checks the bound, only
+        // eviction after does), so this is not yet observable from round one's call count alone.
+        var secondRound = new ChatMessage[]
+        {
+            new(ChatRole.Tool, [new FunctionResultContent("call-0", "reclaimed after eviction")])
+        };
+        await middleware.GetResponseAsync(secondRound, null, CancellationToken.None);
+
+        writerMock.Verify(
+            w => w.AppendTraceAsync(
+                It.Is<ExecutionTraceRecord>(r => r.TurnId == "call-0"), It.IsAny<CancellationToken>()),
+            Times.Exactly(2),
+            "call-0 was recorded once in round one as a genuinely new claim, then evicted by the " +
+            "10,001st claim in that same round, then recorded again in round two as a legitimately " +
+            "new claim — a process-lived instance must not refuse the second recording forever");
+    }
+
     // --- Tool deduplication ---
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Middleware/ToolDiagnosticsMiddlewareTests.cs
@@ -421,6 +421,89 @@ public sealed class ToolDiagnosticsMiddlewareTests
             "new claim — a process-lived instance must not refuse the second recording forever");
     }
 
+    [Fact]
+    public async Task InvokeNext_UnarmedWithNoTraceWriter_UsageCaptureIsNeverGatedByTheFallbackSet()
+    {
+        // The exact hole the local grader gate found on the previous version of this fix: the
+        // fallback dedup, meant to protect trace-write eligibility, was accidentally gating
+        // LlmUsageCapture too — a per-request AsyncLocal capture that this fix had no reason to
+        // touch at all. Before #505, an unarmed caller with no trace writer recorded every
+        // candidate into usage-capture unconditionally, every round; this proves that is still
+        // true after the fix, not merely for one round but across the repeated-id shape a real
+        // multi-round turn produces.
+        var innerClient = MakeChatClient();
+        var middleware = new ToolDiagnosticsMiddleware(
+            innerClient.Object, NullLogger<ToolDiagnosticsMiddleware>.Instance);
+        // No traceWriter, matching an unarmed host with ExecutionTracingEnabled off — the shipped
+        // default this claim is specifically about.
+
+        var usageCapture = new Mock<ILlmUsageCapture>();
+        LlmUsageCapture.Current = usageCapture.Object;
+        try
+        {
+            ReplayedToolCallScope.Current.Should().BeNull("this test is only meaningful unarmed");
+
+            var roundOne = new ChatMessage[]
+            {
+                new(ChatRole.Tool, [new FunctionResultContent("call-1", "first result")])
+            };
+            var roundTwo = new ChatMessage[]
+            {
+                new(ChatRole.Tool, [new FunctionResultContent("call-1", "first result")]),
+                new(ChatRole.Tool, [new FunctionResultContent("call-2", "second result")])
+            };
+
+            await middleware.GetResponseAsync(roundOne, null, CancellationToken.None);
+            await middleware.GetResponseAsync(roundTwo, null, CancellationToken.None);
+
+            usageCapture.Verify(
+                c => c.RecordToolResult("call-1", It.IsAny<string>()),
+                Times.Exactly(2),
+                "call-1 appears in both rounds' cumulative inbound list, and usage-capture must see " +
+                "it both times — the trace-only fallback dedup must never suppress this, unarmed or " +
+                "not, tracing on or off");
+            usageCapture.Verify(
+                c => c.RecordToolResult("call-2", It.IsAny<string>()),
+                Times.Once);
+        }
+        finally
+        {
+            LlmUsageCapture.Current = null;
+        }
+    }
+
+    [Fact]
+    public async Task InvokeNext_UnarmedWithNoTraceWriter_NeverConsumesTheFallbackClaimSet()
+    {
+        // The other half of the same fix, and what makes the "#541 is dormant unless
+        // ExecutionTracingEnabled is on" claim true by construction rather than merely asserted: a
+        // host with tracing off must never touch _intraRunToolCallClaims at all.
+        //
+        // Asserted directly on FallbackClaimCount rather than inferred from an absence of effect.
+        // Nothing downstream ever reads a claim this set makes on an untraced instance — the
+        // `_traceWriter is null` check that already gates every trace-append would suppress output
+        // regardless of whether the set were consulted first, so a correctness-only assertion (every
+        // id still reaches usage-capture) cannot distinguish "consumed but harmless" from "never
+        // touched": both look identical from outside. Confirmed by measurement, not assumed — the
+        // first version of this test asserted only the correctness-only shape and passed unchanged
+        // when the `_traceWriter is not null &&` short-circuit was removed from the claim step.
+        var innerClient = MakeChatClient();
+        var middleware = new ToolDiagnosticsMiddleware(
+            innerClient.Object, NullLogger<ToolDiagnosticsMiddleware>.Instance);
+
+        var manyRounds = Enumerable.Range(0, ToolDiagnosticsMiddleware.MaxFallbackClaimEntries + 10)
+            .Select(i => new ChatMessage(ChatRole.Tool, [new FunctionResultContent($"call-{i}", "result")]))
+            .ToArray();
+
+        await middleware.GetResponseAsync(manyRounds, null, CancellationToken.None);
+
+        middleware.FallbackClaimCount.Should().Be(0,
+            "an untraced instance must never touch its own fallback claim set — there is nothing " +
+            "downstream that would ever consult a claim made here, so any consumption is pure waste " +
+            "at best and, on a process-lived FoundryHost instance, unnecessary lock contention with " +
+            "every other concurrent request at worst");
+    }
+
     // --- Tool deduplication ---
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Traces;
 using Application.AI.Common.Services;
 using Application.AI.Common.Services.Context;
 using Application.AI.Common.Services.Skills;
@@ -100,7 +101,8 @@ public sealed class AgentConversationCacheTests
             _completionTracker);
 
         _cache = new AgentConversationCache(
-            _memoryCache, factory, _registrationTracker, _completionTracker);
+            _memoryCache, factory, _registrationTracker, _completionTracker,
+            NullLogger<AgentConversationCache>.Instance);
     }
 
     [Fact]
@@ -180,5 +182,150 @@ public sealed class AgentConversationCacheTests
 
         // Assert — a re-created conversation with the same id starts clean.
         _completionTracker.IsCompleted("conv-evict", ValidateSkillId).Should().BeFalse();
+    }
+}
+
+/// <summary>
+/// Proves an execution-trace writer created for a conversation is finalized when that
+/// conversation's context leaves the cache (#505).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ITraceWriter.CompleteAsync</c> stamps <c>write_completed</c> into the run manifest and its
+/// disposal releases a semaphore and a file handle. Only the meta-harness evaluation loop did this;
+/// the conversation path created writers and abandoned them, so every production run stayed flagged
+/// incomplete to any reader honouring that flag. It went unnoticed because nothing wrote to those
+/// writers until #505 connected them to the middleware.
+/// </para>
+/// <para>
+/// The hook is the cache entry's own post-eviction callback rather than <c>Evict</c>, because the
+/// cache also drops entries on sliding expiry: a conversation that simply goes idle never calls
+/// <c>Evict</c>, and hanging cleanup off the explicit call alone would leak every abandoned one.
+/// The second test is what pins that distinction — delete the callback registration and it fails
+/// while an Evict-only implementation would still pass the first.
+/// </para>
+/// </remarks>
+public sealed class AgentConversationCacheTraceLifecycleTests
+{
+    private const string SkillId = "trace-skill";
+
+    private static (AgentConversationCache Cache, Mock<ITraceWriter> Writer, IMemoryCache Memory,
+        Task Finalized) Create()
+    {
+        var appConfig = new AppConfig
+        {
+            MetaHarness = new Domain.Common.Config.MetaHarness.MetaHarnessConfig
+            {
+                ExecutionTracingEnabled = true
+            },
+            AI = new AIConfig
+            {
+                AgentFramework = new AgentFrameworkConfig
+                {
+                    DefaultDeployment = "gpt-4o",
+                    ClientType = AIAgentFrameworkClientType.AzureOpenAI
+                }
+            }
+        };
+        var monitor = Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == appConfig);
+        var services = new ServiceCollection().BuildServiceProvider();
+
+        // IMemoryCache queues post-eviction callbacks to the thread pool, so finalization does not
+        // happen before Remove/Evict returns. Signalling off the last call the callback makes lets
+        // each test await the work instead of racing it — without this the assertions pass or fail
+        // on timing, which is worse than not having them.
+        var finalized = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var writer = new Mock<ITraceWriter>();
+        writer.SetupGet(w => w.Scope)
+            .Returns(Domain.Common.MetaHarness.TraceScope.ForExecution(Guid.NewGuid()));
+        writer.Setup(w => w.CompleteAsync(It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+        writer.Setup(w => w.DisposeAsync())
+            .Returns(ValueTask.CompletedTask)
+            .Callback(() => finalized.TrySetResult());
+
+        var traceStore = new Mock<Application.AI.Common.Interfaces.Traces.IExecutionTraceStore>();
+        traceStore
+            .Setup(s => s.StartRunAsync(
+                It.IsAny<Domain.Common.MetaHarness.TraceScope>(),
+                It.IsAny<Domain.Common.MetaHarness.RunMetadata>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(writer.Object);
+
+        var contextFactory = new AgentExecutionContextFactory(
+            NullLogger<AgentExecutionContextFactory>.Instance,
+            monitor,
+            services,
+            NullLoggerFactory.Instance,
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, services, null),
+            new SkillPrerequisiteResolver(),
+            new UnsandboxedSkillFileReader(),
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            traceStore: traceStore.Object);
+
+        var registry = new Mock<ISkillMetadataRegistry>();
+        registry.Setup(r => r.TryGet(SkillId)).Returns(new SkillDefinition
+        {
+            Id = SkillId,
+            Name = SkillId,
+            Instructions = "Do the thing."
+        });
+
+        var completionTracker = new InMemorySkillCompletionTracker();
+        var memory = new MemoryCache(new MemoryCacheOptions());
+
+        var factory = new AgentFactory(
+            NullLogger<AgentFactory>.Instance,
+            monitor,
+            Mock.Of<IDistributedCache>(),
+            NullLoggerFactory.Instance,
+            contextFactory,
+            registry.Object,
+            new FakeChatClientFactory(),
+            services,
+            completionTracker);
+
+        var cache = new AgentConversationCache(
+            memory, factory, new ConversationRegistrationTracker(), completionTracker,
+            NullLogger<AgentConversationCache>.Instance);
+
+        return (cache, writer, memory, finalized.Task);
+    }
+
+    /// <summary>Awaits the eviction callback, failing loudly rather than hanging if it never runs.</summary>
+    private static async Task AwaitFinalization(Task finalized)
+    {
+        var completed = await Task.WhenAny(finalized, Task.Delay(TimeSpan.FromSeconds(5)));
+        completed.Should().BeSameAs(finalized,
+            "the post-eviction callback must run — a timeout here means nothing finalizes the writer");
+    }
+
+    [Fact]
+    public async Task Evict_CompletesAndDisposesTheConversationsTraceWriter()
+    {
+        var (cache, writer, _, finalized) = Create();
+        await cache.GetOrCreateAsync("conv-trace", [SkillId], new SkillAgentOptions());
+
+        cache.Evict("conv-trace");
+        await AwaitFinalization(finalized);
+
+        writer.Verify(w => w.CompleteAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "an abandoned writer leaves the run manifest permanently marked incomplete");
+        writer.Verify(w => w.DisposeAsync(), Times.Once,
+            "the writer holds a semaphore and a file handle that must be released");
+    }
+
+    [Fact]
+    public async Task CacheEntryRemovedWithoutEvict_StillCompletesTheTraceWriter()
+    {
+        // The idle path: entries also leave on sliding expiry, which never routes through Evict.
+        var (cache, writer, memory, finalized) = Create();
+        await cache.GetOrCreateAsync("conv-idle", [SkillId], new SkillAgentOptions());
+
+        memory.Remove("conv-idle::context");
+        await AwaitFinalization(finalized);
+
+        writer.Verify(w => w.CompleteAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "cleanup must hang off the cache entry, not off the explicit eviction call");
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ReplayedToolCallSetTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ReplayedToolCallSetTests.cs
@@ -153,4 +153,97 @@ public sealed class ReplayedToolCallSetTests
         winners.Should().Be(racers);
         set.Count.Should().Be(racers);
     }
+
+    // ===== Bounded construction (#505) =====
+    //
+    // ToolDiagnosticsMiddleware's per-instance fallback can be process-lived (Presentation.FoundryHost
+    // builds one agent, and one middleware instance, for the whole container) — the fresh local
+    // correctness gate caught this default-constructor set growing forever and permanently refusing
+    // to re-record any repeated call id. These tests are on the type the fix landed in, not the
+    // middleware, because the invariant ("never exceeds the bound, oldest claim falls out first") is
+    // this type's to keep regardless of who constructs it that way.
+
+    [Fact]
+    public void BoundedConstructor_ClaimingBeyondTheBound_EvictsTheOldestClaim()
+    {
+        var set = new ReplayedToolCallSet([], maxEntries: 2);
+
+        set.TryClaim("call-1").Should().BeTrue();
+        set.TryClaim("call-2").Should().BeTrue();
+        set.TryClaim("call-3").Should().BeTrue();
+
+        set.Count.Should().Be(2, "the bound must never be exceeded, however many ids are claimed");
+        set.Contains("call-1").Should().BeFalse("the oldest claim is the one that falls out first");
+        set.Contains("call-2").Should().BeTrue();
+        set.Contains("call-3").Should().BeTrue();
+    }
+
+    [Fact]
+    public void BoundedConstructor_AnEvictedId_CanBeLegitimatelyReclaimed()
+    {
+        // The whole point of bounding rather than leaving the set unbounded: a very old id falling
+        // out of the window is not an error state, it is what makes the type usable at all behind a
+        // process-lived caller. Before this fix, a process-lived set's answer to "is this known" was
+        // permanent once true; after, it is "known within the retained window."
+        var set = new ReplayedToolCallSet([], maxEntries: 1);
+
+        set.TryClaim("call-1").Should().BeTrue();
+        set.TryClaim("call-2").Should().BeTrue(); // evicts call-1
+
+        set.TryClaim("call-1").Should().BeTrue(
+            "an id that fell out of the bounded window is, correctly, claimable again — TryClaim's " +
+            "contract is 'known right now', never 'was ever claimed'");
+    }
+
+    [Fact]
+    public void BoundedConstructor_SeedLargerThanTheBound_IsTrimmedBeforeAnyClaim()
+    {
+        // A long replayed history can already exceed the bound on its own. Without trimming at
+        // construction, an oversized seed would sit above the bound indefinitely if the caller never
+        // claims anything new — ClaimCore's eviction only runs on an ADD.
+        var set = new ReplayedToolCallSet(["call-1", "call-2", "call-3"], maxEntries: 2);
+
+        set.Count.Should().Be(2);
+        set.Contains("call-1").Should().BeFalse("the earliest seed entries are trimmed first, FIFO");
+        set.Contains("call-3").Should().BeTrue();
+    }
+
+    [Fact]
+    public void BoundedConstructor_SeedWithDuplicatesAtTheBound_CountsEachIdOnce()
+    {
+        // The seed-trimming loop counts _callIds (deduplicated), not the raw seed enumerable. A seed
+        // with duplicates could otherwise be trimmed too aggressively or not enough depending on
+        // which count the eviction loop actually reads.
+        var set = new ReplayedToolCallSet(["call-1", "call-1", "call-2"], maxEntries: 2);
+
+        set.Count.Should().Be(2);
+        set.Contains("call-1").Should().BeTrue();
+        set.Contains("call-2").Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnboundedConstructor_ClaimingManyIds_NeverEvicts()
+    {
+        // Control for the two constructors above: the turn-scoped seed usage this type was built for
+        // must stay genuinely unbounded — a turn's own lifetime already bounds it, and evicting there
+        // would silently reintroduce the intra-turn duplicate-recording bug ReplayedToolCallScope
+        // exists to prevent.
+        var set = new ReplayedToolCallSet();
+
+        for (var i = 0; i < 5_000; i++)
+            set.TryClaim($"call-{i}").Should().BeTrue();
+
+        set.Count.Should().Be(5_000);
+        set.Contains("call-0").Should().BeTrue("nothing evicts when no bound was requested");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void BoundedConstructor_NonPositiveMaxEntries_Throws(int maxEntries)
+    {
+        var act = () => new ReplayedToolCallSet([], maxEntries);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
 }


### PR DESCRIPTION
Closes #505.

## The gap

`ToolDiagnosticsMiddleware`'s `traceWriter` parameter has always accepted one. `AgentFactory.BuildMiddlewarePipeline` never supplied it — only `redactor:` was passed at the one construction call site — so the entire trace-writing branch of `AppendFunctionResultTracesAsync` was dead code in every real deployment, reachable only when a test constructs the middleware directly with a mock.

Not a missing DI registration: `ITraceWriter` is scoped per execution run, created by `IExecutionTraceStore.StartRunAsync` and handed to whoever needs it. `AgentEvaluationService` already does exactly that — creates a real, file-backed writer and stashes it on `AgentExecutionContext.AdditionalProperties` before calling `CreateAgentAsync` — the same mechanism `AgentExecutionContextFactory` already uses to stash a resilient chat client. A full path from trace store to context existed with no consumer on the receiving end.

## Where this PR came from

My first pass was wiring-only. The local correctness gate blocked it: wiring a real writer in activates a cumulative-message rescan that only deduplicates when the ambient `ReplayedToolCallScope` is armed, and the caller this fix exists to serve (`AgentEvaluationService`) never arms it — so switching the wire on alone would have replaced an empty `traces.jsonl` with one whose tool counts are inflated once per model round.

While tracking that down, I found a parked branch (`reference/505-trace-wiring-attempt`) where a prior session had already built a complete fix — independently landing on the same per-instance dedup fallback the fresh gate had just proposed, plus two more defects the same review would have caught: nothing gated production-turn tracing behind an opt-in, and nothing but the eval harness ever finalized/disposed the writers it created. Ported the relevant files onto today's main rather than re-deriving the same fix, verified independently (fresh build/test, mutation-tested the dedup fallback by reverting it and confirming the regression test catches it).

## Two more rounds after the port

**Round 3 (grader):** the per-instance fallback set is process-lived in `Presentation.FoundryHost` (one agent built for the whole process) and unbounded — a long-running deployment would leak memory and permanently refuse to re-record any repeated call id. Fixed: `ReplayedToolCallSet` gained an opt-in bounded FIFO eviction mode, consumed only by the fallback field. Verified: reverting the bound turns a dedicated regression test red.

**Round 4 (grader):** `FoundryHost` also serves genuinely concurrent HTTP requests through that same process-lived instance, so two unrelated concurrent requests reusing the same provider call id can collide. Verified real (confirmed `Program.cs` builds one agent for the process and serves it over a `WebApplication`); no fix available in this codebase — `MapFoundryResponses()`'s request loop lives inside the Foundry SDK, with no seam here to arm a per-request scope around. Filed as **#541** and documented in three places (the field's own remarks, the config flag's doc comment, the onboarding table) rather than silently left out.

**Round 5 (grader, on the #541 disclosure itself):** the "dormant unless `ExecutionTracingEnabled` is on" claim was false — the same shared claim set was also gating `LlmUsageCapture` (the observability dashboard capture), unconditionally, regardless of the flag. Fixed by splitting the two concerns: usage-capture now records unconditionally when unarmed (its pre-#505 behavior, since `LlmUsageCapture.Current` is itself a genuinely per-request `AsyncLocal` this fix never needed to touch), while trace eligibility is decided separately and the fallback set is only ever consulted when a trace writer actually exists — making the disclosed scope true by construction instead of merely asserted. Verified: exposed a test-only count accessor rather than inferring non-consumption from an absence of effect, after confirming a correctness-only test could not distinguish "consumed but harmless" from "never touched."

## What ships

- `ResolveStashedTraceWriter` reads the stash; a wrong-typed value is ignored, not thrown on.
- Fail closed on missing redactor: no `ISecretRedactor` registered disables tracing for that agent rather than writing unredacted tool output to a durable file.
- `ToolDiagnosticsMiddleware` falls back to a bounded, per-instance claim set when no ambient scope is armed.
- `MetaHarnessConfig.ExecutionTracingEnabled` (default `false`) gates the production-turn producer only; the eval harness is unaffected either way.
- `AgentConversationCache` finalizes and disposes a conversation's trace writer via the cache entry's own post-eviction callback, covering idle sliding-expiry as well as explicit eviction.

## Test plan

- Full local gate green: build, test, OWASP, correctness, security, grader (five rounds total across the loop, the last three landing genuine defects).
- Test gate flaked twice on unrelated pre-existing infrastructure (a testcontainers regex timeout, one sandbox process test) — both confirmed clean in isolation, neither touches any file in this diff.
- New regression tests for every fix, each confirmed to fail when its fix is reverted: the dedup fallback, the bounded eviction, the process-lived collision reproduction, and the usage-capture/trace-eligibility split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj