### PR TITLE
fix: spill truncated tool output and let the model retrieve it (#521)

### DIFF
--- a/.claude/rules/tools-and-mcp.md
+++ b/.claude/rules/tools-and-mcp.md
@@ -10,15 +10,23 @@ paths: src/Content/**/MCPServer/**/*.cs, src/Content/**/Tools/**/*.cs
 4. Add JSON schema via `IToolSchemaService` for agent discovery
 5. Convert to `AITool` via `IToolConverter`
 
-**Exception — keyed scoped, not singleton:** a tool that constructor-injects a genuinely
-request-scoped dependency (e.g. `IAgentExecutionContext`, to read the CALLING request's own state
-back — not to spawn an independent unit of work) must be registered `AddKeyedScoped`, never
-`AddKeyedSingleton`. A singleton registration would capture whichever caller's scope resolved it
-first and leak that scope to every later caller — a captive-dependency bug, not a style choice.
-`ToolResultFetchTool` (#521) is the first instance; see its own remarks for the full reasoning.
-Contrast with `DocumentIngestTool`, which stays singleton and instead takes `IServiceScopeFactory`
-to spawn its own fresh scope per call — the right shape when the tool starts independent work
-rather than reading the calling request's own identity.
+**A tool that needs the CALLING request's own scoped state (e.g. `IAgentExecutionContext`) stays
+keyed SINGLETON, like every other tool — never `AddKeyedScoped`.** Every production caller resolves
+a keyed `ITool` by name from a singleton holding the ROOT service provider
+(`ToolChainBuilder.ResolveToolByName`, `FirstPartyToolLookup.Resolve`), so there is no per-request
+scope at resolution time to register a scoped tool into — `AddKeyedScoped` throws
+`InvalidOperationException` under `ValidateScopes = true` (every host) the moment either resolver
+reaches it. This was tried and caught by the `correctness` gate before shipping (#521,
+`ToolResultFetchTool`) — do not repeat it.
+
+Instead, constructor-inject `IAmbientRequestScope` (itself a singleton, AsyncLocal-backed) and
+resolve the scoped dependency from `IAmbientRequestScope.Current` inside the tool's `ExecuteAsync`,
+per invocation — not at construction. This is the same pattern already used by a dozen-plus other
+long-lived singletons that need per-request state (see `IAmbientRequestScope`'s own remarks, and
+e.g. `KnowledgeMemoryContextProvider`, `EgressPolicyDelegatingHandler`). `ToolResultFetchTool` is
+the reference example for a tool doing this. Contrast with `DocumentIngestTool`, which takes
+`IServiceScopeFactory` to spawn its own INDEPENDENT fresh scope per call — the right shape when the
+tool starts new work, not when it needs to read the calling request's own identity back.
 
 ## Tool Schema Requirements
 Every tool must have:

--- a/.claude/rules/tools-and-mcp.md
+++ b/.claude/rules/tools-and-mcp.md
@@ -10,6 +10,16 @@ paths: src/Content/**/MCPServer/**/*.cs, src/Content/**/Tools/**/*.cs
 4. Add JSON schema via `IToolSchemaService` for agent discovery
 5. Convert to `AITool` via `IToolConverter`
 
+**Exception — keyed scoped, not singleton:** a tool that constructor-injects a genuinely
+request-scoped dependency (e.g. `IAgentExecutionContext`, to read the CALLING request's own state
+back — not to spawn an independent unit of work) must be registered `AddKeyedScoped`, never
+`AddKeyedSingleton`. A singleton registration would capture whichever caller's scope resolved it
+first and leak that scope to every later caller — a captive-dependency bug, not a style choice.
+`ToolResultFetchTool` (#521) is the first instance; see its own remarks for the full reasoning.
+Contrast with `DocumentIngestTool`, which stays singleton and instead takes `IServiceScopeFactory`
+to spawn its own fresh scope per call — the right shape when the tool starts independent work
+rather than reading the calling request's own identity.
+
 ## Tool Schema Requirements
 Every tool must have:
 - Clear name (snake_case): `"file_system"`, `"document_search"`

--- a/documentation/onboarding/06-tools.html
+++ b/documentation/onboarding/06-tools.html
@@ -99,8 +99,9 @@ services.AddKeyedSingleton&lt;ITool&gt;(RestrictedSearchTool.ToolName, (sp, _) =
                         The real built-in tools are <code>FileSystemTool</code> (<code>file_system</code>),
                         <code>EchoCalculateTool</code> (<code>echo_calculate</code>),
                         <code>RestrictedSearchTool</code> (<code>restricted_search</code>),
-                        <code>DocumentSearchTool</code> (<code>document_search</code>), and the generative-UI render
-                        tools (<a href="16-generative-ui.html">Chapter 16</a>). There is no
+                        <code>DocumentSearchTool</code> (<code>document_search</code>),
+                        <code>ToolResultFetchTool</code> (<code>tool_result_fetch</code>), and the generative-UI
+                        render tools (<a href="16-generative-ui.html">Chapter 16</a>). There is no
                         <code>CalculationTool</code> or <code>WebSearchTool</code> — those names are historical.
                     </p>
 
@@ -381,6 +382,21 @@ services.AddKeyedSingleton&lt;ITool&gt;(RestrictedSearchTool.ToolName, (sp, _) =
                         <code>FreeText</code> that heuristics can't shrink enough.
                     </p>
 
+                    <div class="callout callout-warn">
+                        <span class="callout-icon">!</span>
+                        <div class="callout-body">
+                            <div class="callout-title">The hard ceiling and tool_result_fetch</div>
+                            <p style="margin: 0">
+                                Compression is a best-effort shrink, not a guarantee. Output still over the final
+                                character ceiling after compression is truncated by <code>ToolCallAdmissionPipeline</code>
+                                and marked with <code>[tool output truncated — full output available via
+                                tool_result_fetch, id=...]</code>. The agent can call the <code>tool_result_fetch</code>
+                                tool with that id to retrieve the rest, scoped to its own conversation — a different
+                                conversation's id always reads back as "not found."
+                            </p>
+                        </div>
+                    </div>
+
                     <h2>Where each tool lives in the repo</h2>
                     <table>
                         <thead><tr><th>Tool family</th><th>Project</th></tr></thead>
@@ -390,6 +406,8 @@ services.AddKeyedSingleton&lt;ITool&gt;(RestrictedSearchTool.ToolName, (sp, _) =
                             <tr><td>MCP-discovered tools</td><td>Cast to <code>AITool</code> by <code>McpToolProvider</code> (not <code>ITool</code>)</td></tr>
                             <tr><td>Plugin-provided tools</td><td>Plugin's local directory; loaded via <code>IPluginLoader</code></td></tr>
                             <tr><td>Tool output compression</td><td><code>ToolOutputCompressionBehavior</code> (MediatR pipeline behavior)</td></tr>
+                            <tr><td>Hard-ceiling truncation, spill &amp; retrieval marker</td><td><code>Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs</code></td></tr>
+                            <tr><td>Retrieval tool (<code>tool_result_fetch</code>)</td><td><code>Infrastructure.AI/Tools/ToolResultFetchTool.cs</code></td></tr>
                             <tr><td>Tool DI registration</td><td><code>Infrastructure.AI/DependencyInjection.Tools.cs</code></td></tr>
                             <tr><td>Invocation-time governance wrapper</td><td><code>Application.AI.Common/Services/Tools/GovernedAIFunction.cs</code></td></tr>
                         </tbody>

--- a/documentation/reference/patterns-and-technologies.html
+++ b/documentation/reference/patterns-and-technologies.html
@@ -429,6 +429,14 @@ know the exact filename. Cite file paths in `path:line` form.</code></pre>
                         strategy: drop deep nesting, summarise repetitive rows, gzip-and-pointer for truly large blobs.
                         <code>src/Content/Application/Application.AI.Common/MediatRBehaviors/ToolOutputCompressionBehavior.cs</code>
                     </p>
+                    <p>
+                        When compression alone still leaves output over the ceiling, <code>ToolCallAdmissionPipeline</code>
+                        truncates it, spills the full text to <code>IToolResultStore</code>, and embeds a retrieval id
+                        in the truncation marker — the model can call the <code>tool_result_fetch</code> tool with that
+                        id to recover the rest, scoped to its own conversation.
+                        <code>src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs</code>,
+                        <code>src/Content/Infrastructure/Infrastructure.AI/Tools/ToolResultFetchTool.cs</code>
+                    </p>
 
                     <h3 id="content-safety">Content safety middleware</h3>
                     <p>

--- a/skills/default-agent/SKILL.md
+++ b/skills/default-agent/SKILL.md
@@ -5,12 +5,23 @@ category: "general"
 skill_type: "agent"
 version: "1.0.0"
 tags: ["default", "general", "generative-ui"]
-allowed-tools: ["file_system", "render_image", "render_form", "render_table"]
+allowed-tools:
+  [
+    "file_system",
+    "tool_result_fetch",
+    "render_image",
+    "render_form",
+    "render_table",
+  ]
 tools:
   - name: "file_system"
     operations: ["read", "search", "list"]
     optional: false
     description: "Read and search project files"
+  - name: "tool_result_fetch"
+    operations: ["fetch"]
+    optional: true
+    description: "Retrieve the full text of a tool result that was truncated"
   - name: "render_image"
     operations: ["render"]
     optional: true
@@ -32,6 +43,10 @@ reach for a tool only when the request needs it.
 
 - Read and search project files with the `file_system` tool when a question needs information from the
   codebase (operations `read`, `search`, `list`). Start searches from `src`.
+- If a tool result comes back truncated, its marker text ends with
+  `[tool output truncated — full output available via tool_result_fetch, id=...]`. Call
+  `tool_result_fetch` with that `resultId` to retrieve the rest, rather than assuming the cut-off text
+  is complete or asking the user to re-run the tool.
 - Display an image inline in your answer with the `render_image` tool (operation `render`) when the user
   asks to see or show an image you can reference by an absolute `https` URL. Pass `url` (required) and
   optionally `alt` and `caption`. The image is shown in the user's browser; you receive a short

--- a/skills/research-agent/SKILL.md
+++ b/skills/research-agent/SKILL.md
@@ -5,12 +5,16 @@ category: "research"
 skill_type: "analysis"
 version: "1.2.0"
 tags: ["research", "file-analysis", "standalone"]
-allowed-tools: ["file_system"]
+allowed-tools: ["file_system", "tool_result_fetch"]
 tools:
   - name: "file_system"
     operations: ["read", "search", "list"]
     optional: false
     description: "Read and search project files"
+  - name: "tool_result_fetch"
+    operations: ["fetch"]
+    optional: true
+    description: "Retrieve the full text of a tool result that was truncated"
 ---
 
 You are a research agent specialized in finding and analyzing information from the local file system.
@@ -20,6 +24,10 @@ You are a research agent specialized in finding and analyzing information from t
 - Search and read files from the project file system using the `file_system` tool
 - Analyze source code, configuration, documentation, and data files
 - Locate specific classes, methods, constants, or configuration values
+- If a `read` result comes back truncated (marker text ending
+  `[tool output truncated — full output available via tool_result_fetch, id=...]`), call
+  `tool_result_fetch` with that `resultId` to retrieve the rest before analyzing or citing the file —
+  a large source file cut mid-analysis will otherwise be mistaken for a short one
 
 ## File System Root
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Agent/IAgentExecutionContext.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Agent/IAgentExecutionContext.cs
@@ -52,6 +52,30 @@ public interface IAgentExecutionContext
     string? CallOnceScopeId { get; }
 
     /// <summary>
+    /// Gets the isolation boundary spilled tool output is persisted under and must be retrieved
+    /// within (#521) — never <c>null</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Deliberately not <see cref="ConversationId"/>, and not simply mirroring
+    /// <see cref="CallOnceScopeId"/> either.</strong> A tool-result store is a data-isolation
+    /// boundary, not a rate/repeat gate — <see cref="CallOnceScopeId"/>'s own remarks document
+    /// that a <see langword="null"/> scope there is a correct, deliberate fail-<em>open</em> for
+    /// the direct-invoke path ("no logical conversation for a repeat call to happen within"). The
+    /// identical fail-open on a retrieval boundary would mean "no scope enforced" — the exact
+    /// ownership hole this property exists to close. This property is therefore <em>never</em>
+    /// null: it reuses <see cref="CallOnceScopeId"/>'s value wherever that is already correctly
+    /// scoped (the durable conversation for an agent turn, the run id for a plan run — both
+    /// already exactly right for "which execution may retrieve this result back"), and falls back
+    /// to a freshly generated id, unique to this <see cref="IAgentExecutionContext"/> instance,
+    /// only where <see cref="CallOnceScopeId"/> is null. A fresh id is always safe here — narrower
+    /// than the true caller-appropriate scope is merely inconvenient (retrieval degrades to
+    /// "spilled and immediately gone" for that one call), where wider would be the leak.
+    /// </para>
+    /// </remarks>
+    string ToolResultScopeId { get; }
+
+    /// <summary>
     /// Gets the workload identity of the executing agent, or <c>null</c> when identity
     /// is disabled (<c>AppConfig.AI.Identity.Enabled</c> is false), the call is outside
     /// any agent execution, or the identity has not yet been resolved by

--- a/src/Content/Application/Application.AI.Common/Interfaces/Context/IToolResultStore.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Context/IToolResultStore.cs
@@ -30,13 +30,28 @@ public interface IToolResultStore
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Retrieves the full content of a previously persisted result.
+    /// Retrieves the full content of a previously persisted result, enforced against the scope it was
+    /// stored under (#521).
     /// </summary>
     /// <param name="resultId">The unique identifier of the stored result.</param>
+    /// <param name="scopeId">
+    /// The caller's own isolation boundary — <see cref="Agent.IAgentExecutionContext.ToolResultScopeId"/>
+    /// in production. Must match the <c>sessionId</c> <see cref="StoreIfLargeAsync"/> was called with
+    /// when this result was stored, or retrieval is refused. Enforced <em>here</em>, in the store, not
+    /// left to each call site — the same rule <c>IConversationStore</c> applies to conversation
+    /// ownership, for the identical reason: a check a caller could forget is not a check.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The full content that was persisted to disk.</returns>
-    /// <exception cref="KeyNotFoundException">Thrown when <paramref name="resultId"/> is not found.</exception>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown when <paramref name="resultId"/> is not found <em>under <paramref name="scopeId"/></em> —
+    /// indistinguishable from "does not exist at all" on purpose. A result that exists under a
+    /// different scope must read exactly like one that was never stored; a distinct error for "exists,
+    /// but not yours" would tell an unauthorized caller that guessing worked, which is the same
+    /// information a Denied vs. NotFound split would leak on a conversation lookup.
+    /// </exception>
     Task<string> RetrieveFullContentAsync(
         string resultId,
+        string scopeId,
         CancellationToken cancellationToken = default);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -80,7 +80,7 @@ public interface IToolCallAdmissionPipeline
     /// <returns>
     /// The verdict. A refusal always carries a caller-facing message; an allow may carry an
     /// instruction to redact the tool's output, which the caller applies through
-    /// <see cref="ApplyOutputPolicy"/>.
+    /// <see cref="ApplyOutputPolicyAsync"/>.
     /// </returns>
     ValueTask<ToolCallAdmission> AdmitAsync(ToolCallAdmissionRequest request, CancellationToken cancellationToken);
 
@@ -119,7 +119,15 @@ public interface IToolCallAdmissionPipeline
     /// unlike this pipeline's other execution paths, which already sanitize unconditionally.
     /// </para>
     /// </remarks>
-    object? ApplyOutputPolicy(ToolCallAdmission admission, string toolName, object? result);
+    /// <param name="cancellationToken">
+    /// Cancels the pipeline's own work (sanitize/redact/bound). Does <strong>not</strong> cancel a
+    /// spill write to <c>IToolResultStore</c> when a cut actually drops content (#521) — that write
+    /// finalizes output a tool call already produced, the same "already happened, don't abandon it"
+    /// reasoning <see cref="ReportExecutionAsync"/> applies, so it always runs to completion or logs
+    /// its own failure rather than honoring this token.
+    /// </param>
+    ValueTask<object?> ApplyOutputPolicyAsync(
+        ToolCallAdmission admission, string toolName, object? result, CancellationToken cancellationToken);
 
     /// <summary>
     /// Applies the admission's output policy to a result that must leave as <em>text</em>, reporting
@@ -128,20 +136,25 @@ public interface IToolCallAdmissionPipeline
     /// <param name="admission">The verdict returned by <see cref="AdmitAsync"/> for this same call.</param>
     /// <param name="toolName">The tool that produced <paramref name="content"/>.</param>
     /// <param name="content">The tool's raw text.</param>
-    /// <param name="result">
-    /// <paramref name="content"/>, run unconditionally through the general-purpose sanitizer — the same
-    /// guarantee <see cref="ApplyOutputPolicy"/> carries (#469) — and additionally through
-    /// <see cref="IToolClassificationGate.RedactResult(string, string?)"/>'s known-secret-pattern scrub when a redaction
-    /// was required (#479 closed the gap where this method sanitized only on that second path, unlike
-    /// its sibling). Null content passes through as null: there is nothing to sanitize or redact. Null
-    /// when the method returns <see langword="false"/>.
+    /// <param name="cancellationToken">
+    /// Cancels the pipeline's own work. Does not cancel a spill write on truncation — see
+    /// <see cref="ApplyOutputPolicyAsync"/>'s identical parameter for why.
     /// </param>
     /// <returns>
+    /// See <see cref="TextOutputPolicyResult"/>. <see cref="TextOutputPolicyResult.Success"/> is
     /// <see langword="false"/> when a redaction was required but did not produce text, in which case
     /// the caller must <strong>withhold</strong> the result rather than emit the original.
+    /// <see cref="TextOutputPolicyResult.Result"/> is <paramref name="content"/>, run unconditionally
+    /// through the general-purpose sanitizer — the same guarantee <see cref="ApplyOutputPolicyAsync"/>
+    /// carries (#469) — and additionally through
+    /// <see cref="IToolClassificationGate.RedactResult(string, string?)"/>'s known-secret-pattern scrub
+    /// when a redaction was required (#479 closed the gap where this method sanitized only on that
+    /// second path, unlike its sibling). Null content passes through as null: there is nothing to
+    /// sanitize or redact. Null when <see cref="TextOutputPolicyResult.Success"/> is
+    /// <see langword="false"/>.
     /// </returns>
     /// <remarks>
-    /// Separate from <see cref="ApplyOutputPolicy"/> because the two callers want different things
+    /// Separate from <see cref="ApplyOutputPolicyAsync"/> because the two callers want different things
     /// from the same verdict. The agent turn hands the model structured results and passes them
     /// through untouched, so it wants the object form. The plan step and the Execution API emit text
     /// across a boundary, and for them a non-text answer means a gate did something unexpected — on a
@@ -150,29 +163,26 @@ public interface IToolCallAdmissionPipeline
     /// survives. Both also used to implement the unconditional sanitize themselves, immediately after
     /// calling this method — caller discipline standing in for a guarantee that now lives here instead
     /// (#479).
-    /// </remarks>
-    /// <param name="wasTruncated">
-    /// <see langword="true"/> when this method <em>itself</em> cut <paramref name="content"/> to fit
-    /// the tool-output ceiling (#532). Callers that publish a "was this cut short?" signal across a
-    /// boundary must OR this into it.
     /// <para>
-    /// It is an out-parameter rather than something a caller can infer, because inferring it requires
-    /// the caller to already know this pipeline's ceiling and to assume its own is not larger. The
+    /// <see cref="TextOutputPolicyResult.WasTruncated"/> is <see langword="true"/> when this method
+    /// <em>itself</em> cut <paramref name="content"/> to fit the tool-output ceiling (#532). Callers
+    /// that publish a "was this cut short?" signal across a boundary must OR this into it — reported on
+    /// the return value rather than something a caller can infer, because inferring it requires the
+    /// caller to already know this pipeline's ceiling and to assume its own is not larger. The
     /// Execution API assumed exactly that and was wrong on shipped defaults: its ceiling is 262,144
     /// characters, the pipeline's is 50,000, so for every output between those two numbers its own
-    /// before-and-after measurements both saw nothing to cut while the middle step had already
-    /// removed four fifths of the body — and it answered <c>OutputTruncated = false</c> on a prefix.
-    /// A caller that cannot tell a complete result from a prefix parses the prefix as complete.
-    /// Reporting the fact alongside the value is what makes that unrepresentable; two components
-    /// agreeing on a number is not, because either can change its number alone.
+    /// before-and-after measurements both saw nothing to cut while the middle step had already removed
+    /// four fifths of the body — and it answered <c>OutputTruncated = false</c> on a prefix. A caller
+    /// that cannot tell a complete result from a prefix parses the prefix as complete. Reporting the
+    /// fact alongside the value is what makes that unrepresentable; two components agreeing on a number
+    /// is not, because either can change its number alone.
     /// </para>
-    /// </param>
-    bool TryApplyTextOutputPolicy(
+    /// </remarks>
+    ValueTask<TextOutputPolicyResult> TryApplyTextOutputPolicyAsync(
         ToolCallAdmission admission,
         string toolName,
         string? content,
-        out string? result,
-        out bool wasTruncated);
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Reports what happened when a call this pipeline approved was actually carried out, closing
@@ -228,6 +238,18 @@ public interface IToolCallAdmissionPipeline
     /// </remarks>
     void Reset();
 }
+
+/// <summary>
+/// The outcome of <see cref="IToolCallAdmissionPipeline.TryApplyTextOutputPolicyAsync"/> — see that
+/// method's own remarks for what each member means.
+/// </summary>
+/// <param name="Success">
+/// <see langword="false"/> when a redaction was required but did not produce text; the caller must
+/// withhold the result rather than emit the original.
+/// </param>
+/// <param name="Result">The treated text, or <see langword="null"/> when <paramref name="Success"/> is <see langword="false"/>.</param>
+/// <param name="WasTruncated">Whether the pipeline itself cut the text to fit its ceiling.</param>
+public readonly record struct TextOutputPolicyResult(bool Success, string? Result, bool WasTruncated);
 
 /// <summary>
 /// One tool call, as the admission chain sees it.

--- a/src/Content/Application/Application.AI.Common/Services/Agent/AgentExecutionContext.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/AgentExecutionContext.cs
@@ -23,6 +23,12 @@ public sealed class AgentExecutionContext : IAgentExecutionContext
     private readonly object _gate = new();
     private bool _initialized;
 
+    // Computed once, at construction — before Initialize is ever called, and independent of
+    // whatever it's later called with. This scope must exist and be stable even for a caller
+    // that never calls Initialize at all (nothing today does that, but ToolResultScopeId itself
+    // must not throw or return null just because initialization hasn't happened yet).
+    private readonly string _fallbackToolResultScopeId = Guid.NewGuid().ToString("N");
+
     /// <inheritdoc />
     public string? AgentId { get; private set; }
 
@@ -34,6 +40,9 @@ public sealed class AgentExecutionContext : IAgentExecutionContext
 
     /// <inheritdoc />
     public string? CallOnceScopeId { get; private set; }
+
+    /// <inheritdoc />
+    public string ToolResultScopeId => CallOnceScopeId ?? _fallbackToolResultScopeId;
 
     /// <inheritdoc />
     public AgentIdentity? AgentIdentity { get; private set; }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/BoundedText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/BoundedText.cs
@@ -35,15 +35,33 @@ public static class BoundedText
     /// is not larger than the marker's own length, the marker is dropped rather than overshooting the
     /// ceiling to fit it — the ceiling is the promise a caller sizing a downstream field is relying on.
     /// </param>
-    /// <returns>The (possibly cut) text, and whether anything was cut.</returns>
-    public static (string Text, bool Truncated) Cap(string text, int ceiling, string marker)
+    /// <param name="alwaysEmbedMarker">
+    /// When <see langword="true"/>, embeds <paramref name="marker"/> even when <paramref name="text"/>
+    /// is already within <paramref name="ceiling"/> on its own, cutting only as much of
+    /// <paramref name="text"/> as is needed to make room for it (#521's droppedByPreCut-only case: a
+    /// truncation happened upstream that this call alone would not otherwise see, so the normal
+    /// "nothing to cut, nothing to say" default would silently drop the marker instead of the caller's
+    /// own already-known truncation signal). The returned <c>Truncated</c> is <see langword="false"/> in
+    /// that append-only sub-case, since <paramref name="text"/> itself was never cut — callers using
+    /// this flag already carry their own truncation signal from elsewhere and are expected to OR it in,
+    /// not read it off this return.
+    /// </param>
+    /// <returns>The (possibly cut) text, and whether <paramref name="text"/> itself was cut.</returns>
+    public static (string Text, bool Truncated) Cap(
+        string text, int ceiling, string marker, bool alwaysEmbedMarker = false)
     {
-        if (text.Length <= ceiling)
+        if (!alwaysEmbedMarker && text.Length <= ceiling)
         {
             return (text, false);
         }
 
+        if (alwaysEmbedMarker && text.Length + marker.Length <= ceiling)
+        {
+            return (text + marker, false);
+        }
+
         var cutIndex = ceiling > marker.Length ? ceiling - marker.Length : ceiling;
+        cutIndex = Math.Min(cutIndex, text.Length);
         if (cutIndex > 0 && char.IsHighSurrogate(text[cutIndex - 1]))
         {
             cutIndex--;

--- a/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/DefaultToolClassificationGate.cs
@@ -124,7 +124,7 @@ public sealed class DefaultToolClassificationGate : IToolClassificationGate
     /// <inheritdoc />
     /// <remarks>
     /// #484: a <c>Redact</c> verdict must do strictly more than the unconditional sanitize every other
-    /// tool result already gets (<see cref="ToolCallAdmissionPipeline.ApplyOutputPolicy"/>) — otherwise
+    /// tool result already gets (<see cref="ToolCallAdmissionPipeline.ApplyOutputPolicyAsync"/>) — otherwise
     /// an operator-configured classification policy is a control with no distinct effect. Routes through
     /// <see cref="ToolResultText.SanitizeAndRedact(object?, ICompositeResponseSanitizer, IContentRedactionFilter, string)"/>
     /// rather than <see cref="ToolResultText.Sanitize(object?, ICompositeResponseSanitizer, string)"/>,

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -1,11 +1,14 @@
 using System.Collections.ObjectModel;
 using System.Text.Json;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
+using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -61,6 +64,8 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     private readonly IContentRedactionFilter _redactionFilter;
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly ILogger<ToolCallAdmissionPipeline> _logger;
+    private readonly IAgentExecutionContext _executionContext;
+    private readonly IToolResultStore _resultStore;
 
     /// <summary>Initializes a new instance of the <see cref="ToolCallAdmissionPipeline"/> class.</summary>
     /// <param name="authorizationGate">
@@ -98,11 +103,20 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// raw failure text for reporting — see <see cref="ReportExecutionAsync"/> and
     /// <see cref="ReportedFailureText.PrepareForReporting"/>. On its own, also the unconditional
     /// injection-scrubber every plain-allow tool result is run through in
-    /// <see cref="ApplyOutputPolicy"/> — see #469; that path never reaches
+    /// <see cref="ApplyOutputPolicyAsync"/> — see #469; that path never reaches
     /// <paramref name="redactionFilter"/> at all.
     /// </param>
     /// <param name="redactionFilter">Scrubs known secret patterns from a failed call's reported text.</param>
     /// <param name="logger">Records a redaction that could not be applied.</param>
+    /// <param name="executionContext">
+    /// Supplies <see cref="IAgentExecutionContext.ToolResultScopeId"/> — the isolation boundary a
+    /// truncated result is spilled under (#521). Scoped in DI, same lifetime as this pipeline, so
+    /// plain constructor injection is correct here; no ambient lookup needed.
+    /// </param>
+    /// <param name="resultStore">
+    /// Where a truncated result's full, already-sanitized/redacted text is spilled so a later
+    /// <c>tool_result_fetch</c> call can retrieve it (#521).
+    /// </param>
     public ToolCallAdmissionPipeline(
         IAgentToolAuthorizationGate authorizationGate,
         IToolInvocationGovernor governor,
@@ -115,7 +129,9 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         ICompositeResponseSanitizer sanitizer,
         IContentRedactionFilter redactionFilter,
         IOptionsMonitor<AppConfig> options,
-        ILogger<ToolCallAdmissionPipeline> logger)
+        ILogger<ToolCallAdmissionPipeline> logger,
+        IAgentExecutionContext executionContext,
+        IToolResultStore resultStore)
     {
         ArgumentNullException.ThrowIfNull(options);
         _options = options;
@@ -130,6 +146,8 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         ArgumentNullException.ThrowIfNull(sanitizer);
         ArgumentNullException.ThrowIfNull(redactionFilter);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(resultStore);
 
         _authorizationGate = authorizationGate;
         _governor = governor;
@@ -142,6 +160,8 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         _sanitizer = sanitizer;
         _redactionFilter = redactionFilter;
         _logger = logger;
+        _executionContext = executionContext;
+        _resultStore = resultStore;
     }
 
     /// <inheritdoc />
@@ -265,6 +285,17 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     public const string OutputTruncationMarker = "\n[tool output truncated]";
 
     /// <summary>
+    /// Format string for the marker embedded when a truncated result was spilled and can be retrieved
+    /// via <c>tool_result_fetch</c> (#521) — <c>{0}</c> is the spilled result's id. The single source
+    /// of truth for this text: <c>ToolResultFetchTool.Description</c> (Infrastructure.AI, which may
+    /// reference Application.AI.Common) formats the same string with a placeholder id rather than
+    /// hand-copying the phrase, so the tool's own self-description can never silently drift from the
+    /// marker text it actually needs to recognize (a reuse finding from this package's `/simplify` pass).
+    /// </summary>
+    public const string SpilledResultMarkerFormat =
+        "\n[tool output truncated — full output available via tool_result_fetch, id={0}]";
+
+    /// <summary>
     /// How much beyond <see cref="OutputCeiling"/> is kept while sanitizing and redacting, so a secret
     /// or an injection pattern straddling the ceiling stays inside the scanned region rather than being
     /// sliced in half — removed again by the final cut. See
@@ -303,9 +334,11 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         _options.CurrentValue.AI.ContextManagement.ToolResultStorage.PerResultCharLimit;
 
     /// <inheritdoc />
-    public object? ApplyOutputPolicy(ToolCallAdmission admission, string toolName, object? result)
+    public async ValueTask<object?> ApplyOutputPolicyAsync(
+        ToolCallAdmission admission, string toolName, object? result, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(admission);
+        cancellationToken.ThrowIfCancellationRequested();
 
         // #487: cut to a scan-cost-bounded region BEFORE sanitizing or redacting — the opposite order
         // from the final cut below, and safe only because of the overlap margin: see PreCutForScan's
@@ -313,9 +346,13 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // is also what protects the agent-turn path (GovernedAIFunction), which used to have no bound
         // on scan cost at all.
         //
-        // A real marker is passed, unlike TryApplyTextOutputPolicy's use of the same primitive: this
-        // method has no out-parameter to report a drop through — see PreCutForScan's own marker doc,
-        // and #487's security-review finding on this PR that this line closes.
+        // A real marker is passed, unlike TryApplyTextOutputPolicyAsync's use of the same primitive:
+        // this method has no truncation signal from the pre-cut alone — see PreCutForScan's own marker
+        // doc, and #487's security-review finding on this PR that this line closes. #521's spill below
+        // therefore only fires on the FINAL cut's own drop, not the pre-cut's — a pre-cut-only drop
+        // still leaves its own embedded marker (unchanged, pre-existing behavior) but is not spilled;
+        // narrower than TryApplyTextOutputPolicyAsync's coverage, and stated here rather than left
+        // implicit, matching this repo's own "no silent caps" convention.
         //
         // Ceiling captured once, not re-read from _options.CurrentValue at the pre-cut and again at the
         // final cut: a hot reload between the two reads would otherwise let them disagree about what
@@ -333,45 +370,65 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // different, wider, scan-cost-only bound, not a substitute for this one. It also mirrors
         // ReportExecutionAsync, which has always sanitized, redacted, and THEN bounded tool failure
         // text at this same pipeline (#460); success output simply never got the third step.
-        return ToolResultText.Bound(treated, ceiling, OutputTruncationMarker);
+        var (bounded, dropped) = ToolResultText.Bound(treated, ceiling, OutputTruncationMarker);
+        if (!dropped)
+            return bounded;
+
+        // #521: treated (not preCut) is spilled — sanitized/redacted, but not yet cut to ceiling,
+        // preserving the existing "redacted before it ever touches disk" property. The id-carrying
+        // marker is longer than OutputTruncationMarker, so it is never swapped into the
+        // already-ceiling-respecting `bounded` string after the fact — that would silently overshoot
+        // the ceiling by the length difference between the two markers (caught by
+        // ApplyOutputPolicy_OversizedText_IsBoundedAndMarked). Re-cutting treated against the real
+        // marker instead makes ToolResultText.Bound reserve room for it directly; dropped==true here
+        // guarantees treated's TOTAL length is still over ceiling, so the re-cut always drops
+        // something — but for a multi-block AIContent[] result, that guarantee is total-length only.
+        var marker = await SpillAndBuildMarkerAsync(toolName, ToolResultText.ExtractText(treated)).ConfigureAwait(false);
+        var (reboundedWithId, _) = ToolResultText.Bound(treated, ceiling, marker);
+
+        // A code-review found this residual gap: ToolResultText.Bound/BudgetedCut walks a multi-block
+        // result with a single shared per-block budget, and cuts whichever block first exceeds it.
+        // BoundedText.Cap's own documented contract silently DROPS a marker (not overshoots) whenever
+        // that block's local remaining budget is smaller than the marker's own length — every block
+        // after the cut then runs with a zero budget and is silently emptied too, also markerless. The
+        // short OutputTruncationMarker (~25 chars) made this window narrow; the id-carrying marker
+        // (~107 chars, carrying a GUID) widens it roughly 4x, and #539's own multi-block test
+        // (ApplyOutputPolicy_MultipleTextBlocks_BoundsTheTOTALNotEachBlock) proves multi-block results
+        // are a first-class shape this method handles, not a contrived one. Rather than reworking
+        // BudgetedCut's per-block budget algorithm to guarantee room wherever a cut could land, fall
+        // back to the already-correct, already-computed `bounded` (plain marker) whenever the id
+        // marker didn't actually survive the re-cut — the model always gets an honest truncation
+        // signal, even on the rarer path where this call can't fit a retrieval id in the space left.
+        var idMarkerLanded = ToolResultText.ExtractText(reboundedWithId).Contains(marker, StringComparison.Ordinal);
+        return idMarkerLanded ? reboundedWithId : bounded;
     }
 
     /// <inheritdoc />
-    public bool TryApplyTextOutputPolicy(
+    public async ValueTask<TextOutputPolicyResult> TryApplyTextOutputPolicyAsync(
         ToolCallAdmission admission,
         string toolName,
         string? content,
-        out string? result,
-        out bool wasTruncated)
+        CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(admission);
+        cancellationToken.ThrowIfCancellationRequested();
 
-        // Every early return below leaves nothing to report; only the one branch that actually cuts
-        // overwrites this. Set once here so no future branch can forget it and silently answer "not
-        // truncated" — which is the exact failure this out-parameter exists to make impossible.
-        wasTruncated = false;
-
-        // #487: the same scan-cost pre-cut ApplyOutputPolicy applies, for the same reason — this is the
-        // method the plan step executor (a sandboxed tool's output, unbounded upstream) and the
+        // #487: the same scan-cost pre-cut ApplyOutputPolicyAsync applies, for the same reason — this is
+        // the method the plan step executor (a sandboxed tool's output, unbounded upstream) and the
         // Execution API both call, and neither used to bound scan cost on this side of the boundary.
         //
-        // A real marker is passed here too, not just at ApplyOutputPolicy's call site: this method DOES
-        // report a drop through wasTruncated below, but ToolUseStepExecutor.HandleSuccessAsync (the plan
-        // path) discards that out-parameter with `out _` and relies entirely on a marker embedded in
-        // the text — a premise that held before this PR (the final cut was the only cut, and it always
-        // left a marker when it fired) and stopped holding the moment this pre-cut could drop content
-        // with nothing to show for it whenever sanitizing/redacting then shrinks the survivor back under
-        // OutputCeiling. Caught by run-gates' correctness gate: the second caller of this same new
-        // primitive didn't get the fix #487's own security review already applied to the other one.
+        // An empty marker is passed here, unlike ApplyOutputPolicyAsync's use of the same primitive:
+        // this method reports a drop through the returned WasTruncated instead — droppedByPreCut is
+        // combined with the final cut's own flag below rather than embedding a marker twice.
         //
         // Ceiling captured once, not re-read at the pre-cut and again at the final cut below — see
-        // ApplyOutputPolicy's identical capture for why (run-gates' correctness gate, advisory).
+        // ApplyOutputPolicyAsync's identical capture for why (run-gates' correctness gate, advisory).
         var ceiling = OutputCeiling;
         var (preCut, droppedByPreCut) =
             ToolResultText.PreCutForScan(content, ceiling, ScrubOverlapMargin, OutputTruncationMarker);
 
-        // #479: sanitize unconditionally on both branches, the same guarantee ApplyOutputPolicy carries
-        // (#469) — this method used to sanitize only when a redaction was required, leaving the
+        // #479: sanitize unconditionally on both branches, the same guarantee ApplyOutputPolicyAsync
+        // carries (#469) — this method used to sanitize only when a redaction was required, leaving the
         // invariant enforced by caller discipline (both current callers ran their own unconditional
         // scrub immediately after) rather than by this interface itself.
         //
@@ -393,8 +450,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             {
                 // Non-redact branch: Sanitize's null-in/null-out guarantee (#490) means reaching here
                 // can only mean preCut was null — nothing to sanitize.
-                result = null;
-                return true;
+                return new TextOutputPolicyResult(Success: true, Result: null, WasTruncated: false);
             }
 
             // Fail closed, deliberately without asking whether preCut was itself null. A redact-required
@@ -409,26 +465,99 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 "Classification gate returned null when redacting output of {ToolName}; the result is "
                 + "withheld rather than returned unredacted.",
                 toolName);
-            result = null;
-            return false;
+            return new TextOutputPolicyResult(Success: false, Result: null, WasTruncated: false);
         }
 
-        // #532: bound after sanitize/redact — see ApplyOutputPolicy for why the order is fixed. This is
-        // the plan path's only cut. It is NOT the Execution API's only cut, and an earlier version of
-        // this comment claimed the API was "unaffected while its ceiling is no larger" — a
+        // #532: bound after sanitize/redact — see ApplyOutputPolicyAsync for why the order is fixed.
+        // This is the plan path's only cut. It is NOT the Execution API's only cut, and an earlier
+        // version of this comment claimed the API was "unaffected while its ceiling is no larger" — a
         // precondition that does not hold on shipped defaults (its 262,144 against this 50,000), so its
         // own before-and-after checks both saw an unchanged string while this step had already removed
         // most of the body. Rather than restore that assumption by aligning the two numbers, the cut
         // now reports itself and the caller ORs it into whatever truncation signal it publishes: a fact
         // that travels with the value cannot drift apart the way two independently-owned ceilings can.
         var (bounded, cutAfterProcessing) = BoundedText.Cap(processed, ceiling, OutputTruncationMarker);
-        result = bounded;
         // droppedByPreCut is carried forward, not discarded: content the pre-cut dropped can still
         // leave this final cut with nothing further to drop once sanitizing/redacting has shrunk what
         // remains — this cut's own flag alone would under-report what was actually lost (#487/#493,
         // the same reasoning DirectToolInvoker's now-retired ScrubAndBound used to carry by hand).
-        wasTruncated = droppedByPreCut || cutAfterProcessing;
-        return true;
+        var wasTruncated = droppedByPreCut || cutAfterProcessing;
+
+        if (!wasTruncated)
+            return new TextOutputPolicyResult(Success: true, Result: bounded, WasTruncated: false);
+
+        // #521: processed (not preCut) is spilled — sanitized/redacted, but not yet cut to ceiling. The
+        // id-carrying marker is longer than OutputTruncationMarker, so neither a post-hoc replace nor an
+        // unconditional append is safe here: cutAfterProcessing==true means processed is already known
+        // to exceed ceiling, but droppedByPreCut-only means processed is UNDER ceiling — Cap's normal
+        // "nothing to cut, marker not embedded" default would silently drop the id, since this branch
+        // (unlike ApplyOutputPolicyAsync's) already knows wasTruncated=true from a signal Cap itself
+        // never sees. alwaysEmbedMarker covers both: it only cuts as much of processed as is needed to
+        // make room for the marker, never more, and never lets the result exceed ceiling.
+        var marker = await SpillAndBuildMarkerAsync(toolName, processed).ConfigureAwait(false);
+        var (withId, _) = BoundedText.Cap(processed, ceiling, marker, alwaysEmbedMarker: true);
+        return new TextOutputPolicyResult(Success: true, Result: withId, WasTruncated: true);
+    }
+
+    /// <summary>
+    /// Spills <paramref name="fullTreatedText"/> — already sanitized/redacted for the MODEL-facing copy,
+    /// not yet cut to the tool-output ceiling — to <see cref="_resultStore"/> under this execution's
+    /// <see cref="IAgentExecutionContext.ToolResultScopeId"/>, and returns the marker to substitute for
+    /// the plain <see cref="OutputTruncationMarker"/>, carrying the resulting id so a later
+    /// <c>tool_result_fetch</c> call can retrieve the rest (#521).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The AT-REST copy is redacted with <see cref="RedactionCategories.All"/> regardless of
+    /// <see cref="ToolCallAdmission.RedactsOutput"/> — <paramref name="fullTreatedText"/> has only been
+    /// through <see cref="_sanitizer"/> (an injection scrubber, unconditional) on the plain-allow path;
+    /// <see cref="_redactionFilter"/> only ran if the classification gate demanded it. Persisting to
+    /// disk is a stronger exposure than showing the model its own tool's output, so this is not
+    /// optional the way the model-facing redaction decision is — matching the same
+    /// "redact immediately before persistence so secrets never land at rest" rule
+    /// <c>ToolOutputCompressionBehavior</c> already applies at its own persistence boundary. The
+    /// MODEL-facing text (already cut and marked by the caller) is never touched by this — a security
+    /// review found and closed a #521 residual gap: a plain-allow call was writing unredacted secrets
+    /// to disk on every truncation.
+    /// </para>
+    /// <para>
+    /// A store failure degrades to the plain marker rather than throwing out of a cut every caller of
+    /// this pipeline depends on completing — the same must-not-throw discipline this file applies
+    /// everywhere else. Always writes with <see cref="CancellationToken.None"/>, never the caller's own
+    /// token: the write finalizes output a tool call already produced, the same "already happened,
+    /// don't abandon it" reasoning <see cref="ReportExecutionAsync"/> applies to reporting.
+    /// </para>
+    /// <para>
+    /// If the text turns out to be at or under <c>PerResultCharLimit</c> once redaction has (rarely)
+    /// shrunk it, <see cref="_resultStore"/> answers with an inline reference and no file on disk — the
+    /// plain marker is returned instead of one naming an id nothing was ever written under, so a later
+    /// <c>tool_result_fetch</c> can never be told "not found" for a spill this call believed it made.
+    /// </para>
+    /// </remarks>
+    private async ValueTask<string> SpillAndBuildMarkerAsync(string toolName, string fullTreatedText)
+    {
+        try
+        {
+            var atRest = _redactionFilter.Redact(fullTreatedText, RedactionCategories.All);
+            var reference = await _resultStore
+                .StoreIfLargeAsync(
+                    _executionContext.ToolResultScopeId, toolName, operation: null, atRest,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (reference.FullContentPath is null)
+                return OutputTruncationMarker;
+
+            return string.Format(SpilledResultMarkerFormat, reference.ResultId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to spill truncated output of {ToolName} for later retrieval via tool_result_fetch; "
+                + "the result stays truncated with no retrieval id",
+                toolName);
+            return OutputTruncationMarker;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolResultText.cs
@@ -139,8 +139,15 @@ internal static class ToolResultText
     /// here and belongs to whatever budgets a whole turn (#522).
     /// </para>
     /// </remarks>
-    public static object? Bound(object? result, int ceiling, string marker) =>
-        BudgetedCut(result, ceiling, marker).Result;
+    /// <returns>
+    /// The (possibly cut) result, and whether anything was dropped — the caller's only signal that a
+    /// truncation happened, since (unlike <see cref="PreCutForScan(object?, int, int, string)"/>'s
+    /// caller) nothing else here reports it (#521: the pipeline's <c>object?</c>-shaped cut needed this
+    /// to decide whether to spill the full text for later retrieval; before, it had no truncation
+    /// signal of its own).
+    /// </returns>
+    public static (object? Result, bool Dropped) Bound(object? result, int ceiling, string marker) =>
+        BudgetedCut(result, ceiling, marker);
 
     /// <summary>
     /// Cuts the free text carried by <paramref name="result"/> to a scan-cost-bounded region — the total

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Mcp.cs
@@ -229,35 +229,39 @@ public sealed partial class DirectToolInvoker
             McpReportedBy).ConfigureAwait(false);
 
         sw.Stop();
-        return ShapeMcp(failureText, rawResult, request.ToolName, admissionPipeline, admission, config, sw.Elapsed);
+        return await ShapeMcpAsync(
+            failureText, rawResult, request.ToolName, admissionPipeline, admission, config, sw.Elapsed,
+            cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Reduces an MCP result to <see cref="ShapeText"/>'s shared shape — the MCP analogue of
-    /// <c>DirectToolInvoker.Response.cs</c>'s <c>Shape</c>, differing only in how the raw text is
+    /// Reduces an MCP result to <see cref="ShapeTextAsync"/>'s shared shape — the MCP analogue of
+    /// <c>DirectToolInvoker.Response.cs</c>'s <c>ShapeAsync</c>, differing only in how the raw text is
     /// obtained: a keyed-DI <c>ToolResult</c> already carries a string, an MCP result needs
     /// <see cref="ToolResultText.ExtractText"/> first.
     /// </summary>
-    private DirectToolInvocationOutcome ShapeMcp(
+    private Task<DirectToolInvocationOutcome> ShapeMcpAsync(
         string? failureText,
         object? rawResult,
         string toolName,
         IToolCallAdmissionPipeline admissionPipeline,
         ToolCallAdmission admission,
         DirectToolInvocationConfig config,
-        TimeSpan duration) =>
-        ShapeText(
+        TimeSpan duration,
+        CancellationToken cancellationToken) =>
+        ShapeTextAsync(
             failureText,
-            // ShapeText never reads successText on the failure branch, and ExtractText's own default
-            // case does a full JsonSerializer.Serialize of the raw result — not worth paying on every
-            // MCP failure just to build a value that gets thrown away.
+            // ShapeTextAsync never reads successText on the failure branch, and ExtractText's own
+            // default case does a full JsonSerializer.Serialize of the raw result — not worth paying on
+            // every MCP failure just to build a value that gets thrown away.
             failureText is null ? ToolResultText.ExtractText(rawResult) : string.Empty,
             toolName,
             admissionPipeline,
             admission,
             config.MaxOutputCharacters,
             duration,
-            _logger);
+            _logger,
+            cancellationToken);
 
     /// <summary>
     /// The result of MCP pre-flight: either a refusal to return as-is, or the resolved tool and caller

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
@@ -22,7 +22,7 @@ public sealed partial class DirectToolInvoker
 
     /// <summary>
     /// Redacts if the classification gate said to and sanitizes unconditionally — both now owned
-    /// entirely by <see cref="IToolCallAdmissionPipeline.TryApplyTextOutputPolicy"/> (#487/#489/#490),
+    /// entirely by <see cref="IToolCallAdmissionPipeline.TryApplyTextOutputPolicyAsync"/> (#487/#489/#490),
     /// which pre-cuts, sanitizes, redacts, and bounds to its own ceiling in one place — then applies
     /// this caller's own <paramref name="ceiling"/> on top, which may be stricter than the pipeline's.
     /// </summary>
@@ -45,7 +45,7 @@ public sealed partial class DirectToolInvoker
     /// does not reopen the unbounded-scan cost #487 fixed.
     /// </para>
     /// </remarks>
-    private static DirectToolInvocationOutcome ShapeText(
+    private static async Task<DirectToolInvocationOutcome> ShapeTextAsync(
         string? failureText,
         string successText,
         string toolName,
@@ -53,7 +53,8 @@ public sealed partial class DirectToolInvoker
         ToolCallAdmission admission,
         int ceiling,
         TimeSpan duration,
-        ILogger logger)
+        ILogger logger,
+        CancellationToken cancellationToken)
     {
         if (failureText is not null)
         {
@@ -62,8 +63,11 @@ public sealed partial class DirectToolInvoker
             // text (a connection string, a stack trace carrying an API key) exactly as easily as it
             // can succeed with it in its output — code review on the PR that added #479/#484's
             // guarantees to the success path caught that this branch never picked them up.
-            if (!admissionPipeline.TryApplyTextOutputPolicy(
-                    admission, toolName, failureText, out var admittedError, out _))
+            var errorPolicy = await admissionPipeline
+                .TryApplyTextOutputPolicyAsync(admission, toolName, failureText, cancellationToken)
+                .ConfigureAwait(false);
+            var admittedError = errorPolicy.Result;
+            if (!errorPolicy.Success)
             {
                 // #491: this Denied is not a governance refusal in the usual sense — the tool DID run
                 // and DID produce failure text; only the redaction of that text couldn't be applied.
@@ -95,8 +99,12 @@ public sealed partial class DirectToolInvoker
         // Fails closed: when a redaction was required and could not be applied, the chain returns
         // false and the original must be withheld rather than emitted. See the chain's own remarks
         // for why falling back to the raw content is the trap.
-        if (!admissionPipeline.TryApplyTextOutputPolicy(
-                admission, toolName, successText, out var admitted, out var truncatedByPipeline))
+        var successPolicy = await admissionPipeline
+            .TryApplyTextOutputPolicyAsync(admission, toolName, successText, cancellationToken)
+            .ConfigureAwait(false);
+        var admitted = successPolicy.Result;
+        var truncatedByPipeline = successPolicy.WasTruncated;
+        if (!successPolicy.Success)
         {
             // #491, same gap as the failure branch above and for the identical reason: the tool DID
             // run and DID succeed, with whatever side effects that entailed — only the redaction of its
@@ -125,13 +133,14 @@ public sealed partial class DirectToolInvoker
         };
     }
 
-    /// <summary>Reduces a keyed-DI <see cref="ToolResult"/> to <see cref="ShapeText"/>'s shared shape.</summary>
-    private DirectToolInvocationOutcome Shape(
+    /// <summary>Reduces a keyed-DI <see cref="ToolResult"/> to <see cref="ShapeTextAsync"/>'s shared shape.</summary>
+    private Task<DirectToolInvocationOutcome> ShapeAsync(
         ToolResult result,
         ArmedInvocation armed,
         ToolCallAdmission admission,
-        TimeSpan duration) =>
-        ShapeText(
+        TimeSpan duration,
+        CancellationToken cancellationToken) =>
+        ShapeTextAsync(
             result.Success ? null : result.Error ?? "The tool reported a failure.",
             result.Output ?? string.Empty,
             armed.ToolName,
@@ -139,5 +148,6 @@ public sealed partial class DirectToolInvoker
             admission,
             armed.Config.MaxOutputCharacters,
             duration,
-            _logger);
+            _logger,
+            cancellationToken);
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -221,7 +221,7 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
             .ConfigureAwait(false);
 
         sw.Stop();
-        return Shape(result, armed, admission, sw.Elapsed);
+        return await ShapeAsync(result, armed, admission, sw.Elapsed, cancellationToken).ConfigureAwait(false);
     }
 
     private const string ReportedBy = "direct-invocation";

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -142,7 +142,9 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
                 : new ToolExecutionReport(EscalationExecutionStatus.Failed, failureText, null, ToolName: Name),
             ReportedBy, CancellationToken.None).ConfigureAwait(false);
 
-        return admissionPipeline.ApplyOutputPolicy(admission, Name, Unwrap(result));
+        return await admissionPipeline
+            .ApplyOutputPolicyAsync(admission, Name, Unwrap(result), CancellationToken.None)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Context/FileSystemToolResultStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Context/FileSystemToolResultStore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.Context;
 using Domain.AI.Context;
 using Domain.Common.Config;
@@ -16,7 +15,6 @@ public sealed class FileSystemToolResultStore : IToolResultStore
 {
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly ILogger<FileSystemToolResultStore> _logger;
-    private readonly ConcurrentDictionary<string, string> _resultPaths = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FileSystemToolResultStore"/> class.
@@ -75,7 +73,6 @@ public sealed class FileSystemToolResultStore : IToolResultStore
         Directory.CreateDirectory(directory);
 
         await File.WriteAllTextAsync(storagePath, fullOutput, cancellationToken);
-        _resultPaths[resultId] = storagePath;
 
         var previewLength = Math.Min(config.PreviewSizeChars, fullOutput.Length);
         var preview = $"{fullOutput[..previewLength]}\n... [{fullOutput.Length} chars persisted to {resultId}]";
@@ -99,18 +96,66 @@ public sealed class FileSystemToolResultStore : IToolResultStore
     /// <inheritdoc />
     public async Task<string> RetrieveFullContentAsync(
         string resultId,
+        string scopeId,
         CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(resultId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scopeId);
 
-        if (!_resultPaths.TryGetValue(resultId, out var filePath))
+        // resultId is MODEL-SUPPLIED (ToolResultFetchTool passes the LLM's own 'resultId' argument
+        // straight through) and is interpolated into a path below, so it is sanitized here before it
+        // can become one. Sanitizing scopeId alone is not enough: Path.Combine performs no
+        // normalization, so "../../<other-scope>/tool-results/<id>" lands in ANOTHER scope's
+        // directory once the file APIs normalize it, and a ROOTED resultId ("C:/…", "\\\\host\\share\\…")
+        // makes Path.Combine discard every earlier segment outright — arbitrary *.json read, including
+        // appsettings.json and user-secrets' secrets.json, plus UNC egress on Windows.
+        //
+        // Validated by SHAPE rather than by stripping separators: StoreIfLargeAsync mints ids as, and
+        // only as, Guid.NewGuid().ToString("N"), so accepting exactly that alphabet is the complete
+        // enumeration of what can legitimately be asked for — a rejection here can never refuse a real
+        // id. A malformed id is refused as KeyNotFoundException, with the same message shape as a
+        // genuine miss, for the same reason a wrong scope is: nothing about the outcome may tell a
+        // caller which of its guesses was better-formed than another.
+        if (!Guid.TryParseExact(resultId, "N", out _))
         {
             throw new KeyNotFoundException($"No stored result found for id '{resultId}'.");
         }
 
-        _logger.LogDebug("Retrieving full content for result {ResultId} from {Path}", resultId, filePath);
+        // Reconstructed deterministically from (scopeId, resultId) — the exact shape StoreIfLargeAsync
+        // writes to — rather than trusted from _resultPaths, for two reasons at once (#521):
+        //   1. Ownership: a caller supplying a DIFFERENT scopeId than the one this result was stored
+        //      under can never reach it, because the reconstructed path simply lands in that OTHER
+        //      caller's own directory, which does not contain this resultId's file. No separate
+        //      "does scopeId match what I recorded" check is needed or possible to skip.
+        //   2. Durability: _resultPaths is in-memory only and empties on every process restart, even
+        //      though the file itself is still on disk — reconstructing the path means a restart no
+        //      longer makes an already-spilled result unrecoverable.
+        // SanitizeSessionSegment applies to scopeId for the identical path-traversal reason it already
+        // applies to StoreIfLargeAsync's sessionId — this is the same path segment, read back.
+        // Residual gap accepted (found in /simplify's review): reconstructing from CurrentValue rather
+        // than a path captured at write time means a same-process hot reload of StoragePath between a
+        // spill and its retrieval would point this read at a different root than the write used. Not
+        // fixed — StoragePath is not a value anyone realistically hot-reloads mid-process.
+        var safeScopeId = SanitizeSessionSegment(scopeId);
+        var config = _options.CurrentValue.AI.ContextManagement.ToolResultStorage;
+        var storagePath = Path.Combine(config.StoragePath, safeScopeId, "tool-results", $"{resultId}.json");
 
-        return await File.ReadAllTextAsync(filePath, cancellationToken);
+        _logger.LogDebug("Retrieving full content for result {ResultId} from {Path}", resultId, storagePath);
+
+        try
+        {
+            return await File.ReadAllTextAsync(storagePath, cancellationToken);
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // One filesystem round-trip instead of File.Exists + ReadAllTextAsync (a /simplify
+            // efficiency finding) — this also closes the check-then-read race the two-call version had
+            // (the file could vanish between the check and the read). Deliberately the same exception,
+            // with the same message shape, whether resultId was never stored at all or was stored under
+            // a DIFFERENT scope — see the interface's own remarks on why "exists but not yours" must
+            // read identically to "does not exist".
+            throw new KeyNotFoundException($"No stored result found for id '{resultId}'.");
+        }
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Context/FileSystemToolResultStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Context/FileSystemToolResultStore.cs
@@ -44,7 +44,7 @@ public sealed class FileSystemToolResultStore : IToolResultStore
         // H-1: sessionId must be a single safe path segment. Path.GetFileName equality
         // alone is insufficient — it lets "." and ".." through (GetFileName(("..")) == "..")
         // which Path.Combine then resolves to a parent directory, escaping the storage root.
-        var safeSessionId = SanitizeSessionSegment(sessionId);
+        var safeSessionId = SanitizeSessionSegment(sessionId, nameof(sessionId));
 
         var config = _options.CurrentValue.AI.ContextManagement.ToolResultStorage;
         var resultId = Guid.NewGuid().ToString("N");
@@ -136,7 +136,7 @@ public sealed class FileSystemToolResultStore : IToolResultStore
         // than a path captured at write time means a same-process hot reload of StoragePath between a
         // spill and its retrieval would point this read at a different root than the write used. Not
         // fixed — StoragePath is not a value anyone realistically hot-reloads mid-process.
-        var safeScopeId = SanitizeSessionSegment(scopeId);
+        var safeScopeId = SanitizeSessionSegment(scopeId, nameof(scopeId));
         var config = _options.CurrentValue.AI.ContextManagement.ToolResultStorage;
         var storagePath = Path.Combine(config.StoragePath, safeScopeId, "tool-results", $"{resultId}.json");
 
@@ -164,12 +164,18 @@ public sealed class FileSystemToolResultStore : IToolResultStore
     /// the storage root via path traversal.
     /// </summary>
     /// <param name="sessionId">The caller-supplied session identifier.</param>
+    /// <param name="paramName">
+    /// The CALLING method's own parameter name to report in a thrown <see cref="ArgumentException"/> —
+    /// this helper is shared by <see cref="StoreIfLargeAsync"/> (parameter <c>sessionId</c>) and
+    /// <see cref="RetrieveFullContentAsync"/> (parameter <c>scopeId</c>); a hardcoded <c>nameof(sessionId)</c>
+    /// would misreport the latter (a /code-review finding).
+    /// </param>
     /// <returns>The validated session identifier, guaranteed to be a single path segment.</returns>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="sessionId"/> contains path separators, is rooted, or is a
-    /// relative directory reference ("." or "..").
+    /// Thrown when <paramref name="sessionId"/> contains path separators, is rooted, is a relative
+    /// directory reference ("." or ".."), or has trailing dots/spaces Windows would silently strip.
     /// </exception>
-    private static string SanitizeSessionSegment(string sessionId)
+    private static string SanitizeSessionSegment(string sessionId, string paramName)
     {
         // Reject any path separator from EITHER platform, a rooted path, or a relative
         // directory reference. Path.GetFileName / Path.IsPathRooted are OS-specific — on
@@ -179,14 +185,24 @@ public sealed class FileSystemToolResultStore : IToolResultStore
         if (sessionId.Contains('/') || sessionId.Contains('\\') || Path.IsPathRooted(sessionId))
         {
             throw new ArgumentException(
-                "Session ID must be a single path segment without separators.", nameof(sessionId));
+                "Session ID must be a single path segment without separators.", paramName);
         }
 
         // "." and ".." resolve to the storage root or a parent when combined, so reject them.
         if (sessionId is "." or "..")
         {
             throw new ArgumentException(
-                "Session ID must not be a relative directory reference.", nameof(sessionId));
+                "Session ID must not be a relative directory reference.", paramName);
+        }
+
+        // Windows silently trims trailing dots/spaces off a path segment, so "<id>" and "<id> " (or
+        // "<id>.") resolve to the SAME directory there even though they compare unequal as strings —
+        // two different scopes could collide onto one storage directory (a security-review finding).
+        // Comparing against the OS-trimmed form works identically, and harmlessly, on every platform.
+        if (sessionId != sessionId.TrimEnd(' ', '.'))
+        {
+            throw new ArgumentException(
+                "Session ID must not have trailing dots or spaces.", paramName);
         }
 
         return sessionId;

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -97,15 +97,17 @@ public static partial class DependencyInjection
         services.AddKeyedSingleton<ITool>(EchoLookupTool.ToolName, (_, _) => new EchoLookupTool());
         services.AddKeyedSingleton<ITool>(EchoCalculateTool.ToolName, (_, _) => new EchoCalculateTool());
 
-        // Tool-result retrieval (#521) — Scoped, not Singleton like the tools above. This one depends
-        // on IAgentExecutionContext, itself Scoped, to read the CALLING request's own scope id back —
-        // not to spawn an independent unit of work the way DocumentIngestTool's IServiceScopeFactory
-        // does above. A Singleton registration would capture whichever caller's scope resolved it
-        // first and leak that scope to every later caller; see ToolResultFetchTool's own remarks.
-        services.AddKeyedScoped<ITool>(ToolResultFetchTool.ToolName, (sp, _) =>
+        // Tool-result retrieval (#521) — Singleton, like every other keyed tool above. Every production
+        // caller resolves a keyed ITool by name from a singleton holding the ROOT provider
+        // (ToolChainBuilder.ResolveToolByName, FirstPartyToolLookup.Resolve), so there is no per-request
+        // scope at resolution time to register INTO — an earlier AddKeyedScoped registration threw
+        // InvalidOperationException on every turn of every skill that lists this tool (caught by the
+        // correctness gate). The request-scoped IAgentExecutionContext it needs is resolved per
+        // invocation from IAmbientRequestScope.Current instead — see ToolResultFetchTool's own remarks.
+        services.AddKeyedSingleton<ITool>(ToolResultFetchTool.ToolName, (sp, _) =>
             new ToolResultFetchTool(
                 sp.GetRequiredService<Application.AI.Common.Interfaces.Context.IToolResultStore>(),
-                sp.GetRequiredService<Application.AI.Common.Interfaces.Agent.IAgentExecutionContext>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>(),
                 sp.GetRequiredService<ILogger<ToolResultFetchTool>>()));
 
         // Delegation tool — lets a skill hand a self-contained subtask to the capability-matching

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -97,6 +97,17 @@ public static partial class DependencyInjection
         services.AddKeyedSingleton<ITool>(EchoLookupTool.ToolName, (_, _) => new EchoLookupTool());
         services.AddKeyedSingleton<ITool>(EchoCalculateTool.ToolName, (_, _) => new EchoCalculateTool());
 
+        // Tool-result retrieval (#521) — Scoped, not Singleton like the tools above. This one depends
+        // on IAgentExecutionContext, itself Scoped, to read the CALLING request's own scope id back —
+        // not to spawn an independent unit of work the way DocumentIngestTool's IServiceScopeFactory
+        // does above. A Singleton registration would capture whichever caller's scope resolved it
+        // first and leak that scope to every later caller; see ToolResultFetchTool's own remarks.
+        services.AddKeyedScoped<ITool>(ToolResultFetchTool.ToolName, (sp, _) =>
+            new ToolResultFetchTool(
+                sp.GetRequiredService<Application.AI.Common.Interfaces.Context.IToolResultStore>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.Agent.IAgentExecutionContext>(),
+                sp.GetRequiredService<ILogger<ToolResultFetchTool>>()));
+
         // Delegation tool — lets a skill hand a self-contained subtask to the capability-matching
         // supervisor, which selects, runs, and governs (autonomy tiers, depth limits, audit) a
         // best-fit subagent. Opt-in per skill via SKILL.md allowed-tools.

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -110,7 +110,7 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
             sandboxResult.Attestation?.Signature, ct);
 
         return sandboxResult.Success
-            ? await HandleSuccessAsync(admission, config, sandboxResult, sw)
+            ? await HandleSuccessAsync(admission, config, sandboxResult, sw, ct)
             : await HandleFailureAsync(admission, config, step, sandboxResult, sw);
     }
 
@@ -224,7 +224,8 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
 
     /// <summary>Shapes a successful sandbox result into the step's completed (or policy-denied) outcome.</summary>
     private async Task<StepExecutionResult> HandleSuccessAsync(
-        ToolCallAdmission admission, ToolUseConfig config, SandboxExecutionResult sandboxResult, Stopwatch sw)
+        ToolCallAdmission admission, ToolUseConfig config, SandboxExecutionResult sandboxResult, Stopwatch sw,
+        CancellationToken ct)
     {
         // Admission is not finished when the tool returns: a classified asset can be allowed through
         // and have its output scrubbed instead of being refused outright. Skipping this would leave
@@ -238,8 +239,11 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         // step result has no truncation field to publish it on. The marker the cut leaves in the text
         // is what a later step or a reader sees. If StepExecutionResult ever gains such a field, this
         // is the value it takes.
-        if (!_admissionPipeline.TryApplyTextOutputPolicy(
-                admission, config.ToolName, sandboxResult.Output, out var content, out _))
+        var textPolicy = await _admissionPipeline
+            .TryApplyTextOutputPolicyAsync(admission, config.ToolName, sandboxResult.Output, ct)
+            .ConfigureAwait(false);
+        var content = textPolicy.Result;
+        if (!textPolicy.Success)
         {
             await ReportExecutionAsync(
                 admission, EscalationExecutionStatus.Failed, GovernanceDenials.NotPermitted(config.ToolName),

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/ToolResultFetchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/ToolResultFetchTool.cs
@@ -86,8 +86,9 @@ public sealed class ToolResultFetchTool : ITool
 
     /// <inheritdoc />
     public string Description =>
-        "Retrieves the full text of a tool result that was truncated. Use the id given in the " +
-        $"\"{string.Format(Application.AI.Common.Services.Governance.ToolCallAdmissionPipeline.SpilledResultMarkerFormat, "...").Trim()}\" marker.";
+        "Retrieves the full text of a tool result that was truncated. Pass the id from the " +
+        $"\"{string.Format(Application.AI.Common.Services.Governance.ToolCallAdmissionPipeline.SpilledResultMarkerFormat, "...").Trim()}\" " +
+        "marker as the 'resultId' parameter.";
 
     /// <inheritdoc />
     public IReadOnlyList<string> SupportedOperations => Operations;
@@ -149,7 +150,8 @@ public sealed class ToolResultFetchTool : ITool
             // why "wrong scope" and "never existed" must be indistinguishable from outside the store.
             return ToolResult.Fail($"No stored result found for id '{resultId}'.");
         }
-        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException
+            or NotSupportedException or System.Security.SecurityException)
         {
             // A security review of #521 found these could otherwise escape ExecuteAsync as raw
             // exceptions — AIToolConverter invokes tools with no surrounding try/catch. The write side

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/ToolResultFetchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/ToolResultFetchTool.cs
@@ -1,0 +1,132 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Changes;
+using Domain.AI.Models;
+using Domain.AI.Sandbox;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Retrieves the full text of a tool result that was truncated and spilled to
+/// <see cref="IToolResultStore"/> (#521) — the model's way to ask for the rest of a result it was
+/// only shown a cut-down version of.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>The retrieval scope comes from this instance's own <see cref="IAgentExecutionContext"/>,
+/// never from a caller-supplied parameter.</strong> A model-facing <c>resultId</c> is the only
+/// argument this tool accepts; widening that to also accept a scope id would let the model simply
+/// state whose data it wants to read, defeating the isolation boundary <see cref="IToolResultStore"/>
+/// enforces. Registered <c>Scoped</c>, not <c>Singleton</c> like most keyed tools — this type's
+/// dependency on the request-scoped <see cref="IAgentExecutionContext"/> means a singleton
+/// registration would capture whichever caller's scope happened to resolve it first and leak that
+/// scope to every later caller (a captive-dependency bug, not a mere inconsistency with the other
+/// tools' registration style).
+/// </para>
+/// <para>
+/// <strong>Deliberately not <see cref="ITool.IsDirectlyInvocable"/>.</strong> Direct HTTP invocation
+/// mints a fresh <see cref="IAgentExecutionContext.ToolResultScopeId"/> for every single call (see
+/// that property's remarks) — a result spilled during one direct invocation can never be fetched by a
+/// later, unrelated one, because their scopes never match. That is not a bug on this tool's part; it
+/// is the correct consequence of direct-invoke having no session for "later" to mean anything within.
+/// Removing this tool from that surface avoids offering a call that can only ever answer "not found".
+/// </para>
+/// <para>
+/// A fetched result is routed through the normal <c>ToolResult.Ok</c> return, so it flows back through
+/// the same admission pipeline as any other tool result — the same size threshold applies, and a
+/// result still too large to fit spills again under a fresh id, exactly like any other tool's output.
+/// </para>
+/// </remarks>
+public sealed class ToolResultFetchTool : ITool
+{
+    public const string ToolName = "tool_result_fetch";
+
+    private static readonly IReadOnlyList<string> Operations = ["fetch"];
+
+    private readonly IToolResultStore _resultStore;
+    private readonly IAgentExecutionContext _executionContext;
+    private readonly ILogger<ToolResultFetchTool> _logger;
+
+    public ToolResultFetchTool(
+        IToolResultStore resultStore,
+        IAgentExecutionContext executionContext,
+        ILogger<ToolResultFetchTool> logger)
+    {
+        ArgumentNullException.ThrowIfNull(resultStore);
+        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(logger);
+        _resultStore = resultStore;
+        _executionContext = executionContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public string Name => ToolName;
+
+    /// <inheritdoc />
+    public string Description =>
+        "Retrieves the full text of a tool result that was truncated. Use the id given in the " +
+        $"\"{string.Format(Application.AI.Common.Services.Governance.ToolCallAdmissionPipeline.SpilledResultMarkerFormat, "...").Trim()}\" marker.";
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> SupportedOperations => Operations;
+
+    /// <inheritdoc />
+    public bool IsReadOnly => true;
+
+    /// <inheritdoc />
+    public bool IsConcurrencySafe => true;
+
+    /// <inheritdoc />
+    public bool IsDirectlyInvocable => false;
+
+    /// <inheritdoc />
+    public BlastRadius RiskTier => BlastRadius.Trivial;
+
+    /// <summary>
+    /// The shipped <see cref="IToolResultStore"/> implementation is <c>FileSystemToolResultStore</c> —
+    /// a spilled result is read back from disk, so <see cref="ToolCapability.FileRead"/> is the honest
+    /// declaration rather than <see cref="ToolCapability.None"/> (Infrastructure.AI.Governance.Tests'
+    /// <c>AllToolsCapabilityCoverageTests</c> fails a new tool that leaves this undeclared).
+    /// </summary>
+    public ToolCapability RequiredCapabilities => ToolCapability.FileRead;
+
+    /// <inheritdoc />
+    public async Task<ToolResult> ExecuteAsync(
+        string operation,
+        IReadOnlyDictionary<string, object?> parameters,
+        CancellationToken cancellationToken = default)
+    {
+        if (!parameters.TryGetValue("resultId", out var raw)
+            || raw is not string resultId
+            || string.IsNullOrWhiteSpace(resultId))
+        {
+            return ToolResult.Fail("A non-empty 'resultId' parameter is required.");
+        }
+
+        try
+        {
+            var content = await _resultStore
+                .RetrieveFullContentAsync(resultId, _executionContext.ToolResultScopeId, cancellationToken)
+                .ConfigureAwait(false);
+            return ToolResult.Ok(content);
+        }
+        catch (KeyNotFoundException)
+        {
+            // Deliberately generic — see IToolResultStore.RetrieveFullContentAsync's own remarks for
+            // why "wrong scope" and "never existed" must be indistinguishable from outside the store.
+            return ToolResult.Fail($"No stored result found for id '{resultId}'.");
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or UnauthorizedAccessException)
+        {
+            // A security review of #521 found these could otherwise escape ExecuteAsync as raw
+            // exceptions — AIToolConverter invokes tools with no surrounding try/catch. The write side
+            // (SpillAndBuildMarkerAsync) already degrades store failures instead of throwing; the read
+            // side must give the same guarantee rather than letting a disk error fault the whole turn.
+            _logger.LogWarning(ex, "Failed to retrieve tool result {ResultId}", resultId);
+            return ToolResult.Fail($"No stored result found for id '{resultId}'.");
+        }
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/ToolResultFetchTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/ToolResultFetchTool.cs
@@ -1,9 +1,11 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.AI.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Tools;
@@ -15,15 +17,30 @@ namespace Infrastructure.AI.Tools;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>The retrieval scope comes from this instance's own <see cref="IAgentExecutionContext"/>,
-/// never from a caller-supplied parameter.</strong> A model-facing <c>resultId</c> is the only
-/// argument this tool accepts; widening that to also accept a scope id would let the model simply
-/// state whose data it wants to read, defeating the isolation boundary <see cref="IToolResultStore"/>
-/// enforces. Registered <c>Scoped</c>, not <c>Singleton</c> like most keyed tools — this type's
-/// dependency on the request-scoped <see cref="IAgentExecutionContext"/> means a singleton
-/// registration would capture whichever caller's scope happened to resolve it first and leak that
-/// scope to every later caller (a captive-dependency bug, not a mere inconsistency with the other
-/// tools' registration style).
+/// <strong>The retrieval scope comes from the CALLING request's own <see cref="IAgentExecutionContext"/>,
+/// resolved per invocation, never from a caller-supplied parameter.</strong> A model-facing
+/// <c>resultId</c> is the only argument this tool accepts; widening that to also accept a scope id
+/// would let the model simply state whose data it wants to read, defeating the isolation boundary
+/// <see cref="IToolResultStore"/> enforces.
+/// </para>
+/// <para>
+/// <strong>Registered <c>Singleton</c>, like every other keyed tool — NOT <c>Scoped</c>.</strong> An
+/// earlier version of this type constructor-injected <see cref="IAgentExecutionContext"/> directly and
+/// was registered <c>AddKeyedScoped</c> specifically to avoid a captive-dependency leak. That reasoning
+/// was correct but the mechanism was wrong for this codebase: every production caller resolves a keyed
+/// <see cref="ITool"/> by name from a SINGLETON holding the ROOT service provider
+/// (<c>ToolChainBuilder.ResolveToolByName</c>, <c>FirstPartyToolLookup.Resolve</c>) — there is no
+/// per-request scope at resolution time to be scoped INTO. Every host enables
+/// <c>ServiceProviderOptions.ValidateScopes</c>, so a scoped registration doesn't leak state across
+/// callers the way a naive singleton constructor-injecting a scoped service would — it fails LOUDLY,
+/// with <see cref="InvalidOperationException"/>, on every turn of every skill that lists this tool
+/// (caught by this repo's own <c>correctness</c> gate before this shipped). The fix is the same pattern
+/// already used throughout this codebase for a long-lived singleton that needs a per-request, scoped
+/// service (see <see cref="IAmbientRequestScope"/>'s own remarks, and its dozen-plus other consumers):
+/// resolve <see cref="IAgentExecutionContext"/> from <see cref="IAmbientRequestScope.Current"/> AT
+/// EXECUTION TIME, inside <see cref="ExecuteAsync"/>, never at construction. <see cref="IToolResultStore"/>
+/// itself stays constructor-injected directly — it is registered singleton, so singleton-into-singleton
+/// is safe and needs no ambient indirection.
 /// </para>
 /// <para>
 /// <strong>Deliberately not <see cref="ITool.IsDirectlyInvocable"/>.</strong> Direct HTTP invocation
@@ -32,6 +49,8 @@ namespace Infrastructure.AI.Tools;
 /// later, unrelated one, because their scopes never match. That is not a bug on this tool's part; it
 /// is the correct consequence of direct-invoke having no session for "later" to mean anything within.
 /// Removing this tool from that surface avoids offering a call that can only ever answer "not found".
+/// Direct invocation also does not run inside the MediatR pipeline that establishes the ambient request
+/// scope, so <see cref="IAmbientRequestScope.Current"/> would be null there regardless.
 /// </para>
 /// <para>
 /// A fetched result is routed through the normal <c>ToolResult.Ok</c> return, so it flows back through
@@ -46,19 +65,19 @@ public sealed class ToolResultFetchTool : ITool
     private static readonly IReadOnlyList<string> Operations = ["fetch"];
 
     private readonly IToolResultStore _resultStore;
-    private readonly IAgentExecutionContext _executionContext;
+    private readonly IAmbientRequestScope _ambientScope;
     private readonly ILogger<ToolResultFetchTool> _logger;
 
     public ToolResultFetchTool(
         IToolResultStore resultStore,
-        IAgentExecutionContext executionContext,
+        IAmbientRequestScope ambientScope,
         ILogger<ToolResultFetchTool> logger)
     {
         ArgumentNullException.ThrowIfNull(resultStore);
-        ArgumentNullException.ThrowIfNull(executionContext);
+        ArgumentNullException.ThrowIfNull(ambientScope);
         ArgumentNullException.ThrowIfNull(logger);
         _resultStore = resultStore;
-        _executionContext = executionContext;
+        _ambientScope = ambientScope;
         _logger = logger;
     }
 
@@ -106,10 +125,21 @@ public sealed class ToolResultFetchTool : ITool
             return ToolResult.Fail("A non-empty 'resultId' parameter is required.");
         }
 
+        // Resolved here, not at construction — this instance is a process-lifetime singleton and the
+        // execution context is scoped to the calling request. See this type's own remarks for why.
+        var executionContext = _ambientScope.Current?.GetService<IAgentExecutionContext>();
+        if (executionContext is null)
+        {
+            _logger.LogWarning(
+                "tool_result_fetch invoked with no ambient request scope established; cannot resolve " +
+                "the calling request's own retrieval scope.");
+            return ToolResult.Fail("Unable to retrieve stored results outside an active agent turn.");
+        }
+
         try
         {
             var content = await _resultStore
-                .RetrieveFullContentAsync(resultId, _executionContext.ToolResultScopeId, cancellationToken)
+                .RetrieveFullContentAsync(resultId, executionContext.ToolResultScopeId, cancellationToken)
                 .ConfigureAwait(false);
             return ToolResult.Ok(content);
         }

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/Support/TestHelpers.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/Changes/Support/TestHelpers.cs
@@ -193,7 +193,10 @@ internal static class TestHelpers
         public string? ConversationId { get; private set; }
         public int? TurnNumber { get; private set; }
         public string? CallOnceScopeId { get; private set; }
+        public string ToolResultScopeId => CallOnceScopeId ?? _fallbackToolResultScopeId;
         public AgentIdentity? AgentIdentity { get; private set; }
+
+        private readonly string _fallbackToolResultScopeId = Guid.NewGuid().ToString("N");
 
         public void Initialize(string agentId, string conversationId, int turnNumber, string? callOnceScopeId = null)
         {

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/AdmissionHarness.cs
@@ -1,8 +1,11 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Context;
 using Domain.AI.Governance;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
@@ -34,7 +37,10 @@ internal static class AdmissionHarness
         ICallOnceGate? callOnceGate = null,
         IGovernanceTraceRecorder? trace = null,
         ICompositeResponseSanitizer? sanitizer = null,
-        int? outputCeiling = null) =>
+        IContentRedactionFilter? redactionFilter = null,
+        int? outputCeiling = null,
+        IAgentExecutionContext? executionContext = null,
+        IToolResultStore? resultStore = null) =>
         new(authorizationGate ?? PermissiveAuthorizationGate(),
             governor ?? PermissiveGovernor(),
             classificationGate ?? PermissiveClassificationGate(),
@@ -44,9 +50,74 @@ internal static class AdmissionHarness
             trace ?? TraceRecorder(),
             Mock.Of<IApprovalExecutionReporter>(),
             sanitizer ?? PermissiveSanitizer(),
-            PermissiveRedactionFilter(),
+            redactionFilter ?? PermissiveRedactionFilter(),
             Config(outputCeiling),
-            NullLogger<ToolCallAdmissionPipeline>.Instance);
+            NullLogger<ToolCallAdmissionPipeline>.Instance,
+            executionContext ?? StubExecutionContext(),
+            resultStore ?? StubResultStore());
+
+    /// <summary>
+    /// An execution context with a stable, non-null <see cref="IAgentExecutionContext.ToolResultScopeId"/>
+    /// (#521) — what a test needs to exercise the spill path deterministically, since the real
+    /// implementation's fallback is a fresh GUID per instance and a test asserting round-trip spill/
+    /// retrieve behavior needs the SAME scope on both sides of that round trip.
+    /// </summary>
+    public static IAgentExecutionContext StubExecutionContext(string toolResultScopeId = "test-scope") =>
+        Mock.Of<IAgentExecutionContext>(c => c.ToolResultScopeId == toolResultScopeId);
+
+    /// <summary>
+    /// A result store that answers every store request as if the result were small enough to keep
+    /// inline (#521) — the permissive default for a test that isn't specifically exercising spill
+    /// behavior. A test that IS should build its own mock or pass a real
+    /// <c>FileSystemToolResultStore</c> pointed at a temp directory.
+    /// </summary>
+    public static IToolResultStore StubResultStore()
+    {
+        var store = new Mock<IToolResultStore>();
+        store
+            .Setup(s => s.StoreIfLargeAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string toolName, string? operation, string fullOutput, CancellationToken _) =>
+                new ToolResultReference
+                {
+                    ResultId = Guid.NewGuid().ToString("N"),
+                    ToolName = toolName,
+                    Operation = operation,
+                    PreviewContent = fullOutput,
+                    FullContentPath = null,
+                    SizeChars = fullOutput.Length,
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+        return store.Object;
+    }
+
+    /// <summary>
+    /// A result store that answers every store request as if the result were actually persisted to
+    /// disk (#521) — for a test that IS exercising spill behavior specifically, where
+    /// <see cref="StubResultStore"/>'s "always inline" default would make the pipeline correctly
+    /// decline to embed a retrieval id for a spill that never really happened.
+    /// </summary>
+    public static IToolResultStore PersistedResultStore()
+    {
+        var store = new Mock<IToolResultStore>();
+        store
+            .Setup(s => s.StoreIfLargeAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string scopeId, string toolName, string? operation, string fullOutput, CancellationToken _) =>
+                new ToolResultReference
+                {
+                    ResultId = Guid.NewGuid().ToString("N"),
+                    ToolName = toolName,
+                    Operation = operation,
+                    PreviewContent = fullOutput[..Math.Min(20, fullOutput.Length)],
+                    FullContentPath = $"/fake/{scopeId}/tool-results/persisted.json",
+                    SizeChars = fullOutput.Length,
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+        return store.Object;
+    }
 
     /// <summary>
     /// Config carrying the tool-output ceiling (#532), defaulting to the shipped

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionClassificationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionClassificationTests.cs
@@ -17,7 +17,7 @@ namespace Application.AI.Common.Tests.Governance;
 /// <remarks>
 /// The redact case is the reason admission is not purely a pre-call decision: the verdict has to
 /// survive the tool call and be applied to its output. That second half lives on the chain
-/// (<see cref="IToolCallAdmissionPipeline.ApplyOutputPolicy"/>) rather than at each caller, so a caller
+/// (<see cref="IToolCallAdmissionPipeline.ApplyOutputPolicyAsync"/>) rather than at each caller, so a caller
 /// can neither hold the gate itself nor forget to consult it.
 /// </remarks>
 public sealed class GovernedAIFunctionClassificationTests

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GovernedAIFunctionTests.cs
@@ -97,8 +97,9 @@ public sealed class GovernedAIFunctionTests
             .Callback<ToolCallAdmissionRequest, CancellationToken>((r, _) => seen = r)
             .Returns(ValueTask.FromResult(ToolCallAdmission.Allow()));
         pipeline
-            .Setup(p => p.ApplyOutputPolicy(It.IsAny<ToolCallAdmission>(), It.IsAny<string>(), It.IsAny<object?>()))
-            .Returns<ToolCallAdmission, string, object?>((_, _, result) => result);
+            .Setup(p => p.ApplyOutputPolicyAsync(
+                It.IsAny<ToolCallAdmission>(), It.IsAny<string>(), It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Returns<ToolCallAdmission, string, object?, CancellationToken>((_, _, result, _) => ValueTask.FromResult(result));
 
         await InvokeUnder(pipeline.Object, inner);
 
@@ -119,8 +120,9 @@ public sealed class GovernedAIFunctionTests
             .Setup(p => p.AdmitAsync(It.IsAny<ToolCallAdmissionRequest>(), It.IsAny<CancellationToken>()))
             .Returns(ValueTask.FromResult(ToolCallAdmission.Allow().WithApproval(call)));
         pipeline
-            .Setup(p => p.ApplyOutputPolicy(It.IsAny<ToolCallAdmission>(), It.IsAny<string>(), It.IsAny<object?>()))
-            .Returns<ToolCallAdmission, string, object?>((_, _, result) => result);
+            .Setup(p => p.ApplyOutputPolicyAsync(
+                It.IsAny<ToolCallAdmission>(), It.IsAny<string>(), It.IsAny<object?>(), It.IsAny<CancellationToken>()))
+            .Returns<ToolCallAdmission, string, object?, CancellationToken>((_, _, result, _) => ValueTask.FromResult(result));
         return pipeline;
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -1,9 +1,11 @@
 using System.Text.RegularExpressions;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Changes;
+using Domain.AI.Context;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Microsoft.Extensions.AI;
@@ -261,11 +263,12 @@ public sealed class ToolCallAdmissionPipelineTests
 
         admission.IsAllowed.Should().BeTrue("a redact verdict lets the call run — it scrubs the answer");
         admission.RedactsOutput.Should().BeTrue();
-        pipeline.ApplyOutputPolicy(admission, Tool, "secret").Should().Be("[redacted]");
+        (await pipeline.ApplyOutputPolicyAsync(admission, Tool, "secret", CancellationToken.None))
+            .Should().Be("[redacted]");
     }
 
     [Fact]
-    public void ApplyOutputPolicy_PlainAllow_SanitizesTheResultWithoutCallingTheClassificationGate()
+    public async Task ApplyOutputPolicy_PlainAllow_SanitizesTheResultWithoutCallingTheClassificationGate()
     {
         // #469: a plain allow never consults the classification gate — the sanitizer is the only
         // guarantee a plain-allow result gets. A transforming sanitizer (not the permissive no-op) is
@@ -275,7 +278,7 @@ public sealed class ToolCallAdmissionPipelineTests
             classificationGate: gate.Object,
             sanitizer: AdmissionHarness.SubstitutingSanitizer("secret", "[SCRUBBED]"));
 
-        pipeline.ApplyOutputPolicy(ToolCallAdmission.Allow(), Tool, "a secret value")
+        (await pipeline.ApplyOutputPolicyAsync(ToolCallAdmission.Allow(), Tool, "a secret value", CancellationToken.None))
             .Should().Be("a [SCRUBBED] value");
 
         gate.Verify(g => g.RedactResult(It.IsAny<string>(), It.IsAny<object?>()), Times.Never);
@@ -283,43 +286,44 @@ public sealed class ToolCallAdmissionPipelineTests
 
     // Shape-preservation across every result type (string, JsonElement, TextContent, AIContent[],
     // structured) is covered exhaustively by ToolResultTextTests — this class only needs to prove
-    // ApplyOutputPolicy routes a plain allow to the sanitizer rather than the classification gate.
+    // ApplyOutputPolicyAsync routes a plain allow to the sanitizer rather than the classification gate.
 
     [Fact]
-    public void TryApplyTextOutputPolicy_PlainAllow_SanitizesTheResult()
+    public async Task TryApplyTextOutputPolicy_PlainAllow_SanitizesTheResult()
     {
         // #479: before this fix, the plain-allow branch was a pure passthrough — the string-shaped
-        // sibling of ApplyOutputPolicy did NOT carry the same unconditional-sanitize guarantee #469 gave
-        // its object-shaped twin. Both current callers papered over the gap with their own duplicate
-        // scrub; this proves the guarantee now lives on the interface method itself.
+        // sibling of ApplyOutputPolicyAsync did NOT carry the same unconditional-sanitize guarantee
+        // #469 gave its object-shaped twin. Both current callers papered over the gap with their own
+        // duplicate scrub; this proves the guarantee now lives on the interface method itself.
         var gate = new Mock<IToolClassificationGate>(MockBehavior.Strict);
         var pipeline = AdmissionHarness.Pipeline(
             classificationGate: gate.Object,
             sanitizer: AdmissionHarness.SubstitutingSanitizer("secret", "[SCRUBBED]"));
 
-        var ok = pipeline.TryApplyTextOutputPolicy(ToolCallAdmission.Allow(), Tool, "a secret value", out var result, out _);
+        var policy = await pipeline.TryApplyTextOutputPolicyAsync(
+            ToolCallAdmission.Allow(), Tool, "a secret value", CancellationToken.None);
 
-        ok.Should().BeTrue();
-        result.Should().Be("a [SCRUBBED] value");
+        policy.Success.Should().BeTrue();
+        policy.Result.Should().Be("a [SCRUBBED] value");
         gate.Verify(g => g.RedactResult(It.IsAny<string>(), It.IsAny<object?>()), Times.Never);
     }
 
     [Fact]
-    public void TryApplyTextOutputPolicy_RedactVerdict_RoutesThroughTheClassificationGate()
+    public async Task TryApplyTextOutputPolicy_RedactVerdict_RoutesThroughTheClassificationGate()
     {
         var gate = new Mock<IToolClassificationGate>();
         gate.Setup(g => g.RedactResult(Tool, "raw text")).Returns("[redacted]");
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
-        var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", out var result, out _);
+        var policy = await pipeline.TryApplyTextOutputPolicyAsync(
+            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", CancellationToken.None);
 
-        ok.Should().BeTrue();
-        result.Should().Be("[redacted]");
+        policy.Success.Should().BeTrue();
+        policy.Result.Should().Be("[redacted]");
     }
 
     [Fact]
-    public void TryApplyTextOutputPolicy_RedactVerdict_ClassificationGateReturnsNonString_FailsClosed()
+    public async Task TryApplyTextOutputPolicy_RedactVerdict_ClassificationGateReturnsNonString_FailsClosed()
     {
         // Preserved from before #479: a consumer-supplied IToolClassificationGate that violates the
         // "redact always answers with a string" contract must withhold, not fall back to the original —
@@ -333,11 +337,11 @@ public sealed class ToolCallAdmissionPipelineTests
         gate.Setup(g => g.RedactResult(Tool, "raw text")).Returns((string?)null);
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
-        var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", out var result, out _);
+        var policy = await pipeline.TryApplyTextOutputPolicyAsync(
+            ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", CancellationToken.None);
 
-        ok.Should().BeFalse();
-        result.Should().BeNull();
+        policy.Success.Should().BeFalse();
+        policy.Result.Should().BeNull();
     }
 
     // ===== #532: tool output is bounded, not just sanitized =====
@@ -354,72 +358,125 @@ public sealed class ToolCallAdmissionPipelineTests
     // with PreCutForScrub before this call and ScrubAndBound/FinalCut after it.
 
     [Fact]
-    public void ApplyOutputPolicy_OversizedText_IsBoundedAndMarked()
+    public async Task ApplyOutputPolicy_OversizedText_IsBoundedAndMarked()
     {
-        var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
+        // #521: ceiling raised from 100 to 200 — the id-carrying marker
+        // ("...full output available via tool_result_fetch, id={32-char guid}]") is itself ~107 chars,
+        // so a 100-char ceiling would exercise BoundedText.Cap's own documented "marker doesn't fit,
+        // drop it" branch instead of the truncation-with-marker behavior this test exists to prove.
+        var pipeline = AdmissionHarness.Pipeline(
+            outputCeiling: 200, resultStore: AdmissionHarness.PersistedResultStore());
 
-        var result = pipeline.ApplyOutputPolicy(ToolCallAdmission.Allow(), Tool, new string('x', 5000));
+        var result = await pipeline.ApplyOutputPolicyAsync(
+            ToolCallAdmission.Allow(), Tool, new string('x', 5000), CancellationToken.None);
 
-        result.Should().BeOfType<string>().Which.Length.Should().BeLessThanOrEqualTo(100,
+        result.Should().BeOfType<string>().Which.Length.Should().BeLessThanOrEqualTo(200,
             "the ceiling is the promise a caller sizing the context window relies on — the marker "
             + "counts against it rather than overshooting it");
-        result.As<string>().Should().EndWith(ToolCallAdmissionPipeline.OutputTruncationMarker,
+        result.As<string>().Should().Contain("tool_result_fetch",
+            "a spilled result must tell the model how to retrieve the rest, not just that it was cut");
+        result.As<string>().Should().EndWith("]",
             "a silent cut reads to the model as the tool having returned exactly this much");
     }
 
     [Fact]
-    public void TryApplyTextOutputPolicy_OversizedText_IsBoundedAndMarked()
+    public async Task ApplyOutputPolicy_OversizedText_SpilledCopyIsRedactedEvenOnThePlainAllowPath()
     {
-        var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
+        // #521 security finding: on a plain-allow call (RedactsOutput == false), the MODEL-facing text
+        // only goes through the injection sanitizer — IContentRedactionFilter only runs when the
+        // classification gate demanded it. But persisting to disk is a stronger exposure than showing
+        // the model its own tool's output, so the AT-REST spilled copy must be redacted regardless.
+        var redactionFilter = new Mock<IContentRedactionFilter>();
+        redactionFilter
+            .Setup(f => f.Redact(It.IsAny<string>(), It.Is<IReadOnlyList<Domain.AI.Telemetry.Redaction.RedactionCategory>>(c => c.Count > 0)))
+            .Returns("REDACTED-AT-REST");
 
-        var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.Allow(), Tool, new string('x', 5000), out var result, out _);
+        string? spilledText = null;
+        var resultStore = new Mock<IToolResultStore>();
+        resultStore
+            .Setup(s => s.StoreIfLargeAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string?, string, CancellationToken>((_, _, _, text, _) => spilledText = text)
+            .ReturnsAsync((string _, string toolName, string? operation, string fullOutput, CancellationToken _) =>
+                new ToolResultReference
+                {
+                    ResultId = Guid.NewGuid().ToString("N"),
+                    ToolName = toolName,
+                    Operation = operation,
+                    PreviewContent = fullOutput,
+                    FullContentPath = "/fake/persisted.json",
+                    SizeChars = fullOutput.Length,
+                    Timestamp = DateTimeOffset.UtcNow
+                });
 
-        ok.Should().BeTrue("bounding is not a policy denial — the result is admitted, just cut");
-        result!.Length.Should().BeLessThanOrEqualTo(100);
-        result.Should().EndWith(ToolCallAdmissionPipeline.OutputTruncationMarker);
+        var pipeline = AdmissionHarness.Pipeline(
+            redactionFilter: redactionFilter.Object, outputCeiling: 200, resultStore: resultStore.Object);
+
+        var result = await pipeline.ApplyOutputPolicyAsync(
+            ToolCallAdmission.Allow(), Tool, new string('x', 5000), CancellationToken.None);
+
+        spilledText.Should().Be("REDACTED-AT-REST",
+            "the spilled copy must be redacted even when the model-facing copy's own redaction decision was 'no'");
+        result.As<string>().Should().NotContain("REDACTED-AT-REST",
+            "redaction applies only to the at-rest copy — the model-facing text is unaffected");
     }
 
     [Fact]
-    public void TryApplyTextOutputPolicy_PreCutDropsContentThatSanitizingThenShrinksBelowTheCeiling_StillMarksTheResult()
+    public async Task TryApplyTextOutputPolicy_OversizedText_IsBoundedAndMarked()
+    {
+        var pipeline = AdmissionHarness.Pipeline(
+            outputCeiling: 200, resultStore: AdmissionHarness.PersistedResultStore());
+
+        var policy = await pipeline.TryApplyTextOutputPolicyAsync(
+            ToolCallAdmission.Allow(), Tool, new string('x', 5000), CancellationToken.None);
+
+        policy.Success.Should().BeTrue("bounding is not a policy denial — the result is admitted, just cut");
+        policy.Result!.Length.Should().BeLessThanOrEqualTo(200);
+        policy.Result.Should().Contain("tool_result_fetch");
+        policy.Result.Should().EndWith("]");
+    }
+
+    [Fact]
+    public async Task TryApplyTextOutputPolicy_PreCutDropsContentThatSanitizingThenShrinksBelowTheCeiling_StillMarksTheResult()
     {
         // Found by run-gates' correctness gate: the sibling of ApplyOutputPolicy_...StillMarksTheResult
         // below, on the OTHER caller of the same new pre-cut. This method DOES report a drop through
-        // wasTruncated -- but ToolUseStepExecutor.HandleSuccessAsync (the plan path) discards that
-        // out-parameter with `out _` and depends entirely on a marker embedded in the returned text, a
-        // premise that broke the moment this pre-cut could drop content silently.
+        // WasTruncated -- but ToolUseStepExecutor.HandleSuccessAsync (the plan path) discards that flag
+        // and depends entirely on a marker embedded in the returned text, a premise that broke the
+        // moment this pre-cut could drop content silently.
         var pipeline = AdmissionHarness.Pipeline(
             outputCeiling: 10_000,
             sanitizer: AdmissionHarness.SubstitutingSanitizer(new string('z', 1), string.Empty));
 
-        var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.Allow(), Tool, "HEADER" + new string('z', 50_000), out var result, out var wasTruncated);
+        var policy = await pipeline.TryApplyTextOutputPolicyAsync(
+            ToolCallAdmission.Allow(), Tool, "HEADER" + new string('z', 50_000), CancellationToken.None);
 
-        ok.Should().BeTrue();
-        wasTruncated.Should().BeTrue("the pre-cut genuinely dropped content, regardless of whether a caller reads this flag");
+        policy.Success.Should().BeTrue();
+        policy.WasTruncated.Should().BeTrue("the pre-cut genuinely dropped content, regardless of whether a caller reads this flag");
         // The property under test: a caller that ONLY reads the text (as ToolUseStepExecutor does) must
         // still be able to tell this was cut, because the final BoundedText.Cap never fires here --
         // sanitizing shrank the pre-cut's survivor to "HEADER" + marker, already under the 10,000 ceiling.
-        result.Should().Contain(ToolCallAdmissionPipeline.OutputTruncationMarker,
-            "a reader with no access to wasTruncated (ToolUseStepExecutor.HandleSuccessAsync discards it) "
+        policy.Result.Should().Contain(ToolCallAdmissionPipeline.OutputTruncationMarker,
+            "a reader with no access to WasTruncated (ToolUseStepExecutor.HandleSuccessAsync discards it) "
             + "must not conclude the result is complete just because the final cut never fired");
     }
 
     [Fact]
-    public void ApplyOutputPolicy_PreCutDropsContentThatSanitizingThenShrinksBelowTheCeiling_StillMarksTheResult()
+    public async Task ApplyOutputPolicy_PreCutDropsContentThatSanitizingThenShrinksBelowTheCeiling_StillMarksTheResult()
     {
-        // #487 security-review finding on this PR: unlike TryApplyTextOutputPolicy, this method has no
-        // out-parameter to report a drop through, so a pre-cut drop must leave its OWN marker in the
-        // payload. If it doesn't, and sanitizing then shrinks the survivor back under the ceiling, the
-        // final Bound call never fires to leave a marker of its own -- the model reads a silently
-        // truncated prefix as the complete result. Reproduced with a sanitizer that collapses a large
-        // run the way a real one collapses a base64 blob, exactly the scenario security review named.
+        // #487 security-review finding on this PR: unlike TryApplyTextOutputPolicyAsync, this method
+        // has no truncation signal of its own to report a drop through, so a pre-cut drop must leave
+        // its OWN marker in the payload. If it doesn't, and sanitizing then shrinks the survivor back
+        // under the ceiling, the final Bound call never fires to leave a marker of its own -- the model
+        // reads a silently truncated prefix as the complete result. Reproduced with a sanitizer that
+        // collapses a large run the way a real one collapses a base64 blob, exactly the scenario
+        // security review named.
         var pipeline = AdmissionHarness.Pipeline(
             outputCeiling: 10_000,
             sanitizer: AdmissionHarness.SubstitutingSanitizer(new string('z', 1), string.Empty));
 
-        var result = pipeline.ApplyOutputPolicy(
-            ToolCallAdmission.Allow(), Tool, "HEADER" + new string('z', 50_000));
+        var result = await pipeline.ApplyOutputPolicyAsync(
+            ToolCallAdmission.Allow(), Tool, "HEADER" + new string('z', 50_000), CancellationToken.None);
 
         // The pre-cut (ceiling + 8 KiB margin) fires on the 50,000-character blob long before
         // sanitizing runs; sanitizing then deletes every 'z', leaving "HEADER" plus whatever the
@@ -432,18 +489,18 @@ public sealed class ToolCallAdmissionPipelineTests
     }
 
     [Fact]
-    public void ApplyOutputPolicy_TextWithinTheCeiling_IsReturnedWhole()
+    public async Task ApplyOutputPolicy_TextWithinTheCeiling_IsReturnedWhole()
     {
         // Control. Without this, a bound that cut EVERYTHING would satisfy the two tests above while
         // destroying every tool result in the harness.
         var pipeline = AdmissionHarness.Pipeline(outputCeiling: 100);
 
-        pipeline.ApplyOutputPolicy(ToolCallAdmission.Allow(), Tool, "a short result")
+        (await pipeline.ApplyOutputPolicyAsync(ToolCallAdmission.Allow(), Tool, "a short result", CancellationToken.None))
             .Should().Be("a short result", "text under the ceiling must not be touched or marked");
     }
 
     [Fact]
-    public void ApplyOutputPolicy_MultipleTextBlocks_BoundsTheTOTALNotEachBlock()
+    public async Task ApplyOutputPolicy_MultipleTextBlocks_BoundsTheTOTALNotEachBlock()
     {
         // The one that is easy to get wrong. Capping each block at N yields N x blockCount, which
         // bounds nothing on a result with many blocks — exactly the shape an MCP tool returns.
@@ -456,7 +513,7 @@ public sealed class ToolCallAdmissionPipelineTests
             new TextContent(new string('c', 500))
         };
 
-        var result = pipeline.ApplyOutputPolicy(ToolCallAdmission.Allow(), Tool, blocks);
+        var result = await pipeline.ApplyOutputPolicyAsync(ToolCallAdmission.Allow(), Tool, blocks, CancellationToken.None);
 
         result.Should().BeOfType<AIContent[]>()
             .Which.OfType<TextContent>().Sum(b => b.Text.Length)
@@ -465,19 +522,48 @@ public sealed class ToolCallAdmissionPipelineTests
     }
 
     [Fact]
-    public void TryApplyTextOutputPolicy_PlainAllow_NullContent_PassesThroughWithoutSanitizing()
+    public async Task ApplyOutputPolicy_MultiBlockOverflowLandsInANarrowBudget_StillCarriesATruncationMarker()
+    {
+        // #521 gap found by code review: BudgetedCut's multi-block walk uses one shared, shrinking
+        // per-block budget. Whichever block first overflows is cut with whatever budget remains AT
+        // THAT POINT, which can be smaller than the id-carrying marker (~90+ chars, carries a 32-char
+        // guid) while still larger than the plain OutputTruncationMarker (~25 chars) — BoundedText.Cap
+        // silently DROPS a marker that doesn't fit rather than shrinking it, so re-cutting with the
+        // long marker can lose the marker entirely on a block where the plain marker would have fit.
+        var pipeline = AdmissionHarness.Pipeline(
+            outputCeiling: 600, resultStore: AdmissionHarness.PersistedResultStore());
+
+        var blocks = new AIContent[]
+        {
+            // Leaves ~50 chars of per-block budget when block 2 overflows — enough for the ~25-char
+            // plain marker, not enough for the ~90+-char id marker.
+            new TextContent(new string('a', 550)),
+            new TextContent(new string('b', 500)),
+        };
+
+        var result = await pipeline.ApplyOutputPolicyAsync(
+            ToolCallAdmission.Allow(), Tool, blocks, CancellationToken.None);
+
+        var text = string.Join("\n", ((AIContent[])result!).OfType<TextContent>().Select(b => b.Text));
+        text.Should().Contain("tool output truncated",
+            "the model must always get SOME truncation signal — losing room for the id marker must " +
+            "never mean losing every marker");
+    }
+
+    [Fact]
+    public async Task TryApplyTextOutputPolicy_PlainAllow_NullContent_PassesThroughWithoutSanitizing()
     {
         var sanitizer = new Mock<ICompositeResponseSanitizer>(MockBehavior.Strict);
         var pipeline = AdmissionHarness.Pipeline(sanitizer: sanitizer.Object);
 
-        var ok = pipeline.TryApplyTextOutputPolicy(ToolCallAdmission.Allow(), Tool, null, out var result, out _);
+        var policy = await pipeline.TryApplyTextOutputPolicyAsync(ToolCallAdmission.Allow(), Tool, null, CancellationToken.None);
 
-        ok.Should().BeTrue("there is nothing to sanitize in an absent result");
-        result.Should().BeNull();
+        policy.Success.Should().BeTrue("there is nothing to sanitize in an absent result");
+        policy.Result.Should().BeNull();
     }
 
     [Fact]
-    public void TryApplyTextOutputPolicy_RedactVerdict_NullContent_FailsClosed()
+    public async Task TryApplyTextOutputPolicy_RedactVerdict_NullContent_FailsClosed()
     {
         // Regression: an early null-content short-circuit ahead of the RedactsOutput branch would
         // silently answer true for a redact-required call with no content yet — turning a denial into
@@ -489,11 +575,11 @@ public sealed class ToolCallAdmissionPipelineTests
         gate.Setup(g => g.RedactResult(Tool, (string?)null)).Returns((string?)null);
         var pipeline = AdmissionHarness.Pipeline(classificationGate: gate.Object);
 
-        var ok = pipeline.TryApplyTextOutputPolicy(
-            ToolCallAdmission.AllowWithOutputRedaction(), Tool, null, out var result, out _);
+        var policy = await pipeline.TryApplyTextOutputPolicyAsync(
+            ToolCallAdmission.AllowWithOutputRedaction(), Tool, null, CancellationToken.None);
 
-        ok.Should().BeFalse("a redact-required call must never report success just because there was nothing to redact yet");
-        result.Should().BeNull();
+        policy.Success.Should().BeFalse("a redact-required call must never report success just because there was nothing to redact yet");
+        policy.Result.Should().BeNull();
     }
 
     [Fact]
@@ -649,7 +735,8 @@ public sealed class ToolCallAdmissionPipelineTests
             new Mock<IApprovalExecutionReporter>().Object,
             AdmissionHarness.PermissiveSanitizer(), AdmissionHarness.PermissiveRedactionFilter(),
             AdmissionHarness.Config(),
-            NullLogger<ToolCallAdmissionPipeline>.Instance);
+            NullLogger<ToolCallAdmissionPipeline>.Instance,
+            AdmissionHarness.StubExecutionContext(), AdmissionHarness.StubResultStore());
     }
 
     // ===== ReportExecutionAsync: #325 execution reporting dispatch =====
@@ -663,7 +750,8 @@ public sealed class ToolCallAdmissionPipelineTests
         Mock.Of<ICallOnceGate>(), AdmissionHarness.TraceRecorder(), reporter.Object,
         sanitizer ?? AdmissionHarness.PermissiveSanitizer(), redactionFilter ?? AdmissionHarness.PermissiveRedactionFilter(),
         AdmissionHarness.Config(),
-            NullLogger<ToolCallAdmissionPipeline>.Instance);
+            NullLogger<ToolCallAdmissionPipeline>.Instance,
+            AdmissionHarness.StubExecutionContext(), AdmissionHarness.StubResultStore());
 
     private static ApprovedCall Call() =>
         new(Guid.NewGuid(), new ApprovalFailureKey("conv-1", "agent-1", Tool));

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolResultTextTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolResultTextTests.cs
@@ -14,7 +14,7 @@ namespace Application.AI.Common.Tests.Governance;
 
 /// <summary>
 /// Tests for <see cref="ToolResultText.Sanitize(object?, ICompositeResponseSanitizer, string)"/> directly, across every shape a tool result can
-/// arrive in at a policy boundary — the two callers (<see cref="ToolCallAdmissionPipeline.ApplyOutputPolicy"/>,
+/// arrive in at a policy boundary — the two callers (<see cref="ToolCallAdmissionPipeline.ApplyOutputPolicyAsync"/>,
 /// <see cref="DefaultToolClassificationGate.RedactResult(string, object?)"/>) each get one routing test instead of
 /// re-proving every shape's behavior twice.
 /// </summary>

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/BoundedTextTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Governance/BoundedTextTests.cs
@@ -73,4 +73,38 @@ public sealed class BoundedTextTests
         text.Should().BeEmpty();
         truncated.Should().BeFalse();
     }
+
+    // ===== alwaysEmbedMarker (#521) =====
+
+    [Fact]
+    public void Cap_AlwaysEmbedMarker_TextUnderCeilingButFitsWithMarker_AppendsMarkerWithoutCutting()
+    {
+        var (text, truncated) = BoundedText.Cap("hello", 20, Marker, alwaysEmbedMarker: true);
+
+        text.Should().Be("hello" + Marker,
+            "the default (non-embedding) contract would drop the marker entirely here — this is the whole point of the flag");
+        truncated.Should().BeFalse("nothing in text itself was cut, only appended");
+    }
+
+    [Fact]
+    public void Cap_AlwaysEmbedMarker_TextPlusMarkerExceedsCeiling_CutsTextToMakeRoom()
+    {
+        var input = new string('x', 15);
+        var (text, truncated) = BoundedText.Cap(input, 20, Marker, alwaysEmbedMarker: true);
+
+        text.Length.Should().Be(20);
+        text.Should().EndWith(Marker);
+        truncated.Should().BeTrue("text itself had to be cut to make room for the marker");
+    }
+
+    [Fact]
+    public void Cap_AlwaysEmbedMarkerFalse_TextUnderCeiling_MarkerNeverEmbedded()
+    {
+        // Pins the default's unchanged behavior now that Cap has a second parameter — the flag must
+        // be opt-in, not a silent change to every existing call site.
+        var (text, truncated) = BoundedText.Cap("hello", 20, Marker);
+
+        text.Should().Be("hello");
+        truncated.Should().BeFalse();
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -890,6 +890,11 @@ public sealed class DirectToolInvokerTests
         services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
             new StaticOptionsMonitor<Domain.Common.Config.AppConfig>(pipelineConfig));
 
+        // #521: the chain now constructor-injects IToolResultStore to spill truncated output — same
+        // "an absent registration is a composition that cannot exist in production" reasoning as every
+        // gate above. AgentExecutionContext (registered scoped above) supplies a real ToolResultScopeId.
+        services.AddSingleton(AdmissionHarness.StubResultStore());
+
         // The real chain, not a mock of it, built the same way the production root builds it. This
         // suite's whole subject is what the Execution API does before, during and after a tool call,
         // and that is now the chain's behaviour plus this type's response shaping — mocking the chain
@@ -1043,7 +1048,7 @@ public sealed class DirectToolInvokerTests
         public object? RedactResult(string toolName, object? result) => RedactionResult ?? Redacted;
 
         /// <summary>
-        /// The string-typed overload <see cref="Application.AI.Common.Services.Governance.ToolCallAdmissionPipeline.TryApplyTextOutputPolicy"/>
+        /// The string-typed overload <see cref="Application.AI.Common.Services.Governance.ToolCallAdmissionPipeline.TryApplyTextOutputPolicyAsync"/>
         /// actually calls. <see cref="RedactionResult"/> being set to anything other than a string
         /// (e.g. a boxed <see langword="int"/>) simulates a consumer gate breaking the
         /// non-null-in/non-null-out contract <see cref="IToolClassificationGate.RedactResult(string, string?)"/>

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -146,6 +146,11 @@ public class AgentPipelineIntegrationTests
         services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
             Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
                 m => m.CurrentValue == new Domain.Common.Config.AppConfig()));
+
+        // #521: the chain now constructor-injects IToolResultStore to spill truncated output — same
+        // "an absent registration is a composition that cannot exist in production" reasoning as
+        // every gate above. None of these tests truncate output, so a permissive stub is enough.
+        services.AddSingleton(Mock.Of<IToolResultStore>());
         services.AddToolCallAdmissionChain();
 
         // Conversation-lifetime budget — not under test here; permissive mock (disabled) so the

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Orchestration/PermissiveAdmission.cs
@@ -1,8 +1,11 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Context;
 using Domain.AI.Governance;
 using Domain.Common.Config.AI;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -92,6 +95,30 @@ internal static class PermissiveAdmission
             // ceiling rather than an artificial one.
             Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
                 m => m.CurrentValue == new Domain.Common.Config.AppConfig()),
-            NullLogger<ToolCallAdmissionPipeline>.Instance);
+            NullLogger<ToolCallAdmissionPipeline>.Instance,
+            Mock.Of<IAgentExecutionContext>(c => c.ToolResultScopeId == "test-scope"),
+            StubResultStore());
+    }
+
+    /// <summary>A result store that answers as if every result were small enough to keep inline.</summary>
+    private static IToolResultStore StubResultStore()
+    {
+        var store = new Mock<IToolResultStore>();
+        store
+            .Setup(s => s.StoreIfLargeAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string toolName, string? operation, string fullOutput, CancellationToken _) =>
+                new ToolResultReference
+                {
+                    ResultId = Guid.NewGuid().ToString("N"),
+                    ToolName = toolName,
+                    Operation = operation,
+                    PreviewContent = fullOutput,
+                    FullContentPath = null,
+                    SizeChars = fullOutput.Length,
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+        return store.Object;
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Context/FileSystemToolResultStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Context/FileSystemToolResultStoreTests.cs
@@ -68,7 +68,7 @@ public sealed class FileSystemToolResultStoreTests : IDisposable
         var output = new string('a', 200);
         var stored = await _sut.StoreIfLargeAsync("session1", "tool", null, output);
 
-        var retrieved = await _sut.RetrieveFullContentAsync(stored.ResultId);
+        var retrieved = await _sut.RetrieveFullContentAsync(stored.ResultId, "session1");
 
         retrieved.Should().Be(output);
     }
@@ -76,8 +76,70 @@ public sealed class FileSystemToolResultStoreTests : IDisposable
     [Fact]
     public async Task RetrieveFullContentAsync_MissingId_ThrowsKeyNotFoundException()
     {
-        var act = () => _sut.RetrieveFullContentAsync("nonexistent-id");
+        var act = () => _sut.RetrieveFullContentAsync("nonexistent-id", "session1");
 
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task RetrieveFullContentAsync_CorrectIdWrongScope_ThrowsKeyNotFoundException()
+    {
+        // #521: the retrieval scope must match the write scope. A different (but otherwise valid)
+        // scopeId must be refused identically to a resultId that was never stored at all — see
+        // IToolResultStore.RetrieveFullContentAsync's own remarks for why the two must be
+        // indistinguishable from outside the store.
+        var output = new string('a', 200);
+        var stored = await _sut.StoreIfLargeAsync("session1", "tool", null, output);
+
+        var act = () => _sut.RetrieveFullContentAsync(stored.ResultId, "session2");
+
+        await act.Should().ThrowAsync<KeyNotFoundException>();
+    }
+
+    [Fact]
+    public async Task RetrieveFullContentAsync_AfterANewStoreInstance_StillFindsTheResult()
+    {
+        // #521: the path is reconstructed deterministically from (scopeId, resultId), not trusted from
+        // an in-memory index — proving this needs a genuinely SEPARATE store instance (a fresh process
+        // would build its own empty index), not just a second call on the same _sut.
+        var output = new string('a', 200);
+        var stored = await _sut.StoreIfLargeAsync("session1", "tool", null, output);
+
+        var monitor = new Mock<IOptionsMonitor<AppConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(_appConfig);
+        var freshInstance = new FileSystemToolResultStore(monitor.Object, Mock.Of<ILogger<FileSystemToolResultStore>>());
+
+        var retrieved = await freshInstance.RetrieveFullContentAsync(stored.ResultId, "session1");
+
+        retrieved.Should().Be(output);
+    }
+
+    [Theory]
+    // Reaches ANOTHER scope's directory: Path.Combine does not normalize, the file APIs do.
+    [InlineData("../../session1/tool-results/PLACEHOLDER")]
+    [InlineData("..\\..\\session1\\tool-results\\PLACEHOLDER")]
+    // A ROOTED segment makes Path.Combine discard every earlier segment — arbitrary *.json read.
+    [InlineData("C:/Windows/win.ini")]
+    [InlineData("/etc/passwd")]
+    [InlineData("\\\\attacker\\share\\payload")]
+    // Not a traversal, just not an id this store ever mints — refused for the same reason.
+    [InlineData("nonexistent-id")]
+    public async Task RetrieveFullContentAsync_ResultIdThatIsNotAMintedId_ThrowsKeyNotFoundException(string resultId)
+    {
+        // resultId is model-supplied (ToolResultFetchTool hands the LLM's own argument straight to this
+        // method), so an unsanitized one is a path-traversal sink: sanitizing scopeId alone leaves the
+        // isolation boundary reachable by writing the traversal into the OTHER path segment instead.
+        // Mutation test: delete the Guid.TryParseExact guard in RetrieveFullContentAsync and the first
+        // two cases retrieve session1's data from session2's scope.
+        var output = new string('a', 200);
+        var stored = await _sut.StoreIfLargeAsync("session1", "tool", null, output);
+
+        var act = () => _sut.RetrieveFullContentAsync(
+            resultId.Replace("PLACEHOLDER", stored.ResultId, StringComparison.Ordinal), "session2");
+
+        // KeyNotFoundException, not ArgumentException: a caller must not learn from the exception type
+        // which of its guesses was better-formed — see the interface's remarks on why "exists but not
+        // yours" and "never existed" must be indistinguishable.
         await act.Should().ThrowAsync<KeyNotFoundException>();
     }
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Context/FileSystemToolResultStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Context/FileSystemToolResultStoreTests.cs
@@ -152,6 +152,33 @@ public sealed class FileSystemToolResultStoreTests : IDisposable
             .WithParameterName("sessionId");
     }
 
+    [Theory]
+    [InlineData("session1 ")]
+    [InlineData("session1.")]
+    public async Task StoreIfLargeAsync_TrailingDotOrSpaceInSessionId_ThrowsArgumentException(string sessionId)
+    {
+        // Security-review finding: Windows silently trims trailing dots/spaces off a path segment, so
+        // "session1" and "session1 " would resolve to the SAME directory there even though they compare
+        // unequal as strings — two different scopes colliding onto one storage directory. Rejected here
+        // rather than allowed to (on Windows only) collide with a different caller's scope.
+        var act = () => _sut.StoreIfLargeAsync(sessionId, "tool", null, "data");
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("sessionId");
+    }
+
+    [Fact]
+    public async Task RetrieveFullContentAsync_TrailingSpaceInScopeId_ThrowsArgumentExceptionNamingScopeId()
+    {
+        // Same collision guard, exercised through the retrieval side — and confirms the exception names
+        // the CALLING method's own parameter (scopeId), not a copy-pasted "sessionId" from the sibling
+        // method that shares this validation helper (a /code-review finding).
+        var act = () => _sut.RetrieveFullContentAsync(Guid.NewGuid().ToString("N"), "session1 ");
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithParameterName("scopeId");
+    }
+
     [Fact]
     public async Task StoreIfLargeAsync_NullOutput_ThrowsArgumentNullException()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/Support/FakeAmbientRequestScope.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/Support/FakeAmbientRequestScope.cs
@@ -32,6 +32,7 @@ internal sealed class FakeAmbientRequestScope : IAmbientRequestScope
         public string? ConversationId => null;
         public int? TurnNumber => null;
         public string? CallOnceScopeId => null;
+        public string ToolResultScopeId { get; } = Guid.NewGuid().ToString("N");
         public AgentIdentity? AgentIdentity { get; private set; }
 
         public void Initialize(string agentId, string conversationId, int turnNumber, string? callOnceScopeId = null)

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlanRunLlmCallScopeTests.cs
@@ -172,6 +172,11 @@ public sealed class PlanRunLlmCallScopeTests
         services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
             Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
                 m => m.CurrentValue == new Domain.Common.Config.AppConfig()));
+
+        // #521: the chain now constructor-injects IToolResultStore to spill truncated output — same
+        // "an absent registration is a composition that cannot exist in production" reasoning as
+        // every gate above. This suite doesn't truncate output, so a permissive stub is enough.
+        services.AddSingleton(StepExecutors.PermissiveAdmission.StubResultStore());
         services.AddToolCallAdmissionChain();
         services.AddSingleton(Mock.Of<IPlanProgressNotifier>());
         services.AddScoped(_ => new PlanExecutionContext());

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/PermissiveAdmission.cs
@@ -1,8 +1,11 @@
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Context;
 using Domain.AI.Governance;
 using Domain.Common.Config.AI;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -61,7 +64,35 @@ internal static class PermissiveAdmission
             PermissiveRedactionFilter(),
             Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
                 m => m.CurrentValue == new Domain.Common.Config.AppConfig()),
-            NullLogger<ToolCallAdmissionPipeline>.Instance);
+            NullLogger<ToolCallAdmissionPipeline>.Instance,
+            StubExecutionContext(),
+            StubResultStore());
+
+    /// <summary>An execution context with a stable, non-null ToolResultScopeId (#521).</summary>
+    public static IAgentExecutionContext StubExecutionContext(string toolResultScopeId = "test-scope") =>
+        Mock.Of<IAgentExecutionContext>(c => c.ToolResultScopeId == toolResultScopeId);
+
+    /// <summary>A result store that answers as if every result were small enough to keep inline.</summary>
+    public static IToolResultStore StubResultStore()
+    {
+        var store = new Mock<IToolResultStore>();
+        store
+            .Setup(s => s.StoreIfLargeAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, string toolName, string? operation, string fullOutput, CancellationToken _) =>
+                new ToolResultReference
+                {
+                    ResultId = Guid.NewGuid().ToString("N"),
+                    ToolName = toolName,
+                    Operation = operation,
+                    PreviewContent = fullOutput,
+                    FullContentPath = null,
+                    SizeChars = fullOutput.Length,
+                    Timestamp = DateTimeOffset.UtcNow
+                });
+        return store.Object;
+    }
 
     /// <summary>A sanitizer that returns content unchanged — the answer a real one gives to clean text.</summary>
     public static ICompositeResponseSanitizer PermissiveSanitizer()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -523,7 +523,9 @@ public sealed class ToolUseStepExecutorTests
             PermissiveAdmission.PermissiveRedactionFilter(),
             Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
                 m => m.CurrentValue == new Domain.Common.Config.AppConfig()),
-            NullLogger<ToolCallAdmissionPipeline>.Instance);
+            NullLogger<ToolCallAdmissionPipeline>.Instance,
+            PermissiveAdmission.StubExecutionContext(),
+            PermissiveAdmission.StubResultStore());
 
     /// <summary>
     /// Admits everything, matching what the real gate answers with

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillEndToEndAcceptanceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillEndToEndAcceptanceTests.cs
@@ -259,7 +259,9 @@ public sealed class WorkspaceSkillEndToEndAcceptanceTests : IDisposable
         public string? ConversationId { get; private set; }
         public int? TurnNumber { get; private set; }
         public string? CallOnceScopeId { get; private set; }
+        public string ToolResultScopeId => CallOnceScopeId ?? _fallbackToolResultScopeId;
         public AgentIdentity? AgentIdentity { get; private set; }
+        private readonly string _fallbackToolResultScopeId = Guid.NewGuid().ToString("N");
         public void Initialize(string agentId, string conversationId, int turnNumber, string? callOnceScopeId = null)
         {
             AgentId = agentId;

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ToolResultFetchToolCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ToolResultFetchToolCompositionTests.cs
@@ -1,0 +1,36 @@
+using Application.AI.Common.Interfaces.Tools;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Presentation.Common.Tests.Composition;
+
+/// <summary>
+/// Proves <c>tool_result_fetch</c> (#521) resolves on the REAL composition root, not just in a
+/// hand-rolled test container. The plan for this package calls this out explicitly: no existing test
+/// already covers "does this keyed tool resolve", so a deleted or mistyped registration line in
+/// <c>Infrastructure.AI/DependencyInjection.Tools.cs</c> would otherwise ship silently — the model
+/// would offer a marker naming a tool nothing can resolve.
+/// </summary>
+/// <remarks>
+/// Resolved from a CREATED SCOPE, not the root provider — <see cref="ToolResultFetchTool"/> is
+/// registered <c>AddKeyedScoped</c>, deliberately unlike most keyed tools (see its own remarks on
+/// why a singleton registration would capture whichever caller's scope resolved it first). Resolving
+/// it from the root under <see cref="CompositionRootTestHost"/>'s <c>ValidateScopes = true</c> would
+/// itself throw, so a root-provider resolution here would prove the wrong thing.
+/// </remarks>
+public sealed class ToolResultFetchToolCompositionTests
+{
+    [Fact]
+    public void ToolResultFetchTool_IsRegisteredOnTheProductionGraph()
+    {
+        using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>());
+        using var scope = provider.CreateScope();
+
+        var tool = scope.ServiceProvider.GetRequiredKeyedService<ITool>(ToolResultFetchTool.ToolName);
+
+        tool.Should().BeOfType<ToolResultFetchTool>(
+            "the model's only way to retrieve a spilled result is this exact keyed tool");
+    }
+}

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/ToolResultFetchToolCompositionTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/ToolResultFetchToolCompositionTests.cs
@@ -1,3 +1,6 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Tools;
 using FluentAssertions;
 using Infrastructure.AI.Tools;
@@ -7,30 +10,105 @@ using Xunit;
 namespace Presentation.Common.Tests.Composition;
 
 /// <summary>
-/// Proves <c>tool_result_fetch</c> (#521) resolves on the REAL composition root, not just in a
-/// hand-rolled test container. The plan for this package calls this out explicitly: no existing test
-/// already covers "does this keyed tool resolve", so a deleted or mistyped registration line in
-/// <c>Infrastructure.AI/DependencyInjection.Tools.cs</c> would otherwise ship silently — the model
-/// would offer a marker naming a tool nothing can resolve.
+/// Proves <c>tool_result_fetch</c> (#521) actually works on the REAL composition root — both that it
+/// resolves the way every production caller resolves a keyed tool, and that it can retrieve a result
+/// end to end once a request's own scope is established.
 /// </summary>
 /// <remarks>
-/// Resolved from a CREATED SCOPE, not the root provider — <see cref="ToolResultFetchTool"/> is
-/// registered <c>AddKeyedScoped</c>, deliberately unlike most keyed tools (see its own remarks on
-/// why a singleton registration would capture whichever caller's scope resolved it first). Resolving
-/// it from the root under <see cref="CompositionRootTestHost"/>'s <c>ValidateScopes = true</c> would
-/// itself throw, so a root-provider resolution here would prove the wrong thing.
+/// <para>
+/// <strong>Root-provider resolution is the regression test, not an afterthought.</strong> An earlier
+/// version of <see cref="ToolResultFetchTool"/> was registered <c>AddKeyedScoped</c>, reasoning (only
+/// half correctly) that it needed the calling request's own <see cref="IAgentExecutionContext"/>. Every
+/// production caller of a keyed <see cref="ITool"/> — <c>ToolChainBuilder.ResolveToolByName</c>,
+/// <c>FirstPartyToolLookup.Resolve</c> — is itself a SINGLETON holding the ROOT provider, so that
+/// registration threw <see cref="InvalidOperationException"/> on every turn of every skill that lists
+/// this tool, under the <c>ValidateScopes = true</c> every host enables. Caught by this repo's own
+/// <c>correctness</c> gate before it shipped. The first test below resolves the SAME way those two
+/// real callers do — directly from the root provider, no created scope — specifically so this exact
+/// defect can never silently return.
+/// </para>
+/// <para>
+/// <see cref="ToolResultFetchTool_WithAnEstablishedAmbientScope_RetrievesASpilledResult"/> proves the
+/// actual fix: the tool resolves the calling request's <see cref="IAgentExecutionContext"/> from
+/// <see cref="IAmbientRequestScope.Current"/> at execution time, not construction — the pattern this
+/// codebase already uses for every other singleton that needs per-request scoped state.
+/// </para>
 /// </remarks>
 public sealed class ToolResultFetchToolCompositionTests
 {
     [Fact]
-    public void ToolResultFetchTool_IsRegisteredOnTheProductionGraph()
+    public void ToolResultFetchTool_ResolvesFromTheRootProvider_UnderScopeValidation()
     {
         using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>());
-        using var scope = provider.CreateScope();
 
-        var tool = scope.ServiceProvider.GetRequiredKeyedService<ITool>(ToolResultFetchTool.ToolName);
+        var act = () => provider.GetRequiredKeyedService<ITool>(ToolResultFetchTool.ToolName);
 
-        tool.Should().BeOfType<ToolResultFetchTool>(
+        act.Should().NotThrow(
+            "ToolChainBuilder and FirstPartyToolLookup both resolve keyed tools from the root " +
+            "provider — a scoped registration for this tool would throw here in production");
+        act().Should().BeOfType<ToolResultFetchTool>(
             "the model's only way to retrieve a spilled result is this exact keyed tool");
+    }
+
+    [Fact]
+    public async Task ToolResultFetchTool_WithAnEstablishedAmbientScope_RetrievesASpilledResult()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "tool-result-fetch-composition-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Below the shipped 50,000-char default, StoreIfLargeAsync keeps content inline and never
+            // writes a file — RetrieveFullContentAsync would then correctly report "not found" for
+            // content that was never persisted. Lower the threshold so a small test string still spills.
+            using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>
+            {
+                ["AppConfig:AI:ContextManagement:ToolResultStorage:PerResultCharLimit"] = "50",
+                ["AppConfig:AI:ContextManagement:ToolResultStorage:StoragePath"] = tempDir,
+            });
+            var tool = provider.GetRequiredKeyedService<ITool>(ToolResultFetchTool.ToolName);
+
+            using var requestScope = provider.CreateScope();
+            var executionContext = requestScope.ServiceProvider.GetRequiredService<IAgentExecutionContext>();
+            executionContext.Initialize(agentId: "test-agent", conversationId: "conv-1", turnNumber: 1);
+
+            var resultStore = provider.GetRequiredService<IToolResultStore>();
+            var storedText = new string('x', 200);
+            var stored = await resultStore.StoreIfLargeAsync(
+                executionContext.ToolResultScopeId, "some_tool", operation: null, storedText);
+            stored.FullContentPath.Should().NotBeNull(
+                "the test setup itself must actually spill to disk, or this proves nothing");
+
+            var ambientScope = provider.GetRequiredService<IAmbientRequestScope>();
+            using (ambientScope.BeginScope(requestScope.ServiceProvider))
+            {
+                var result = await tool.ExecuteAsync(
+                    "fetch", new Dictionary<string, object?> { ["resultId"] = stored.ResultId });
+
+                result.Success.Should().BeTrue(
+                    "the singleton tool must resolve the CALLING request's own scope via the ambient " +
+                    "request scope, not fail just because it isn't constructor-injected anymore");
+                result.Output.Should().Be(storedText);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task ToolResultFetchTool_WithNoAmbientScopeEstablished_FailsRatherThanThrows()
+    {
+        // The direct-invoke surface never establishes an ambient scope (this tool is deliberately
+        // excluded from it — see its own remarks), and any other caller that resolves this tool
+        // outside the MediatR pipeline must degrade the same way: a clear failure, not a NullReferenceException.
+        using var provider = CompositionRootTestHost.BuildProvider(new Dictionary<string, string?>());
+        var tool = provider.GetRequiredKeyedService<ITool>(ToolResultFetchTool.ToolName);
+
+        var result = await tool.ExecuteAsync(
+            "fetch", new Dictionary<string, object?> { ["resultId"] = Guid.NewGuid().ToString("N") });
+
+        result.Success.Should().BeFalse("there is no calling request scope to resolve a retrieval scope from");
     }
 }


### PR DESCRIPTION
## Summary
- When a tool result is cut to fit the output ceiling, the full sanitized/redacted text is now persisted under the calling agent's own scope, and a new `tool_result_fetch` tool lets the model retrieve it later — routed back through the same admission pipeline as any other tool result. Closes #521's original gap, where the truncation marker promised recoverability that didn't exist.
- Security review found and fixed a **critical** path-traversal hole: a model-supplied `resultId` reached the filesystem unvalidated. Result ids are now verified against the exact GUID shape the store ever mints, before being interpolated into a path.
- The at-rest spilled copy is redacted independently of the model-facing redaction decision, so a plain-allow tool result never writes an unredacted secret to disk.
- A multi-block truncation path (MCP tool results, several `TextContent` blocks) could silently drop the retrieval marker entirely when the per-block budget was too narrow for the longer id-carrying marker — the model would see truncated text with zero signal that anything was cut. Fixed with a marker-survival check that falls back to the plain truncation marker.
- `run-gates.sh`'s `correctness` gate caught a real defect in an earlier commit on this branch: the new tool was registered `AddKeyedScoped`, but every production caller resolves a keyed tool from a singleton holding the root DI container, so the registration threw on every turn of any skill that lists this tool. Fixed by registering it singleton (like every other tool) and resolving the calling request's scoped identity from `IAmbientRequestScope` at execution time — the pattern this codebase already uses for this exact situation.
- Windows silently trims trailing dots/spaces off a path segment, so two different scope ids could otherwise collide onto the same storage directory — closed with an explicit rejection.
- `tool_result_fetch` wired into `default-agent` and `research-agent`'s `allowed-tools` (the two shipped skills where truncation is realistic); onboarding and reference docs updated to mention it.

## Follow-ups filed (not blocking)
- #559 — no retention/off-switch for spilled results, and direct-invocation spills are write-only garbage
- #560 — an unvalidated conversation id used as the isolation-scope fallback on the non-durable path
- #561 — `ToolOutputCompressionBehavior`'s dead `result://` marker path never reconciled with `tool_result_fetch`
- #562 — a `ToolResultScopeId` ordering hazard, confirmed unreachable in any current production call path
- #563 — the spilled "full output" is itself capped at roughly `OutputCeiling + 8KB`, not the tool's true original output, for very large results

## Test plan
- [x] Full solution build + test clean across all ~24 test projects (only pre-existing, unrelated sandbox-timing flakiness observed, confirmed passing in isolation)
- [x] `security-reviewer` agent + `/code-review` + `/simplify` all run; every finding either fixed (with mutation-tested regression coverage) or filed as a tracked follow-up with rationale
- [x] `scripts/rails/run-gates.sh` (full AI-gated set, including `correctness` and `security`) passes clean
- [x] Path-traversal, cross-scope retrieval, multi-block marker-drop, and DI-scoping regressions all reproduced via mutation testing (revert fix → confirm test fails with the real production error; restore → confirm it passes) before being accepted as fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj