### PR TITLE
fix: unify the arm/authorize/catch skeleton (#494)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Arming.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Arming.cs
@@ -1,0 +1,231 @@
+using System.Diagnostics;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Governance;
+using Domain.AI.Governance;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// The arm/authorize/catch skeleton and its supporting pieces — shared by both direct-invocation
+/// surfaces (#494), split into its own partial so this file stays about one concern: getting a call
+/// safely from "here is a tool name and a caller" to "the admission chain is armed, ready, and torn
+/// down again no matter how the call ends."
+/// </summary>
+public sealed partial class DirectToolInvoker
+{
+    /// <summary>
+    /// Kept as full message templates, not assembled from a shared prefix + suffix, so the rendered
+    /// text AND the structured log's message-template string (what Application Insights groups and
+    /// alerts by) are both byte-identical to what this surface has always logged — found in review on
+    /// #494: an earlier version of this refactor collapsed both surfaces onto one shared template with
+    /// the surface name demoted to a property, which keeps the rendered text but silently breaks any
+    /// saved query or alert keyed on the old, now-vanished template string.
+    /// </summary>
+    private const string TimeoutLogTemplate = "Direct invocation of {ToolName} exceeded its {Timeout} deadline";
+
+    /// <summary>See <see cref="TimeoutLogTemplate"/>'s remarks — the fault-branch counterpart.</summary>
+    private const string FaultLogTemplate = "Direct invocation of {ToolName} threw";
+
+    /// <summary>
+    /// The arm/authorize/catch skeleton every direct-invocation surface runs, whatever kind of tool
+    /// it turns out to be (#481) — extracted so <c>RunArmedAsync</c> and
+    /// <c>DirectToolInvoker.Mcp.cs</c>'s <c>RunMcpArmedAsync</c> share the one implementation rather
+    /// than each re-deriving it by hand (#494). <see cref="ArmGovernance"/> was already extracted for
+    /// exactly this reason but stopped one level too shallow — the scope creation, the arm, the
+    /// three-arm catch ladder, and the trace log around all of it were still duplicated.
+    /// </summary>
+    /// <param name="toolName">The tool being invoked, for the trace log and the deadline/fault log messages.</param>
+    /// <param name="agentId">The caller's synthetic identity — see <see cref="ArmGovernance"/>'s remarks.</param>
+    /// <param name="envelope">The caller's capability envelope to arm around the call.</param>
+    /// <param name="effectiveTimeout">
+    /// The deadline this invocation runs under, already resolved by the caller from its request and
+    /// the host's config — reported in the timeout log message, not enforced here; enforcement is
+    /// <paramref name="body"/>'s own concern. Deliberately not re-derived here from a request/config
+    /// pair: <paramref name="body"/> needs the identical value for its own deadline token, and a
+    /// second, independent derivation of "requested timeout or config default" is exactly the shape of
+    /// bug where the logged deadline and the enforced one quietly drift apart after a future change to
+    /// one derivation site and not the other.
+    /// </param>
+    /// <param name="timeoutLogTemplate">
+    /// The caller's own full message template for the deadline-timeout warning, e.g.
+    /// <see cref="TimeoutLogTemplate"/> — a complete template, not a prefix this method assembles
+    /// into a shared one, so the structured log's message-template string (what a log backend groups
+    /// and alerts by) stays exactly what each surface has always emitted. Must accept exactly the two
+    /// placeholders <see cref="TimedOut"/> supplies (tool name, then timeout) in that order — nothing
+    /// in this method's signature enforces that shape, so a future invocation surface with a
+    /// differently-shaped template needs its own logging call, not a third template passed here.
+    /// </param>
+    /// <param name="faultLogTemplate">
+    /// The caller's own full message template for the fault-branch error, e.g.
+    /// <see cref="FaultLogTemplate"/> — same one-placeholder (tool name) constraint as
+    /// <paramref name="timeoutLogTemplate"/>, enforced the same way: by convention, not the type system.
+    /// </param>
+    /// <param name="cancellationToken">The caller's own token — see the first catch arm for why it
+    /// alone distinguishes "the caller went away" from "the deadline elapsed".</param>
+    /// <param name="body">
+    /// Authorizes and runs the tool itself, given the armed pipeline, the invocation's DI scope (used
+    /// by the keyed-DI path to resolve the tool; ignored by the MCP path, which already holds its
+    /// <c>AIFunction</c>), and the shared stopwatch every outcome's <c>Duration</c> is measured against.
+    /// </param>
+    private async Task<DirectToolInvocationOutcome> RunArmedCoreAsync(
+        string toolName,
+        string agentId,
+        Domain.AI.Bundles.CapabilityEnvelope envelope,
+        TimeSpan effectiveTimeout,
+        string timeoutLogTemplate,
+        string faultLogTemplate,
+        CancellationToken cancellationToken,
+        Func<IToolCallAdmissionPipeline, AsyncServiceScope, Stopwatch, Task<DirectToolInvocationOutcome>> body)
+    {
+        var sw = Stopwatch.StartNew();
+
+        await using var scope = _scopeFactory.CreateAsyncScope();
+
+        try
+        {
+            // Identity and envelope. Both must be in place before AuthorizeAsync — see the type
+            // remarks for what the governor reads, and when. The conversation-id and
+            // callOnceScopeId choices ArmGovernance makes are documented on ArmGovernance itself,
+            // not repeated here — this method only calls it (#494: the repeat was stale
+            // documentation left behind when ArmGovernance was first extracted).
+            var (admissionPipeline, grantedEnvelope, armedAdmission) =
+                ArmGovernance(scope.ServiceProvider, agentId, envelope);
+            using var _grantedEnvelope = grantedEnvelope;
+            using var _armedAdmission = armedAdmission;
+
+            try
+            {
+                return await body(admissionPipeline, scope, sw).ConfigureAwait(false);
+            }
+            finally
+            {
+                LogTrace(toolName, agentId, admissionPipeline.GetTrace);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller went away or the host is shutting down. Distinct from the deadline below:
+            // nobody is waiting for an answer, so unwind rather than manufacture one.
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            return TimedOut(sw, toolName, effectiveTimeout, timeoutLogTemplate);
+        }
+        catch (Exception ex)
+        {
+            return Faulted(ex, sw, toolName, faultLogTemplate);
+        }
+    }
+
+    /// <summary>Builds the timeout outcome and logs it. Split out of <see cref="RunArmedCoreAsync"/> to keep that method under this repo's function-length convention.</summary>
+    private DirectToolInvocationOutcome TimedOut(
+        Stopwatch sw, string toolName, TimeSpan effectiveTimeout, string logTemplate)
+    {
+        sw.Stop();
+        _logger.LogWarning(logTemplate, toolName, effectiveTimeout);
+        return DirectToolInvocationOutcome.Refused(
+            DirectToolInvocationStatus.TimedOut, "The tool did not complete within its deadline.", sw.Elapsed);
+    }
+
+    /// <summary>
+    /// Builds the fault outcome and logs it. Split out of <see cref="RunArmedCoreAsync"/> for the same
+    /// reason as <see cref="TimedOut"/>. Full detail stays in the structured log — the caller gets a
+    /// stable code and nothing derived from the exception, since this response crosses a trust boundary
+    /// and tool/infrastructure exceptions carry host paths, connection strings and container internals.
+    /// </summary>
+    private DirectToolInvocationOutcome Faulted(Exception ex, Stopwatch sw, string toolName, string logTemplate)
+    {
+        sw.Stop();
+        _logger.LogError(ex, logTemplate, toolName);
+        return DirectToolInvocationOutcome.Refused(
+            DirectToolInvocationStatus.Faulted, DirectToolInvocationErrors.Failed, sw.Elapsed);
+    }
+
+    /// <summary>
+    /// Establishes the caller's identity and capability envelope, then arms the ambient admission
+    /// chain — the fixed-order sequence every direct-invocation surface must run before its own
+    /// tool-specific resolution, whatever kind of tool that turns out to be (#481). Extracted so the
+    /// keyed-DI <see cref="ITool"/> path (<c>RunArmedAsync</c>) and the MCP path
+    /// (<c>DirectToolInvoker.Mcp.cs</c>) share the one implementation rather than each re-deriving this
+    /// order by hand — see this type's remarks for what goes wrong when that discipline is duplicated.
+    /// </summary>
+    /// <returns>
+    /// The scoped admission chain, reset and ready, plus the two restoring scopes the caller must
+    /// dispose (in either order — both restore independently) when the invocation ends.
+    /// </returns>
+    private (IToolCallAdmissionPipeline Pipeline, IDisposable EnvelopeScope, IDisposable AdmissionScope) ArmGovernance(
+        IServiceProvider scopedProvider, string agentId, Domain.AI.Bundles.CapabilityEnvelope envelope)
+    {
+        // Identity and envelope. Both must be in place before AdmitAsync — see the type remarks for
+        // what the governor reads, and when.
+        //
+        // The conversation id is deliberately NOT agentId. #325's retry-attribution memory is keyed on
+        // (conversation, agent, tool) precisely so it expires — but agentId here is the caller's stable
+        // synthetic identity, reused for every direct invocation that caller ever makes. Passing it as
+        // the conversation id too would give the failure-memory key no expiry at all. A direct
+        // invocation is a single, standalone call with no request-level session concept to key on, so
+        // each one mints its own one-shot id.
+        //
+        // callOnceScopeId is deliberately omitted (null), for the identical reason: a direct invocation
+        // has no request-level session to key a repeat-call check on either. A call-once tool reached
+        // through this surface is therefore not enforceable here — the call-once gate fails open on a
+        // null scope, which is the documented, correct answer, not a gap. See
+        // IAgentExecutionContext.CallOnceScopeId's remarks.
+        var executionContext = scopedProvider.GetRequiredService<IAgentExecutionContext>();
+        executionContext.Initialize(agentId, conversationId: Guid.NewGuid().ToString(), turnNumber: 1);
+
+        // Required, not GetService: the chain is registered unconditionally, and an absent one is
+        // indistinguishable at runtime from a host whose gates all happen to be off — so tolerating
+        // null here would let a broken composition run this path silently unguarded.
+        var admissionPipeline = scopedProvider.GetRequiredService<IToolCallAdmissionPipeline>();
+        admissionPipeline.Reset();
+
+        // Both ambient values are published with restoring scopes rather than assigned and nulled. The
+        // difference only shows under nesting, where it is the whole game: nulling on teardown disarms
+        // whatever an enclosing flow had armed, leaving the outer call ungoverned for the rest of its
+        // life. Restoring cannot do that.
+        //
+        // The chain is armed as well as called directly, because a tool that spawns an agent turn
+        // beneath it must reach the same chain rather than run unadmitted.
+        var grantedEnvelope = CapabilityEnvelopeAccessor.Begin(envelope);
+        var armedAdmission = ToolAdmissionAccessor.Begin(admissionPipeline);
+
+        return (admissionPipeline, grantedEnvelope, armedAdmission);
+    }
+
+    /// <summary>
+    /// Builds a refusal and stops the clock. This method owns stopping it, so callers must not — a
+    /// second stop is harmless but splits ownership, and a caller that forgets is then
+    /// indistinguishable from one that did not need to.
+    /// </summary>
+    private static DirectToolInvocationOutcome Refused(
+        DirectToolInvocationStatus status, string error, Stopwatch sw)
+    {
+        sw.Stop();
+        return DirectToolInvocationOutcome.Refused(status, error, sw.Elapsed);
+    }
+
+    /// <summary>
+    /// Records what governance decided. The trace carries rule ids and policy reasons, so it is written
+    /// to the host's log and never returned to the caller.
+    /// </summary>
+    private void LogTrace(string toolName, string agentId, Func<GovernanceTrace> trace)
+    {
+        // Checked before calling the factory: GetTrace() snapshots the decision list under a lock, and
+        // a production host running at Warning would pay for that on every invocation to log nothing.
+        if (!_logger.IsEnabled(LogLevel.Information))
+            return;
+
+        foreach (var decision in trace().ToolDecisions)
+        {
+            _logger.LogInformation(
+                "Direct invocation governance: caller {AgentId} tool {ToolName} → {Outcome} ({Reason}); enforced={Enforced}",
+                agentId, toolName, decision.Outcome, decision.Reason, decision.Enforced);
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Arming.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Arming.cs
@@ -31,6 +31,46 @@ public sealed partial class DirectToolInvoker
     private const string FaultLogTemplate = "Direct invocation of {ToolName} threw";
 
     /// <summary>
+    /// Everything <see cref="RunArmedCoreAsync"/> needs to arm one invocation, gathered into a single
+    /// value rather than six positional parameters — found in review on #494: both call sites already
+    /// needed named-argument syntax to stay readable, which is itself the signal that the list had
+    /// grown too long for positional passing.
+    /// </summary>
+    /// <param name="ToolName">The tool being invoked, for the trace log and the deadline/fault log messages.</param>
+    /// <param name="AgentId">The caller's synthetic identity — see <see cref="ArmGovernance"/>'s remarks.</param>
+    /// <param name="Envelope">The caller's capability envelope to arm around the call.</param>
+    /// <param name="EffectiveTimeout">
+    /// The deadline this invocation runs under, already resolved by the caller from its request and
+    /// the host's config — reported in the timeout log message, not enforced here; enforcement is the
+    /// arming body's own concern. Deliberately not re-derived here from a request/config pair: the
+    /// body needs the identical value for its own deadline token, and a second, independent derivation
+    /// of "requested timeout or config default" is exactly the shape of bug where the logged deadline
+    /// and the enforced one quietly drift apart after a future change to one derivation site and not
+    /// the other.
+    /// </param>
+    /// <param name="TimeoutLogTemplate">
+    /// The caller's own full message template for the deadline-timeout warning, e.g. this type's
+    /// <see cref="DirectToolInvoker.TimeoutLogTemplate"/> — a complete template, not a prefix this
+    /// method assembles into a shared one, so the structured log's message-template string (what a log
+    /// backend groups and alerts by) stays exactly what each surface has always emitted. Must accept
+    /// exactly the two placeholders <see cref="TimedOut"/> supplies (tool name, then timeout) in that
+    /// order — nothing enforces that shape, so a future invocation surface with a differently-shaped
+    /// template needs its own logging call, not a third template passed here.
+    /// </param>
+    /// <param name="FaultLogTemplate">
+    /// The caller's own full message template for the fault-branch error, e.g. this type's
+    /// <see cref="DirectToolInvoker.FaultLogTemplate"/> — same one-placeholder (tool name) constraint
+    /// as <see cref="TimeoutLogTemplate"/>, enforced the same way: by convention, not the type system.
+    /// </param>
+    private readonly record struct ArmingRequest(
+        string ToolName,
+        string AgentId,
+        Domain.AI.Bundles.CapabilityEnvelope Envelope,
+        TimeSpan EffectiveTimeout,
+        string TimeoutLogTemplate,
+        string FaultLogTemplate);
+
+    /// <summary>
     /// The arm/authorize/catch skeleton every direct-invocation surface runs, whatever kind of tool
     /// it turns out to be (#481) — extracted so <c>RunArmedAsync</c> and
     /// <c>DirectToolInvoker.Mcp.cs</c>'s <c>RunMcpArmedAsync</c> share the one implementation rather
@@ -38,32 +78,7 @@ public sealed partial class DirectToolInvoker
     /// exactly this reason but stopped one level too shallow — the scope creation, the arm, the
     /// three-arm catch ladder, and the trace log around all of it were still duplicated.
     /// </summary>
-    /// <param name="toolName">The tool being invoked, for the trace log and the deadline/fault log messages.</param>
-    /// <param name="agentId">The caller's synthetic identity — see <see cref="ArmGovernance"/>'s remarks.</param>
-    /// <param name="envelope">The caller's capability envelope to arm around the call.</param>
-    /// <param name="effectiveTimeout">
-    /// The deadline this invocation runs under, already resolved by the caller from its request and
-    /// the host's config — reported in the timeout log message, not enforced here; enforcement is
-    /// <paramref name="body"/>'s own concern. Deliberately not re-derived here from a request/config
-    /// pair: <paramref name="body"/> needs the identical value for its own deadline token, and a
-    /// second, independent derivation of "requested timeout or config default" is exactly the shape of
-    /// bug where the logged deadline and the enforced one quietly drift apart after a future change to
-    /// one derivation site and not the other.
-    /// </param>
-    /// <param name="timeoutLogTemplate">
-    /// The caller's own full message template for the deadline-timeout warning, e.g.
-    /// <see cref="TimeoutLogTemplate"/> — a complete template, not a prefix this method assembles
-    /// into a shared one, so the structured log's message-template string (what a log backend groups
-    /// and alerts by) stays exactly what each surface has always emitted. Must accept exactly the two
-    /// placeholders <see cref="TimedOut"/> supplies (tool name, then timeout) in that order — nothing
-    /// in this method's signature enforces that shape, so a future invocation surface with a
-    /// differently-shaped template needs its own logging call, not a third template passed here.
-    /// </param>
-    /// <param name="faultLogTemplate">
-    /// The caller's own full message template for the fault-branch error, e.g.
-    /// <see cref="FaultLogTemplate"/> — same one-placeholder (tool name) constraint as
-    /// <paramref name="timeoutLogTemplate"/>, enforced the same way: by convention, not the type system.
-    /// </param>
+    /// <param name="request">Everything this invocation needs to arm — see <see cref="ArmingRequest"/>.</param>
     /// <param name="cancellationToken">The caller's own token — see the first catch arm for why it
     /// alone distinguishes "the caller went away" from "the deadline elapsed".</param>
     /// <param name="body">
@@ -72,12 +87,7 @@ public sealed partial class DirectToolInvoker
     /// <c>AIFunction</c>), and the shared stopwatch every outcome's <c>Duration</c> is measured against.
     /// </param>
     private async Task<DirectToolInvocationOutcome> RunArmedCoreAsync(
-        string toolName,
-        string agentId,
-        Domain.AI.Bundles.CapabilityEnvelope envelope,
-        TimeSpan effectiveTimeout,
-        string timeoutLogTemplate,
-        string faultLogTemplate,
+        ArmingRequest request,
         CancellationToken cancellationToken,
         Func<IToolCallAdmissionPipeline, AsyncServiceScope, Stopwatch, Task<DirectToolInvocationOutcome>> body)
     {
@@ -93,7 +103,7 @@ public sealed partial class DirectToolInvoker
             // not repeated here — this method only calls it (#494: the repeat was stale
             // documentation left behind when ArmGovernance was first extracted).
             var (admissionPipeline, grantedEnvelope, armedAdmission) =
-                ArmGovernance(scope.ServiceProvider, agentId, envelope);
+                ArmGovernance(scope.ServiceProvider, request.AgentId, request.Envelope);
             using var _grantedEnvelope = grantedEnvelope;
             using var _armedAdmission = armedAdmission;
 
@@ -103,7 +113,7 @@ public sealed partial class DirectToolInvoker
             }
             finally
             {
-                LogTrace(toolName, agentId, admissionPipeline.GetTrace);
+                LogTrace(request.ToolName, request.AgentId, admissionPipeline.GetTrace);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -114,11 +124,11 @@ public sealed partial class DirectToolInvoker
         }
         catch (OperationCanceledException)
         {
-            return TimedOut(sw, toolName, effectiveTimeout, timeoutLogTemplate);
+            return TimedOut(sw, request.ToolName, request.EffectiveTimeout, request.TimeoutLogTemplate);
         }
         catch (Exception ex)
         {
-            return Faulted(ex, sw, toolName, faultLogTemplate);
+            return Faulted(ex, sw, request.ToolName, request.FaultLogTemplate);
         }
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -8,7 +8,6 @@ using Domain.AI.Bundles;
 using Domain.AI.Escalation;
 using Domain.Common.Config.AI.DirectToolInvocation;
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Tools;
@@ -142,56 +141,20 @@ public sealed partial class DirectToolInvoker
         return null;
     }
 
-    /// <summary>Arms the invocation and runs it, mirroring <see cref="DirectToolInvoker.RunArmedAsync"/>.</summary>
-    private async Task<DirectToolInvocationOutcome> RunMcpArmedAsync(
+    /// <summary>Arms the invocation and runs it, sharing <see cref="DirectToolInvoker.RunArmedCoreAsync"/>
+    /// with the keyed-DI path (#494) rather than mirroring it by hand.</summary>
+    private Task<DirectToolInvocationOutcome> RunMcpArmedAsync(
         DirectMcpToolInvocationRequest request,
         AIFunction tool,
         string agentId,
         DirectToolInvocationConfig config,
-        CancellationToken cancellationToken)
-    {
-        var sw = Stopwatch.StartNew();
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-
-        try
-        {
-            var (admissionPipeline, grantedEnvelope, armedAdmission) =
-                ArmGovernance(scope.ServiceProvider, agentId, request.Envelope);
-            using var _grantedEnvelope = grantedEnvelope;
-            using var _armedAdmission = armedAdmission;
-
-            try
-            {
-                return await AuthorizeAndRunMcpAsync(request, tool, admissionPipeline, config, sw, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            finally
-            {
-                LogTrace(request.ToolName, agentId, admissionPipeline.GetTrace);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (OperationCanceledException)
-        {
-            sw.Stop();
-            _logger.LogWarning(
-                "Direct MCP invocation of {ToolName} exceeded its {Timeout} deadline",
-                request.ToolName, request.RequestedTimeout ?? config.InvocationTimeout);
-            return DirectToolInvocationOutcome.Refused(
-                DirectToolInvocationStatus.TimedOut, "The tool did not complete within its deadline.", sw.Elapsed);
-        }
-        catch (Exception ex)
-        {
-            sw.Stop();
-            _logger.LogError(ex, "Direct MCP invocation of {ToolName} threw", request.ToolName);
-            return DirectToolInvocationOutcome.Refused(
-                DirectToolInvocationStatus.Faulted, DirectToolInvocationErrors.Failed, sw.Elapsed);
-        }
-    }
+        CancellationToken cancellationToken) =>
+        RunArmedCoreAsync(
+            request.ToolName, agentId, request.Envelope,
+            request.RequestedTimeout ?? config.InvocationTimeout,
+            "Direct MCP invocation", cancellationToken,
+            (admissionPipeline, _, sw) =>
+                AuthorizeAndRunMcpAsync(request, tool, admissionPipeline, config, sw, cancellationToken));
 
     /// <summary>
     /// Runs the admission chain and then the MCP tool itself, mirroring
@@ -243,12 +206,13 @@ public sealed partial class DirectToolInvoker
 
         // #460: the raw failure text is passed through untreated — ShapeMcp sanitizes, redacts, and
         // bounds it exactly once, at the same chokepoint the keyed-DI path's Shape uses.
-        await admissionPipeline.ReportExecutionAsync(
+        await ReportExecutionAsync(
+            admissionPipeline,
             admission,
             failureText is null
                 ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
                 : new ToolExecutionReport(EscalationExecutionStatus.Failed, failureText, null, ToolName: request.ToolName),
-            McpReportedBy, CancellationToken.None).ConfigureAwait(false);
+            McpReportedBy).ConfigureAwait(false);
 
         sw.Stop();
         return ShapeMcp(failureText, rawResult, request.ToolName, admissionPipeline, admission, config, sw.Elapsed);

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -141,6 +141,17 @@ public sealed partial class DirectToolInvoker
         return null;
     }
 
+    /// <summary>
+    /// The full message templates this surface has always logged — kept distinct from the keyed-DI
+    /// path's own <c>TimeoutLogTemplate</c>/<c>FaultLogTemplate</c> rather than assembled from a
+    /// shared prefix, so a log backend grouping by message template still sees two surfaces, not one
+    /// with a property tacked on. See <c>DirectToolInvoker.TimeoutLogTemplate</c>'s remarks.
+    /// </summary>
+    private const string McpTimeoutLogTemplate = "Direct MCP invocation of {ToolName} exceeded its {Timeout} deadline";
+
+    /// <summary>See <see cref="McpTimeoutLogTemplate"/>'s remarks — the fault-branch counterpart.</summary>
+    private const string McpFaultLogTemplate = "Direct MCP invocation of {ToolName} threw";
+
     /// <summary>Arms the invocation and runs it, sharing <see cref="DirectToolInvoker.RunArmedCoreAsync"/>
     /// with the keyed-DI path (#494) rather than mirroring it by hand.</summary>
     private Task<DirectToolInvocationOutcome> RunMcpArmedAsync(
@@ -152,7 +163,7 @@ public sealed partial class DirectToolInvoker
         RunArmedCoreAsync(
             request.ToolName, agentId, request.Envelope,
             request.RequestedTimeout ?? config.InvocationTimeout,
-            "Direct MCP invocation", cancellationToken,
+            McpTimeoutLogTemplate, McpFaultLogTemplate, cancellationToken,
             (admissionPipeline, _, sw) =>
                 AuthorizeAndRunMcpAsync(request, tool, admissionPipeline, config, sw, cancellationToken));
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -159,13 +159,20 @@ public sealed partial class DirectToolInvoker
         AIFunction tool,
         string agentId,
         DirectToolInvocationConfig config,
-        CancellationToken cancellationToken) =>
-        RunArmedCoreAsync(
-            request.ToolName, agentId, request.Envelope,
-            request.RequestedTimeout ?? config.InvocationTimeout,
-            McpTimeoutLogTemplate, McpFaultLogTemplate, cancellationToken,
-            (admissionPipeline, _, sw) =>
-                AuthorizeAndRunMcpAsync(request, tool, admissionPipeline, config, sw, cancellationToken));
+        CancellationToken cancellationToken)
+    {
+        var effectiveTimeout = request.RequestedTimeout ?? config.InvocationTimeout;
+        return RunArmedCoreAsync(
+            toolName: request.ToolName,
+            agentId: agentId,
+            envelope: request.Envelope,
+            effectiveTimeout: effectiveTimeout,
+            timeoutLogTemplate: McpTimeoutLogTemplate,
+            faultLogTemplate: McpFaultLogTemplate,
+            cancellationToken: cancellationToken,
+            body: (admissionPipeline, _, sw) =>
+                AuthorizeAndRunMcpAsync(request, tool, admissionPipeline, config, effectiveTimeout, sw, cancellationToken));
+    }
 
     /// <summary>
     /// Runs the admission chain and then the MCP tool itself, mirroring
@@ -178,11 +185,12 @@ public sealed partial class DirectToolInvoker
         AIFunction tool,
         IToolCallAdmissionPipeline admissionPipeline,
         DirectToolInvocationConfig config,
+        TimeSpan effectiveTimeout,
         Stopwatch sw,
         CancellationToken cancellationToken)
     {
         using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        deadline.CancelAfter(request.RequestedTimeout ?? config.InvocationTimeout);
+        deadline.CancelAfter(effectiveTimeout);
 
         var admission = await admissionPipeline
             .AdmitAsync(

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -163,14 +163,9 @@ public sealed partial class DirectToolInvoker
     {
         var effectiveTimeout = request.RequestedTimeout ?? config.InvocationTimeout;
         return RunArmedCoreAsync(
-            toolName: request.ToolName,
-            agentId: agentId,
-            envelope: request.Envelope,
-            effectiveTimeout: effectiveTimeout,
-            timeoutLogTemplate: McpTimeoutLogTemplate,
-            faultLogTemplate: McpFaultLogTemplate,
-            cancellationToken: cancellationToken,
-            body: (admissionPipeline, _, sw) =>
+            new ArmingRequest(request.ToolName, agentId, request.Envelope, effectiveTimeout, McpTimeoutLogTemplate, McpFaultLogTemplate),
+            cancellationToken,
+            (admissionPipeline, _, sw) =>
                 AuthorizeAndRunMcpAsync(request, tool, admissionPipeline, config, effectiveTimeout, sw, cancellationToken));
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -129,14 +129,9 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     {
         var effectiveTimeout = request.RequestedTimeout ?? config.InvocationTimeout;
         return RunArmedCoreAsync(
-            toolName: toolName,
-            agentId: agentId,
-            envelope: request.Envelope,
-            effectiveTimeout: effectiveTimeout,
-            timeoutLogTemplate: TimeoutLogTemplate,
-            faultLogTemplate: FaultLogTemplate,
-            cancellationToken: cancellationToken,
-            body: (admissionPipeline, scope, sw) =>
+            new ArmingRequest(toolName, agentId, request.Envelope, effectiveTimeout, TimeoutLogTemplate, FaultLogTemplate),
+            cancellationToken,
+            (admissionPipeline, scope, sw) =>
             {
                 var armed = new ArmedInvocation(request, toolName, admissionPipeline, scope, config);
                 return AuthorizeAndRunAsync(armed, effectiveTimeout, sw, cancellationToken);

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -132,12 +132,25 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         RunArmedCoreAsync(
             toolName, agentId, request.Envelope,
             request.RequestedTimeout ?? config.InvocationTimeout,
-            "Direct invocation", cancellationToken,
+            TimeoutLogTemplate, FaultLogTemplate, cancellationToken,
             (admissionPipeline, scope, sw) =>
             {
                 var armed = new ArmedInvocation(request, toolName, admissionPipeline, scope, config);
                 return AuthorizeAndRunAsync(armed, sw, cancellationToken);
             });
+
+    /// <summary>
+    /// Kept as full message templates, not assembled from a shared prefix + suffix, so the rendered
+    /// text AND the structured log's message-template string (what Application Insights groups and
+    /// alerts by) are both byte-identical to what this surface has always logged — found in review on
+    /// #494: an earlier version of this refactor collapsed both surfaces onto one shared template with
+    /// the surface name demoted to a property, which keeps the rendered text but silently breaks any
+    /// saved query or alert keyed on the old, now-vanished template string.
+    /// </summary>
+    private const string TimeoutLogTemplate = "Direct invocation of {ToolName} exceeded its {Timeout} deadline";
+
+    /// <summary>See <see cref="TimeoutLogTemplate"/>'s remarks — the fault-branch counterpart.</summary>
+    private const string FaultLogTemplate = "Direct invocation of {ToolName} threw";
 
     /// <summary>
     /// The arm/authorize/catch skeleton every direct-invocation surface runs, whatever kind of tool
@@ -156,11 +169,13 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     /// <paramref name="body"/>'s own concern, since only it knows where the linked deadline token
     /// needs to reach.
     /// </param>
-    /// <param name="logPrefix">
-    /// Distinguishes the keyed-DI and MCP surfaces in the log ("Direct invocation" vs "Direct MCP
-    /// invocation") — the one difference between the two catch ladders previously required two
-    /// hand-copied blocks to express.
+    /// <param name="timeoutLogTemplate">
+    /// The caller's own full message template for the deadline-timeout warning, e.g.
+    /// <see cref="TimeoutLogTemplate"/> — a complete template, not a prefix this method assembles
+    /// into a shared one, so the structured log's message-template string (what a log backend groups
+    /// and alerts by) stays exactly what each surface has always emitted.
     /// </param>
+    /// <param name="faultLogTemplate">The caller's own full message template for the fault-branch error, e.g. <see cref="FaultLogTemplate"/>.</param>
     /// <param name="cancellationToken">The caller's own token — see the first catch arm for why it
     /// alone distinguishes "the caller went away" from "the deadline elapsed".</param>
     /// <param name="body">
@@ -173,7 +188,8 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         string agentId,
         Domain.AI.Bundles.CapabilityEnvelope envelope,
         TimeSpan effectiveTimeout,
-        string logPrefix,
+        string timeoutLogTemplate,
+        string faultLogTemplate,
         CancellationToken cancellationToken,
         Func<IToolCallAdmissionPipeline, AsyncServiceScope, Stopwatch, Task<DirectToolInvocationOutcome>> body)
     {
@@ -211,9 +227,7 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         catch (OperationCanceledException)
         {
             sw.Stop();
-            _logger.LogWarning(
-                "{LogPrefix} of {ToolName} exceeded its {Timeout} deadline",
-                logPrefix, toolName, effectiveTimeout);
+            _logger.LogWarning(timeoutLogTemplate, toolName, effectiveTimeout);
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.TimedOut, "The tool did not complete within its deadline.", sw.Elapsed);
         }
@@ -223,7 +237,7 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
             // Full detail stays in the structured log. Tool and infrastructure exceptions carry host
             // paths, connection strings and container internals, and this response crosses a trust
             // boundary — so the caller gets a stable code and nothing derived from the exception.
-            _logger.LogError(ex, "{LogPrefix} of {ToolName} threw", logPrefix, toolName);
+            _logger.LogError(ex, faultLogTemplate, toolName);
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.Faulted, DirectToolInvocationErrors.Failed, sw.Elapsed);
         }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -1,11 +1,8 @@
 using System.Diagnostics;
 using Application.AI.Common.Interfaces;
-using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
-using Application.AI.Common.Services.Governance;
 using Domain.AI.Escalation;
-using Domain.AI.Governance;
 using Domain.AI.Models;
 using Domain.Common.Config.AI.DirectToolInvocation;
 using Microsoft.Extensions.DependencyInjection;
@@ -128,171 +125,22 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         string toolName,
         string agentId,
         DirectToolInvocationConfig config,
-        CancellationToken cancellationToken) =>
-        RunArmedCoreAsync(
-            toolName, agentId, request.Envelope,
-            request.RequestedTimeout ?? config.InvocationTimeout,
-            TimeoutLogTemplate, FaultLogTemplate, cancellationToken,
-            (admissionPipeline, scope, sw) =>
+        CancellationToken cancellationToken)
+    {
+        var effectiveTimeout = request.RequestedTimeout ?? config.InvocationTimeout;
+        return RunArmedCoreAsync(
+            toolName: toolName,
+            agentId: agentId,
+            envelope: request.Envelope,
+            effectiveTimeout: effectiveTimeout,
+            timeoutLogTemplate: TimeoutLogTemplate,
+            faultLogTemplate: FaultLogTemplate,
+            cancellationToken: cancellationToken,
+            body: (admissionPipeline, scope, sw) =>
             {
                 var armed = new ArmedInvocation(request, toolName, admissionPipeline, scope, config);
-                return AuthorizeAndRunAsync(armed, sw, cancellationToken);
+                return AuthorizeAndRunAsync(armed, effectiveTimeout, sw, cancellationToken);
             });
-
-    /// <summary>
-    /// Kept as full message templates, not assembled from a shared prefix + suffix, so the rendered
-    /// text AND the structured log's message-template string (what Application Insights groups and
-    /// alerts by) are both byte-identical to what this surface has always logged — found in review on
-    /// #494: an earlier version of this refactor collapsed both surfaces onto one shared template with
-    /// the surface name demoted to a property, which keeps the rendered text but silently breaks any
-    /// saved query or alert keyed on the old, now-vanished template string.
-    /// </summary>
-    private const string TimeoutLogTemplate = "Direct invocation of {ToolName} exceeded its {Timeout} deadline";
-
-    /// <summary>See <see cref="TimeoutLogTemplate"/>'s remarks — the fault-branch counterpart.</summary>
-    private const string FaultLogTemplate = "Direct invocation of {ToolName} threw";
-
-    /// <summary>
-    /// The arm/authorize/catch skeleton every direct-invocation surface runs, whatever kind of tool
-    /// it turns out to be (#481) — extracted so <see cref="RunArmedAsync"/> and
-    /// <c>DirectToolInvoker.Mcp.cs</c>'s <c>RunMcpArmedAsync</c> share the one implementation rather
-    /// than each re-deriving it by hand (#494). <see cref="ArmGovernance"/> was already extracted for
-    /// exactly this reason but stopped one level too shallow — the scope creation, the arm, the
-    /// three-arm catch ladder, and the trace log around all of it were still duplicated.
-    /// </summary>
-    /// <param name="toolName">The tool being invoked, for the trace log and the deadline/fault log messages.</param>
-    /// <param name="agentId">The caller's synthetic identity — see <see cref="ArmGovernance"/>'s remarks.</param>
-    /// <param name="envelope">The caller's capability envelope to arm around the call.</param>
-    /// <param name="effectiveTimeout">
-    /// The deadline this invocation runs under, already resolved from the caller's request and the
-    /// host's config — reported in the timeout log message, not enforced here; enforcement is
-    /// <paramref name="body"/>'s own concern, since only it knows where the linked deadline token
-    /// needs to reach.
-    /// </param>
-    /// <param name="timeoutLogTemplate">
-    /// The caller's own full message template for the deadline-timeout warning, e.g.
-    /// <see cref="TimeoutLogTemplate"/> — a complete template, not a prefix this method assembles
-    /// into a shared one, so the structured log's message-template string (what a log backend groups
-    /// and alerts by) stays exactly what each surface has always emitted.
-    /// </param>
-    /// <param name="faultLogTemplate">The caller's own full message template for the fault-branch error, e.g. <see cref="FaultLogTemplate"/>.</param>
-    /// <param name="cancellationToken">The caller's own token — see the first catch arm for why it
-    /// alone distinguishes "the caller went away" from "the deadline elapsed".</param>
-    /// <param name="body">
-    /// Authorizes and runs the tool itself, given the armed pipeline, the invocation's DI scope (used
-    /// by the keyed-DI path to resolve the tool; ignored by the MCP path, which already holds its
-    /// <c>AIFunction</c>), and the shared stopwatch every outcome's <c>Duration</c> is measured against.
-    /// </param>
-    private async Task<DirectToolInvocationOutcome> RunArmedCoreAsync(
-        string toolName,
-        string agentId,
-        Domain.AI.Bundles.CapabilityEnvelope envelope,
-        TimeSpan effectiveTimeout,
-        string timeoutLogTemplate,
-        string faultLogTemplate,
-        CancellationToken cancellationToken,
-        Func<IToolCallAdmissionPipeline, AsyncServiceScope, Stopwatch, Task<DirectToolInvocationOutcome>> body)
-    {
-        var sw = Stopwatch.StartNew();
-
-        await using var scope = _scopeFactory.CreateAsyncScope();
-
-        try
-        {
-            // Identity and envelope. Both must be in place before AuthorizeAsync — see the type
-            // remarks for what the governor reads, and when. The conversation-id and
-            // callOnceScopeId choices ArmGovernance makes are documented on ArmGovernance itself,
-            // not repeated here — this method only calls it (#494: the repeat was stale
-            // documentation left behind when ArmGovernance was first extracted).
-            var (admissionPipeline, grantedEnvelope, armedAdmission) =
-                ArmGovernance(scope.ServiceProvider, agentId, envelope);
-            using var _grantedEnvelope = grantedEnvelope;
-            using var _armedAdmission = armedAdmission;
-
-            try
-            {
-                return await body(admissionPipeline, scope, sw).ConfigureAwait(false);
-            }
-            finally
-            {
-                LogTrace(toolName, agentId, admissionPipeline.GetTrace);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // The caller went away or the host is shutting down. Distinct from the deadline below:
-            // nobody is waiting for an answer, so unwind rather than manufacture one.
-            throw;
-        }
-        catch (OperationCanceledException)
-        {
-            sw.Stop();
-            _logger.LogWarning(timeoutLogTemplate, toolName, effectiveTimeout);
-            return DirectToolInvocationOutcome.Refused(
-                DirectToolInvocationStatus.TimedOut, "The tool did not complete within its deadline.", sw.Elapsed);
-        }
-        catch (Exception ex)
-        {
-            sw.Stop();
-            // Full detail stays in the structured log. Tool and infrastructure exceptions carry host
-            // paths, connection strings and container internals, and this response crosses a trust
-            // boundary — so the caller gets a stable code and nothing derived from the exception.
-            _logger.LogError(ex, faultLogTemplate, toolName);
-            return DirectToolInvocationOutcome.Refused(
-                DirectToolInvocationStatus.Faulted, DirectToolInvocationErrors.Failed, sw.Elapsed);
-        }
-    }
-
-    /// <summary>
-    /// Establishes the caller's identity and capability envelope, then arms the ambient admission
-    /// chain — the fixed-order sequence every direct-invocation surface must run before its own
-    /// tool-specific resolution, whatever kind of tool that turns out to be (#481). Extracted so the
-    /// keyed-DI <see cref="ITool"/> path (<see cref="RunArmedAsync"/>) and the MCP path
-    /// (<c>DirectToolInvoker.Mcp.cs</c>) share the one implementation rather than each re-deriving this
-    /// order by hand — see this type's remarks for what goes wrong when that discipline is duplicated.
-    /// </summary>
-    /// <returns>
-    /// The scoped admission chain, reset and ready, plus the two restoring scopes the caller must
-    /// dispose (in either order — both restore independently) when the invocation ends.
-    /// </returns>
-    private (IToolCallAdmissionPipeline Pipeline, IDisposable EnvelopeScope, IDisposable AdmissionScope) ArmGovernance(
-        IServiceProvider scopedProvider, string agentId, Domain.AI.Bundles.CapabilityEnvelope envelope)
-    {
-        // Identity and envelope. Both must be in place before AdmitAsync — see the type remarks for
-        // what the governor reads, and when.
-        //
-        // The conversation id is deliberately NOT agentId. #325's retry-attribution memory is keyed on
-        // (conversation, agent, tool) precisely so it expires — but agentId here is the caller's stable
-        // synthetic identity, reused for every direct invocation that caller ever makes. Passing it as
-        // the conversation id too would give the failure-memory key no expiry at all. A direct
-        // invocation is a single, standalone call with no request-level session concept to key on, so
-        // each one mints its own one-shot id.
-        //
-        // callOnceScopeId is deliberately omitted (null), for the identical reason: a direct invocation
-        // has no request-level session to key a repeat-call check on either. A call-once tool reached
-        // through this surface is therefore not enforceable here — the call-once gate fails open on a
-        // null scope, which is the documented, correct answer, not a gap. See
-        // IAgentExecutionContext.CallOnceScopeId's remarks.
-        var executionContext = scopedProvider.GetRequiredService<IAgentExecutionContext>();
-        executionContext.Initialize(agentId, conversationId: Guid.NewGuid().ToString(), turnNumber: 1);
-
-        // Required, not GetService: the chain is registered unconditionally, and an absent one is
-        // indistinguishable at runtime from a host whose gates all happen to be off — so tolerating
-        // null here would let a broken composition run this path silently unguarded.
-        var admissionPipeline = scopedProvider.GetRequiredService<IToolCallAdmissionPipeline>();
-        admissionPipeline.Reset();
-
-        // Both ambient values are published with restoring scopes rather than assigned and nulled. The
-        // difference only shows under nesting, where it is the whole game: nulling on teardown disarms
-        // whatever an enclosing flow had armed, leaving the outer call ungoverned for the rest of its
-        // life. Restoring cannot do that.
-        //
-        // The chain is armed as well as called directly, because a tool that spawns an agent turn
-        // beneath it must reach the same chain rather than run unadmitted.
-        var grantedEnvelope = CapabilityEnvelopeAccessor.Begin(envelope);
-        var armedAdmission = ToolAdmissionAccessor.Begin(admissionPipeline);
-
-        return (admissionPipeline, grantedEnvelope, armedAdmission);
     }
 
     /// <summary>
@@ -309,10 +157,10 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     /// </para>
     /// </remarks>
     private async Task<DirectToolInvocationOutcome> AuthorizeAndRunAsync(
-        ArmedInvocation armed, Stopwatch sw, CancellationToken cancellationToken)
+        ArmedInvocation armed, TimeSpan effectiveTimeout, Stopwatch sw, CancellationToken cancellationToken)
     {
         using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        deadline.CancelAfter(armed.Request.RequestedTimeout ?? armed.Config.InvocationTimeout);
+        deadline.CancelAfter(effectiveTimeout);
 
         // Parameters are passed for the same reason the agent path passes them: if a verdict is routed
         // to a human, approving a bare tool name tells them nothing. This is the surface most exposed
@@ -403,37 +251,6 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     private static ValueTask ReportExecutionAsync(
         IToolCallAdmissionPipeline pipeline, ToolCallAdmission admission, ToolExecutionReport report, string reportedBy) =>
         pipeline.ReportExecutionAsync(admission, report, reportedBy, CancellationToken.None);
-
-    /// <summary>
-    /// Builds a refusal and stops the clock. This method owns stopping it, so callers must not — a
-    /// second stop is harmless but splits ownership, and a caller that forgets is then
-    /// indistinguishable from one that did not need to.
-    /// </summary>
-    private static DirectToolInvocationOutcome Refused(
-        DirectToolInvocationStatus status, string error, Stopwatch sw)
-    {
-        sw.Stop();
-        return DirectToolInvocationOutcome.Refused(status, error, sw.Elapsed);
-    }
-
-    /// <summary>
-    /// Records what governance decided. The trace carries rule ids and policy reasons, so it is written
-    /// to the host's log and never returned to the caller.
-    /// </summary>
-    private void LogTrace(string toolName, string agentId, Func<GovernanceTrace> trace)
-    {
-        // Checked before calling the factory: GetTrace() snapshots the decision list under a lock, and
-        // a production host running at Warning would pay for that on every invocation to log nothing.
-        if (!_logger.IsEnabled(LogLevel.Information))
-            return;
-
-        foreach (var decision in trace().ToolDecisions)
-        {
-            _logger.LogInformation(
-                "Direct invocation governance: caller {AgentId} tool {ToolName} → {Outcome} ({Reason}); enforced={Enforced}",
-                agentId, toolName, decision.Outcome, decision.Reason, decision.Enforced);
-        }
-    }
 
     /// <summary>
     /// Everything an armed invocation needs, gathered once rather than threaded through each step as a

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -123,12 +123,59 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     /// <summary>
     /// Arms the invocation and runs it. Every exit path tears down what it armed.
     /// </summary>
-    private async Task<DirectToolInvocationOutcome> RunArmedAsync(
+    private Task<DirectToolInvocationOutcome> RunArmedAsync(
         DirectToolInvocationRequest request,
         string toolName,
         string agentId,
         DirectToolInvocationConfig config,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken) =>
+        RunArmedCoreAsync(
+            toolName, agentId, request.Envelope,
+            request.RequestedTimeout ?? config.InvocationTimeout,
+            "Direct invocation", cancellationToken,
+            (admissionPipeline, scope, sw) =>
+            {
+                var armed = new ArmedInvocation(request, toolName, admissionPipeline, scope, config);
+                return AuthorizeAndRunAsync(armed, sw, cancellationToken);
+            });
+
+    /// <summary>
+    /// The arm/authorize/catch skeleton every direct-invocation surface runs, whatever kind of tool
+    /// it turns out to be (#481) — extracted so <see cref="RunArmedAsync"/> and
+    /// <c>DirectToolInvoker.Mcp.cs</c>'s <c>RunMcpArmedAsync</c> share the one implementation rather
+    /// than each re-deriving it by hand (#494). <see cref="ArmGovernance"/> was already extracted for
+    /// exactly this reason but stopped one level too shallow — the scope creation, the arm, the
+    /// three-arm catch ladder, and the trace log around all of it were still duplicated.
+    /// </summary>
+    /// <param name="toolName">The tool being invoked, for the trace log and the deadline/fault log messages.</param>
+    /// <param name="agentId">The caller's synthetic identity — see <see cref="ArmGovernance"/>'s remarks.</param>
+    /// <param name="envelope">The caller's capability envelope to arm around the call.</param>
+    /// <param name="effectiveTimeout">
+    /// The deadline this invocation runs under, already resolved from the caller's request and the
+    /// host's config — reported in the timeout log message, not enforced here; enforcement is
+    /// <paramref name="body"/>'s own concern, since only it knows where the linked deadline token
+    /// needs to reach.
+    /// </param>
+    /// <param name="logPrefix">
+    /// Distinguishes the keyed-DI and MCP surfaces in the log ("Direct invocation" vs "Direct MCP
+    /// invocation") — the one difference between the two catch ladders previously required two
+    /// hand-copied blocks to express.
+    /// </param>
+    /// <param name="cancellationToken">The caller's own token — see the first catch arm for why it
+    /// alone distinguishes "the caller went away" from "the deadline elapsed".</param>
+    /// <param name="body">
+    /// Authorizes and runs the tool itself, given the armed pipeline, the invocation's DI scope (used
+    /// by the keyed-DI path to resolve the tool; ignored by the MCP path, which already holds its
+    /// <c>AIFunction</c>), and the shared stopwatch every outcome's <c>Duration</c> is measured against.
+    /// </param>
+    private async Task<DirectToolInvocationOutcome> RunArmedCoreAsync(
+        string toolName,
+        string agentId,
+        Domain.AI.Bundles.CapabilityEnvelope envelope,
+        TimeSpan effectiveTimeout,
+        string logPrefix,
+        CancellationToken cancellationToken,
+        Func<IToolCallAdmissionPipeline, AsyncServiceScope, Stopwatch, Task<DirectToolInvocationOutcome>> body)
     {
         var sw = Stopwatch.StartNew();
 
@@ -137,34 +184,18 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         try
         {
             // Identity and envelope. Both must be in place before AuthorizeAsync — see the type
-            // remarks for what the governor reads, and when.
-            //
-            // The conversation id is deliberately NOT agentId. #325's retry-attribution memory is
-            // keyed on (conversation, agent, tool) precisely so it expires — but agentId here is
-            // the caller's stable synthetic identity, reused for every direct invocation that
-            // caller ever makes. Passing it as the conversation id too would give the failure-memory
-            // key no expiry at all: two calls to the same tool by the same caller, hours apart and
-            // sharing nothing else, would be mislabeled as the same retry sequence forever. A direct
-            // invocation is a single, standalone call with no request-level session concept to key
-            // on, so each one mints its own one-shot id — TryRecall can then never find a match for
-            // it, which is the correct behaviour (retry attribution genuinely does not apply here),
-            // achieved without a special case rather than through an accidental permanent one.
-            //
-            // callOnceScopeId is deliberately omitted (null), for the identical reason the
-            // conversation id above is a fresh GUID rather than something stable: a direct invocation
-            // has no request-level session to key a repeat-call check on either. A call-once tool
-            // reached through this surface is therefore not enforceable here — the call-once gate
-            // fails open on a null scope, which is the documented, correct answer, not a gap. See
-            // IAgentExecutionContext.CallOnceScopeId's remarks.
+            // remarks for what the governor reads, and when. The conversation-id and
+            // callOnceScopeId choices ArmGovernance makes are documented on ArmGovernance itself,
+            // not repeated here — this method only calls it (#494: the repeat was stale
+            // documentation left behind when ArmGovernance was first extracted).
             var (admissionPipeline, grantedEnvelope, armedAdmission) =
-                ArmGovernance(scope.ServiceProvider, agentId, request.Envelope);
+                ArmGovernance(scope.ServiceProvider, agentId, envelope);
             using var _grantedEnvelope = grantedEnvelope;
             using var _armedAdmission = armedAdmission;
 
             try
             {
-                var armed = new ArmedInvocation(request, toolName, admissionPipeline, scope, config);
-                return await AuthorizeAndRunAsync(armed, sw, cancellationToken).ConfigureAwait(false);
+                return await body(admissionPipeline, scope, sw).ConfigureAwait(false);
             }
             finally
             {
@@ -181,8 +212,8 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         {
             sw.Stop();
             _logger.LogWarning(
-                "Direct invocation of {ToolName} exceeded its {Timeout} deadline",
-                toolName, request.RequestedTimeout ?? config.InvocationTimeout);
+                "{LogPrefix} of {ToolName} exceeded its {Timeout} deadline",
+                logPrefix, toolName, effectiveTimeout);
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.TimedOut, "The tool did not complete within its deadline.", sw.Elapsed);
         }
@@ -192,7 +223,7 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
             // Full detail stays in the structured log. Tool and infrastructure exceptions carry host
             // paths, connection strings and container internals, and this response crosses a trust
             // boundary — so the caller gets a stable code and nothing derived from the exception.
-            _logger.LogError(ex, "Direct invocation of {ToolName} threw", toolName);
+            _logger.LogError(ex, "{LogPrefix} of {ToolName} threw", logPrefix, toolName);
             return DirectToolInvocationOutcome.Refused(
                 DirectToolInvocationStatus.Faulted, DirectToolInvocationErrors.Failed, sw.Elapsed);
         }
@@ -320,23 +351,33 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         // (this one and GovernedAIFunction's) funnels through, rather than each duplicating that
         // treatment.
         await ReportExecutionAsync(
-            armed.AdmissionPipeline, admission,
+            armed.AdmissionPipeline,
+            admission,
             result.Success
                 ? new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null)
                 : new ToolExecutionReport(
                     EscalationExecutionStatus.Failed,
                     result.Error ?? "the tool reported failure with no message",
                     null,
-                    ToolName: armed.ToolName))
+                    ToolName: armed.ToolName),
+            ReportedBy)
             .ConfigureAwait(false);
 
         sw.Stop();
         return Shape(result, armed, admission, sw.Elapsed);
     }
 
+    private const string ReportedBy = "direct-invocation";
+
     /// <summary>
     /// Closes the approval loop for this call, when it was one a human approved.
     /// </summary>
+    /// <param name="reportedBy">
+    /// The calling surface's own identifier (#494) — the MCP path used to inline this same call
+    /// rather than share this helper, specifically because the helper used to hard-wire
+    /// <see cref="ReportedBy"/>; now both surfaces resolve to the identical call, differing only in
+    /// which constant they pass (<see cref="ReportedBy"/> or <c>McpReportedBy</c>).
+    /// </param>
     /// <remarks>
     /// Deliberately reported on <see cref="CancellationToken.None"/>, not the deadline or caller
     /// token — both are typically already fired by the time this runs (a fault means the deadline
@@ -345,11 +386,9 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
     /// <see cref="IToolCallAdmissionPipeline.ReportExecutionAsync"/> never throws — see its own
     /// must-not-throw contract — so this is not itself a new fault surface.
     /// </remarks>
-    private const string ReportedBy = "direct-invocation";
-
     private static ValueTask ReportExecutionAsync(
-        IToolCallAdmissionPipeline pipeline, ToolCallAdmission admission, ToolExecutionReport report) =>
-        pipeline.ReportExecutionAsync(admission, report, ReportedBy, CancellationToken.None);
+        IToolCallAdmissionPipeline pipeline, ToolCallAdmission admission, ToolExecutionReport report, string reportedBy) =>
+        pipeline.ReportExecutionAsync(admission, report, reportedBy, CancellationToken.None);
 
     /// <summary>
     /// Builds a refusal and stops the clock. This method owns stopping it, so callers must not — a


### PR DESCRIPTION
## Summary

Package 2 of the tool-output-pipeline cluster (10 packages, 15 issues — see #545 for
Package 1). Closes #494.

`RunArmedAsync` (keyed-DI tool path, `DirectToolInvoker.cs`) and `RunMcpArmedAsync` (MCP
tool path, `DirectToolInvoker.Mcp.cs`) duplicated ~45 lines of identical scaffolding: build
a DI scope, arm governance (identity + capability envelope + admission pipeline), run the
inner body, tear down, and catch cancellation/timeout/fault into the same three outcomes —
each hand-copied rather than shared. `ArmGovernance` had already been extracted once for
this exact reason but stopped one level too shallow.

- Extracted the full skeleton into a new `RunArmedCoreAsync`, in a new partial file
  `DirectToolInvoker.Arming.cs` (following this class's own partial-by-responsibility
  convention, e.g. `.Response.cs`, `.Mcp.cs`). `TimedOut`/`Faulted` split out of it to stay
  under the function-length limit.
- Both surfaces now compute their effective timeout once and thread it through by
  parameter instead of each independently re-deriving `RequestedTimeout ?? config.InvocationTimeout`
  a second time inside their own authorize-and-run method — closing a spot where the
  logged deadline and the enforced one could silently drift apart after a future change to
  one derivation site and not the other.
- `/simplify`'s simplification-angle pass flagged that `RunArmedCoreAsync`'s parameter list
  had grown long enough that both call sites already needed named-argument syntax to stay
  readable — collapsed the six non-delegate values into a small `ArmingRequest` record.
- Kept both surfaces' log message templates as distinct, byte-identical string constants
  rather than assembling them from a shared prefix — a log backend groups and alerts by
  the raw template string, not the rendered text, so collapsing them would silently break
  any saved query or alert keyed on the old template.

## Deferred, filed as follow-ups

- **#547** — `AuthorizeAndRunAsync`/`AuthorizeAndRunMcpAsync` still duplicate a deeper layer
  (deadline linking, admission check, report-on-exception, shared reporting/shaping) that
  genuinely differs only in how the tool itself is resolved and invoked. Riskier
  unification, deliberately out of this PR's scope.
- **#546** — the MCP direct-invocation path has no fast unit-level test coverage, only the
  heavy HTTP integration suite (found while reviewing this change's MCP-side attribution
  and cancellation behavior).

## Review

- `security-reviewer` run explicitly (trust-boundary file). One LOW advisory noted (log
  templates are now runtime-`string` parameters rather than compile-time literals at the
  two `TimedOut`/`Faulted` call sites — not exploitable today since only private constants
  are ever passed, left as documented convention rather than a stricter type, matching how
  this file already threads `McpTimeoutLogTemplate`/`McpFaultLogTemplate` the same way).
- `/code-review` and `/simplify` (4 parallel angles: reuse, simplification, efficiency,
  altitude) both run; findings applied or explicitly deferred as above.
- `scripts/rails/run-gates.sh` clean: build, test, OWASP, grader, correctness, security,
  docs-drift (advisory) all pass.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` clean
- [x] `dotnet test src/AgenticHarness.slnx` — full solution suite green (0 failures)
- [x] `Application.AI.Common.Tests` `DirectToolInvoker*` tests (47) re-verified after the
      `ArmingRequest` refactor
- [x] All 8 CI gates expected green (local `run-gates.sh` pass is a formality check, not a
      substitute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj