### PR TITLE
fix: single-owner tool-output shaping (closes #487, #489, #490, #491, #493)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -94,7 +94,7 @@ public interface IToolCallAdmissionPipeline
     /// <paramref name="result"/>'s text, run unconditionally through the general-purpose sanitizer
     /// (injection payloads, invisible characters, exfiltration URLs) regardless of whether the admission
     /// carried a redact verdict; a redact verdict additionally routes through
-    /// <see cref="IToolClassificationGate.RedactResult"/>'s known-secret-pattern scrub (#484) — a strict
+    /// <see cref="IToolClassificationGate.RedactResult(string, object?)"/>'s known-secret-pattern scrub (#484) — a strict
     /// superset of the baseline sanitize, not a substitute for it. A structured (non-text) result is
     /// returned unchanged — the sanitizer operates on free text, and every recognized text-carrying
     /// shape (a plain string, a serialized MCP <c>CallToolResult</c>'s text and embedded-resource content
@@ -131,7 +131,7 @@ public interface IToolCallAdmissionPipeline
     /// <param name="result">
     /// <paramref name="content"/>, run unconditionally through the general-purpose sanitizer — the same
     /// guarantee <see cref="ApplyOutputPolicy"/> carries (#469) — and additionally through
-    /// <see cref="IToolClassificationGate.RedactResult"/>'s known-secret-pattern scrub when a redaction
+    /// <see cref="IToolClassificationGate.RedactResult(string, string?)"/>'s known-secret-pattern scrub when a redaction
     /// was required (#479 closed the gap where this method sanitized only on that second path, unlike
     /// its sibling). Null content passes through as null: there is nothing to sanitize or redact. Null
     /// when the method returns <see langword="false"/>.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolClassificationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolClassificationGate.cs
@@ -32,7 +32,7 @@ public interface IToolClassificationGate
     /// <returns>
     /// <see cref="ClassificationVerdict.Allow"/> to proceed, <see cref="ClassificationVerdict.Block"/> to
     /// deny with a model-facing message, or <see cref="ClassificationVerdict.RedactOutput"/> to proceed but
-    /// scrub the result via <see cref="RedactResult"/>. Always <see cref="ClassificationVerdict.Allow"/>
+    /// scrub the result via <see cref="RedactResult(string, object?)"/>. Always <see cref="ClassificationVerdict.Allow"/>
     /// when the gate is off or in audit mode.
     /// </returns>
     ValueTask<ClassificationVerdict> EvaluateAsync(
@@ -55,6 +55,27 @@ public interface IToolClassificationGate
     /// shape-preserving scrub to, for the exact set of shapes recognized as text.
     /// </returns>
     object? RedactResult(string toolName, object? result);
+
+    /// <summary>
+    /// String-typed overload of <see cref="RedactResult(string, object?)"/> for a caller that already
+    /// knows its content is plain text and needs to leave as text — the
+    /// <c>ToolCallAdmissionPipeline.TryApplyTextOutputPolicy</c> boundary (the plan step executor and
+    /// the Execution API, neither of which replays structured content back to a model).
+    /// </summary>
+    /// <param name="toolName">The tool whose result is being redacted (passed to the sanitizers as context).</param>
+    /// <param name="content">The tool's raw text.</param>
+    /// <returns>
+    /// The redacted text. <strong>Contract: non-null <paramref name="content"/> must produce a non-null
+    /// result.</strong> <see cref="RedactResult(string, object?)"/>'s general <c>object?</c> signature
+    /// legitimately returns a structured, non-string value unchanged — but a string in, string out
+    /// call site has no structured shape to preserve, so a non-null-input/null-output response here can
+    /// only mean this implementation broke that contract, and the caller
+    /// (<c>ToolCallAdmissionPipeline</c>) treats it as one: it withholds the result and fails the call
+    /// closed rather than falling back to the untreated original. This is the fix for the third instance
+    /// of the <c>object?</c>-conflation defect shape this repo's CLAUDE.md already tracks twice (#490) —
+    /// the return type states the guarantee instead of a caller re-deriving it from a runtime check.
+    /// </returns>
+    string? RedactResult(string toolName, string? content);
 }
 
 /// <summary>The action the classification gate takes for a tool call.</summary>
@@ -66,7 +87,7 @@ public enum ClassificationGateOutcome
     /// <summary>The call is denied; the model receives <see cref="ClassificationVerdict.BlockedMessage"/>.</summary>
     Block,
 
-    /// <summary>The call proceeds, but its result is scrubbed via <see cref="IToolClassificationGate.RedactResult"/>.</summary>
+    /// <summary>The call proceeds, but its result is scrubbed via <see cref="IToolClassificationGate.RedactResult(string, object?)"/>.</summary>
     RedactOutput
 }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
@@ -137,11 +137,6 @@ public sealed class DefaultToolClassificationGate : IToolClassificationGate
         ToolResultText.SanitizeAndRedact(result, _sanitizer, _redactionFilter, toolName);
 
     /// <inheritdoc />
-    /// <remarks>
-    /// Same treatment as the general overload, through the string-typed
-    /// <see cref="ToolResultText.SanitizeAndRedact(string?, ICompositeResponseSanitizer, IContentRedactionFilter, string)"/>
-    /// overload, which carries the non-null-in/non-null-out guarantee the interface's remarks describe.
-    /// </remarks>
     public string? RedactResult(string toolName, string? content) =>
         ToolResultText.SanitizeAndRedact(content, _sanitizer, _redactionFilter, toolName);
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
@@ -126,14 +126,24 @@ public sealed class DefaultToolClassificationGate : IToolClassificationGate
     /// #484: a <c>Redact</c> verdict must do strictly more than the unconditional sanitize every other
     /// tool result already gets (<see cref="ToolCallAdmissionPipeline.ApplyOutputPolicy"/>) — otherwise
     /// an operator-configured classification policy is a control with no distinct effect. Routes through
-    /// <see cref="ToolResultText.SanitizeAndRedact"/> rather than <see cref="ToolResultText.Sanitize"/>,
+    /// <see cref="ToolResultText.SanitizeAndRedact(object?, ICompositeResponseSanitizer, IContentRedactionFilter, string)"/>
+    /// rather than <see cref="ToolResultText.Sanitize(object?, ICompositeResponseSanitizer, string)"/>,
     /// which also applies <see cref="_redactionFilter"/>'s known-secret-pattern scrub. See
-    /// <see cref="ToolResultText.Sanitize"/> for why the result's shape (raw string vs. serialized JSON
+    /// <see cref="ToolResultText.Sanitize(object?, ICompositeResponseSanitizer, string)"/> for why the result's shape (raw string vs. serialized JSON
     /// string element) must survive the round trip, and why a structured result is left unchanged — such
     /// cases are better handled by a Block policy.
     /// </remarks>
     public object? RedactResult(string toolName, object? result) =>
         ToolResultText.SanitizeAndRedact(result, _sanitizer, _redactionFilter, toolName);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Same treatment as the general overload, through the string-typed
+    /// <see cref="ToolResultText.SanitizeAndRedact(string?, ICompositeResponseSanitizer, IContentRedactionFilter, string)"/>
+    /// overload, which carries the non-null-in/non-null-out guarantee the interface's remarks describe.
+    /// </remarks>
+    public string? RedactResult(string toolName, string? content) =>
+        ToolResultText.SanitizeAndRedact(content, _sanitizer, _redactionFilter, toolName);
 
     private AssetReference Resolve(string toolName, IReadOnlyDictionary<string, object?> arguments)
     {

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -265,6 +265,22 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     public const string OutputTruncationMarker = "\n[tool output truncated]";
 
     /// <summary>
+    /// How much beyond <see cref="OutputCeiling"/> is kept while sanitizing and redacting, so a secret
+    /// or an injection pattern straddling the ceiling stays inside the scanned region rather than being
+    /// sliced in half — removed again by the final cut. See <see cref="ToolResultText.PreCutForScan(object?, int, int)"/>
+    /// for the full rationale and the residual risk it accepts.
+    /// </summary>
+    /// <remarks>
+    /// Sized generously against the longest thing the sanitizers look for — connection strings and
+    /// PEM-armoured keys run to a few kilobytes — because the cost of being wrong in one direction is a
+    /// few spare kilobytes scanned, and in the other it is an unredacted secret on the wire. This value,
+    /// and the pre-cut it sizes, used to live privately on <c>DirectToolInvoker</c> alone; every path
+    /// that reaches a tool needs the same protection against scanning an unbounded result, so it moved
+    /// here — the one place that already owns <see cref="OutputCeiling"/> (#487).
+    /// </remarks>
+    internal const int ScrubOverlapMargin = 8 * 1024;
+
+    /// <summary>
     /// The maximum characters of free text a single tool result may contribute to the context window.
     /// </summary>
     /// <remarks>
@@ -289,17 +305,23 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     {
         ArgumentNullException.ThrowIfNull(admission);
 
+        // #487: cut to a scan-cost-bounded region BEFORE sanitizing or redacting — the opposite order
+        // from the final cut below, and safe only because of the overlap margin: see PreCutForScan's
+        // remarks for the trade this accepts. Every caller of this method funnels through it, so this
+        // is also what protects the agent-turn path (GovernedAIFunction), which used to have no bound
+        // on scan cost at all.
+        var (preCut, _) = ToolResultText.PreCutForScan(result, OutputCeiling, ScrubOverlapMargin);
+
         // #469: the sanitize pass below is unconditional — see the interface remarks for why. It stays
         // in shape-preserving lockstep with RedactResult below via the shared ToolResultText.Sanitize.
         var treated = admission.RedactsOutput
-            ? _classificationGate.RedactResult(toolName, result)
-            : ToolResultText.Sanitize(result, _sanitizer, toolName);
+            ? _classificationGate.RedactResult(toolName, preCut)
+            : ToolResultText.Sanitize(preCut, _sanitizer, toolName);
 
-        // #532: bound AFTER sanitize and redact, never before. Cutting first would hand the scrubbers
-        // a truncated string — a secret split across the cut survives, and an injection payload whose
-        // tail was removed can still carry its head. It also mirrors ReportExecutionAsync, which has
-        // always sanitized, redacted, and THEN bounded tool failure text at this same pipeline (#460);
-        // success output simply never got the third step.
+        // #532: bound AFTER sanitize and redact, never before the FINAL cut — the pre-cut above is a
+        // different, wider, scan-cost-only bound, not a substitute for this one. It also mirrors
+        // ReportExecutionAsync, which has always sanitized, redacted, and THEN bounded tool failure
+        // text at this same pipeline (#460); success output simply never got the third step.
         return ToolResultText.Bound(treated, OutputCeiling, OutputTruncationMarker);
     }
 
@@ -313,67 +335,72 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     {
         ArgumentNullException.ThrowIfNull(admission);
 
-        // Every early return below leaves nothing to report; only the one branch that actually cuts
-        // overwrites this. Set once here so no future branch can forget it and silently answer "not
-        // truncated" — which is the exact failure this out-parameter exists to make impossible.
-        wasTruncated = false;
+        // #487: the same scan-cost pre-cut ApplyOutputPolicy applies, for the same reason — this is the
+        // method the plan step executor (a sandboxed tool's output, unbounded upstream) and the
+        // Execution API both call, and neither used to bound scan cost on this side of the boundary.
+        var (preCut, droppedByPreCut) = ToolResultText.PreCutForScan(content, OutputCeiling, ScrubOverlapMargin);
 
         // #479: sanitize unconditionally on both branches, the same guarantee ApplyOutputPolicy carries
         // (#469) — this method used to sanitize only when a redaction was required, leaving the
         // invariant enforced by caller discipline (both current callers ran their own unconditional
         // scrub immediately after) rather than by this interface itself.
         //
-        // Null content is deliberately NOT special-cased ahead of this branch: ToolResultText.Sanitize
-        // already answers null with null on the non-redact path (its default, unrecognized-shape case),
-        // and on the redact path _classificationGate.RedactResult answers null with null too — which
-        // then correctly fails the `is string text` check below and fails closed, exactly as it did
-        // before #479. A short-circuit here that returned true for null unconditionally would silently
-        // skip that fail-closed check for a redact-required call that happens to have no content yet,
-        // turning a denial into a reported success — caught by code review on the PR that introduced it.
+        // Null content is deliberately NOT special-cased ahead of this branch — same reason as before
+        // #490: on the non-redact branch, Sanitize's null-in/null-out guarantee (now structural, not
+        // re-derived from Transform's switch on every read) means a null preCut reaches the null branch
+        // below cleanly. On the REDACT branch it is deliberately NOT short-circuited the same way: a
+        // redact-required call answering with null is treated identically whether preCut was null (the
+        // well-behaved gate correctly echoing "nothing to redact") or the gate broke its contract on
+        // real input — see the fail-closed branch below for why collapsing that distinction is the
+        // point, not an oversight (#479's original regression).
         var processed = admission.RedactsOutput
-            ? _classificationGate.RedactResult(toolName, content)
-            : ToolResultText.Sanitize(content, _sanitizer, toolName);
+            ? _classificationGate.RedactResult(toolName, preCut)
+            : ToolResultText.Sanitize(preCut, _sanitizer, toolName);
 
-        if (processed is string text)
+        if (processed is null)
         {
-            // #532: bound after sanitize/redact — see ApplyOutputPolicy for why the order is fixed.
-            // This is the plan path's only cut. It is NOT the Execution API's only cut, and an earlier
-            // version of this comment claimed the API was "unaffected while its ceiling is no larger"
-            // — a precondition that does not hold on shipped defaults (its 262,144 against this
-            // 50,000), so its own before-and-after checks both saw an unchanged string while this step
-            // had already removed most of the body. Rather than restore that assumption by aligning
-            // the two numbers, the cut now reports itself and the caller ORs it into whatever
-            // truncation signal it publishes: a fact that travels with the value cannot drift apart
-            // the way two independently-owned ceilings can.
-            var (bounded, truncated) = BoundedText.Cap(text, OutputCeiling, OutputTruncationMarker);
-            result = bounded;
-            wasTruncated = truncated;
-            return true;
-        }
+            if (!admission.RedactsOutput)
+            {
+                // Non-redact branch: Sanitize's null-in/null-out guarantee (#490) means reaching here
+                // can only mean preCut was null — nothing to sanitize.
+                result = null;
+                wasTruncated = false;
+                return true;
+            }
 
-        if (!admission.RedactsOutput)
-        {
-            // Reaching here on the non-redact branch means content was null: ToolResultText.Sanitize's
-            // only non-string outcome for a string? input is null-in -> null-out (its default,
-            // unrecognized-shape case), and every non-null string always comes back as a string from
-            // its `case string content:` branch — so `processed is string text` above already ruled
-            // out every other possibility on this branch.
+            // Fail closed, deliberately without asking whether preCut was itself null. A redact-required
+            // call that produced nothing to redact and a redact-required call whose gate broke the
+            // non-null-in/non-null-out contract on real input are indistinguishable from outside the
+            // gate, and #479's regression was exactly a refactor that treated "no content yet" as safe
+            // to short-circuit past this branch — turning a denial into a reported success with no
+            // fail-closed signal at all. Falling back to the original would be the harmless-looking
+            // default that defeats the control; the shipped gate always honors the contract, so this
+            // guards against a consumer-supplied one, same as it always has.
+            _logger.LogWarning(
+                "Classification gate returned null when redacting output of {ToolName}; the result is "
+                + "withheld rather than returned unredacted.",
+                toolName);
             result = null;
-            return true;
+            wasTruncated = false;
+            return false;
         }
 
-        // Fail closed. The gate decided this asset must not be emitted as-is, so falling back to the
-        // original is precisely the harmless-looking default that would defeat the control — which is
-        // what `RedactResult(...) as string ?? content` would have done. The shipped gate always
-        // answers with a string here, so this guards against a consumer-supplied one.
-        _logger.LogWarning(
-            "Classification gate returned a {ResultType} rather than a string when redacting output of "
-            + "{ToolName}; the result is withheld rather than returned unredacted.",
-            processed?.GetType().Name ?? "null",
-            toolName);
-
-        result = null;
-        return false;
+        // #532: bound after sanitize/redact — see ApplyOutputPolicy for why the order is fixed. This is
+        // the plan path's only cut. It is NOT the Execution API's only cut, and an earlier version of
+        // this comment claimed the API was "unaffected while its ceiling is no larger" — a
+        // precondition that does not hold on shipped defaults (its 262,144 against this 50,000), so its
+        // own before-and-after checks both saw an unchanged string while this step had already removed
+        // most of the body. Rather than restore that assumption by aligning the two numbers, the cut
+        // now reports itself and the caller ORs it into whatever truncation signal it publishes: a fact
+        // that travels with the value cannot drift apart the way two independently-owned ceilings can.
+        var (bounded, cutAfterProcessing) = BoundedText.Cap(processed, OutputCeiling, OutputTruncationMarker);
+        result = bounded;
+        // droppedByPreCut is carried forward, not discarded: content the pre-cut dropped can still
+        // leave this final cut with nothing further to drop once sanitizing/redacting has shrunk what
+        // remains — this cut's own flag alone would under-report what was actually lost (#487/#493,
+        // the same reasoning DirectToolInvoker's now-retired ScrubAndBound used to carry by hand).
+        wasTruncated = droppedByPreCut || cutAfterProcessing;
+        return true;
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -278,11 +278,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// and the pre-cut it sizes, used to live privately on <c>DirectToolInvoker</c> alone; every caller
     /// of THIS pipeline needs the same protection against scanning an unbounded result, so it moved here
     /// — the one place that already owns <see cref="OutputCeiling"/> (#487). Not a claim about every
-    /// path that reaches a tool result: <c>GoverningToolContextProvider.SanitizingAIFunction</c> calls
-    /// <see cref="ToolResultText.Sanitize(object?, ICompositeResponseSanitizer, string)"/> directly for
-    /// <c>load_skill</c>/<c>read_skill_resource</c>, bypassing this pipeline (and its bound) entirely —
-    /// tracked separately, since a plugin-sourced <c>SKILL.md</c> is lower-trust-delta content than a
-    /// live tool result but is not out of scope on principle.
+    /// path that reaches a tool result — see #544 for one known bypass.
     /// </remarks>
     internal const int ScrubOverlapMargin = 8 * 1024;
 
@@ -317,11 +313,9 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // is also what protects the agent-turn path (GovernedAIFunction), which used to have no bound
         // on scan cost at all.
         //
-        // The marker is passed here, unlike TryApplyTextOutputPolicy's use of the same primitive:
-        // THIS method has no out-parameter to report a drop through, so a drop that only the pre-cut
-        // makes (sanitizing/redacting then shrinks the survivor back under OutputCeiling, so the final
-        // Bound call below never fires to leave a marker of its own) would otherwise be invisible to
-        // the model reading the result — caught by security review on this PR.
+        // A real marker is passed, unlike TryApplyTextOutputPolicy's use of the same primitive: this
+        // method has no out-parameter to report a drop through — see PreCutForScan's own marker doc,
+        // and #487's security-review finding on this PR that this line closes.
         var (preCut, _) = ToolResultText.PreCutForScan(result, OutputCeiling, ScrubOverlapMargin, OutputTruncationMarker);
 
         // #469: the sanitize pass below is unconditional — see the interface remarks for why. It stays
@@ -346,6 +340,11 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         out bool wasTruncated)
     {
         ArgumentNullException.ThrowIfNull(admission);
+
+        // Every early return below leaves nothing to report; only the one branch that actually cuts
+        // overwrites this. Set once here so no future branch can forget it and silently answer "not
+        // truncated" — which is the exact failure this out-parameter exists to make impossible.
+        wasTruncated = false;
 
         // #487: the same scan-cost pre-cut ApplyOutputPolicy applies, for the same reason — this is the
         // method the plan step executor (a sandboxed tool's output, unbounded upstream) and the
@@ -376,7 +375,6 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 // Non-redact branch: Sanitize's null-in/null-out guarantee (#490) means reaching here
                 // can only mean preCut was null — nothing to sanitize.
                 result = null;
-                wasTruncated = false;
                 return true;
             }
 
@@ -393,7 +391,6 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 + "withheld rather than returned unredacted.",
                 toolName);
             result = null;
-            wasTruncated = false;
             return false;
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -267,16 +267,22 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// <summary>
     /// How much beyond <see cref="OutputCeiling"/> is kept while sanitizing and redacting, so a secret
     /// or an injection pattern straddling the ceiling stays inside the scanned region rather than being
-    /// sliced in half — removed again by the final cut. See <see cref="ToolResultText.PreCutForScan(object?, int, int)"/>
-    /// for the full rationale and the residual risk it accepts.
+    /// sliced in half — removed again by the final cut. See
+    /// <see cref="ToolResultText.PreCutForScan(object?, int, int, string)"/> for the full rationale and
+    /// the residual risk it accepts.
     /// </summary>
     /// <remarks>
     /// Sized generously against the longest thing the sanitizers look for — connection strings and
     /// PEM-armoured keys run to a few kilobytes — because the cost of being wrong in one direction is a
     /// few spare kilobytes scanned, and in the other it is an unredacted secret on the wire. This value,
-    /// and the pre-cut it sizes, used to live privately on <c>DirectToolInvoker</c> alone; every path
-    /// that reaches a tool needs the same protection against scanning an unbounded result, so it moved
-    /// here — the one place that already owns <see cref="OutputCeiling"/> (#487).
+    /// and the pre-cut it sizes, used to live privately on <c>DirectToolInvoker</c> alone; every caller
+    /// of THIS pipeline needs the same protection against scanning an unbounded result, so it moved here
+    /// — the one place that already owns <see cref="OutputCeiling"/> (#487). Not a claim about every
+    /// path that reaches a tool result: <c>GoverningToolContextProvider.SanitizingAIFunction</c> calls
+    /// <see cref="ToolResultText.Sanitize(object?, ICompositeResponseSanitizer, string)"/> directly for
+    /// <c>load_skill</c>/<c>read_skill_resource</c>, bypassing this pipeline (and its bound) entirely —
+    /// tracked separately, since a plugin-sourced <c>SKILL.md</c> is lower-trust-delta content than a
+    /// live tool result but is not out of scope on principle.
     /// </remarks>
     internal const int ScrubOverlapMargin = 8 * 1024;
 
@@ -310,7 +316,13 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // remarks for the trade this accepts. Every caller of this method funnels through it, so this
         // is also what protects the agent-turn path (GovernedAIFunction), which used to have no bound
         // on scan cost at all.
-        var (preCut, _) = ToolResultText.PreCutForScan(result, OutputCeiling, ScrubOverlapMargin);
+        //
+        // The marker is passed here, unlike TryApplyTextOutputPolicy's use of the same primitive:
+        // THIS method has no out-parameter to report a drop through, so a drop that only the pre-cut
+        // makes (sanitizing/redacting then shrinks the survivor back under OutputCeiling, so the final
+        // Bound call below never fires to leave a marker of its own) would otherwise be invisible to
+        // the model reading the result — caught by security review on this PR.
+        var (preCut, _) = ToolResultText.PreCutForScan(result, OutputCeiling, ScrubOverlapMargin, OutputTruncationMarker);
 
         // #469: the sanitize pass below is unconditional — see the interface remarks for why. It stays
         // in shape-preserving lockstep with RedactResult below via the shared ToolResultText.Sanitize.

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -316,7 +316,12 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // A real marker is passed, unlike TryApplyTextOutputPolicy's use of the same primitive: this
         // method has no out-parameter to report a drop through — see PreCutForScan's own marker doc,
         // and #487's security-review finding on this PR that this line closes.
-        var (preCut, _) = ToolResultText.PreCutForScan(result, OutputCeiling, ScrubOverlapMargin, OutputTruncationMarker);
+        //
+        // Ceiling captured once, not re-read from _options.CurrentValue at the pre-cut and again at the
+        // final cut: a hot reload between the two reads would otherwise let them disagree about what
+        // ceiling this one call is bounding to (run-gates' correctness gate, advisory).
+        var ceiling = OutputCeiling;
+        var (preCut, _) = ToolResultText.PreCutForScan(result, ceiling, ScrubOverlapMargin, OutputTruncationMarker);
 
         // #469: the sanitize pass below is unconditional — see the interface remarks for why. It stays
         // in shape-preserving lockstep with RedactResult below via the shared ToolResultText.Sanitize.
@@ -328,7 +333,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // different, wider, scan-cost-only bound, not a substitute for this one. It also mirrors
         // ReportExecutionAsync, which has always sanitized, redacted, and THEN bounded tool failure
         // text at this same pipeline (#460); success output simply never got the third step.
-        return ToolResultText.Bound(treated, OutputCeiling, OutputTruncationMarker);
+        return ToolResultText.Bound(treated, ceiling, OutputTruncationMarker);
     }
 
     /// <inheritdoc />
@@ -349,7 +354,21 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // #487: the same scan-cost pre-cut ApplyOutputPolicy applies, for the same reason — this is the
         // method the plan step executor (a sandboxed tool's output, unbounded upstream) and the
         // Execution API both call, and neither used to bound scan cost on this side of the boundary.
-        var (preCut, droppedByPreCut) = ToolResultText.PreCutForScan(content, OutputCeiling, ScrubOverlapMargin);
+        //
+        // A real marker is passed here too, not just at ApplyOutputPolicy's call site: this method DOES
+        // report a drop through wasTruncated below, but ToolUseStepExecutor.HandleSuccessAsync (the plan
+        // path) discards that out-parameter with `out _` and relies entirely on a marker embedded in
+        // the text — a premise that held before this PR (the final cut was the only cut, and it always
+        // left a marker when it fired) and stopped holding the moment this pre-cut could drop content
+        // with nothing to show for it whenever sanitizing/redacting then shrinks the survivor back under
+        // OutputCeiling. Caught by run-gates' correctness gate: the second caller of this same new
+        // primitive didn't get the fix #487's own security review already applied to the other one.
+        //
+        // Ceiling captured once, not re-read at the pre-cut and again at the final cut below — see
+        // ApplyOutputPolicy's identical capture for why (run-gates' correctness gate, advisory).
+        var ceiling = OutputCeiling;
+        var (preCut, droppedByPreCut) =
+            ToolResultText.PreCutForScan(content, ceiling, ScrubOverlapMargin, OutputTruncationMarker);
 
         // #479: sanitize unconditionally on both branches, the same guarantee ApplyOutputPolicy carries
         // (#469) — this method used to sanitize only when a redaction was required, leaving the
@@ -402,7 +421,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // most of the body. Rather than restore that assumption by aligning the two numbers, the cut
         // now reports itself and the caller ORs it into whatever truncation signal it publishes: a fact
         // that travels with the value cannot drift apart the way two independently-owned ceilings can.
-        var (bounded, cutAfterProcessing) = BoundedText.Cap(processed, OutputCeiling, OutputTruncationMarker);
+        var (bounded, cutAfterProcessing) = BoundedText.Cap(processed, ceiling, OutputTruncationMarker);
         result = bounded;
         // droppedByPreCut is carried forward, not discarded: content the pre-cut dropped can still
         // leave this final cut with nothing further to drop once sanitizing/redacting has shrunk what

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
@@ -172,6 +172,19 @@ internal static class ToolResultText
     /// sanitizer/redaction pass that follows, rather than being sliced in half and emitted. Removed
     /// again by the later <see cref="Bound"/> call.
     /// </param>
+    /// <param name="marker">
+    /// Appended where the pre-cut itself lands. Leave as the default empty string when the caller
+    /// reports truncation through its own out-parameter instead (OR the returned <c>Dropped</c> flag
+    /// into it) — the marker the model sees then comes from the later <see cref="Bound"/> call alone,
+    /// and a second one here would be redundant noise inside the still-scanned region.
+    /// <strong>A caller with no such out-parameter must pass a real marker</strong>, or a drop this
+    /// method makes is invisible whenever the sanitize/redact pass that follows shrinks the surviving
+    /// text back under <paramref name="ceiling"/> — the one case <see cref="Bound"/>'s own cut never
+    /// fires to leave a marker of its own. This is what ties a prefix DIRECTLY to being reported as one,
+    /// not left to a caller remembering to OR two booleans it does not have when it has no
+    /// out-parameter to OR them into (see <see cref="Services.Tools.DirectToolInvoker"/>'s remarks on
+    /// exactly this shape of miss).
+    /// </param>
     /// <returns>The (possibly cut) result, and whether anything was dropped.</returns>
     /// <remarks>
     /// <para>
@@ -191,7 +204,8 @@ internal static class ToolResultText
     /// on paths a remote caller or a sandboxed tool can trigger — the trade this method exists to make.
     /// </para>
     /// </remarks>
-    public static (object? Result, bool Dropped) PreCutForScan(object? result, int ceiling, int overlapMargin)
+    public static (object? Result, bool Dropped) PreCutForScan(
+        object? result, int ceiling, int overlapMargin, string marker = "")
     {
         // Saturating rather than wrapping: the arithmetic should not depend on a check in another
         // assembly (the config validator bounds the ceiling) to stay correct on this path.
@@ -208,9 +222,7 @@ internal static class ToolResultText
             }
 
             dropped = true;
-            // Empty marker: the pre-cut is invisible in the payload, and only the returned flag records
-            // it — the marker the model actually sees comes from the later Bound call.
-            var (cut, _) = BoundedText.Cap(text, remaining, string.Empty);
+            var (cut, _) = BoundedText.Cap(text, remaining, marker);
             remaining = 0;
             return cut;
         });
@@ -219,15 +231,17 @@ internal static class ToolResultText
     }
 
     /// <summary>
-    /// String-typed overload of <see cref="PreCutForScan(object?, int, int)"/> for a caller that already
-    /// knows its content is plain text — see that overload's remarks for the pre-cut rationale. Carries
-    /// the same non-null-in/non-null-out guarantee as <see cref="Sanitize(string?, ICompositeResponseSanitizer, string)"/>,
-    /// for the identical reason: a <see langword="string"/>-typed input can only produce a
+    /// String-typed overload of <see cref="PreCutForScan(object?, int, int, string)"/> for a caller that
+    /// already knows its content is plain text — see that overload's remarks for the pre-cut rationale
+    /// and for when <paramref name="marker"/> must be non-empty. Carries the same non-null-in/non-null-out
+    /// guarantee as <see cref="Sanitize(string?, ICompositeResponseSanitizer, string)"/>, for the
+    /// identical reason: a <see langword="string"/>-typed input can only produce a
     /// <see langword="string"/>-typed output through <see cref="Transform"/>'s <c>case string</c> arm.
     /// </summary>
-    public static (string? Text, bool Dropped) PreCutForScan(string? content, int ceiling, int overlapMargin)
+    public static (string? Text, bool Dropped) PreCutForScan(
+        string? content, int ceiling, int overlapMargin, string marker = "")
     {
-        var (transformed, dropped) = PreCutForScan((object?)content, ceiling, overlapMargin);
+        var (transformed, dropped) = PreCutForScan((object?)content, ceiling, overlapMargin, marker);
         return ((string?)transformed, dropped);
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
@@ -68,7 +68,7 @@ internal static class ToolResultText
     /// (#490).
     /// </remarks>
     public static string? Sanitize(string? content, ICompositeResponseSanitizer sanitizer, string toolName) =>
-        content is null ? null : SanitizeText(content, sanitizer, toolName);
+        (string?)Sanitize((object?)content, sanitizer, toolName);
 
     /// <summary>
     /// Runs <paramref name="result"/>'s text through <paramref name="sanitizer"/> and then
@@ -107,7 +107,7 @@ internal static class ToolResultText
         ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter redactionFilter,
         string toolName) =>
-        content is null ? null : redactionFilter.Redact(SanitizeText(content, sanitizer, toolName), RedactionCategories.All);
+        (string?)SanitizeAndRedact((object?)content, sanitizer, redactionFilter, toolName);
 
     /// <summary>
     /// Cuts the free text carried by <paramref name="result"/> so that its <strong>total</strong>
@@ -139,23 +139,8 @@ internal static class ToolResultText
     /// here and belongs to whatever budgets a whole turn (#522).
     /// </para>
     /// </remarks>
-    public static object? Bound(object? result, int ceiling, string marker)
-    {
-        var remaining = ceiling;
-
-        return Transform(result, text =>
-        {
-            if (text.Length <= remaining)
-            {
-                remaining -= text.Length;
-                return text;
-            }
-
-            var (bounded, _) = BoundedText.Cap(text, remaining, marker);
-            remaining = 0;
-            return bounded;
-        });
-    }
+    public static object? Bound(object? result, int ceiling, string marker) =>
+        BudgetedCut(result, ceiling, marker).Result;
 
     /// <summary>
     /// Cuts the free text carried by <paramref name="result"/> to a scan-cost-bounded region — the total
@@ -210,7 +195,17 @@ internal static class ToolResultText
         // Saturating rather than wrapping: the arithmetic should not depend on a check in another
         // assembly (the config validator bounds the ceiling) to stay correct on this path.
         var scanCeiling = ceiling <= int.MaxValue - overlapMargin ? ceiling + overlapMargin : int.MaxValue;
-        var remaining = scanCeiling;
+        return BudgetedCut(result, scanCeiling, marker);
+    }
+
+    /// <summary>
+    /// The shared cross-block budget walk both <see cref="Bound"/> and <see cref="PreCutForScan(object?, int, int, string)"/>
+    /// reduce to — the two differ only in what ceiling they pass in and whether they need
+    /// <c>Dropped</c> back, not in how the walk itself works.
+    /// </summary>
+    private static (object? Result, bool Dropped) BudgetedCut(object? result, int ceiling, string marker)
+    {
+        var remaining = ceiling;
         var dropped = false;
 
         var transformed = Transform(result, text =>

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
@@ -34,7 +34,7 @@ internal static class ToolResultText
     /// <summary>
     /// Substituted when a sanitizer reports it changed something but returns no text to show for it — a
     /// runtime contract break <see cref="ICompositeResponseSanitizer"/> doesn't enforce against a
-    /// consumer-supplied implementation. Every caller of <see cref="Sanitize"/> relies on a must-not-throw
+    /// consumer-supplied implementation. Every caller of <see cref="Sanitize(object?, ICompositeResponseSanitizer, string)"/> relies on a must-not-throw
     /// contract (see <c>GovernedAIFunction</c>'s and <c>DirectToolInvoker</c>'s own remarks); degrading to
     /// a visible placeholder here, the same way <c>ReportedFailureText</c> does for its own sanitizer
     /// dependency, keeps that contract rather than propagating an exception out of nearly every tool call
@@ -55,11 +55,28 @@ internal static class ToolResultText
         Transform(result, text => SanitizeText(text, sanitizer, toolName));
 
     /// <summary>
+    /// String-typed overload of <see cref="Sanitize(object?, ICompositeResponseSanitizer, string)"/> for a
+    /// caller that already knows its content is plain text, not a shape needing preservation — the
+    /// <c>ToolCallAdmissionPipeline.TryApplyTextOutputPolicy</c> boundary.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Non-null input always produces non-null output.</strong> <c>Transform</c>'s <c>case
+    /// string</c> arm can only return <paramref name="content"/> itself or a sanitized string — never
+    /// null, never a different type — so this overload's return type makes that guarantee structural
+    /// rather than something a caller re-derives from <see cref="Transform"/>'s switch, which is the
+    /// third instance of the <c>object?</c>-conflation shape this repo's CLAUDE.md already tracks twice
+    /// (#490).
+    /// </remarks>
+    public static string? Sanitize(string? content, ICompositeResponseSanitizer sanitizer, string toolName) =>
+        content is null ? null : SanitizeText(content, sanitizer, toolName);
+
+    /// <summary>
     /// Runs <paramref name="result"/>'s text through <paramref name="sanitizer"/> and then
-    /// <paramref name="redactionFilter"/>, in that order, preserving shape exactly as <see cref="Sanitize"/>
-    /// does. Used only by <see cref="DefaultToolClassificationGate.RedactResult"/> — the path a
-    /// classification policy's <c>Redact</c> verdict takes, which must do strictly more than the baseline
-    /// sanitize every other tool result already gets (#484), not the same thing under a different name.
+    /// <paramref name="redactionFilter"/>, in that order, preserving shape exactly as <see cref="Sanitize(object?, ICompositeResponseSanitizer, string)"/>
+    /// does. Used only by <see cref="DefaultToolClassificationGate.RedactResult(string, object?)"/> — the
+    /// path a classification policy's <c>Redact</c> verdict takes, which must do strictly more than the
+    /// baseline sanitize every other tool result already gets (#484), not the same thing under a
+    /// different name.
     /// </summary>
     /// <remarks>
     /// Sanitize before redact, mirroring <see cref="Tools.ReportedFailureText.PrepareForReporting"/>'s
@@ -75,9 +92,27 @@ internal static class ToolResultText
         Transform(result, text => redactionFilter.Redact(SanitizeText(text, sanitizer, toolName), RedactionCategories.All));
 
     /// <summary>
+    /// String-typed overload of <see cref="SanitizeAndRedact(object?, ICompositeResponseSanitizer, IContentRedactionFilter, string)"/>
+    /// for a caller that already knows its content is plain text — the <c>RedactResult(string, string?)</c>
+    /// boundary <see cref="IToolClassificationGate"/> exposes for exactly this case.
+    /// </summary>
+    /// <remarks>
+    /// <strong>Non-null input always produces non-null output.</strong> <see cref="IContentRedactionFilter.Redact"/>
+    /// never returns null (its own contract: null/empty/no-match input is returned unchanged), so this
+    /// overload carries the same guarantee as the sibling <see cref="Sanitize(string?, ICompositeResponseSanitizer, string)"/>
+    /// overload — see its remarks for why that guarantee matters (#490).
+    /// </remarks>
+    public static string? SanitizeAndRedact(
+        string? content,
+        ICompositeResponseSanitizer sanitizer,
+        IContentRedactionFilter redactionFilter,
+        string toolName) =>
+        content is null ? null : redactionFilter.Redact(SanitizeText(content, sanitizer, toolName), RedactionCategories.All);
+
+    /// <summary>
     /// Cuts the free text carried by <paramref name="result"/> so that its <strong>total</strong>
     /// across every text-carrying block is at most <paramref name="ceiling"/> characters, preserving
-    /// shape exactly as <see cref="Sanitize"/> does.
+    /// shape exactly as <see cref="Sanitize(object?, ICompositeResponseSanitizer, string)"/> does.
     /// </summary>
     /// <param name="result">The tool result to bound.</param>
     /// <param name="ceiling">Maximum total characters of free text, inclusive of the marker.</param>
@@ -97,7 +132,7 @@ internal static class ToolResultText
     /// (#467/#470) — a cut that would land inside a surrogate pair backs off by one instead.
     /// </para>
     /// <para>
-    /// Structured values are untouched for the same reason <see cref="Sanitize"/> leaves them alone:
+    /// Structured values are untouched for the same reason <see cref="Sanitize(object?, ICompositeResponseSanitizer, string)"/> leaves them alone:
     /// a serialized result's <c>structuredContent</c> is typed JSON, not free text, and cutting it
     /// mid-value produces something the model mis-parses rather than something it reads as truncated.
     /// Bounding a result whose size lives entirely in structured content is therefore out of scope
@@ -120,6 +155,80 @@ internal static class ToolResultText
             remaining = 0;
             return bounded;
         });
+    }
+
+    /// <summary>
+    /// Cuts the free text carried by <paramref name="result"/> to a scan-cost-bounded region — the total
+    /// budget across every text-carrying block is <paramref name="ceiling"/> plus
+    /// <paramref name="overlapMargin"/> — before any sanitizer or redaction filter sees it, so a result
+    /// far larger than <paramref name="ceiling"/> does not pay to be scanned in full to return a
+    /// fraction (#487).
+    /// </summary>
+    /// <param name="result">The tool result to pre-cut.</param>
+    /// <param name="ceiling">The ceiling the eventual <see cref="Bound"/> call will cut to.</param>
+    /// <param name="overlapMargin">
+    /// How much beyond <paramref name="ceiling"/> is kept while scanning, so a secret or an injection
+    /// pattern straddling the ceiling is still inside the scanned region and is still caught by the
+    /// sanitizer/redaction pass that follows, rather than being sliced in half and emitted. Removed
+    /// again by the later <see cref="Bound"/> call.
+    /// </param>
+    /// <returns>The (possibly cut) result, and whether anything was dropped.</returns>
+    /// <remarks>
+    /// <para>
+    /// The budget spans blocks, exactly as <see cref="Bound"/>'s does — a multi-content-block MCP
+    /// result would otherwise admit <c>(ceiling + overlapMargin) x blockCount</c> characters of scan
+    /// cost, which bounds nothing on the shape that most needs bounding.
+    /// </para>
+    /// <para>
+    /// <strong>Known residual, stated rather than papered over.</strong> The pre-cut can bisect a match
+    /// at the scan ceiling, leaving a prefix the sanitizer/redaction pass cannot match. That prefix
+    /// normally sits beyond <paramref name="ceiling"/> and is discarded by the later <see cref="Bound"/>
+    /// call — but sanitizing and redacting shrink text, so if net shrinkage across the scanned region
+    /// exceeds <paramref name="overlapMargin"/>, the prefix can migrate below the ceiling and be
+    /// returned. No cheap check distinguishes a migrated prefix from ordinary content; the honest
+    /// mitigation is the margin being large relative to plausible shrinkage. Removing this pre-cut
+    /// entirely means paying for a full sanitizer/redaction pass over an arbitrarily large tool result
+    /// on paths a remote caller or a sandboxed tool can trigger — the trade this method exists to make.
+    /// </para>
+    /// </remarks>
+    public static (object? Result, bool Dropped) PreCutForScan(object? result, int ceiling, int overlapMargin)
+    {
+        // Saturating rather than wrapping: the arithmetic should not depend on a check in another
+        // assembly (the config validator bounds the ceiling) to stay correct on this path.
+        var scanCeiling = ceiling <= int.MaxValue - overlapMargin ? ceiling + overlapMargin : int.MaxValue;
+        var remaining = scanCeiling;
+        var dropped = false;
+
+        var transformed = Transform(result, text =>
+        {
+            if (text.Length <= remaining)
+            {
+                remaining -= text.Length;
+                return text;
+            }
+
+            dropped = true;
+            // Empty marker: the pre-cut is invisible in the payload, and only the returned flag records
+            // it — the marker the model actually sees comes from the later Bound call.
+            var (cut, _) = BoundedText.Cap(text, remaining, string.Empty);
+            remaining = 0;
+            return cut;
+        });
+
+        return (transformed, dropped);
+    }
+
+    /// <summary>
+    /// String-typed overload of <see cref="PreCutForScan(object?, int, int)"/> for a caller that already
+    /// knows its content is plain text — see that overload's remarks for the pre-cut rationale. Carries
+    /// the same non-null-in/non-null-out guarantee as <see cref="Sanitize(string?, ICompositeResponseSanitizer, string)"/>,
+    /// for the identical reason: a <see langword="string"/>-typed input can only produce a
+    /// <see langword="string"/>-typed output through <see cref="Transform"/>'s <c>case string</c> arm.
+    /// </summary>
+    public static (string? Text, bool Dropped) PreCutForScan(string? content, int ceiling, int overlapMargin)
+    {
+        var (transformed, dropped) = PreCutForScan((object?)content, ceiling, overlapMargin);
+        return ((string?)transformed, dropped);
     }
 
     /// <summary>
@@ -257,7 +366,7 @@ internal static class ToolResultText
     /// Every other property (<c>isError</c>, <c>structuredContent</c>, <c>_meta</c>, non-text-carrying
     /// blocks) is carried through unchanged — <c>structuredContent</c> is typed JSON, not free text, and
     /// rewriting it risks producing a malformed result the model then mis-parses (tracked separately,
-    /// see <see cref="IToolClassificationGate.RedactResult"/>'s remarks on the Redact verdict's coverage
+    /// see <see cref="IToolClassificationGate.RedactResult(string, object?)"/>'s remarks on the Redact verdict's coverage
     /// there). Returns <see langword="null"/> when no block's content changed, so the caller can keep
     /// the original <see cref="JsonElement"/> instead of an equivalent reconstruction.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -1,13 +1,11 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces;
-using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Bundles;
 using Domain.AI.Escalation;
-using Domain.AI.Governance;
 using Domain.Common.Config.AI.DirectToolInvocation;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
@@ -257,11 +255,10 @@ public sealed partial class DirectToolInvoker
     }
 
     /// <summary>
-    /// Redacts if the classification gate said to, sanitizes unconditionally, then bounds the length —
-    /// the MCP analogue of <c>DirectToolInvoker.Response.cs</c>'s <c>Shape</c>, reusing its scrub/bound
-    /// primitives (<c>ScrubAndBound</c>, <c>PreCutForScrub</c>) rather than re-deriving them, since an
-    /// MCP tool's raw result and a keyed-DI tool's <c>ToolResult.Output</c> need identical treatment
-    /// once both are reduced to text.
+    /// Reduces an MCP result to <see cref="ShapeText"/>'s shared shape — the MCP analogue of
+    /// <c>DirectToolInvoker.Response.cs</c>'s <c>Shape</c>, differing only in how the raw text is
+    /// obtained: a keyed-DI <c>ToolResult</c> already carries a string, an MCP result needs
+    /// <see cref="ToolResultText.ExtractText"/> first.
     /// </summary>
     private DirectToolInvocationOutcome ShapeMcp(
         string? failureText,
@@ -270,55 +267,16 @@ public sealed partial class DirectToolInvoker
         IToolCallAdmissionPipeline admissionPipeline,
         ToolCallAdmission admission,
         DirectToolInvocationConfig config,
-        TimeSpan duration)
-    {
-        var ceiling = config.MaxOutputCharacters;
-
-        if (failureText is not null)
-        {
-            var (preCutError, _) = PreCutForScrub(failureText, ceiling);
-            // Truncation discarded: the outcome carries no ErrorTruncated field to report it on,
-            // exactly as the ScrubAndBound below discards its own.
-            if (!admissionPipeline.TryApplyTextOutputPolicy(
-                    admission, toolName, preCutError, out var admittedError, out _))
-            {
-                return DirectToolInvocationOutcome.Refused(
-                    DirectToolInvocationStatus.Denied, GovernanceDenials.NotPermitted(toolName), duration);
-            }
-
-            var (error, _) = ScrubAndBound(admittedError ?? string.Empty, ceiling, toolName);
-            return new DirectToolInvocationOutcome
-            {
-                Status = DirectToolInvocationStatus.ToolFailed,
-                Error = error,
-                Duration = duration
-            };
-        }
-
-        var raw = ToolResultText.ExtractText(rawResult);
-        var (preCut, droppedByPreCut) = PreCutForScrub(raw, ceiling);
-
-        if (!admissionPipeline.TryApplyTextOutputPolicy(
-                admission, toolName, preCut, out var admitted, out var truncatedByPipeline))
-        {
-            return DirectToolInvocationOutcome.Refused(
-                DirectToolInvocationStatus.Denied, GovernanceDenials.NotPermitted(toolName), duration);
-        }
-
-        var (output, truncatedByOwnScrub) = ScrubAndBound(admitted ?? string.Empty, ceiling, toolName);
-
-        // truncatedByPipeline is the third term - see the sibling in DirectToolInvoker.Response.cs
-        // for why the other two cannot see the admission pipeline's own, smaller cut (#532).
-        var truncated = droppedByPreCut || truncatedByPipeline || truncatedByOwnScrub;
-
-        return new DirectToolInvocationOutcome
-        {
-            Status = DirectToolInvocationStatus.Succeeded,
-            Output = output,
-            OutputTruncated = truncated,
-            Duration = duration
-        };
-    }
+        TimeSpan duration) =>
+        ShapeText(
+            failureText,
+            ToolResultText.ExtractText(rawResult),
+            toolName,
+            admissionPipeline,
+            admission,
+            config.MaxOutputCharacters,
+            duration,
+            _logger);
 
     /// <summary>
     /// The result of MCP pre-flight: either a refusal to return as-is, or the resolved tool and caller

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -270,7 +270,10 @@ public sealed partial class DirectToolInvoker
         TimeSpan duration) =>
         ShapeText(
             failureText,
-            ToolResultText.ExtractText(rawResult),
+            // ShapeText never reads successText on the failure branch, and ExtractText's own default
+            // case does a full JsonSerializer.Serialize of the raw result — not worth paying on every
+            // MCP failure just to build a value that gets thrown away.
+            failureText is null ? ToolResultText.ExtractText(rawResult) : string.Empty,
             toolName,
             admissionPipeline,
             admission,

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
@@ -98,6 +98,16 @@ public sealed partial class DirectToolInvoker
         if (!admissionPipeline.TryApplyTextOutputPolicy(
                 admission, toolName, successText, out var admitted, out var truncatedByPipeline))
         {
+            // #491, same gap as the failure branch above and for the identical reason: the tool DID
+            // run and DID succeed, with whatever side effects that entailed — only the redaction of its
+            // output couldn't be applied. Without this line a withheld-but-executed success is
+            // indistinguishable in the audit trail from a call refused before it ever ran. Caught by
+            // code review noticing the failure branch got this treatment and the success branch didn't,
+            // in the same method, same commit.
+            logger.LogWarning(
+                "Direct invocation of {ToolName} executed and succeeded, but its output could not be "
+                + "redacted; the result is withheld rather than returned unredacted.",
+                toolName);
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.Denied,
                 GovernanceDenials.NotPermitted(toolName),

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
@@ -21,68 +21,69 @@ public sealed partial class DirectToolInvoker
     private const string TruncationMarker = "\n…[output truncated]";
 
     /// <summary>
-    /// How much beyond the output ceiling is kept while scrubbing, so a secret straddling the cut is
-    /// still inside the scanned region and is still redacted. Removed again by the final cut.
+    /// Redacts if the classification gate said to and sanitizes unconditionally — both now owned
+    /// entirely by <see cref="IToolCallAdmissionPipeline.TryApplyTextOutputPolicy"/> (#487/#489/#490),
+    /// which pre-cuts, sanitizes, redacts, and bounds to its own ceiling in one place — then applies
+    /// this caller's own <paramref name="ceiling"/> on top, which may be stricter than the pipeline's.
     /// </summary>
     /// <remarks>
-    /// Sized generously against the longest thing the sanitizers look for — connection strings and
-    /// PEM-armoured keys run to a few kilobytes — because the cost of being wrong in one direction is
-    /// a few spare kilobytes scanned, and in the other it is an unredacted secret on the wire.
     /// <para>
-    /// <strong>Known residual, stated rather than papered over.</strong> The pre-cut can bisect a
-    /// secret at <c>ceiling + margin</c>, leaving a prefix the sanitizers cannot match. That prefix
-    /// normally sits beyond the ceiling and is discarded by the final cut — but redaction shrinks text,
-    /// so if net shrinkage across the scanned region exceeds this margin the prefix can migrate below
-    /// the ceiling and be returned. Re-scrubbing the result does not fix it (a partial pattern still
-    /// does not match), and no cheap check distinguishes a migrated prefix from ordinary content, so
-    /// the honest mitigation is the margin being large relative to plausible shrinkage. Removing the
-    /// class entirely means not pre-cutting at all, which costs a full sanitizer pass over an
-    /// arbitrarily large tool result on a remotely-triggered path — the trade this constant exists to
-    /// make. Revisit if a sanitizer is added whose replacements are much shorter than what they match.
+    /// Both halves of a <see cref="ToolResult"/> or MCP result go through the same treatment. A tool's
+    /// error text is the likeliest place for a path or a connection string to surface, and an error
+    /// string is as capable of being enormous as an output one — treating only success as sensitive, or
+    /// only success as large, would leave the more dangerous half unhandled on both counts.
+    /// </para>
+    /// <para>
+    /// This class used to run its own second sanitize pass and its own pre-cut/final-cut pair after the
+    /// pipeline's — <c>ScrubAndBound</c>/<c>PreCutForScrub</c>/<c>Scrub</c>/<c>FinalCut</c>, all retired
+    /// by this method. The second sanitize pass was pure duplicated cost (#489: the two sanitizer
+    /// instances are the same singleton in every real composition), and the second pre-cut/final-cut
+    /// pair duplicated exactly what the pipeline's own pre-cut/final-cut now does (#487/#493). What
+    /// remains here is the one thing the pipeline cannot do on this class's behalf: apply a
+    /// caller-specific ceiling that may be stricter than the pipeline's own. That final cut is a pure
+    /// length operation over text the pipeline already sanitized and redacted, never a re-scan, so it
+    /// does not reopen the unbounded-scan cost #487 fixed.
     /// </para>
     /// </remarks>
-    private const int ScrubOverlapMargin = 8 * 1024;
-
-    /// <summary>
-    /// Redacts if the classification gate said to, sanitizes unconditionally, then bounds the length.
-    /// </summary>
-    /// <remarks>
-    /// Both halves of a <see cref="ToolResult"/> go through the same treatment. A tool's error text is
-    /// the likeliest place for a path or a connection string to surface, and an error string is as
-    /// capable of being enormous as an output one — treating only success as sensitive, or only
-    /// success as large, would leave the more dangerous half unhandled on both counts.
-    /// </remarks>
-    private DirectToolInvocationOutcome Shape(
-        ToolResult result,
-        ArmedInvocation armed,
+    private static DirectToolInvocationOutcome ShapeText(
+        string? failureText,
+        string successText,
+        string toolName,
+        IToolCallAdmissionPipeline admissionPipeline,
         ToolCallAdmission admission,
-        TimeSpan duration)
+        int ceiling,
+        TimeSpan duration,
+        ILogger logger)
     {
-        var ceiling = armed.Config.MaxOutputCharacters;
-
-        if (!result.Success)
+        if (failureText is not null)
         {
-            var rawError = result.Error ?? "The tool reported a failure.";
-
             // Classification-gate redaction applies here too, not just to a success. A call the gate
             // flagged as touching sensitive data can fail with that data embedded in its own error
             // text (a connection string, a stack trace carrying an API key) exactly as easily as it
             // can succeed with it in its output — code review on the PR that added #479/#484's
-            // guarantees to the success path below caught that this branch never picked them up.
-            var (preCutError, _) = PreCutForScrub(rawError, ceiling);
-            // Truncation discarded here for the same reason the ScrubAndBound below discards its own:
-            // the outcome carries no ErrorTruncated field to report it on.
-            if (!armed.AdmissionPipeline.TryApplyTextOutputPolicy(
-                    admission, armed.ToolName, preCutError, out var admittedError, out _))
+            // guarantees to the success path caught that this branch never picked them up.
+            if (!admissionPipeline.TryApplyTextOutputPolicy(
+                    admission, toolName, failureText, out var admittedError, out _))
             {
+                // #491: this Denied is not a governance refusal in the usual sense — the tool DID run
+                // and DID produce failure text; only the redaction of that text couldn't be applied.
+                // Without this line the audit trail cannot tell "the tool never ran" (every other
+                // Denied outcome) from "the tool ran, had side effects, and its failure text was
+                // withheld" — an executed-vs-never-ran distinction the caller-facing status alone
+                // cannot carry, since GovernanceDenials.NotPermitted is deliberately the same generic
+                // text every gate returns.
+                logger.LogWarning(
+                    "Direct invocation of {ToolName} executed and failed, but its failure text could "
+                    + "not be redacted; the result is withheld rather than returned unredacted.",
+                    toolName);
                 return DirectToolInvocationOutcome.Refused(
                     DirectToolInvocationStatus.Denied,
-                    GovernanceDenials.NotPermitted(armed.ToolName),
+                    GovernanceDenials.NotPermitted(toolName),
                     duration);
             }
 
             // No ErrorTruncated outcome field exists to report a drop on, matching prior behavior.
-            var (error, _) = ScrubAndBound(admittedError ?? string.Empty, ceiling, armed.ToolName);
+            var (error, _) = Governance.BoundedText.Cap(admittedError ?? string.Empty, ceiling, TruncationMarker);
             return new DirectToolInvocationOutcome
             {
                 Status = DirectToolInvocationStatus.ToolFailed,
@@ -91,123 +92,42 @@ public sealed partial class DirectToolInvoker
             };
         }
 
-        var raw = result.Output ?? string.Empty;
-
-        // #479: TryApplyTextOutputPolicy now sanitizes unconditionally on both branches, via the
-        // admission pipeline's OWN sanitizer — a distinct instance from this class's _sanitizer field
-        // in general (they happen to be the same singleton in every real composition, but this class
-        // does not assume that). Pre-cutting here bounds what THAT sanitizer has to scan, for the same
-        // reason ScrubAndBound below always pre-cuts before ITS sanitizer scans: a tool returning 20 MB
-        // against a 256 KiB ceiling should not pay to scan all 20 MB twice over to return a fraction.
-        //
-        // droppedByPreCut is carried forward rather than discarded: content this pre-cut drops can
-        // still leave ScrubAndBound's own (second) pre-cut with nothing further to drop — the text it
-        // sees is already within the ceiling+margin — so its own flag alone would under-report what was
-        // actually lost.
-        var (preCut, droppedByPreCut) = PreCutForScrub(raw, ceiling);
-
         // Fails closed: when a redaction was required and could not be applied, the chain returns
         // false and the original must be withheld rather than emitted. See the chain's own remarks
         // for why falling back to the raw content is the trap.
-        if (!armed.AdmissionPipeline.TryApplyTextOutputPolicy(
-                admission, armed.ToolName, preCut, out var admitted, out var truncatedByPipeline))
+        if (!admissionPipeline.TryApplyTextOutputPolicy(
+                admission, toolName, successText, out var admitted, out var truncatedByPipeline))
         {
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.Denied,
-                GovernanceDenials.NotPermitted(armed.ToolName),
+                GovernanceDenials.NotPermitted(toolName),
                 duration);
         }
 
-        // This class's own unconditional caller-facing scrub, via _sanitizer — the same treatment the
-        // failure branch above applies to result.Error, and independent of whatever the admission
-        // pipeline's sanitizer already did above.
-        var (output, truncatedByOwnScrub) = ScrubAndBound(admitted ?? string.Empty, ceiling, armed.ToolName);
-
-        // truncatedByPipeline is the third term, and without it the other two are not enough (#532).
-        // Both of them measure against THIS class's ceiling; the admission pipeline cuts to its own,
-        // which on shipped defaults is roughly five times smaller. For any output between the two,
-        // the pre-cut found nothing to drop, the pipeline removed most of the body, and the scrub
-        // then saw a string already well inside the ceiling and also found nothing to drop — so the
-        // response carried a prefix while reporting OutputTruncated = false. The DTO's own remarks
-        // name that harm exactly: a caller that cannot tell a complete result from a prefix parses
-        // the prefix as complete.
-        var truncated = droppedByPreCut || truncatedByPipeline || truncatedByOwnScrub;
+        var (output, truncatedByOwnCeiling) = Governance.BoundedText.Cap(admitted ?? string.Empty, ceiling, TruncationMarker);
 
         return new DirectToolInvocationOutcome
         {
             Status = DirectToolInvocationStatus.Succeeded,
             Output = output,
-            OutputTruncated = truncated,
+            OutputTruncated = truncatedByPipeline || truncatedByOwnCeiling,
             Duration = duration
         };
     }
 
-    /// <summary>
-    /// Redacts if the classification gate said to, sanitizes unconditionally, then bounds the length —
-    /// this class's own unconditional treatment, via <see cref="_sanitizer"/>. Used for both halves of
-    /// a <see cref="ToolResult"/>: an error string is as capable of being enormous, or of carrying a
-    /// secret, as an output one.
-    /// </summary>
-    /// <param name="text">The raw text from the tool.</param>
-    /// <param name="ceiling">The maximum number of characters to return, inclusive of any marker.</param>
-    /// <param name="toolName">Passed to the sanitizers as context.</param>
-    /// <returns>The safe text, and whether anything was dropped to produce it.</returns>
-    private (string Text, bool Truncated) ScrubAndBound(string text, int ceiling, string toolName)
-    {
-        var (preCut, droppedBeforeScrubbing) = PreCutForScrub(text, ceiling);
-        var scrubbed = Scrub(preCut, toolName);
-        return FinalCut(scrubbed, ceiling, droppedBeforeScrubbing);
-    }
-
-    /// <summary>
-    /// Cuts <paramref name="text"/> down to a scan-cost-bounded region before it reaches a sanitizer,
-    /// so a tool returning far more than <paramref name="ceiling"/> allows does not pay to scan all of
-    /// it to return a fraction. Extracted from <see cref="ScrubAndBound"/> so <see cref="Shape"/> can
-    /// apply the same pre-cut ahead of the admission pipeline's own
-    /// <see cref="Application.AI.Common.Interfaces.Governance.IToolCallAdmissionPipeline.TryApplyTextOutputPolicy"/>
-    /// call, which performs its own, separate sanitize/redact pass (#479).
-    /// </summary>
-    /// <returns>The (possibly cut) text, and whether anything was cut.</returns>
-    private static (string Text, bool Dropped) PreCutForScrub(string text, int ceiling)
-    {
-        // The margin is what makes cutting before scrubbing safe: a secret straddling the ceiling stays
-        // inside the scanned region, so it is still redacted rather than sliced in half and emitted.
-        // FinalCut removes the margin again.
-        //
-        // Saturating rather than wrapping. The validator bounds MaxOutputCharacters so this cannot
-        // overflow from configuration, but the arithmetic should not depend on a check in another
-        // assembly to stay correct — a negative slice length here turns a successful tool call into a
-        // 500 for every caller.
-        var scanCeiling = ceiling <= int.MaxValue - ScrubOverlapMargin
-            ? ceiling + ScrubOverlapMargin
-            : int.MaxValue;
-
-        var dropped = text.Length > scanCeiling;
-        // BoundedText.Cap, not a raw slice: guards the surrogate boundary the same way FinalCut's own
-        // cut does (found in independent security review — this was the one truncation site in this
-        // file that predated BoundedText and never migrated to it).
-        return dropped ? (Governance.BoundedText.Cap(text, scanCeiling, string.Empty).Text, true) : (text, false);
-    }
-
-    /// <summary>
-    /// Bounds already-sanitized text to <paramref name="ceiling"/> characters via the shared
-    /// <see cref="Governance.BoundedText.Cap"/> primitive (#467/#470), and folds in whether
-    /// <see cref="PreCutForScrub"/> already dropped anything ahead of sanitizing.
-    /// </summary>
-    private static (string Text, bool Truncated) FinalCut(string scrubbed, int ceiling, bool droppedBeforeScrubbing)
-    {
-        // Re-checked rather than inferred from the pre-cut: scrubbing changes length in both directions
-        // (a placeholder is rarely the width of what it replaced), so whether the ceiling is still
-        // exceeded is only knowable now.
-        var (bounded, cutAfterScrubbing) = Governance.BoundedText.Cap(scrubbed, ceiling, TruncationMarker);
-
-        // Reported from what was actually dropped, never from what the raw length suggested. A string
-        // barely over the ceiling that scrubbing shortened below it lost nothing, and claiming
-        // otherwise would send a caller looking for content that is all present.
-        return (bounded, droppedBeforeScrubbing || cutAfterScrubbing);
-    }
-
-    /// <summary>Runs text through the response-sanitizer chain. Empty text is returned untouched.</summary>
-    private string Scrub(string content, string toolName) =>
-        string.IsNullOrEmpty(content) ? content : _sanitizer.Sanitize(content, toolName).SanitizedContent;
+    /// <summary>Reduces a keyed-DI <see cref="ToolResult"/> to <see cref="ShapeText"/>'s shared shape.</summary>
+    private DirectToolInvocationOutcome Shape(
+        ToolResult result,
+        ArmedInvocation armed,
+        ToolCallAdmission admission,
+        TimeSpan duration) =>
+        ShapeText(
+            result.Success ? null : result.Error ?? "The tool reported a failure.",
+            result.Output ?? string.Empty,
+            armed.ToolName,
+            armed.AdmissionPipeline,
+            admission,
+            armed.Config.MaxOutputCharacters,
+            duration,
+            _logger);
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -60,7 +60,6 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
 {
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IToolCatalog _catalog;
-    private readonly ICompositeResponseSanitizer _sanitizer;
     private readonly IOptionsMonitor<DirectToolInvocationConfig> _config;
     private readonly IMcpToolProvider? _mcpToolProvider;
     private readonly ILogger<DirectToolInvoker> _logger;
@@ -68,7 +67,6 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     /// <summary>Initializes the invoker.</summary>
     /// <param name="scopeFactory">Creates the per-invocation DI scope holding the scoped governor and execution context.</param>
     /// <param name="catalog">Resolves the tool, filtered to the caller's grant.</param>
-    /// <param name="sanitizer">Scrubs everything leaving the trust boundary.</param>
     /// <param name="config">The host's direct-invocation settings, read per request.</param>
     /// <param name="mcpToolProvider">
     /// Resolves MCP-published tools for <see cref="InvokeMcpToolAsync"/> (#481). Optional, mirroring
@@ -80,20 +78,17 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     public DirectToolInvoker(
         IServiceScopeFactory scopeFactory,
         IToolCatalog catalog,
-        ICompositeResponseSanitizer sanitizer,
         IOptionsMonitor<DirectToolInvocationConfig> config,
         ILogger<DirectToolInvoker> logger,
         IMcpToolProvider? mcpToolProvider = null)
     {
         ArgumentNullException.ThrowIfNull(scopeFactory);
         ArgumentNullException.ThrowIfNull(catalog);
-        ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         _scopeFactory = scopeFactory;
         _catalog = catalog;
-        _sanitizer = sanitizer;
         _config = config;
         _mcpToolProvider = mcpToolProvider;
         _logger = logger;

--- a/src/Content/Application/Application.Core/Validation/DirectToolInvocationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/DirectToolInvocationConfigValidator.cs
@@ -27,16 +27,22 @@ namespace Application.Core.Validation;
 public sealed class DirectToolInvocationConfigValidator : AbstractValidator<DirectToolInvocationConfig>
 {
     /// <summary>
-    /// The largest usable output ceiling: <see cref="int.MaxValue"/> less headroom for the overlap
-    /// margin the invoker adds to it while scrubbing.
+    /// The largest usable output ceiling: <see cref="int.MaxValue"/> less a fixed margin.
     /// </summary>
     /// <remarks>
-    /// The margin is added in <c>int</c> arithmetic, so a ceiling near <see cref="int.MaxValue"/>
-    /// overflows to a negative slice length and turns every successful tool call into a <c>500</c>.
-    /// An operator writing <c>2147483647</c> to mean "no limit" is the realistic way to land there, and
-    /// a validator whose stated purpose is to name a bad setting at startup should catch it rather than
-    /// let the host boot into that state. A gigabyte of characters is already far past any use for this
-    /// surface, so the bound costs nothing real.
+    /// <para>
+    /// This value bounds <see cref="DirectToolInvocationConfig.MaxOutputCharacters"/> alone, which
+    /// <c>DirectToolInvoker</c> now applies as a plain final cut (<c>BoundedText.Cap</c>, no addition,
+    /// no overflow risk of its own — #487/#489/#493 retired the invoker's private overlap-margin
+    /// arithmetic that used to justify this bound; scan-cost bounding is now the admission pipeline's
+    /// own concern, sized off a different config value entirely).
+    /// </para>
+    /// <para>
+    /// Kept anyway as ordinary hygiene against a config typo: an operator writing
+    /// <c>2147483647</c> to mean "no limit" gets a validation failure naming the setting at startup
+    /// rather than a value so large it is meaningless for this surface. A gigabyte of characters is
+    /// already far past any use here, so the bound costs nothing real.
+    /// </para>
     /// </remarks>
     public const int MaxOutputCharactersCeiling = int.MaxValue - (64 * 1024);
 
@@ -71,7 +77,7 @@ public sealed class DirectToolInvocationConfigValidator : AbstractValidator<Dire
             .GreaterThan(0)
             .WithMessage("MaxOutputCharacters must be > 0 — a non-positive ceiling slices the output with a negative length, turning a successful tool call into a 500.")
             .LessThanOrEqualTo(MaxOutputCharactersCeiling)
-            .WithMessage($"MaxOutputCharacters must be <= {MaxOutputCharactersCeiling} — the invoker adds an overlap margin to it in int arithmetic, and a larger value overflows to a negative length, which turns every successful tool call into a 500. Use a large finite value rather than int.MaxValue to mean 'no limit'.");
+            .WithMessage($"MaxOutputCharacters must be <= {MaxOutputCharactersCeiling} — a value this large is meaningless for this surface and is the realistic shape of a typo (writing int.MaxValue to mean 'no limit'). Use a large finite value instead.");
 
         RuleFor(x => x.MaxParameterCount)
             .GreaterThan(0)

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -381,6 +381,32 @@ public sealed class ToolCallAdmissionPipelineTests
     }
 
     [Fact]
+    public void ApplyOutputPolicy_PreCutDropsContentThatSanitizingThenShrinksBelowTheCeiling_StillMarksTheResult()
+    {
+        // #487 security-review finding on this PR: unlike TryApplyTextOutputPolicy, this method has no
+        // out-parameter to report a drop through, so a pre-cut drop must leave its OWN marker in the
+        // payload. If it doesn't, and sanitizing then shrinks the survivor back under the ceiling, the
+        // final Bound call never fires to leave a marker of its own -- the model reads a silently
+        // truncated prefix as the complete result. Reproduced with a sanitizer that collapses a large
+        // run the way a real one collapses a base64 blob, exactly the scenario security review named.
+        var pipeline = AdmissionHarness.Pipeline(
+            outputCeiling: 10_000,
+            sanitizer: AdmissionHarness.SubstitutingSanitizer(new string('z', 1), string.Empty));
+
+        var result = pipeline.ApplyOutputPolicy(
+            ToolCallAdmission.Allow(), Tool, "HEADER" + new string('z', 50_000));
+
+        // The pre-cut (ceiling + 8 KiB margin) fires on the 50,000-character blob long before
+        // sanitizing runs; sanitizing then deletes every 'z', leaving "HEADER" plus whatever the
+        // pre-cut's own marker appended -- far under the 10,000 ceiling, so the FINAL Bound call has
+        // nothing left to cut. The only place a marker can come from is the pre-cut itself.
+        result.Should().BeOfType<string>().Which
+            .Should().Contain(ToolCallAdmissionPipeline.OutputTruncationMarker,
+                "sanitizing collapsed the pre-cut's survivor below the ceiling, so a reader must not "
+                + "conclude the result is complete just because the final cut never fired");
+    }
+
+    [Fact]
     public void ApplyOutputPolicy_TextWithinTheCeiling_IsReturnedWhole()
     {
         // Control. Without this, a bound that cut EVERYTHING would satisfy the two tests above while

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -381,6 +381,31 @@ public sealed class ToolCallAdmissionPipelineTests
     }
 
     [Fact]
+    public void TryApplyTextOutputPolicy_PreCutDropsContentThatSanitizingThenShrinksBelowTheCeiling_StillMarksTheResult()
+    {
+        // Found by run-gates' correctness gate: the sibling of ApplyOutputPolicy_...StillMarksTheResult
+        // below, on the OTHER caller of the same new pre-cut. This method DOES report a drop through
+        // wasTruncated -- but ToolUseStepExecutor.HandleSuccessAsync (the plan path) discards that
+        // out-parameter with `out _` and depends entirely on a marker embedded in the returned text, a
+        // premise that broke the moment this pre-cut could drop content silently.
+        var pipeline = AdmissionHarness.Pipeline(
+            outputCeiling: 10_000,
+            sanitizer: AdmissionHarness.SubstitutingSanitizer(new string('z', 1), string.Empty));
+
+        var ok = pipeline.TryApplyTextOutputPolicy(
+            ToolCallAdmission.Allow(), Tool, "HEADER" + new string('z', 50_000), out var result, out var wasTruncated);
+
+        ok.Should().BeTrue();
+        wasTruncated.Should().BeTrue("the pre-cut genuinely dropped content, regardless of whether a caller reads this flag");
+        // The property under test: a caller that ONLY reads the text (as ToolUseStepExecutor does) must
+        // still be able to tell this was cut, because the final BoundedText.Cap never fires here --
+        // sanitizing shrank the pre-cut's survivor to "HEADER" + marker, already under the 10,000 ceiling.
+        result.Should().Contain(ToolCallAdmissionPipeline.OutputTruncationMarker,
+            "a reader with no access to wasTruncated (ToolUseStepExecutor.HandleSuccessAsync discards it) "
+            + "must not conclude the result is complete just because the final cut never fired");
+    }
+
+    [Fact]
     public void ApplyOutputPolicy_PreCutDropsContentThatSanitizingThenShrinksBelowTheCeiling_StillMarksTheResult()
     {
         // #487 security-review finding on this PR: unlike TryApplyTextOutputPolicy, this method has no

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -324,8 +324,13 @@ public sealed class ToolCallAdmissionPipelineTests
         // Preserved from before #479: a consumer-supplied IToolClassificationGate that violates the
         // "redact always answers with a string" contract must withhold, not fall back to the original —
         // see the pipeline's own remarks on why `RedactResult(...) as string ?? content` would be a trap.
+        //
+        // #490: the string-typed RedactResult(string, string?) overload this call site now resolves to
+        // makes "answers with a non-string" unrepresentable at the type level — the only way left to
+        // simulate a gate breaking its non-null-in/non-null-out contract is a null return for non-null
+        // input, which is exactly what this now sets up.
         var gate = new Mock<IToolClassificationGate>();
-        gate.Setup(g => g.RedactResult(Tool, "raw text")).Returns(new { Rows = 3 });
+        gate.Setup(g => g.RedactResult(Tool, "raw text")).Returns((string?)null);
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
         var ok = pipeline.TryApplyTextOutputPolicy(
@@ -430,7 +435,7 @@ public sealed class ToolCallAdmissionPipelineTests
         // answers any non-string result: not a string, so this must fail closed exactly like
         // TryApplyTextOutputPolicy_RedactVerdict_ClassificationGateReturnsNonString_FailsClosed.
         var gate = new Mock<IToolClassificationGate>();
-        gate.Setup(g => g.RedactResult(Tool, null)).Returns((object?)null);
+        gate.Setup(g => g.RedactResult(Tool, (string?)null)).Returns((string?)null);
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
         var ok = pipeline.TryApplyTextOutputPolicy(

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolResultTextTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolResultTextTests.cs
@@ -13,9 +13,9 @@ using Xunit;
 namespace Application.AI.Common.Tests.Governance;
 
 /// <summary>
-/// Tests for <see cref="ToolResultText.Sanitize"/> directly, across every shape a tool result can
+/// Tests for <see cref="ToolResultText.Sanitize(object?, ICompositeResponseSanitizer, string)"/> directly, across every shape a tool result can
 /// arrive in at a policy boundary — the two callers (<see cref="ToolCallAdmissionPipeline.ApplyOutputPolicy"/>,
-/// <see cref="DefaultToolClassificationGate.RedactResult"/>) each get one routing test instead of
+/// <see cref="DefaultToolClassificationGate.RedactResult(string, object?)"/>) each get one routing test instead of
 /// re-proving every shape's behavior twice.
 /// </summary>
 /// <remarks>

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -220,7 +220,6 @@ public sealed class DirectToolInvokerTests
         // in int arithmetic, so a wrapping add yields a negative slice length and turns EVERY successful
         // tool call into a 500. Saturating instead costs one comparison.
         _config.MaxOutputCharacters = int.MaxValue;
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Ok("fine"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -236,7 +235,6 @@ public sealed class DirectToolInvokerTests
         // set the ceiling to satisfy a downstream size contract would otherwise get a payload just
         // over the limit — the one thing such a ceiling exists to prevent.
         _config.MaxOutputCharacters = 40;
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Ok(new string('x', 500)));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -380,7 +378,11 @@ public sealed class DirectToolInvokerTests
     public async Task Sanitizes_the_tools_output()
     {
         // Unconditional, because this crosses a trust boundary. Tool output routinely carries paths,
-        // tokens and connection strings picked up from the host's own environment.
+        // tokens and connection strings picked up from the host's own environment. Scrubbing itself now
+        // happens entirely on the admission pipeline's own sanitizer (#487/#489), which this fixture
+        // registers as _sanitizer — ScrubEverything opts it into the blunt "replace everything" mode
+        // the real chain never takes but this test needs to observe "was Sanitize called at all".
+        _sanitizer.ScrubEverything = true;
         var tool = Tool("alpha", result: ToolResult.Ok("secret=hunter2"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -394,6 +396,7 @@ public sealed class DirectToolInvokerTests
         // The likeliest place a path or a connection string surfaces is a failure message, and it
         // crosses the same boundary the output does. Scrubbing only the success half would leave the
         // more dangerous half in the clear.
+        _sanitizer.ScrubEverything = true;
         var tool = Tool("alpha", result: ToolResult.Fail("could not open C:\\keys\\prod.pem"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -432,7 +435,6 @@ public sealed class DirectToolInvokerTests
     {
         _config.MaxOutputCharacters = 10;
         var tool = Tool("alpha", result: ToolResult.Ok(new string('x', 500)));
-        _sanitizer.PassThrough = true;
 
         var outcome = await Invoke(Request("alpha"), tool);
 
@@ -446,7 +448,6 @@ public sealed class DirectToolInvokerTests
         // A caller who cannot distinguish a complete result from a prefix of one will parse the prefix
         // as complete — which is worse than being refused the result altogether.
         _config.MaxOutputCharacters = 10;
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Ok(new string('x', 500)));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -461,7 +462,12 @@ public sealed class DirectToolInvokerTests
         // a remote caller can demand at will. The overlap margin is what keeps that safe — a secret
         // spanning the cut must still be inside the scanned region. Get this wrong and the surface
         // emits the first half of a key.
-        _config.MaxOutputCharacters = 10;
+        //
+        // #487: this pre-cut now lives on ToolCallAdmissionPipeline, the one place that owns the
+        // ceiling it is bounding scan cost against — so it is _pipelineOutputCeiling that must be
+        // small to exercise it, not _config.MaxOutputCharacters (the invoker's own, now-unrelated,
+        // final length cut applied on top of whatever the pipeline already sanitized).
+        _pipelineOutputCeiling = 10;
         _sanitizer.ScrubTarget = "SECRET";
         var tool = Tool("alpha", result: ToolResult.Ok(new string('x', 10) + "SECRET" + new string('y', 20)));
 
@@ -479,7 +485,11 @@ public sealed class DirectToolInvokerTests
         // fire — and a flag derived from that alone would tell the caller nothing was lost, when in
         // fact most of the result was. This is also the only test that reaches the pre-cut branch at
         // all: everything else is small enough to fit inside the overlap margin.
-        _config.MaxOutputCharacters = 10;
+        //
+        // #487: see the sibling test above for why this sets _pipelineOutputCeiling, not
+        // _config.MaxOutputCharacters — ScrubOverlapMargin (8 KiB) is the same constant value it
+        // always was, just relocated to ToolCallAdmissionPipeline alongside the ceiling it protects.
+        _pipelineOutputCeiling = 10;
         _sanitizer.ScrubTarget = new string('z', 8197);
         var tool = Tool("alpha", result: ToolResult.Ok(new string('a', 5) + new string('z', 20_000)));
 
@@ -508,7 +518,6 @@ public sealed class DirectToolInvokerTests
     public async Task Does_not_claim_truncation_for_output_that_fits()
     {
         _config.MaxOutputCharacters = 1000;
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Ok("short"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -529,7 +538,6 @@ public sealed class DirectToolInvokerTests
         // a prefix.
         _config.MaxOutputCharacters = 1000;
         _pipelineOutputCeiling = 100;
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Ok(new string('a', 500)));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -576,7 +584,6 @@ public sealed class DirectToolInvokerTests
     {
         _classificationGate = new FakeClassificationGate(
             ClassificationVerdict.RedactOutput());
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Ok("classified"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -596,7 +603,6 @@ public sealed class DirectToolInvokerTests
         {
             RedactionResult = 42
         };
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Ok("classified"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -615,7 +621,6 @@ public sealed class DirectToolInvokerTests
         // the identical scenario on the success path was already covered by
         // A_redact_verdict_scrubs_the_output_before_it_leaves.
         _classificationGate = new FakeClassificationGate(ClassificationVerdict.RedactOutput());
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Fail("classified failure detail"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -633,7 +638,6 @@ public sealed class DirectToolInvokerTests
         {
             RedactionResult = 42
         };
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Fail("classified failure detail"));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -649,7 +653,6 @@ public sealed class DirectToolInvokerTests
         // input back in its failure message, say. Bounding only the success half would leave the
         // ceiling trivially bypassable through the path a caller can trigger by sending bad input.
         _config.MaxOutputCharacters = 50;
-        _sanitizer.PassThrough = true;
         var tool = Tool("alpha", result: ToolResult.Fail(new string('e', 100_000)));
 
         var outcome = await Invoke(Request("alpha"), tool);
@@ -858,15 +861,15 @@ public sealed class DirectToolInvokerTests
         // no-op one must never be confusable at runtime.
         services.AddSingleton(_executionReporter.Object);
 
-        // #460: ToolCallAdmissionPipeline.ReportExecutionAsync now sanitizes and redacts the reported
-        // copy itself — this fixture's own _sanitizer (RecordingSanitizer) is deliberately NOT reused
-        // here. It defaults to replacing content with the fixed "[scrubbed]" marker unless a test opts
-        // into PassThrough, which exists to observe DirectToolInvoker's OWN caller-facing scrub — reusing
-        // it for the reporting path would blank the reported copy in every test that doesn't set
-        // PassThrough, breaking the redaction assertion below for reasons unrelated to what it tests. A
-        // real IContentRedactionFilter is used, not a pass-through, because
-        // ToolReturnsFailure_WithASecretInTheErrorText_ReportedCopyIsRedacted asserts real redaction.
-        services.AddSingleton(AdmissionHarness.PermissiveSanitizer());
+        // #487/#489: DirectToolInvoker no longer owns a private sanitizer at all — every sanitize pass,
+        // on every path (the caller-facing output/error AND ToolCallAdmissionPipeline.ReportExecutionAsync's
+        // reported copy), now runs through the ONE sanitizer registered here. That is safe to be this
+        // fixture's own _sanitizer specifically because RecordingSanitizer defaults to pass-through
+        // (see its own remarks) — the old default of blanking everything is what used to force two
+        // separate instances; a real IContentRedactionFilter is still used, not a pass-through, because
+        // ToolReturnsFailure_WithASecretInTheErrorText_ReportedCopyIsRedacted asserts real redaction on
+        // the reported copy independent of whatever the sanitizer did.
+        services.AddSingleton<ICompositeResponseSanitizer>(_sanitizer);
         services.AddSingleton<IContentRedactionFilter>(TestRedactionFilter.Instance);
 
         // #532: the chain now bounds tool output and reads its ceiling from AppConfig, so it requires
@@ -899,7 +902,6 @@ public sealed class DirectToolInvokerTests
         var sut = new DirectToolInvoker(
             provider.GetRequiredService<IServiceScopeFactory>(),
             new ToolCatalog(provider, [tool.Name], NullLogger<ToolCatalog>.Instance),
-            _sanitizer,
             new StaticOptionsMonitor<DirectToolInvocationConfig>(_config),
             NullLogger<DirectToolInvoker>.Instance);
 
@@ -976,13 +978,20 @@ public sealed class DirectToolInvokerTests
         public void Deny(string reason) => Decision = ToolInvocationDecision.Deny(reason);
     }
 
-    /// <summary>A sanitizer that reports having scrubbed, so "was it called" is directly observable.</summary>
+    /// <summary>
+    /// A sanitizer that passes content through unchanged by default, so registering it as BOTH the
+    /// admission pipeline's sanitizer and (implicitly, via <c>ReportExecutionAsync</c>'s own use of the
+    /// same registered singleton) the reporting-path sanitizer is safe without a test opting in — the
+    /// two roles used to need two different fixture instances specifically because the old default
+    /// blanked everything (see #487/#489: this fixture's own sanitizer is now the ONLY one, since
+    /// <c>DirectToolInvoker</c> no longer owns a private one of its own).
+    /// </summary>
     private sealed class RecordingSanitizer : ICompositeResponseSanitizer
     {
         public const string Scrubbed = "[scrubbed]";
 
-        /// <summary>When true, returns content unchanged so length-based assertions stay meaningful.</summary>
-        public bool PassThrough { get; set; }
+        /// <summary>When set, replaces all content with <see cref="Scrubbed"/> — "was Sanitize called at all", the blunt case a real sanitizer never takes.</summary>
+        public bool ScrubEverything { get; set; }
 
         /// <summary>
         /// When set, behaves like a real sanitizer instead of a blunt one: removes just this substring
@@ -1001,9 +1010,9 @@ public sealed class DirectToolInvokerTests
                     : SanitizationResult.WithFindings(cleaned, content, []);
             }
 
-            return PassThrough
-                ? SanitizationResult.Clean(content)
-                : SanitizationResult.WithFindings(Scrubbed, content, []);
+            return ScrubEverything
+                ? SanitizationResult.WithFindings(Scrubbed, content, [])
+                : SanitizationResult.Clean(content);
         }
     }
 
@@ -1032,6 +1041,17 @@ public sealed class DirectToolInvokerTests
         public object? RedactionResult { get; set; }
 
         public object? RedactResult(string toolName, object? result) => RedactionResult ?? Redacted;
+
+        /// <summary>
+        /// The string-typed overload <see cref="Application.AI.Common.Services.Governance.ToolCallAdmissionPipeline.TryApplyTextOutputPolicy"/>
+        /// actually calls. <see cref="RedactionResult"/> being set to anything other than a string
+        /// (e.g. a boxed <see langword="int"/>) simulates a consumer gate breaking the
+        /// non-null-in/non-null-out contract <see cref="IToolClassificationGate.RedactResult(string, string?)"/>
+        /// documents — returning null here for non-null <paramref name="content"/> is exactly that
+        /// violation, and is what the pipeline's fail-closed branch (#490) exists to catch.
+        /// </summary>
+        public string? RedactResult(string toolName, string? content) =>
+            content is null ? null : RedactionResult switch { null => Redacted, string s => s, _ => null };
     }
 
     private sealed class StaticOptionsMonitor<T>(T value) : IOptionsMonitor<T>

--- a/src/Content/Tests/Application.Core.Tests/Validation/DirectToolInvocationConfigValidatorTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Validation/DirectToolInvocationConfigValidatorTests.cs
@@ -92,9 +92,9 @@ public sealed class DirectToolInvocationConfigValidatorTests
     [Fact]
     public void An_output_ceiling_near_int_max_is_refused()
     {
-        // The realistic way to land here is an operator writing 2147483647 to mean "no limit". The
-        // invoker adds an overlap margin to this value in int arithmetic, so it wraps negative and
-        // every successful tool call becomes a 500 — with nothing in the response naming the setting.
+        // The realistic way to land here is an operator writing 2147483647 to mean "no limit" — a value
+        // this large is meaningless for this surface, so the validator names the setting at startup
+        // rather than let the host boot with it.
         var config = new DirectToolInvocationConfig { MaxOutputCharacters = int.MaxValue };
 
         _sut.Validate(config).IsValid.Should().BeFalse();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -375,7 +375,12 @@ public sealed class ToolUseStepExecutorTests
         _classificationGate.Setup(g => g.EvaluateAsync(
                 "file_system", It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(ClassificationVerdict.RedactOutput()));
-        _classificationGate.Setup(g => g.RedactResult("file_system", It.IsAny<object?>()))
+        // #490: the plan path calls TryApplyTextOutputPolicy, which resolves to the string-typed
+        // RedactResult(string, string?) overload — the object-typed one is what ApplyOutputPolicy
+        // (the agent-turn path) uses instead, and stubbing only that one leaves this call unstubbed,
+        // defaulting to null and failing closed for the wrong reason (an unstubbed Moq call, not a
+        // deliberate simulation of anything).
+        _classificationGate.Setup(g => g.RedactResult("file_system", It.IsAny<string?>()))
             .Returns("[redacted]");
 
         _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
@@ -399,11 +404,16 @@ public sealed class ToolUseStepExecutorTests
         // Fails closed. The gate decided this asset must not be emitted as-is and the redaction did
         // not produce usable text, so the one thing that must not happen is falling back to the
         // original — the harmless-looking default that silently defeats the control.
+        //
+        // #490: the string-typed RedactResult(string, string?) overload TryApplyTextOutputPolicy calls
+        // makes "answers with a non-string" unrepresentable at the type level — the only way left to
+        // simulate a gate breaking its non-null-in/non-null-out contract is a null return for non-null
+        // input.
         _classificationGate.Setup(g => g.EvaluateAsync(
                 "file_system", It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(ClassificationVerdict.RedactOutput()));
-        _classificationGate.Setup(g => g.RedactResult("file_system", It.IsAny<object?>()))
-            .Returns(new object());
+        _classificationGate.Setup(g => g.RedactResult("file_system", It.IsAny<string?>()))
+            .Returns((string?)null);
 
         _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new SandboxExecutionResult


### PR DESCRIPTION
## Summary

Package 1 of the tool-output pipeline cluster. Makes `ToolCallAdmissionPipeline` the single
owner of the full sequence a tool result goes through before it reaches a model or a caller —
scan-cost-bounded pre-cut → sanitize → redact → final cut — closing five issues that turned
out to be five facets of the same design gap.

- **#487** — nothing bounded sandbox tool output upstream, and the admission pipeline scanned
  the full unbounded string with the complete sanitize/redact chain before cutting to size.
  Worse than filed: this affected the agent-turn path (`ApplyOutputPolicy`, used on every
  ordinary tool call) as well as the plan-step path the issue named.
- **#489** — `DirectToolInvoker` ran its own private sanitize pass *after* the pipeline's
  already-unconditional one, on every successful result. Confirmed same singleton in every real
  composition, so this was pure duplicated cost.
- **#490** — the classification gate's redact result was `object?`-typed, collapsing five
  distinct outcomes into two observable states. Added a string-typed overload for the text
  boundary so "nothing to redact" and "gate broke its contract" are distinguishable by type.
- **#491** — two LOW security findings in the same code: a sanitizer-contract-violation crash
  guard (closed by deleting the vulnerable path, not patching around it), and an
  executed-vs-never-ran audit gap on a withheld redaction.
- **#493** — `Shape`/`ShapeMcp` duplicated ~50 lines of orchestration each; collapsed into one
  shared `ShapeText`.

## Review history on this branch

- `/code-review high` — 8 findings; 2 real bugs fixed (with mutation-verified regression
  tests), 1 stale (already fixed), 3 doc/comment corrections, 2 deferred to `/simplify`.
- Independent `security-reviewer` pass — found the same pre-cut/marker gap `/code-review`
  later confirmed, plus verified fail-closed semantics hold on every path (null input, a
  contract-breaking gate, the pre-cut/sanitize/redact ordering).
- `/simplify` — 4 parallel angles (reuse, simplification, efficiency, altitude). Deduped a
  block-walking loop, fixed an inconsistent overload pattern, trimmed 3 sites of restated
  rationale. Filed #543 (a real efficiency finding — 3 walks of the result shape where 1
  suffices — deliberately deferred: fusing passes on already-reviewed trust-boundary code
  needs its own careful pass) and #544 (a pre-existing, disclosed bypass).
- `scripts/rails/run-gates.sh`'s own correctness gate caught a second instance of the exact
  pre-cut/marker bug on the sibling method (`TryApplyTextOutputPolicy`, reached by
  `ToolUseStepExecutor`, which discards the truncation flag and depends entirely on a marker
  in the text) — fixed with the identical pattern, also mutation-verified.

All gates pass on the final commit (build, test, owasp, grader, correctness, security,
docs-drift). Full solution test suite: 8700+ tests, 0 failures (one confirmed-flaky, unrelated
`ProcessSandboxExecutorTests` case — Windows named-pipe transient, passed 5/5 on immediate
retry).

## Test plan

- [x] Full solution build clean
- [x] Full solution test suite green (8700+ tests)
- [x] Two mutation-verified regression tests for the marker/truncation-reporting fix
- [x] `run-gates.sh` clean pass on final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj