### PR TITLE
fix: cache MCP tool lists within one request to stop the double-fetch (#495)

### DIFF
--- a/documentation/security/mcp-tool-definition-scanning.md
+++ b/documentation/security/mcp-tool-definition-scanning.md
@@ -18,6 +18,8 @@ So the scan sits at the single point where MCP tools cross into the harness: `Sc
 
 All three tool-returning methods are screened, including the by-name lookup. That last one matters: the inner provider's own by-name implementation calls its own tool listing rather than the decorated one, so a decorator that delegated it unscreened would hand back a withheld tool to anyone who asked for it directly.
 
+A request-scoped list cache (`CachingMcpToolProvider`, #495) sits **outside** `ScanningMcpToolProvider` — outside every decorator in the chain, in fact — so a second lookup of the same server within one HTTP request is served from cache without re-scanning. That window is bounded to a single request; it does not weaken this scan across requests, which is where a server changing its own tool definition is actually observable.
+
 ## 3. What is detected
 
 | Finding | Severity | What it looks for |

--- a/documentation/security/tool-behavior-gating.md
+++ b/documentation/security/tool-behavior-gating.md
@@ -16,7 +16,7 @@ Two sources, and the difference between them is the whole security argument.
 
 **First-party tools** declare themselves through `ITool.IsReadOnly`, which already existed for concurrency classification and graded autonomy. It defaults to `false` — assume it writes — so a tool that never thought about the question is gated rather than exempt.
 
-**External MCP tools** declare themselves through the protocol's tool annotations: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. These arrive on the definition a server advertises and were previously discarded. They are captured now at discovery by `BehaviorRecordingMcpToolProvider`, a decorator over `IMcpToolProvider` that sits **outside** the security scanner, so only tools that survived the definition scan are recorded.
+**External MCP tools** declare themselves through the protocol's tool annotations: `readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`. These arrive on the definition a server advertises and were previously discarded. They are captured at discovery by `BehaviorRecordingMcpToolProvider`, a decorator over `IMcpToolProvider` that sits **outside** the security scanner, so only tools that survived the definition scan are recorded — except on a cache hit within the same HTTP request, where a request-scoped list cache (`CachingMcpToolProvider`, #495) sits outside this decorator too and serves the earlier fetch's already-recorded result without a second recording pass. That window is bounded to one request.
 
 Discovery is the only moment the information exists. By the time a tool call arrives, all that remains is a name; the annotations are not reachable from it.
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
@@ -32,6 +32,23 @@ namespace Application.AI.Common.Services.Tools;
 /// are a superset of the second call's per-server lookups within the same request.
 /// </para>
 /// <para>
+/// <strong>Read/write access is behind methods, not a raw dictionary.</strong> An earlier version
+/// exposed the underlying <see cref="ConcurrentDictionary{TKey,TValue}"/> directly through <c>Current</c>
+/// — a public, directly-mutable collection, which this repo's own coding-style rule requires public
+/// surfaces to avoid (<c>IReadOnlyDictionary&lt;K,V&gt;</c> or narrower). Only <c>CachingMcpToolProvider</c>
+/// is meant to write, so the write surface is <see cref="TrySet"/>/<see cref="TryAdd"/> rather than a
+/// settable collection any holder of a reference could mutate (#495 security review, finding L3/#3).
+/// </para>
+/// <para>
+/// <strong>The backing dictionary is allocated lazily, on first write.</strong> <see cref="Begin"/> is
+/// called on every MCP tool invocation, including the common case — a caller with an operator-configured
+/// grant — where nothing is ever cached because <c>ResolveMcpEnvelopeAsync</c> never takes the
+/// <c>GetAllToolsAsync</c> fallback branch that would populate it. Eagerly allocating a
+/// <see cref="ConcurrentDictionary{TKey,TValue}"/> on every call would pay that cost on the majority path
+/// for a benefit only the minority fallback path uses (#495 review finding #8); deferring the allocation
+/// to the first actual write means an unused scope costs one small wrapper object, not a dictionary.
+/// </para>
+/// <para>
 /// Caveat, identical to the other ambient accessors: like any <see cref="AsyncLocal{T}"/>, the cache is
 /// captured into the <c>ExecutionContext</c> of any fire-and-forget work started <em>while it is
 /// active</em>, and that work keeps reading it after the request's own flow has torn it down. The one
@@ -42,10 +59,69 @@ namespace Application.AI.Common.Services.Tools;
 /// </remarks>
 public static class McpToolListCacheAccessor
 {
-    private static readonly AsyncLocal<ConcurrentDictionary<string, IList<AITool>>?> s_current = new();
+    private static readonly AsyncLocal<Scope?> s_current = new();
 
-    /// <summary>The active cache for the current async flow, or <see langword="null"/> when no scope is open.</summary>
-    public static ConcurrentDictionary<string, IList<AITool>>? Current => s_current.Value;
+    /// <summary>
+    /// Whether a cache scope is open for the current async flow. Read-only, unlike the retired
+    /// <c>Current</c> property this type used to expose — lets a caller behave identically to an
+    /// undecorated provider off the one call site that opens a scope, without handing out anything
+    /// mutable to check that against.
+    /// </summary>
+    public static bool IsActive => s_current.Value is not null;
+
+    /// <summary>
+    /// Attempts to read a previously-cached server's tool list for the current async flow.
+    /// </summary>
+    /// <returns><see langword="true"/> when a scope is open and it holds an entry for <paramref name="serverName"/>.</returns>
+    public static bool TryGet(string serverName, out IList<AITool> tools)
+    {
+        var cache = s_current.Value?.Cache;
+        if (cache is not null && cache.TryGetValue(serverName, out var found))
+        {
+            tools = found;
+            return true;
+        }
+
+        tools = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Caches <paramref name="tools"/> for <paramref name="serverName"/> only if no entry already exists,
+    /// for the rest of the current scope. A no-op when no scope is open.
+    /// </summary>
+    /// <remarks>
+    /// Used by an opportunistic single-server fetch (<c>IMcpToolProvider.GetToolsAsync</c>) — "only if
+    /// absent" so a single-server lookup can never clobber a fresher, authoritative entry a preceding
+    /// <c>GetAllToolsAsync</c> discovery already published for the same server.
+    /// </remarks>
+    public static void TryAdd(string serverName, IList<AITool> tools)
+    {
+        var scope = s_current.Value;
+        if (scope is null)
+            return;
+
+        (scope.Cache ??= new ConcurrentDictionary<string, IList<AITool>>()).TryAdd(serverName, tools);
+    }
+
+    /// <summary>
+    /// Caches <paramref name="tools"/> for <paramref name="serverName"/>, unconditionally overwriting any
+    /// existing entry, for the rest of the current scope. A no-op when no scope is open.
+    /// </summary>
+    /// <remarks>
+    /// Used by an authoritative discovery fetch (<c>IMcpToolProvider.GetAllToolsAsync</c>), which always
+    /// overwrites — a re-discovery within the same scope is the freshest information available and
+    /// should win over whatever a stale entry held.
+    /// </remarks>
+    public static void TrySet(string serverName, IList<AITool> tools)
+    {
+        var scope = s_current.Value;
+        if (scope is null)
+            return;
+
+        var cache = scope.Cache ??= new ConcurrentDictionary<string, IList<AITool>>();
+        cache[serverName] = tools;
+    }
 
     /// <summary>
     /// Opens an empty cache for the current async flow and returns a handle that restores the previous
@@ -57,11 +133,17 @@ public static class McpToolListCacheAccessor
     public static IDisposable Begin()
     {
         var previous = s_current.Value;
-        s_current.Value = new ConcurrentDictionary<string, IList<AITool>>();
+        s_current.Value = new Scope();
         return new CacheScope(previous);
     }
 
-    private sealed class CacheScope(ConcurrentDictionary<string, IList<AITool>>? previous) : IDisposable
+    /// <summary>The per-flow state: a lazily-allocated backing dictionary, present only once something is cached.</summary>
+    private sealed class Scope
+    {
+        public ConcurrentDictionary<string, IList<AITool>>? Cache;
+    }
+
+    private sealed class CacheScope(Scope? previous) : IDisposable
     {
         private bool _disposed;
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
@@ -101,7 +101,7 @@ public static class McpToolListCacheAccessor
         if (scope is null)
             return;
 
-        (scope.Cache ??= new ConcurrentDictionary<string, IList<AITool>>()).TryAdd(serverName, tools);
+        GetOrCreateCache(scope).TryAdd(serverName, tools);
     }
 
     /// <summary>
@@ -119,9 +119,11 @@ public static class McpToolListCacheAccessor
         if (scope is null)
             return;
 
-        var cache = scope.Cache ??= new ConcurrentDictionary<string, IList<AITool>>();
-        cache[serverName] = tools;
+        GetOrCreateCache(scope)[serverName] = tools;
     }
+
+    private static ConcurrentDictionary<string, IList<AITool>> GetOrCreateCache(Scope scope) =>
+        scope.Cache ??= new ConcurrentDictionary<string, IList<AITool>>();
 
     /// <summary>
     /// Opens an empty cache for the current async flow and returns a handle that restores the previous

--- a/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
@@ -31,6 +31,14 @@ namespace Application.AI.Common.Services.Tools;
 /// time to find the one tool being invoked — is exactly this shape: the first call's discovered servers
 /// are a superset of the second call's per-server lookups within the same request.
 /// </para>
+/// <para>
+/// Caveat, identical to the other ambient accessors: like any <see cref="AsyncLocal{T}"/>, the cache is
+/// captured into the <c>ExecutionContext</c> of any fire-and-forget work started <em>while it is
+/// active</em>, and that work keeps reading it after the request's own flow has torn it down. The one
+/// call site's scope spans the whole tool invocation, not just list resolution — it has to, since the
+/// second per-server fetch happens inside <c>InvokeMcpToolAsync</c>'s own preflight — so anything the
+/// invoked tool transitively triggers while that scope is open is served from this cache too.
+/// </para>
 /// </remarks>
 public static class McpToolListCacheAccessor
 {
@@ -41,9 +49,10 @@ public static class McpToolListCacheAccessor
 
     /// <summary>
     /// Opens an empty cache for the current async flow and returns a handle that restores the previous
-    /// ambient value when disposed. Use with <c>using</c> so the cache is guaranteed to be torn down when
-    /// the request completes, even on exception — a cache that outlived its request would go stale the
-    /// moment any MCP server's tool list changed.
+    /// ambient value when disposed. Use with <c>using</c> so the cache is torn down for the request's own
+    /// flow when it completes, even on exception — a cache that outlived its request would go stale the
+    /// moment any MCP server's tool list changed. See this type's remarks for the one exception: work
+    /// started detached while the scope is open keeps its own captured reference.
     /// </summary>
     public static IDisposable Begin()
     {

--- a/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
@@ -122,8 +122,29 @@ public static class McpToolListCacheAccessor
         GetOrCreateCache(scope)[serverName] = tools;
     }
 
-    private static ConcurrentDictionary<string, IList<AITool>> GetOrCreateCache(Scope scope) =>
-        scope.Cache ??= new ConcurrentDictionary<string, IList<AITool>>();
+    /// <summary>
+    /// Returns <paramref name="scope"/>'s backing dictionary, allocating it on first use.
+    /// </summary>
+    /// <remarks>
+    /// <c>??=</c> alone is not atomic — two concurrent writers into the same scope (reachable if the
+    /// invoked tool transitively triggers more MCP resolution, e.g. <c>ToolChainBuilder</c>'s own
+    /// <c>Task.WhenAll</c> fan-out) could each allocate, with the loser's dictionary and whatever it
+    /// wrote silently discarded (run-gates correctness/security review, #495). The consequence was
+    /// always benign — a dropped write here means a redundant fetch next time, never a wrong or
+    /// corrupted result, since nothing is ever read back from the discarded instance — but
+    /// <see cref="Interlocked.CompareExchange{T}(ref T, T, T)"/> closes it structurally rather than
+    /// leaving the cache's own thread-safety weaker than the <see cref="ConcurrentDictionary{TKey,TValue}"/>
+    /// inside it implies.
+    /// </remarks>
+    private static ConcurrentDictionary<string, IList<AITool>> GetOrCreateCache(Scope scope)
+    {
+        var cache = scope.Cache;
+        if (cache is not null)
+            return cache;
+
+        var created = new ConcurrentDictionary<string, IList<AITool>>();
+        return Interlocked.CompareExchange(ref scope.Cache, created, null) ?? created;
+    }
 
     /// <summary>
     /// Opens an empty cache for the current async flow and returns a handle that restores the previous

--- a/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/McpToolListCacheAccessor.cs
@@ -1,0 +1,68 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Ambient, per-flow cache of each MCP server's tool list, so a caller who has already fetched
+/// every connected server's tools (<see cref="Application.AI.Common.Interfaces.IMcpToolProvider.GetAllToolsAsync"/>)
+/// does not pay for a second wire round trip when something later in the same logical request
+/// re-resolves individual servers by name (<see cref="Application.AI.Common.Interfaces.IMcpToolProvider.GetToolsAsync"/>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why ambient, not DI-scoped.</strong> <c>IMcpToolProvider</c> and <c>IDirectToolInvoker</c> are
+/// both registered as singletons — a caller resolves the exact same provider instance on every request,
+/// so a Scoped-lifetime decorator could not compose here even if the container allowed it (a singleton
+/// consumer capturing a scoped dependency at construction is a captive dependency, and the container
+/// would refuse to build). Follows the same pattern as this codebase's other per-flow accessors
+/// (<c>CapabilityEnvelopeAccessor</c>, <c>ToolAdmissionAccessor</c>): an <see cref="AsyncLocal{T}"/> the
+/// request path sets at the start of the work it wants cached and clears in a <c>finally</c>, read at the
+/// provider. When unset — every call outside a begun scope — the provider sees no cache and behaves
+/// exactly as it did before this existed, so this adds zero behaviour off the one call site that opens it.
+/// </para>
+/// <para>
+/// <strong>One direction only, deliberately.</strong> Only a <c>GetAllToolsAsync</c>-equivalent fetch
+/// publishes into the cache; a single <c>GetToolsAsync(serverName)</c> call only ever reads it — that
+/// asymmetry is the point, since populating from a single-server call would not capture the other servers
+/// a later per-server lookup might need. The scenario this exists for — <c>McpController.ResolveMcpEnvelopeAsync</c>'s
+/// ungranted-caller fallback fetching every server's tools to build a wide-open envelope, then
+/// <c>DirectToolInvoker.ResolveGrantedMcpToolAsync</c> re-fetching each of those same servers one at a
+/// time to find the one tool being invoked — is exactly this shape: the first call's discovered servers
+/// are a superset of the second call's per-server lookups within the same request.
+/// </para>
+/// </remarks>
+public static class McpToolListCacheAccessor
+{
+    private static readonly AsyncLocal<ConcurrentDictionary<string, IList<AITool>>?> s_current = new();
+
+    /// <summary>The active cache for the current async flow, or <see langword="null"/> when no scope is open.</summary>
+    public static ConcurrentDictionary<string, IList<AITool>>? Current => s_current.Value;
+
+    /// <summary>
+    /// Opens an empty cache for the current async flow and returns a handle that restores the previous
+    /// ambient value when disposed. Use with <c>using</c> so the cache is guaranteed to be torn down when
+    /// the request completes, even on exception — a cache that outlived its request would go stale the
+    /// moment any MCP server's tool list changed.
+    /// </summary>
+    public static IDisposable Begin()
+    {
+        var previous = s_current.Value;
+        s_current.Value = new ConcurrentDictionary<string, IList<AITool>>();
+        return new CacheScope(previous);
+    }
+
+    private sealed class CacheScope(ConcurrentDictionary<string, IList<AITool>>? previous) : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+
+            _disposed = true;
+            s_current.Value = previous;
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -78,18 +78,23 @@ public static class DependencyInjection
         // throws rather than silently publishing unscanned tool descriptions into the model's context.
         // The governance layer registers a no-op scanner when governance is switched off, so an
         // intentionally ungoverned host still composes.
-        // Two decorators, and the order is the argument. Recording sits OUTSIDE screening so only the
+        // Three decorators, and the order is the argument. Recording sits OUTSIDE screening so only the
         // tools that survived the definition scan get their declared behaviour put on file — a tool
-        // withheld for a poisoned description is never offered to the model and needs no entry.
-        services.AddSingleton<IMcpToolProvider>(sp => new BehaviorRecordingMcpToolProvider(
-            new ScanningMcpToolProvider(
-                sp.GetRequiredService<McpToolProvider>(),
-                sp.GetRequiredService<IMcpSecurityScanner>(),
+        // withheld for a poisoned description is never offered to the model and needs no entry. Caching
+        // sits OUTSIDE recording so a cache hit within one request (#495) skips the wire, the scan, AND
+        // re-recording identical behaviour annotations a second time — every consumer, including
+        // DirectToolInvoker's grant re-resolution, sees the same screened, recorded result whether it
+        // came from the wire or the cache.
+        services.AddSingleton<IMcpToolProvider>(sp => new CachingMcpToolProvider(
+            new BehaviorRecordingMcpToolProvider(
+                new ScanningMcpToolProvider(
+                    sp.GetRequiredService<McpToolProvider>(),
+                    sp.GetRequiredService<IMcpSecurityScanner>(),
+                    sp.GetRequiredService<IOptionsMonitor<AIConfig>>(),
+                    sp.GetRequiredService<ILogger<ScanningMcpToolProvider>>()),
+                sp.GetRequiredService<IToolBehaviorRegistry>(),
                 sp.GetRequiredService<IOptionsMonitor<AIConfig>>(),
-                sp.GetRequiredService<ILogger<ScanningMcpToolProvider>>()),
-            sp.GetRequiredService<IToolBehaviorRegistry>(),
-            sp.GetRequiredService<IOptionsMonitor<AIConfig>>(),
-            sp.GetRequiredService<ILogger<BehaviorRecordingMcpToolProvider>>()));
+                sp.GetRequiredService<ILogger<BehaviorRecordingMcpToolProvider>>())));
 
         // Trace resource provider — exposes optimization run trace files at trace:// URIs.
         // Auth-gated and feature-flagged via MetaHarnessConfig.EnableMcpTraceResources.

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/DependencyInjection.cs
@@ -68,9 +68,9 @@ public static class DependencyInjection
                 scopeFactory, ambientScope, sp);
         });
 
-        // Tool provider — singleton wrapping connection manager. Only the scanning decorator is
-        // published as IMcpToolProvider, so every consumer sees screened tools; the transport
-        // implementation stays resolvable by its concrete type for the decorator to wrap.
+        // Tool provider — singleton wrapping connection manager. The full decorator chain below is
+        // published as IMcpToolProvider, so every consumer sees screened, recorded, cached tools; the
+        // transport implementation stays resolvable by its concrete type for the chain to wrap.
         services.AddSingleton<McpToolProvider>();
 
         // Resolving IMcpSecurityScanner makes the tool-definition scan a mandatory dependency, on the

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BehaviorRecordingMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/BehaviorRecordingMcpToolProvider.cs
@@ -36,6 +36,14 @@ namespace Infrastructure.AI.MCP.Services;
 /// registry has never heard of resolves to <see cref="ToolBehavior.Unknown"/> and is gated, so
 /// declining to guess fails closed.
 /// </para>
+/// <para>
+/// A request-scoped list cache (<c>CachingMcpToolProvider</c>, #495) sits OUTSIDE this decorator, so a
+/// cache hit within one HTTP request skips re-recording too — not just re-scanning. <c>IsTrusted</c>
+/// reads <c>IOptionsMonitor&lt;AIConfig&gt;.CurrentValue</c> per call specifically so an operator's
+/// config-reload trust change takes effect on the next discovery; within the narrow window of one
+/// in-flight request that window doesn't reopen on a cache hit, the same bounded exception the scanning
+/// decorator's own remarks describe for re-scanning.
+/// </para>
 /// </remarks>
 public sealed class BehaviorRecordingMcpToolProvider : IMcpToolProvider
 {

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
@@ -1,0 +1,91 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Services.Tools;
+using Microsoft.Extensions.AI;
+
+namespace Infrastructure.AI.MCP.Services;
+
+/// <summary>
+/// Decorates an <see cref="IMcpToolProvider"/> so a caller who already fetched every connected server's
+/// tools within the current request does not pay for a second per-server round trip when something later
+/// in that same request re-resolves individual servers by name (#495).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Outermost in the decorator chain, deliberately.</strong> A cache hit here must skip everything
+/// downstream — the wire call, the security scan, and re-recording identical tool-behaviour annotations
+/// into <c>IToolBehaviorRegistry</c> a second time for data that was already recorded on the first,
+/// real fetch — not just the wire. Wrapping <c>BehaviorRecordingMcpToolProvider</c> is what makes that
+/// true; wrapping anything further in would leave the redundant work this exists to remove still running
+/// on a cache hit.
+/// </para>
+/// <para>
+/// Reads and writes go through <see cref="McpToolListCacheAccessor"/>, which is <see langword="null"/>
+/// outside a request that has explicitly opened a cache scope — see its own remarks for why an ambient
+/// per-flow value is used here rather than a DI-scoped registration. Off that one call site, every method
+/// here behaves exactly as the provider it decorates.
+/// </para>
+/// </remarks>
+public sealed class CachingMcpToolProvider : IMcpToolProvider
+{
+    private readonly IMcpToolProvider _inner;
+
+    /// <summary>Initializes the decorator.</summary>
+    /// <param name="inner">The tool provider whose results are cached.</param>
+    public CachingMcpToolProvider(IMcpToolProvider inner)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        _inner = inner;
+    }
+
+    /// <inheritdoc />
+    public async Task<IList<AITool>> GetToolsAsync(string serverName, CancellationToken cancellationToken = default)
+    {
+        var cache = McpToolListCacheAccessor.Current;
+        if (cache is not null && cache.TryGetValue(serverName, out var cached))
+            return cached;
+
+        var tools = await _inner.GetToolsAsync(serverName, cancellationToken).ConfigureAwait(false);
+        cache?.TryAdd(serverName, tools);
+        return tools;
+    }
+
+    /// <inheritdoc />
+    public async Task<Dictionary<string, IList<AITool>>> GetAllToolsAsync(CancellationToken cancellationToken = default)
+    {
+        var discovered = await _inner.GetAllToolsAsync(cancellationToken).ConfigureAwait(false);
+
+        var cache = McpToolListCacheAccessor.Current;
+        if (cache is not null)
+        {
+            foreach (var (serverName, tools) in discovered)
+                cache[serverName] = tools;
+        }
+
+        return discovered;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Not cached. This searches every configured server for one tool by name — a different shape from
+    /// the "fetch this server's full list" call the cache exists for, and
+    /// <c>BehaviorRecordingMcpToolProvider</c>'s own by-name lookup is left unrecorded for the analogous
+    /// reason (see its remarks): this path does not report which server answered, so there is nothing to
+    /// key a per-server cache entry on.
+    /// </remarks>
+    public Task<AIFunction?> GetToolByNameAsync(string name, CancellationToken cancellationToken = default) =>
+        _inner.GetToolByNameAsync(name, cancellationToken);
+
+    /// <inheritdoc />
+    public Task<bool> IsServerAvailableAsync(string serverName, CancellationToken cancellationToken = default) =>
+        _inner.IsServerAvailableAsync(serverName, cancellationToken);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Does not dispose the decorated provider — the container registers both as singletons and owns
+    /// its lifetime, matching the arrangement the scanning and behavior-recording decorators have with
+    /// the transport provider.
+    /// </remarks>
+    public void Dispose()
+    {
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
@@ -49,16 +49,15 @@ public sealed class CachingMcpToolProvider : IMcpToolProvider
     /// </remarks>
     public async Task<IList<AITool>> GetToolsAsync(string serverName, CancellationToken cancellationToken = default)
     {
-        var cache = McpToolListCacheAccessor.Current;
-        if (cache is not null && cache.TryGetValue(serverName, out var cached))
+        if (McpToolListCacheAccessor.TryGet(serverName, out var cached))
             return cached;
 
         var tools = await _inner.GetToolsAsync(serverName, cancellationToken).ConfigureAwait(false);
-        if (cache is null)
+        if (!McpToolListCacheAccessor.IsActive)
             return tools;
 
         var snapshot = new ReadOnlyCollection<AITool>([.. tools]);
-        cache.TryAdd(serverName, snapshot);
+        McpToolListCacheAccessor.TryAdd(serverName, snapshot);
         return snapshot;
     }
 
@@ -68,15 +67,14 @@ public sealed class CachingMcpToolProvider : IMcpToolProvider
     {
         var discovered = await _inner.GetAllToolsAsync(cancellationToken).ConfigureAwait(false);
 
-        var cache = McpToolListCacheAccessor.Current;
-        if (cache is null)
+        if (!McpToolListCacheAccessor.IsActive)
             return discovered;
 
         var snapshot = new Dictionary<string, IList<AITool>>(discovered.Count);
         foreach (var (serverName, tools) in discovered)
         {
             var readOnly = new ReadOnlyCollection<AITool>([.. tools]);
-            cache[serverName] = readOnly;
+            McpToolListCacheAccessor.TrySet(serverName, readOnly);
             snapshot[serverName] = readOnly;
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Services.Tools;
 using Microsoft.Extensions.AI;
@@ -38,6 +39,14 @@ public sealed class CachingMcpToolProvider : IMcpToolProvider
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// A list served from the cache is shared with every other caller who asks for the same server
+    /// within this request, so it is wrapped read-only before caching (#495 security review, finding
+    /// L3) — a formerly-private, freshly-allocated list becoming a value multiple callers alias would
+    /// otherwise let one consumer's in-place mutation silently corrupt what the grant-enforcement
+    /// re-resolution (<c>DirectToolInvoker.ResolveGrantedMcpToolAsync</c>) reads. No current consumer
+    /// mutates the list it gets back, but the invariant is made structural rather than conventional.
+    /// </remarks>
     public async Task<IList<AITool>> GetToolsAsync(string serverName, CancellationToken cancellationToken = default)
     {
         var cache = McpToolListCacheAccessor.Current;
@@ -45,23 +54,33 @@ public sealed class CachingMcpToolProvider : IMcpToolProvider
             return cached;
 
         var tools = await _inner.GetToolsAsync(serverName, cancellationToken).ConfigureAwait(false);
-        cache?.TryAdd(serverName, tools);
-        return tools;
+        if (cache is null)
+            return tools;
+
+        var snapshot = new ReadOnlyCollection<AITool>([.. tools]);
+        cache.TryAdd(serverName, snapshot);
+        return snapshot;
     }
 
     /// <inheritdoc />
+    /// <remarks>See <see cref="GetToolsAsync"/>'s remarks — the same read-only-snapshot reasoning applies here.</remarks>
     public async Task<Dictionary<string, IList<AITool>>> GetAllToolsAsync(CancellationToken cancellationToken = default)
     {
         var discovered = await _inner.GetAllToolsAsync(cancellationToken).ConfigureAwait(false);
 
         var cache = McpToolListCacheAccessor.Current;
-        if (cache is not null)
+        if (cache is null)
+            return discovered;
+
+        var snapshot = new Dictionary<string, IList<AITool>>(discovered.Count);
+        foreach (var (serverName, tools) in discovered)
         {
-            foreach (var (serverName, tools) in discovered)
-                cache[serverName] = tools;
+            var readOnly = new ReadOnlyCollection<AITool>([.. tools]);
+            cache[serverName] = readOnly;
+            snapshot[serverName] = readOnly;
         }
 
-        return discovered;
+        return snapshot;
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
@@ -56,7 +56,7 @@ public sealed class CachingMcpToolProvider : IMcpToolProvider
         if (!McpToolListCacheAccessor.IsActive)
             return tools;
 
-        var snapshot = new ReadOnlyCollection<AITool>([.. tools]);
+        var snapshot = Snapshot(tools);
         McpToolListCacheAccessor.TryAdd(serverName, snapshot);
         return snapshot;
     }
@@ -70,16 +70,28 @@ public sealed class CachingMcpToolProvider : IMcpToolProvider
         if (!McpToolListCacheAccessor.IsActive)
             return discovered;
 
-        var snapshot = new Dictionary<string, IList<AITool>>(discovered.Count);
-        foreach (var (serverName, tools) in discovered)
+        // Mutated in place rather than copied into a second dictionary: discovered is a fresh instance
+        // this call exclusively owns (ScanningMcpToolProvider.GetAllToolsAsync allocates it and hands
+        // it nowhere else), so there is no other holder for a second dictionary to protect against.
+        foreach (var serverName in discovered.Keys)
         {
-            var readOnly = new ReadOnlyCollection<AITool>([.. tools]);
+            var readOnly = Snapshot(discovered[serverName]);
+            discovered[serverName] = readOnly;
             McpToolListCacheAccessor.TrySet(serverName, readOnly);
-            snapshot[serverName] = readOnly;
         }
 
-        return snapshot;
+        return discovered;
     }
+
+    /// <summary>
+    /// Wraps <paramref name="tools"/> read-only without copying it — safe because every producer in the
+    /// chain (<c>ScanningMcpToolProvider.Screen</c>, and <c>BehaviorRecordingMcpToolProvider</c>'s
+    /// pass-through) hands back a freshly-allocated list this call exclusively owns, never one retained
+    /// or reused elsewhere. An earlier version defensively re-copied it (<c>[.. tools]</c>) before
+    /// wrapping; <c>/simplify</c>'s reuse and efficiency passes both flagged that as a wasted allocation
+    /// once the ownership was traced end to end.
+    /// </summary>
+    private static ReadOnlyCollection<AITool> Snapshot(IList<AITool> tools) => new(tools);
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/CachingMcpToolProvider.cs
@@ -73,7 +73,11 @@ public sealed class CachingMcpToolProvider : IMcpToolProvider
         // Mutated in place rather than copied into a second dictionary: discovered is a fresh instance
         // this call exclusively owns (ScanningMcpToolProvider.GetAllToolsAsync allocates it and hands
         // it nowhere else), so there is no other holder for a second dictionary to protect against.
-        foreach (var serverName in discovered.Keys)
+        // .ToList(): overwriting an existing key's value doesn't invalidate a live Dictionary
+        // enumerator today, but that's an implementation detail, not the documented contract — the one
+        // guarantee is "don't add or remove during enumeration," which a throwaway key snapshot keeps
+        // true regardless (run-gates correctness review, #495).
+        foreach (var serverName in discovered.Keys.ToList())
         {
             var readOnly = Snapshot(discovered[serverName]);
             discovered[serverName] = readOnly;

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/ScanningMcpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/ScanningMcpToolProvider.cs
@@ -48,6 +48,12 @@ namespace Infrastructure.AI.MCP.Services;
 /// surface, and then changes that description would keep its cached verdict forever. Re-reading the
 /// definition each time is the only thing that catches a definition that changed.
 /// </para>
+/// <para>
+/// A request-scoped list cache (<c>CachingMcpToolProvider</c>, #495) sits OUTSIDE this decorator, so a
+/// second lookup of the same server within one HTTP request is served without re-scanning. That window
+/// is bounded by a single request and does not weaken rug-pull detection across requests, which is
+/// where a definition change is actually observable.
+/// </para>
 /// </remarks>
 public sealed class ScanningMcpToolProvider : IMcpToolProvider
 {

--- a/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Controllers/McpController.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Bundles;
 using Domain.AI.Governance;
 using Domain.AI.MCP;
@@ -180,15 +181,25 @@ public sealed class McpController : ControllerBase
                 arguments[prop.Name] = prop.Value;
         }
 
-        var outcome = await _invoker.InvokeMcpToolAsync(
-            new DirectMcpToolInvocationRequest
-            {
-                ToolName = name,
-                Arguments = arguments,
-                OwnerId = userId,
-                Envelope = await ResolveMcpEnvelopeAsync(ct)
-            },
-            ct);
+        DirectToolInvocationOutcome outcome;
+        using (McpToolListCacheAccessor.Begin())
+        {
+            // Scoped around envelope resolution AND invocation, not just the former: on the
+            // ungranted-caller fallback (see ResolveMcpEnvelopeAsync's remarks), the envelope resolves
+            // by fetching every connected server's tools, and the invoker's own grant re-resolution
+            // (DirectToolInvoker.ResolveGrantedMcpToolAsync) re-fetches each of those same servers one
+            // at a time to find the one being invoked — #495. Both calls must share one cache scope for
+            // the second to ever hit it.
+            outcome = await _invoker.InvokeMcpToolAsync(
+                new DirectMcpToolInvocationRequest
+                {
+                    ToolName = name,
+                    Arguments = arguments,
+                    OwnerId = userId,
+                    Envelope = await ResolveMcpEnvelopeAsync(ct)
+                },
+                ct);
+        }
 
         _logger.LogInformation(
             "MCP tool completed. UserId={UserId} ToolName={ToolName} Status={Status} DurationMs={DurationMs} CorrelationId={CorrelationId}",

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/DependencyInjectionTests.cs
@@ -80,10 +80,16 @@ public sealed class DependencyInjectionTests : IAsyncLifetime
         var toolProvider = provider.GetService<IMcpToolProvider>();
 
         toolProvider.Should().NotBeNull();
-        toolProvider.Should().BeOfType<BehaviorRecordingMcpToolProvider>(
+        // CachingMcpToolProvider (#495) is now outermost — see its own remarks for why a cache hit must
+        // skip everything downstream, not just the wire. Pinning the outermost type here is what makes
+        // this test fail if that decorator is ever dropped from the chain or registered somewhere other
+        // than outermost.
+        toolProvider.Should().BeOfType<CachingMcpToolProvider>(
             "every consumer resolves the interface, so the decorators have to be what the interface "
             + "returns — registering the bare transport provider would leave tool definitions from "
-            + "external servers unscanned and their declared behaviour unrecorded");
+            + "external servers unscanned and their declared behaviour unrecorded, and skipping the "
+            + "caching decorator would reintroduce #495's double-fetch");
+        toolProvider.Should().NotBeOfType<BehaviorRecordingMcpToolProvider>();
         toolProvider.Should().NotBeOfType<McpToolProvider>();
     }
 

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/CachingMcpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/CachingMcpToolProviderTests.cs
@@ -118,6 +118,69 @@ public sealed class CachingMcpToolProviderTests
     }
 
     [Fact]
+    public async Task GetAllToolsAsync_PopulatingOneServersEntry_NeverAnswersALookupForADifferentServer()
+    {
+        // Security review finding (#495): the grant-enforcement re-resolution
+        // (DirectToolInvoker.ResolveGrantedMcpToolAsync) walks a caller's granted server list one name
+        // at a time. This is the sharpest proof available at this layer that the cache cannot turn that
+        // lookup into contact with a server the caller was never granted: populating the cache with
+        // ServerA's tools must never satisfy a GetToolsAsync(ServerB) call for an ungranted server.
+        _inner
+            .Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, IList<AITool>> { [ServerA] = [Tool("a1")] });
+        InnerReturns(ServerB, Tool("b1"));
+
+        using (McpToolListCacheAccessor.Begin())
+        {
+            await _sut.GetAllToolsAsync();
+
+            await _sut.GetToolsAsync(ServerB);
+        }
+
+        _inner.Verify(p => p.GetToolsAsync(ServerB, It.IsAny<CancellationToken>()), Times.Once,
+            "ServerB was never discovered, so asking for it must still reach the inner provider — a "
+            + "cache miss must never resolve to another server's cached entry");
+    }
+
+    [Fact]
+    public async Task ConcurrentFlows_EachWithItsOwnScope_DoNotSeeEachOthersCache()
+    {
+        // Pins the property Q1/Q4 of the security review depend on: AsyncLocal isolates concurrent
+        // flows from each other, which is what makes this an ambient per-REQUEST cache rather than an
+        // accidental per-process one. A future "optimisation" to a shared static field would break this
+        // silently — this test is what catches it.
+        InnerReturns(ServerA, Tool("a1"));
+        InnerReturns(ServerB, Tool("b1"));
+
+        var flowASawServerB = false;
+        var flowBSawServerA = false;
+
+        var flowA = Task.Run(async () =>
+        {
+            using (McpToolListCacheAccessor.Begin())
+            {
+                await _sut.GetToolsAsync(ServerA);
+                await Task.Delay(20);
+                flowASawServerB = McpToolListCacheAccessor.Current!.ContainsKey(ServerB);
+            }
+        });
+        var flowB = Task.Run(async () =>
+        {
+            using (McpToolListCacheAccessor.Begin())
+            {
+                await _sut.GetToolsAsync(ServerB);
+                await Task.Delay(20);
+                flowBSawServerA = McpToolListCacheAccessor.Current!.ContainsKey(ServerA);
+            }
+        });
+
+        await Task.WhenAll(flowA, flowB);
+
+        flowASawServerB.Should().BeFalse();
+        flowBSawServerA.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task GetToolByNameAsync_IsNeverCached_AndAlwaysDelegates()
     {
         // Different shape from a per-server fetch — see the type's remarks on why this path is not

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/CachingMcpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/CachingMcpToolProviderTests.cs
@@ -1,0 +1,159 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Services.Tools;
+using FluentAssertions;
+using Infrastructure.AI.MCP.Services;
+using Microsoft.Extensions.AI;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// Tests for the decorator that caches each MCP server's tool list within one ambient
+/// <see cref="McpToolListCacheAccessor"/> scope (#495), so a caller who has already fetched every
+/// connected server's tools does not pay for a second wire round trip when something later in the same
+/// request re-resolves individual servers by name.
+/// </summary>
+public sealed class CachingMcpToolProviderTests
+{
+    private const string ServerA = "server-a";
+    private const string ServerB = "server-b";
+
+    private readonly Mock<IMcpToolProvider> _inner = new();
+    private readonly CachingMcpToolProvider _sut;
+
+    public CachingMcpToolProviderTests()
+    {
+        _sut = new CachingMcpToolProvider(_inner.Object);
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_NoActiveScope_AlwaysHitsTheInnerProvider()
+    {
+        // Off the one call site that opens a scope, this decorator must be invisible — a caching layer
+        // that changed behaviour with no scope open would be a correctness regression for every other
+        // consumer of IMcpToolProvider (ToolChainBuilder, BundleRunExecutor, ...).
+        InnerReturns(ServerA, Tool("a1"));
+
+        await _sut.GetToolsAsync(ServerA);
+        await _sut.GetToolsAsync(ServerA);
+
+        _inner.Verify(p => p.GetToolsAsync(ServerA, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetAllToolsAsync_PopulatesTheScope_SoALaterPerServerCallHitsTheCacheNotTheWire()
+    {
+        // The exact shape #495 is about: McpController's envelope-resolution fallback fetches every
+        // server via GetAllToolsAsync, then DirectToolInvoker.ResolveGrantedMcpToolAsync re-fetches
+        // individual servers one at a time to find the tool being invoked. The second call must not
+        // reach the inner provider at all when it names a server the first call already discovered.
+        _inner
+            .Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, IList<AITool>>
+            {
+                [ServerA] = [Tool("a1")],
+                [ServerB] = [Tool("b1")],
+            });
+
+        using (McpToolListCacheAccessor.Begin())
+        {
+            await _sut.GetAllToolsAsync();
+
+            var fromCache = await _sut.GetToolsAsync(ServerA);
+
+            fromCache.Select(t => t.Name).Should().Equal("a1");
+        }
+
+        _inner.Verify(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_ASecondCallForTheSameServerInTheSameScope_HitsTheCache()
+    {
+        InnerReturns(ServerA, Tool("a1"));
+
+        using (McpToolListCacheAccessor.Begin())
+        {
+            await _sut.GetToolsAsync(ServerA);
+            await _sut.GetToolsAsync(ServerA);
+        }
+
+        _inner.Verify(p => p.GetToolsAsync(ServerA, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetToolsAsync_AServerNotYetInTheScope_StillFetchesFromTheInnerProvider_AndThenCachesIt()
+    {
+        // A cache miss must fall through, not fail closed — an operator-configured narrow grant that
+        // never calls GetAllToolsAsync first must keep working exactly as it did before this existed.
+        InnerReturns(ServerA, Tool("a1"));
+
+        using (McpToolListCacheAccessor.Begin())
+        {
+            var first = await _sut.GetToolsAsync(ServerA);
+            var second = await _sut.GetToolsAsync(ServerA);
+
+            first.Select(t => t.Name).Should().Equal("a1");
+            second.Should().BeSameAs(first);
+        }
+
+        _inner.Verify(p => p.GetToolsAsync(ServerA, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ScopesDoNotLeakAcrossOneAnother_EachBeginStartsEmpty()
+    {
+        InnerReturns(ServerA, Tool("a1"));
+
+        using (McpToolListCacheAccessor.Begin())
+            await _sut.GetToolsAsync(ServerA);
+
+        // A fresh scope must not inherit a server list a previous, already-disposed scope discovered —
+        // a cache that outlived its request would go stale the moment the server's tools changed.
+        using (McpToolListCacheAccessor.Begin())
+            await _sut.GetToolsAsync(ServerA);
+
+        _inner.Verify(p => p.GetToolsAsync(ServerA, It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetToolByNameAsync_IsNeverCached_AndAlwaysDelegates()
+    {
+        // Different shape from a per-server fetch — see the type's remarks on why this path is not
+        // cached, matching BehaviorRecordingMcpToolProvider's own reasoning for the same method.
+        _inner
+            .Setup(p => p.GetToolByNameAsync("search", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Tool("search"));
+
+        using (McpToolListCacheAccessor.Begin())
+        {
+            await _sut.GetToolByNameAsync("search");
+            await _sut.GetToolByNameAsync("search");
+        }
+
+        _inner.Verify(p => p.GetToolByNameAsync("search", It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task GetAllToolsAsync_ReturnsTheInnerProvidersResultUnchanged()
+    {
+        var discovered = new Dictionary<string, IList<AITool>>
+        {
+            [ServerA] = [Tool("a1"), Tool("a2")],
+        };
+        _inner.Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(discovered);
+
+        var result = await _sut.GetAllToolsAsync();
+
+        result.Should().BeSameAs(discovered);
+    }
+
+    private void InnerReturns(string serverName, params AITool[] tools) =>
+        _inner
+            .Setup(p => p.GetToolsAsync(serverName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tools.ToList());
+
+    private static AIFunction Tool(string name) =>
+        AIFunctionFactory.Create(() => "result", name, "does a thing");
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/CachingMcpToolProviderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/CachingMcpToolProviderTests.cs
@@ -161,7 +161,7 @@ public sealed class CachingMcpToolProviderTests
             {
                 await _sut.GetToolsAsync(ServerA);
                 await Task.Delay(20);
-                flowASawServerB = McpToolListCacheAccessor.Current!.ContainsKey(ServerB);
+                flowASawServerB = McpToolListCacheAccessor.TryGet(ServerB, out _);
             }
         });
         var flowB = Task.Run(async () =>
@@ -170,7 +170,7 @@ public sealed class CachingMcpToolProviderTests
             {
                 await _sut.GetToolsAsync(ServerB);
                 await Task.Delay(20);
-                flowBSawServerA = McpToolListCacheAccessor.Current!.ContainsKey(ServerA);
+                flowBSawServerA = McpToolListCacheAccessor.TryGet(ServerA, out _);
             }
         });
 


### PR DESCRIPTION
## Summary

Package 3 of the tool-output-pipeline cluster (10 packages, 15 issues — see #545, #548 for
Packages 1-2). Closes #495.

On the MCP invocation path's ungranted-caller fallback, `McpController.ResolveMcpEnvelopeAsync`
fetches every connected server's full tool list to build a wide-open envelope, then
`DirectToolInvoker.ResolveGrantedMcpToolAsync` re-fetches each of those same servers one at a
time to find the tool being invoked — a full second wire round trip per server, per request.

Passing the already-fetched tool through was considered and rejected: the invoker's
re-resolution against the granted server list **is** the enforcement that an ungranted server
is never contacted, even on the wide-open envelope.

## The fix

An ambient, per-request cache (`McpToolListCacheAccessor`) that a new outermost
`IMcpToolProvider` decorator (`CachingMcpToolProvider`) reads and writes. Ambient rather than
DI-scoped: `IMcpToolProvider` and `IDirectToolInvoker` are both singletons, so a Scoped
registration couldn't compose (a singleton capturing a scoped dependency is a captive
dependency the container would refuse to build). Follows this codebase's existing per-flow
accessor pattern (`CapabilityEnvelopeAccessor`, `ToolAdmissionAccessor`).

- Outermost in the decorator chain, so a cache hit skips the wire, the security scan, and
  behavior re-recording — not just the fetch.
- Read/write access is behind `TryGet`/`TryAdd`/`TrySet`/`IsActive`, not a raw mutable
  dictionary, per this repo's public-surface immutability rule.
- Lazily allocated and allocation is race-free (`Interlocked.CompareExchange`) — the common
  case (a caller with an operator-configured grant) never populates the cache at all, so it
  costs one small wrapper object, not a `ConcurrentDictionary`, on the majority path.
- Cached lists are wrapped read-only, with no defensive copy — traced ownership through the
  full decorator chain (`ScanningMcpToolProvider.Screen` always allocates fresh,
  `BehaviorRecordingMcpToolProvider` passes it through unchanged) to confirm nothing else
  ever holds a reference.

## Review

Five rounds: an explicit `security-reviewer` pass (trust-boundary-adjacent — this sits
directly on the MCP grant-enforcement path), `/code-review` (8 findings applied, 2 filed as
follow-ups below), `/simplify` (4 parallel angles), and two fixes `run-gates.sh`'s own
correctness/security passes surfaced directly (an atomicity gap in the lazy cache allocation,
and a `Dictionary` enumeration relying on an undocumented implementation detail rather than
the documented contract).

Deferred as follow-ups, out of this PR's scope:
- **#549** — a duplicate server name in a caller's granted list can turn one transient fetch
  failure into a cached one within a request; the real fix is deduplicating
  `AllowedMcpServers` at its two producer sites, not teaching the cache to distinguish
  transient failure from stable empty state.
- **#550** — three ambient accessors (this one, `CapabilityEnvelopeAccessor`,
  `ToolAdmissionAccessor`) now hand-copy the identical `AsyncLocal`-restore `IDisposable`
  shape; extracting a shared base touches two files outside this cluster's scope.
- **#546** (filed on #494/PR #548) — the MCP direct-invocation path has no fast unit-level
  test coverage, only the heavy HTTP integration suite; this PR's new tests are at the
  decorator level for exactly that reason.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` clean
- [x] `dotnet test src/AgenticHarness.slnx` — full solution suite green (0 failures)
- [x] `Infrastructure.AI.MCP.Tests` (144 tests, including 9 new `CachingMcpToolProviderTests`
      covering cache-key isolation across servers, concurrent-flow isolation, and the
      grant-enforcement property directly)
- [x] `scripts/rails/run-gates.sh` full pass clean: build, test, OWASP, grader, correctness,
      security, docs-drift (advisory)
- [x] All 8 CI gates expected green (local pass is a formality check, not a substitute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj