### PR TITLE
refactor: dedupe replay-window delegation, make snapshot-vs-live an explicit policy

### DIFF
--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -41,7 +41,13 @@ public static class ConversationMessageMapping
     };
 
     /// <summary>
-    /// Projects a transcript window onto chat messages, oldest first, ready to seed a dispatch.
+    /// Core projection logic, taking the two <see cref="ToolCallReplayWindowPolicy"/> settings as loose
+    /// parameters rather than the bundled record. Internal rather than private only so the test suite
+    /// that exercises the budget/expansion mechanics directly (predating
+    /// <see cref="ToolCallReplayWindowPolicy"/>) keeps working without every test constructing a policy
+    /// record it isn't testing — every production caller goes through the public, policy-based overload
+    /// below instead, which is where a caller belongs: one entry point production code can reach for,
+    /// not two kept in sync only by convention.
     /// </summary>
     /// <param name="messages">The window, in transcript order.</param>
     /// <param name="replayToolCalls">
@@ -89,7 +95,7 @@ public static class ConversationMessageMapping
     /// which takes a logger the same way and for the same reason — silently shrinking a model's memory
     /// is exactly the kind of change that must leave a trace.
     /// </param>
-    public static IReadOnlyList<ChatMessage> ToChatMessages(
+    internal static IReadOnlyList<ChatMessage> ToChatMessages(
         IReadOnlyList<ConversationMessage> messages,
         bool replayToolCalls,
         int maxReplayedChars,
@@ -151,11 +157,23 @@ public static class ConversationMessageMapping
     }
 
     /// <summary>
-    /// Overload of <see cref="ToChatMessages(IReadOnlyList{ConversationMessage},bool,int,ILogger?)"/>
-    /// taking the two settings bundled as one <see cref="ToolCallReplayWindowPolicy"/> rather than as
-    /// loose parameters — the type production callers should reach for; see that record's remarks for
-    /// why bundling them exists at all.
+    /// Projects a transcript window onto chat messages, oldest first, ready to seed a dispatch — the
+    /// public entry point every production caller uses. See the internal
+    /// <see cref="ToChatMessages(IReadOnlyList{ConversationMessage},bool,int,ILogger?)"/> overload's
+    /// own remarks for the full expansion/budget mechanics this delegates to.
     /// </summary>
+    /// <param name="messages">The window, in transcript order.</param>
+    /// <param name="replayPolicy">
+    /// Whether tool calls expand at all, and the character budget for the whole window if they do — see
+    /// <see cref="ToolCallReplayWindowPolicy"/>'s own remarks for what each setting means and for why
+    /// bundling them, and being explicit about when they're read, exists at all. Build via
+    /// <see cref="ToolCallReplayWindowPolicy.FromCurrentSettings"/>.
+    /// </param>
+    /// <param name="logger">
+    /// Optional, for reporting what the budget dropped. Matching <c>ToolCallTranscriptExtractor.Extract</c>,
+    /// which takes a logger the same way and for the same reason — silently shrinking a model's memory
+    /// is exactly the kind of change that must leave a trace.
+    /// </param>
     public static IReadOnlyList<ChatMessage> ToChatMessages(
         IReadOnlyList<ConversationMessage> messages,
         ToolCallReplayWindowPolicy replayPolicy,

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Application.AI.Common.Interfaces;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 
@@ -165,25 +164,6 @@ public static class ConversationMessageMapping
         ArgumentNullException.ThrowIfNull(replayPolicy);
         return ToChatMessages(messages, replayPolicy.ReplayToolCalls, replayPolicy.MaxReplayedChars, logger);
     }
-
-    /// <summary>
-    /// Projects a window using <paramref name="treatment"/>'s <em>current</em> settings, read fresh on
-    /// this call — the shared helper for a caller that wants "live" (<c>AgUiRunHandler</c> and
-    /// <c>ConversationOrchestrator</c> both call this once per turn, so a hot-reloaded config
-    /// change applies starting the very next one). Previously each of those two files hand-wrote this
-    /// same delegation; a role or setting added to one copy and not the other was a silent split, not a
-    /// compile error. A caller that instead wants "snapshot once, fixed for a run" — <c>DurableTranscript</c>
-    /// — calls <see cref="ToolCallReplayWindowPolicy.FromCurrentSettings"/> itself, once, at
-    /// construction, and reuses the resulting policy across every <see cref="ToChatMessages(IReadOnlyList{ConversationMessage},ToolCallReplayWindowPolicy,ILogger?)"/>
-    /// call it makes — the same factory, called at a different point in the caller's lifetime, is what
-    /// makes "live vs. snapshot" an explicit choice each caller states rather than an accident of which
-    /// file it happens to be.
-    /// </summary>
-    public static IReadOnlyList<ChatMessage> ToChatMessagesFromLiveSettings(
-        IReadOnlyList<ConversationMessage> messages,
-        IToolCallReplayTreatment treatment,
-        ILogger? logger = null) =>
-        ToChatMessages(messages, ToolCallReplayWindowPolicy.FromCurrentSettings(treatment), logger);
 
     /// <summary>
     /// Decides, for every row in the window, which of its tool calls fit inside

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ConversationMessageMapping.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Application.AI.Common.Interfaces;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 
@@ -149,6 +150,40 @@ public static class ConversationMessageMapping
 
         return result;
     }
+
+    /// <summary>
+    /// Overload of <see cref="ToChatMessages(IReadOnlyList{ConversationMessage},bool,int,ILogger?)"/>
+    /// taking the two settings bundled as one <see cref="ToolCallReplayWindowPolicy"/> rather than as
+    /// loose parameters — the type production callers should reach for; see that record's remarks for
+    /// why bundling them exists at all.
+    /// </summary>
+    public static IReadOnlyList<ChatMessage> ToChatMessages(
+        IReadOnlyList<ConversationMessage> messages,
+        ToolCallReplayWindowPolicy replayPolicy,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(replayPolicy);
+        return ToChatMessages(messages, replayPolicy.ReplayToolCalls, replayPolicy.MaxReplayedChars, logger);
+    }
+
+    /// <summary>
+    /// Projects a window using <paramref name="treatment"/>'s <em>current</em> settings, read fresh on
+    /// this call — the shared helper for a caller that wants "live" (<c>AgUiRunHandler</c> and
+    /// <c>ConversationOrchestrator</c> both call this once per turn, so a hot-reloaded config
+    /// change applies starting the very next one). Previously each of those two files hand-wrote this
+    /// same delegation; a role or setting added to one copy and not the other was a silent split, not a
+    /// compile error. A caller that instead wants "snapshot once, fixed for a run" — <c>DurableTranscript</c>
+    /// — calls <see cref="ToolCallReplayWindowPolicy.FromCurrentSettings"/> itself, once, at
+    /// construction, and reuses the resulting policy across every <see cref="ToChatMessages(IReadOnlyList{ConversationMessage},ToolCallReplayWindowPolicy,ILogger?)"/>
+    /// call it makes — the same factory, called at a different point in the caller's lifetime, is what
+    /// makes "live vs. snapshot" an explicit choice each caller states rather than an accident of which
+    /// file it happens to be.
+    /// </summary>
+    public static IReadOnlyList<ChatMessage> ToChatMessagesFromLiveSettings(
+        IReadOnlyList<ConversationMessage> messages,
+        IToolCallReplayTreatment treatment,
+        ILogger? logger = null) =>
+        ToChatMessages(messages, ToolCallReplayWindowPolicy.FromCurrentSettings(treatment), logger);
 
     /// <summary>
     /// Decides, for every row in the window, which of its tool calls fit inside

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ToolCallReplayWindowPolicy.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ToolCallReplayWindowPolicy.cs
@@ -1,0 +1,39 @@
+using Application.AI.Common.Interfaces;
+
+namespace Application.AI.Common.Models.Conversations;
+
+/// <summary>
+/// The two <see cref="IToolCallReplayTreatment"/> settings that together govern one window
+/// projection — bundled so a caller states "read live, every projection" or "snapshot once, fix for
+/// the run" as an explicit choice of when it calls <see cref="FromCurrentSettings"/>, rather than as
+/// an accidental convention two call sites happened to follow differently.
+/// </summary>
+/// <param name="ReplayToolCalls">
+/// See <see cref="ConversationMessageMapping.ToChatMessages(IReadOnlyList{ConversationMessage},bool,int,Microsoft.Extensions.Logging.ILogger?)"/>'s
+/// <c>replayToolCalls</c> parameter.
+/// </param>
+/// <param name="MaxReplayedChars">
+/// See <see cref="ConversationMessageMapping.ToChatMessages(IReadOnlyList{ConversationMessage},bool,int,Microsoft.Extensions.Logging.ILogger?)"/>'s
+/// <c>maxReplayedChars</c> parameter. This record has no parameterless constructor and no default for
+/// either field, on purpose: <see cref="IToolCallReplayTreatment.MaxReplayedChars"/>'s own remarks
+/// warn that an unstubbed mock returns <see langword="default"/>, silently reading as "zero budget,
+/// drop everything." Building this record only through <see cref="FromCurrentSettings"/> means that
+/// trap can only be hit by a mock of <see cref="IToolCallReplayTreatment"/> itself — the same warning
+/// that interface already carries — never silently through this type.
+/// </param>
+public sealed record ToolCallReplayWindowPolicy(bool ReplayToolCalls, int MaxReplayedChars)
+{
+    /// <summary>
+    /// Reads <paramref name="treatment"/>'s current property values into a policy. Calling this fresh
+    /// on every projection (see <c>ConversationMessageMapping.ToChatMessagesFromLiveSettings</c>)
+    /// states "live" — a hot-reloaded config change applies to the very next turn. Calling it once and
+    /// reusing the result (see <c>DurableTranscript</c>, which does this in its constructor) states
+    /// "snapshot" — fixed for the caller's lifetime, deliberately, because the caller gates one run's
+    /// dispatch and a mid-run reload applying half the policy would be worse than applying none of it.
+    /// </summary>
+    public static ToolCallReplayWindowPolicy FromCurrentSettings(IToolCallReplayTreatment treatment)
+    {
+        ArgumentNullException.ThrowIfNull(treatment);
+        return new ToolCallReplayWindowPolicy(treatment.Enabled, treatment.MaxReplayedChars);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Models/Conversations/ToolCallReplayWindowPolicy.cs
+++ b/src/Content/Application/Application.AI.Common/Models/Conversations/ToolCallReplayWindowPolicy.cs
@@ -17,19 +17,28 @@ namespace Application.AI.Common.Models.Conversations;
 /// <c>maxReplayedChars</c> parameter. This record has no parameterless constructor and no default for
 /// either field, on purpose: <see cref="IToolCallReplayTreatment.MaxReplayedChars"/>'s own remarks
 /// warn that an unstubbed mock returns <see langword="default"/>, silently reading as "zero budget,
-/// drop everything." Building this record only through <see cref="FromCurrentSettings"/> means that
-/// trap can only be hit by a mock of <see cref="IToolCallReplayTreatment"/> itself — the same warning
-/// that interface already carries — never silently through this type.
+/// drop everything." Every <em>production</em> path builds this record through
+/// <see cref="FromCurrentSettings"/> — the constructor stays public, as an ordinary record's does, so
+/// a test can still construct one directly — which means the trap can only be hit by a mock of
+/// <see cref="IToolCallReplayTreatment"/> itself, the same warning that interface already carries,
+/// never silently through this type on the production path.
 /// </param>
 public sealed record ToolCallReplayWindowPolicy(bool ReplayToolCalls, int MaxReplayedChars)
 {
     /// <summary>
     /// Reads <paramref name="treatment"/>'s current property values into a policy. Calling this fresh
-    /// on every projection (see <c>ConversationMessageMapping.ToChatMessagesFromLiveSettings</c>)
-    /// states "live" — a hot-reloaded config change applies to the very next turn. Calling it once and
-    /// reusing the result (see <c>DurableTranscript</c>, which does this in its constructor) states
-    /// "snapshot" — fixed for the caller's lifetime, deliberately, because the caller gates one run's
-    /// dispatch and a mid-run reload applying half the policy would be worse than applying none of it.
+    /// on every projection — <c>AgUiRunHandler.ToMeaiHistory</c> and
+    /// <c>ConversationOrchestrator.ToMeaiHistory</c> both call
+    /// <c>ConversationMessageMapping.ToChatMessages(messages, FromCurrentSettings(treatment), logger)</c>
+    /// once per turn — states "live": a hot-reloaded config change applies starting the very next turn.
+    /// Previously each of those two files hand-wrote the <see cref="IToolCallReplayTreatment.Enabled"/>/
+    /// <see cref="IToolCallReplayTreatment.MaxReplayedChars"/> unpacking separately; a role or setting
+    /// added to one copy and not the other was a silent split, not a compile error. Calling this once
+    /// and reusing the result — <c>DurableTranscript</c>, in its constructor — states "snapshot": fixed
+    /// for the caller's lifetime, deliberately, because that caller gates one run's dispatch and a
+    /// mid-run reload applying half the policy would be worse than applying none of it. Same factory,
+    /// called at a different point in the caller's lifetime — that is what makes "live vs. snapshot" an
+    /// explicit choice each caller states, rather than an accident of which file it happens to be.
     /// </summary>
     public static ToolCallReplayWindowPolicy FromCurrentSettings(IToolCallReplayTreatment treatment)
     {

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/DurableTranscript.cs
@@ -28,24 +28,19 @@ internal sealed class DurableTranscript
     private readonly IConversationStore _store;
     private readonly string _conversationId;
     private readonly string _ownerId;
-    private readonly bool _replayToolCalls;
-    private readonly int _maxReplayedChars;
+    private readonly ToolCallReplayWindowPolicy _replayPolicy;
     private readonly ILogger? _logger;
 
     /// <summary>Binds a transcript to the conversation and caller a run is executing for.</summary>
     /// <param name="store">The transcript store. Enforces ownership on every call made here.</param>
     /// <param name="conversationId">The conversation being continued.</param>
     /// <param name="ownerId">The authenticated caller. Must be non-blank.</param>
-    /// <param name="replayToolCalls">
-    /// The deployment's live <c>IToolCallReplayTreatment.Enabled</c> value at the moment this transcript
-    /// was opened — see <see cref="LoadHistoryAsync"/>. Read once, at construction, deliberately: it
-    /// gates one run's dispatch, not a value re-checked mid-run.
-    /// </param>
-    /// <param name="maxReplayedChars">
-    /// The deployment's <c>IToolCallReplayTreatment.MaxReplayedChars</c> budget, snapshotted at the same
-    /// moment and for the same reason as <paramref name="replayToolCalls"/> — the two settings gate one
-    /// run's dispatch together, and reading one live while the other is fixed would let a mid-run config
-    /// reload apply half a policy.
+    /// <param name="replayPolicy">
+    /// The deployment's <c>IToolCallReplayTreatment</c> settings at the moment this transcript was
+    /// opened (see <see cref="ToolCallReplayWindowPolicy.FromCurrentSettings"/>) — see
+    /// <see cref="LoadHistoryAsync"/>. Captured once, at construction, deliberately: it gates one run's
+    /// dispatch, not a value re-checked mid-run, and reading one of its two settings live while the
+    /// other stayed fixed would let a mid-run config reload apply half a policy.
     /// </param>
     /// <param name="logger">
     /// Optional, for reporting tool-call history the budget dropped. Absent in tests that construct a
@@ -55,19 +50,18 @@ internal sealed class DurableTranscript
         IConversationStore store,
         string conversationId,
         string ownerId,
-        bool replayToolCalls,
-        int maxReplayedChars,
+        ToolCallReplayWindowPolicy replayPolicy,
         ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentException.ThrowIfNullOrWhiteSpace(conversationId);
         ArgumentException.ThrowIfNullOrWhiteSpace(ownerId);
+        ArgumentNullException.ThrowIfNull(replayPolicy);
 
         _store = store;
         _conversationId = conversationId;
         _ownerId = ownerId;
-        _replayToolCalls = replayToolCalls;
-        _maxReplayedChars = maxReplayedChars;
+        _replayPolicy = replayPolicy;
         _logger = logger;
     }
 
@@ -133,8 +127,7 @@ internal sealed class DurableTranscript
         if (messages is null || messages.Count == 0)
             return [];
 
-        return ConversationMessageMapping.ToChatMessages(
-            messages, _replayToolCalls, _maxReplayedChars, _logger);
+        return ConversationMessageMapping.ToChatMessages(messages, _replayPolicy, _logger);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/RunConversation/RunConversationCommandHandler.cs
@@ -147,12 +147,14 @@ public class RunConversationCommandHandler : IRequestHandler<RunConversationComm
 		using var turnCts = CancellationTokenSource.CreateLinkedTokenSource(
 			cancellationToken, lease.LeaseLost);
 
+		// Snapshotted once, here, deliberately — see DurableTranscript's own constructor remarks for why
+		// this run's replay policy must stay fixed rather than re-read live mid-run.
+		var replayPolicy = ToolCallReplayWindowPolicy.FromCurrentSettings(_toolCallReplayTreatment);
 		var transcript = new DurableTranscript(
 			_conversationStore,
 			request.ConversationId,
 			ownerId,
-			_toolCallReplayTreatment.Enabled,
-			_toolCallReplayTreatment.MaxReplayedChars,
+			replayPolicy,
 			_logger);
 
 		return await RunAsync(request, transcript, turnCts.Token);

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -471,15 +471,11 @@ public sealed class AgUiRunHandler
             ? parsed
             : Guid.NewGuid();
 
-    // Delegates to the shared live-settings projection (#515) rather than reading
-    // _toolCallReplayTreatment's two properties here directly — this file and the SignalR orchestrator
-    // used to each hand-write that same two-line unpacking, which is exactly the kind of duplication a
-    // role or setting added to one copy and not the other turns into a silent split, not a compile
-    // error. Read fresh on every call (not cached): an operator's replay kill switch
-    // (IToolCallReplayTreatment.Enabled) must stop replaying already-persisted tool payloads starting
-    // the very next turn, not just stop writing new ones.
+    // Read fresh on every call, not cached — states "live" (#515); see
+    // ToolCallReplayWindowPolicy.FromCurrentSettings' remarks for why that's a deliberate choice here.
     private IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        ConversationMessageMapping.ToChatMessagesFromLiveSettings(messages, _toolCallReplayTreatment, _logger);
+        ConversationMessageMapping.ToChatMessages(
+            messages, ToolCallReplayWindowPolicy.FromCurrentSettings(_toolCallReplayTreatment), _logger);
 
     private static async Task TryWriteErrorAsync(IAgUiEventWriter writer, string message, CancellationToken ct)
     {

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -471,17 +471,15 @@ public sealed class AgUiRunHandler
             ? parsed
             : Guid.NewGuid();
 
-    // Delegates to the shared projection rather than repeating the role switch. This file, the SignalR
-    // orchestrator and the durable multi-turn loop each carried a byte-identical copy; a role added to
-    // one of three copies does not fail, it silently replays as the fallback. Not static: gates
-    // tool-call expansion on the live IToolCallReplayTreatment.Enabled value so an operator's kill
-    // switch stops replaying already-persisted tool payloads, not just stop writing new ones.
+    // Delegates to the shared live-settings projection (#515) rather than reading
+    // _toolCallReplayTreatment's two properties here directly — this file and the SignalR orchestrator
+    // used to each hand-write that same two-line unpacking, which is exactly the kind of duplication a
+    // role or setting added to one copy and not the other turns into a silent split, not a compile
+    // error. Read fresh on every call (not cached): an operator's replay kill switch
+    // (IToolCallReplayTreatment.Enabled) must stop replaying already-persisted tool payloads starting
+    // the very next turn, not just stop writing new ones.
     private IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        ConversationMessageMapping.ToChatMessages(
-            messages,
-            _toolCallReplayTreatment.Enabled,
-            _toolCallReplayTreatment.MaxReplayedChars,
-            _logger);
+        ConversationMessageMapping.ToChatMessagesFromLiveSettings(messages, _toolCallReplayTreatment, _logger);
 
     private static async Task TryWriteErrorAsync(IAgUiEventWriter writer, string message, CancellationToken ct)
     {

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -683,11 +683,9 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         };
     }
 
-    // Delegates to the shared live-settings projection (#515) — see ConversationMessageMapping for why
-    // hand-writing this same two-line unpacking here and in AgUiRunHandler was a latent bug. Read
-    // fresh on every call (not cached): an operator's replay kill switch
-    // (IToolCallReplayTreatment.Enabled) must stop replaying already-persisted tool payloads starting
-    // the very next turn, not just stop writing new ones.
+    // Read fresh on every call, not cached — states "live" (#515); see
+    // ToolCallReplayWindowPolicy.FromCurrentSettings' remarks for why that's a deliberate choice here.
     private IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        ConversationMessageMapping.ToChatMessagesFromLiveSettings(messages, _toolCallReplayTreatment, _logger);
+        ConversationMessageMapping.ToChatMessages(
+            messages, ToolCallReplayWindowPolicy.FromCurrentSettings(_toolCallReplayTreatment), _logger);
 }

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -683,14 +683,11 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         };
     }
 
-    // Delegates to the shared projection rather than repeating the role switch — see
-    // ConversationMessageMapping for why three copies of one mapping was a latent bug. Not static:
-    // gates tool-call expansion on the live IToolCallReplayTreatment.Enabled value so an operator's
-    // kill switch stops replaying already-persisted tool payloads, not just stop writing new ones.
+    // Delegates to the shared live-settings projection (#515) — see ConversationMessageMapping for why
+    // hand-writing this same two-line unpacking here and in AgUiRunHandler was a latent bug. Read
+    // fresh on every call (not cached): an operator's replay kill switch
+    // (IToolCallReplayTreatment.Enabled) must stop replaying already-persisted tool payloads starting
+    // the very next turn, not just stop writing new ones.
     private IReadOnlyList<ChatMessage> ToMeaiHistory(IReadOnlyList<ConversationMessage> messages) =>
-        ConversationMessageMapping.ToChatMessages(
-            messages,
-            _toolCallReplayTreatment.Enabled,
-            _toolCallReplayTreatment.MaxReplayedChars,
-            _logger);
+        ConversationMessageMapping.ToChatMessagesFromLiveSettings(messages, _toolCallReplayTreatment, _logger);
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingBudgetTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.AI;
 namespace Application.AI.Common.Tests.Models.Conversations;
 
 /// <summary>
-/// Proves the read-side half of #508: <see cref="ConversationMessageMapping.ToChatMessages"/> bounds
+/// Proves the read-side half of #508: <see cref="ConversationMessageMapping.ToChatMessages(IReadOnlyList{ConversationMessage},bool,int,Microsoft.Extensions.Logging.ILogger?)"/> bounds
 /// the total treated tool-call text one replayed window sends to the model, dropping oldest-first.
 /// </summary>
 /// <remarks>

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ConversationMessageMappingTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace Application.AI.Common.Tests.Models.Conversations;
 
 /// <summary>
-/// Proves <see cref="ConversationMessageMapping.ToChatMessages"/> expands a persisted
+/// Proves <see cref="ConversationMessageMapping.ToChatMessages(IReadOnlyList{ConversationMessage},bool,int,Microsoft.Extensions.Logging.ILogger?)"/> expands a persisted
 /// <see cref="ConversationMessage.ToolCalls"/> record back into the real
 /// <see cref="FunctionCallContent"/>/<see cref="FunctionResultContent"/> pair the model actually
 /// produced (#249 item 6), rather than the narrated-text-only projection this mapping used to be

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ToolCallReplayWindowPolicyTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ToolCallReplayWindowPolicyTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Models.Conversations;
 using FluentAssertions;
@@ -73,8 +74,11 @@ public sealed class ToolCallReplayWindowPolicyTests
     }
 
     [Fact]
-    public void ToChatMessagesFromLiveSettings_DelegatesToThePolicyOverloadUsingCurrentTreatmentValues()
+    public void ToChatMessages_ComposedWithFromCurrentSettings_UsesCurrentTreatmentValues()
     {
+        // AgUiRunHandler/ConversationOrchestrator's actual call shape: ToChatMessages composed directly
+        // with FromCurrentSettings, not through an intermediate wrapper (#515 code-review round — a
+        // one-line wrapper whose body was just this composition was its own unnecessary duplication).
         var toolCall = new ToolCallRecord(
             "search", """{"q":"weather"}""", """{"r":"sunny"}""", DurationMs: 1, CallId: "call-1", RoundOrdinal: 0);
         var transcript = new List<ConversationMessage>
@@ -85,7 +89,8 @@ public sealed class ToolCallReplayWindowPolicyTests
         treatment.Setup(t => t.Enabled).Returns(true);
         treatment.Setup(t => t.MaxReplayedChars).Returns(int.MaxValue);
 
-        var result = ConversationMessageMapping.ToChatMessagesFromLiveSettings(transcript, treatment.Object);
+        var result = ConversationMessageMapping.ToChatMessages(
+            transcript, ToolCallReplayWindowPolicy.FromCurrentSettings(treatment.Object));
 
         // Expansion (call + result + trailing text = 3 messages) only happens when ReplayToolCalls is
         // true — proves the live Enabled value actually reached the projection, not just that some
@@ -95,7 +100,7 @@ public sealed class ToolCallReplayWindowPolicyTests
     }
 
     [Fact]
-    public void ToChatMessagesFromLiveSettings_TreatmentDisabled_FallsBackToTextOnlyProjection()
+    public void ToChatMessages_ComposedWithFromCurrentSettings_TreatmentDisabled_FallsBackToTextOnlyProjection()
     {
         var toolCall = new ToolCallRecord(
             "search", """{"q":"weather"}""", """{"r":"sunny"}""", DurationMs: 1, CallId: "call-1", RoundOrdinal: 0);
@@ -105,10 +110,42 @@ public sealed class ToolCallReplayWindowPolicyTests
         };
         var treatment = new Mock<IToolCallReplayTreatment>();
         treatment.Setup(t => t.Enabled).Returns(false);
+        // Stubbed even though this test is about Enabled=false, and load-bearing: an unstubbed
+        // MaxReplayedChars is 0, and a zero budget admits nothing, so the assertions below would hold
+        // for a kill switch that had silently failed OPEN. Mutation-checked — flipping Enabled to true
+        // fails this test only because this line is here. This is the exact trap
+        // IToolCallReplayTreatment.MaxReplayedChars' own remarks warn about.
+        treatment.Setup(t => t.MaxReplayedChars).Returns(int.MaxValue);
 
-        var result = ConversationMessageMapping.ToChatMessagesFromLiveSettings(transcript, treatment.Object);
+        var result = ConversationMessageMapping.ToChatMessages(
+            transcript, ToolCallReplayWindowPolicy.FromCurrentSettings(treatment.Object));
 
         result.Should().ContainSingle();
         result[0].Contents.OfType<FunctionCallContent>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void IToolCallReplayTreatment_MemberSet_IsPinnedSoANewSettingCannotSilentlyMissFromCurrentSettings()
+    {
+        // FromCurrentSettings hand-maps exactly today's two read-side settings (Enabled,
+        // MaxReplayedChars) with nothing compiler-enforced tying its shape to the interface's member
+        // set — a new property added to IToolCallReplayTreatment compiles cleanly whether or not
+        // FromCurrentSettings picks it up. This pins the interface's full member set so that addition
+        // fails THIS test, forcing a human decision: read-side (wire it into FromCurrentSettings) or
+        // write-side, like MaxCallsPerTurn, Treat and NoResultPlaceholder already are (leave it out,
+        // update the expected set below). Not a claim FromCurrentSettings is complete on its own — a
+        // pin on the thing that can drift, matching this repo's own precedent for enum/interface
+        // member-set staleness (see ContentCaptureConfigValidatorTests' DefaultValues_MatchEvery...).
+        var members = typeof(IToolCallReplayTreatment)
+            .GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+            // Excludes property accessor methods (get_Enabled etc.) — MemberInfo itself has no
+            // IsSpecialName; only MethodInfo does, so non-method members (properties) pass through.
+            .Where(m => m is not MethodInfo method || !method.IsSpecialName)
+            .Select(m => m.Name)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        members.Should().BeEquivalentTo(
+            ["Enabled", "MaxCallsPerTurn", "MaxReplayedChars", "NoResultPlaceholder", "Treat"]);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ToolCallReplayWindowPolicyTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ToolCallReplayWindowPolicyTests.cs
@@ -38,24 +38,6 @@ public sealed class ToolCallReplayWindowPolicyTests
     }
 
     [Fact]
-    public void FromCurrentSettings_CalledTwice_ReflectsWhateverTheMockReturnsAtEachCall()
-    {
-        // Proves "live" is a property of WHEN a caller calls this, not of the record itself — the same
-        // factory, called again after the underlying setting changes, produces a different policy. This
-        // is what AgUiRunHandler/ConversationOrchestrator rely on by calling it fresh every turn, and
-        // what DurableTranscript deliberately does NOT do by calling it once and reusing the result.
-        var treatment = new Mock<IToolCallReplayTreatment>();
-        treatment.Setup(t => t.Enabled).Returns(true);
-        treatment.SetupSequence(t => t.MaxReplayedChars).Returns(1000).Returns(2000);
-
-        var first = ToolCallReplayWindowPolicy.FromCurrentSettings(treatment.Object);
-        var second = ToolCallReplayWindowPolicy.FromCurrentSettings(treatment.Object);
-
-        first.MaxReplayedChars.Should().Be(1000);
-        second.MaxReplayedChars.Should().Be(2000);
-    }
-
-    [Fact]
     public void ToChatMessages_PolicyOverload_MatchesTheLooseParameterOverload()
     {
         var transcript = new List<ConversationMessage>

--- a/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ToolCallReplayWindowPolicyTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Models/Conversations/ToolCallReplayWindowPolicyTests.cs
@@ -1,0 +1,114 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Models.Conversations;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Models.Conversations;
+
+/// <summary>
+/// Tests for <see cref="ToolCallReplayWindowPolicy"/> and the two
+/// <see cref="ConversationMessageMapping"/> overloads built on it (#515) — the shared vocabulary that
+/// replaced two hand-written, byte-identical <c>ToMeaiHistory</c> copies in <c>AgUiRunHandler</c> and
+/// <c>ConversationOrchestrator</c>.
+/// </summary>
+public sealed class ToolCallReplayWindowPolicyTests
+{
+    [Fact]
+    public void FromCurrentSettings_ReadsBothPropertiesFromTheTreatment()
+    {
+        var treatment = new Mock<IToolCallReplayTreatment>();
+        treatment.Setup(t => t.Enabled).Returns(true);
+        treatment.Setup(t => t.MaxReplayedChars).Returns(12345);
+
+        var policy = ToolCallReplayWindowPolicy.FromCurrentSettings(treatment.Object);
+
+        policy.ReplayToolCalls.Should().BeTrue();
+        policy.MaxReplayedChars.Should().Be(12345);
+    }
+
+    [Fact]
+    public void FromCurrentSettings_NullTreatment_Throws()
+    {
+        var act = () => ToolCallReplayWindowPolicy.FromCurrentSettings(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void FromCurrentSettings_CalledTwice_ReflectsWhateverTheMockReturnsAtEachCall()
+    {
+        // Proves "live" is a property of WHEN a caller calls this, not of the record itself — the same
+        // factory, called again after the underlying setting changes, produces a different policy. This
+        // is what AgUiRunHandler/ConversationOrchestrator rely on by calling it fresh every turn, and
+        // what DurableTranscript deliberately does NOT do by calling it once and reusing the result.
+        var treatment = new Mock<IToolCallReplayTreatment>();
+        treatment.Setup(t => t.Enabled).Returns(true);
+        treatment.SetupSequence(t => t.MaxReplayedChars).Returns(1000).Returns(2000);
+
+        var first = ToolCallReplayWindowPolicy.FromCurrentSettings(treatment.Object);
+        var second = ToolCallReplayWindowPolicy.FromCurrentSettings(treatment.Object);
+
+        first.MaxReplayedChars.Should().Be(1000);
+        second.MaxReplayedChars.Should().Be(2000);
+    }
+
+    [Fact]
+    public void ToChatMessages_PolicyOverload_MatchesTheLooseParameterOverload()
+    {
+        var transcript = new List<ConversationMessage>
+        {
+            new(Guid.NewGuid(), MessageRole.User, "hello", DateTimeOffset.UtcNow),
+            new(Guid.NewGuid(), MessageRole.Assistant, "hi there", DateTimeOffset.UtcNow),
+        };
+        var policy = new ToolCallReplayWindowPolicy(ReplayToolCalls: true, MaxReplayedChars: 500);
+
+        var viaPolicy = ConversationMessageMapping.ToChatMessages(transcript, policy);
+        var viaLooseParams = ConversationMessageMapping.ToChatMessages(
+            transcript, policy.ReplayToolCalls, policy.MaxReplayedChars);
+
+        viaPolicy.Should().HaveCount(viaLooseParams.Count);
+        viaPolicy.Select(m => m.Role).Should().BeEquivalentTo(viaLooseParams.Select(m => m.Role));
+    }
+
+    [Fact]
+    public void ToChatMessagesFromLiveSettings_DelegatesToThePolicyOverloadUsingCurrentTreatmentValues()
+    {
+        var toolCall = new ToolCallRecord(
+            "search", """{"q":"weather"}""", """{"r":"sunny"}""", DurationMs: 1, CallId: "call-1", RoundOrdinal: 0);
+        var transcript = new List<ConversationMessage>
+        {
+            new(Guid.NewGuid(), MessageRole.Assistant, "it's sunny", DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
+        };
+        var treatment = new Mock<IToolCallReplayTreatment>();
+        treatment.Setup(t => t.Enabled).Returns(true);
+        treatment.Setup(t => t.MaxReplayedChars).Returns(int.MaxValue);
+
+        var result = ConversationMessageMapping.ToChatMessagesFromLiveSettings(transcript, treatment.Object);
+
+        // Expansion (call + result + trailing text = 3 messages) only happens when ReplayToolCalls is
+        // true — proves the live Enabled value actually reached the projection, not just that some
+        // projection ran.
+        result.Should().HaveCount(3);
+        result[0].Contents.OfType<FunctionCallContent>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void ToChatMessagesFromLiveSettings_TreatmentDisabled_FallsBackToTextOnlyProjection()
+    {
+        var toolCall = new ToolCallRecord(
+            "search", """{"q":"weather"}""", """{"r":"sunny"}""", DurationMs: 1, CallId: "call-1", RoundOrdinal: 0);
+        var transcript = new List<ConversationMessage>
+        {
+            new(Guid.NewGuid(), MessageRole.Assistant, "it's sunny", DateTimeOffset.UtcNow, ToolCalls: [toolCall]),
+        };
+        var treatment = new Mock<IToolCallReplayTreatment>();
+        treatment.Setup(t => t.Enabled).Returns(false);
+
+        var result = ConversationMessageMapping.ToChatMessagesFromLiveSettings(transcript, treatment.Object);
+
+        result.Should().ContainSingle();
+        result[0].Contents.OfType<FunctionCallContent>().Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ToolCallReplayTrimDirectionCompositionTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ToolCallReplayTrimDirectionCompositionTests.cs
@@ -83,7 +83,7 @@ public sealed class ToolCallReplayTrimDirectionCompositionTests
         };
 
         var replayed = ConversationMessageMapping.ToChatMessages(
-            transcript, replayToolCalls: true, maxReplayedChars: 3 * CostPerCall);
+            transcript, new ToolCallReplayWindowPolicy(ReplayToolCalls: true, MaxReplayedChars: 3 * CostPerCall));
 
         ReplayedCallIds(replayed).Should().Equal(
             ["call-7", "call-8", "call-9"],
@@ -111,7 +111,8 @@ public sealed class ToolCallReplayTrimDirectionCompositionTests
                 };
 
                 var survivors = ReplayedCallIds(ConversationMessageMapping.ToChatMessages(
-                    transcript, replayToolCalls: true, maxReplayedChars: affordable * CostPerCall));
+                    transcript,
+                    new ToolCallReplayWindowPolicy(ReplayToolCalls: true, MaxReplayedChars: affordable * CostPerCall)));
 
                 var expectedCount = Math.Min(cap, affordable);
                 var expected = allCalls


### PR DESCRIPTION
## Summary

Package 6 of the tool-output pipeline cluster (10-package plan). Closes #515.

The heavy duplication #515 was originally filed against was already gone — both AgentHub call sites (`AgUiRunHandler.ToMeaiHistory`, `ConversationOrchestrator.ToMeaiHistory`) already delegated to `ConversationMessageMapping.ToChatMessages`. What remained: ~5 identical lines of `IToolCallReplayTreatment` property-unpacking in each, and no signal that reading those two settings live (both AgentHub sites, every turn) versus snapshotting them once (`DurableTranscript`, for a whole multi-turn run) was a deliberate choice rather than an accident of which file the code happened to live in.

- Added `ToolCallReplayWindowPolicy`, bundling `Enabled`/`MaxReplayedChars` as one record built only through `FromCurrentSettings(IToolCallReplayTreatment)` — closes the zero-default trap on `MaxReplayedChars` (an unstubbed mock silently reading as "drop everything").
- `DurableTranscript`'s constructor now takes one `ToolCallReplayWindowPolicy` instead of two loose parameters, built once by `RunConversationCommandHandler` at construction — the same "read once, fixed for a run" timing as before, now an explicit, documented choice.
- `AgUiRunHandler.ToMeaiHistory`/`ConversationOrchestrator.ToMeaiHistory` now compose `ConversationMessageMapping.ToChatMessages(policy)` with `ToolCallReplayWindowPolicy.FromCurrentSettings(treatment)` directly — no logic left to drift between the two files.

## Review rounds applied

- **Independent `security-reviewer`**: verified the live-vs-snapshot timing is preserved exactly (an operator's replay kill switch still applies on the very next turn at both live sites), and caught that my own new "kill switch disabled" test didn't stub `MaxReplayedChars` — an unstubbed mock defaults to 0, which also empties the replay window, so the test couldn't tell a working kill switch from one that had silently failed open. Fixed and mutation-verified.
- **`/code-review`**: found the intermediate wrapper `ToChatMessagesFromLiveSettings` I'd added was itself unnecessary (a one-line composition of two things that already existed independently) and had caused its own rationale comment to be duplicated across the two call sites — the exact problem this issue exists to fix, now in a comment instead of code. Removed it. Also added a reflection-based pinning test so a future `IToolCallReplayTreatment` setting can't silently miss the read-side policy, mutation-tested by actually adding a member to the real interface and confirming the guard fires.
- **`/simplify`** (4 parallel angles): found the record-based `ToChatMessages` overload had become a pass-through kept in sync with the loose-parameter overload only by a cross-check test. Made the loose overload `internal` (reusing this project's existing `InternalsVisibleTo` wiring, so 20+ existing tests needed no changes) rather than public, so there's one production-facing entry point. Also removed a redundant test.

All fixes mutation-tested where applicable.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` clean
- [x] `dotnet test src/AgenticHarness.slnx` — full solution green. One transient failure in an unrelated project (`Infrastructure.AI.Tests.ProcessSandboxExecutorTests`, a Windows process-pipe timing flake, "The pipe is being closed") did not reproduce on isolated re-run (5/5 clean) — pre-existing flakiness this repo already tracks (#537), not a regression from this change.
- [x] `scripts/rails/run-gates.sh` clean (build, test, owasp, grader, correctness, docs-drift)
- [x] Mutation-tested every new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj