### PR TITLE
fix: inject peer-agent descriptions, widen delegation to named agents (#518)

### DIFF
--- a/documentation/reference/patterns-and-technologies.html
+++ b/documentation/reference/patterns-and-technologies.html
@@ -513,7 +513,12 @@ know the exact filename. Cite file paths in `path:line` form.</code></pre>
                         Agents can dispatch <em>subagents</em> for parallel sub-tasks. <code>SubagentToolResolver</code>
                         exposes a subagent as a callable tool to its parent; <code>InMemoryAgentMailbox</code> routes
                         messages; <code>BuiltInSubagentProfiles</code> ships ready-made profiles (planner, architect,
-                        explorer, ...). Delegation transcripts persist via <code>JsonlDelegationStore</code>.
+                        explorer, ...). Delegation transcripts persist via <code>JsonlDelegationStore</code>. A
+                        caller can also target a specific, named <code>AGENT.md</code>-registered peer directly
+                        (<code>target_agent</code> on the delegate tool, <code>SubagentType.NamedAgent</code>),
+                        bypassing capability-match scoring. <code>PeerAgentContextProvider</code> injects each
+                        agent's delegatable-peer descriptions into its own instructions every turn so it knows
+                        who is available to name.
                     </p>
 
                     <h3 id="a2a">A2A hosting</h3>

--- a/skills/orchestrator-agent/SKILL.md
+++ b/skills/orchestrator-agent/SKILL.md
@@ -31,10 +31,16 @@ and returns its output back to you. Its parameters:
 - `task` (required): a self-contained description of the subtask. The sub-agent sees
   **only** this text and none of the surrounding conversation, so include every piece
   of context it needs to succeed.
+- `target_agent` (optional): the id of a specific registered peer agent to delegate to
+  directly, when your own instructions list one whose description already fits this
+  subtask. Prefer this over `capabilities`/`minimum_tier` when you know exactly who
+  should handle the subtask — it skips selection entirely and hands the subtask to that
+  agent. `capabilities` and `minimum_tier` are ignored when this is set.
 - `capabilities` (optional): comma-separated tool names the sub-agent will need
   (e.g. `"file_system"`). Leave empty when the subtask is pure reasoning or writing.
+  Ignored when `target_agent` is set.
 - `minimum_tier` (optional): one of `Restricted`, `Supervised`, `Autonomous`
-  (default `Supervised`).
+  (default `Supervised`). Ignored when `target_agent` is set.
 
 Issue one `delegate_task` call per subtask. When subtasks are independent, delegate
 them all before synthesizing; when a later subtask depends on an earlier result, wait

--- a/src/Content/Application/Application.AI.Common/Categorization/RegistrationBreakdownCalculator.cs
+++ b/src/Content/Application/Application.AI.Common/Categorization/RegistrationBreakdownCalculator.cs
@@ -134,9 +134,14 @@ public static class RegistrationBreakdownCalculator
             : 0;
     }
 
-    /// <summary>One delegatable peer agent's description.</summary>
+    /// <summary>
+    /// One delegatable peer agent's entry — sized from the same formatted text
+    /// <see cref="Services.Agent.PeerAgentContextProvider"/> actually injects (#518), not
+    /// <see cref="AgentRegistration.Description"/> alone, so this total and the prompt agree by
+    /// construction rather than by two independent estimates happening to match.
+    /// </summary>
     public static int TokensFor(AgentRegistration agent) =>
-        TokenEstimationHelper.EstimateTokens(agent.Description);
+        TokenEstimationHelper.EstimateTokens(Services.Agent.PeerAgentContextFormatter.FormatEntry(agent));
 
     /// <summary>
     /// A tool's footprint: its serialized schema when it has one, else its name and description.

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -50,6 +50,10 @@ public partial class AgentExecutionContextFactory
     /// <param name="effectiveAllowlist">The one allowlist governing this agent, or <see langword="null"/>.</param>
     /// <param name="disclosableSkills">The skills the framework provider is given, built once by the caller.</param>
     /// <param name="baseline">What the agent was already charged for; see <see cref="PerTurnBudgetBaseline"/>.</param>
+    /// <param name="owningAgentId">
+    /// This agent's own id, for <see cref="Services.Agent.PeerAgentContextProvider"/>'s self-exclusion
+    /// (#518) — <see langword="null"/> for a bare-skill agent with no owning <c>AGENT.md</c>.
+    /// </param>
     /// <returns>
     /// The ordered rail as a read-only list. Never empty: the governance wrapper is on every agent's
     /// rail (see the attachment site below), so there is no such thing as an agent with no providers.
@@ -66,9 +70,17 @@ public partial class AgentExecutionContextFactory
         int skillCount,
         IReadOnlyList<string>? effectiveAllowlist,
         IReadOnlyList<DisclosableSkill> disclosableSkills,
-        PerTurnBudgetBaseline baseline)
+        PerTurnBudgetBaseline baseline,
+        string? owningAgentId)
     {
         var providers = new List<AIContextProvider>();
+
+        // Peer-agent descriptions (#518). No config gate — unlike the two recall providers below,
+        // this is not an optional feature: it is what makes the Agents lane correct. Placed early,
+        // ahead of the governance wrapper and the per-turn measurer, so its contribution is governed
+        // and charged like everything else on the rail. Contributes nothing (empty AIContext) when
+        // this agent has zero delegatable peers, so a host with one agent pays nothing extra.
+        providers.Add(new Services.Agent.PeerAgentContextProvider(_agentRegistry, owningAgentId));
 
         if (disclosableSkills.Count > 0)
         {

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -50,6 +50,7 @@ public partial class AgentExecutionContextFactory
     private readonly ISkillPrerequisiteResolver _prerequisiteResolver;
     private readonly ISkillFileReader _skillFileReader;
     private readonly ICompositeResponseSanitizer _sanitizer;
+    private readonly IAgentMetadataRegistry _agentRegistry;
     private readonly IContextBudgetTracker? _budgetTracker;
     private readonly IExecutionTraceStore? _traceStore;
     private readonly IAgentConfigReporter? _agentConfigReporter;
@@ -76,6 +77,11 @@ public partial class AgentExecutionContextFactory
     /// <param name="traceStore">Persists per-turn execution traces, when the host wires one in.</param>
     /// <param name="agentConfigReporter">Reports the resolved agent configuration, when the host wires one in.</param>
     /// <param name="resilientChatClientProvider">Supplies a resilience-wrapped chat client, when the host wires one in.</param>
+    /// <param name="agentRegistry">
+    /// Discovers registered peer agents for <see cref="Services.Agent.PeerAgentContextProvider"/> (#518).
+    /// A singleton with no per-request state, so unlike the recall providers it is a first-class
+    /// constructor dependency rather than resolved through <see cref="IAmbientRequestScope"/>.
+    /// </param>
     public AgentExecutionContextFactory(
         ILogger<AgentExecutionContextFactory> logger,
         IOptionsMonitor<AppConfig> appConfig,
@@ -85,12 +91,14 @@ public partial class AgentExecutionContextFactory
         ISkillPrerequisiteResolver prerequisiteResolver,
         ISkillFileReader skillFileReader,
         ICompositeResponseSanitizer sanitizer,
+        IAgentMetadataRegistry agentRegistry,
         IContextBudgetTracker? budgetTracker = null,
         IExecutionTraceStore? traceStore = null,
         IAgentConfigReporter? agentConfigReporter = null,
         IResilientChatClientProvider? resilientChatClientProvider = null)
     {
         ArgumentNullException.ThrowIfNull(skillFileReader);
+        ArgumentNullException.ThrowIfNull(agentRegistry);
 
         _logger = logger;
         _appConfig = appConfig;
@@ -100,6 +108,7 @@ public partial class AgentExecutionContextFactory
         _prerequisiteResolver = prerequisiteResolver;
         _skillFileReader = skillFileReader;
         _sanitizer = sanitizer;
+        _agentRegistry = agentRegistry;
         _budgetTracker = budgetTracker;
         _traceStore = traceStore;
         _agentConfigReporter = agentConfigReporter;
@@ -183,7 +192,8 @@ public partial class AgentExecutionContextFactory
             skills.Count,
             effectiveAllowedTools,
             disclosableSkills,
-            staticBudget);
+            staticBudget,
+            options.OwningAgentId);
 
         var frameworkType = options.FrameworkType
             ?? ResolveFrameworkTypeFromMetadata(primarySkill)

--- a/src/Content/Application/Application.AI.Common/Interfaces/Agents/ISupervisor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Agents/ISupervisor.cs
@@ -25,6 +25,42 @@ public interface ISupervisor
         IReadOnlyList<string>? toolOverrides = null,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Delegates a task directly to a specific, named <c>AGENT.md</c>-registered peer agent (#518),
+    /// bypassing <see cref="ISupervisorStrategy"/>'s scoring entirely — the caller already knows
+    /// exactly which peer it wants, typically because <c>PeerAgentContextProvider</c> told it. Unlike
+    /// <see cref="DelegateAsync"/>, there is no minimum-tier floor to enforce: an <c>AgentDefinition</c>
+    /// carries no autonomy tier of its own to check against, and the caller has already made an
+    /// informed, specific choice rather than asking to be matched to one.
+    /// </summary>
+    /// <param name="targetAgentId">
+    /// The peer's <c>AgentDefinition.Id</c>. Must be registered and must not be
+    /// <paramref name="callingAgentId"/> — both are refused with a caller-facing failure, never a
+    /// thrown exception, matching <see cref="DelegateAsync"/>'s existing "no capable agent" refusal
+    /// shape.
+    /// </param>
+    /// <param name="taskDescription">Human-readable description of the task.</param>
+    /// <param name="callingAgentId">
+    /// The delegating agent's own id, for self-exclusion — <see langword="null"/> when the caller
+    /// could not resolve its own identity (no ambient request scope), in which case self-exclusion is
+    /// skipped rather than refusing the call: reaching one's own id by name is wasteful, not unsafe,
+    /// and is still bounded by <paramref name="currentDelegationDepth"/> like any other delegation.
+    /// </param>
+    /// <param name="currentDelegationDepth">Current nesting depth (0 for top-level). Enforced against MaxDelegationDepth.</param>
+    /// <param name="toolOverrides">
+    /// Unused on this path — a named peer agent already carries its own skill-derived tool set, unlike
+    /// a built-in profile's restrictive allowlist. Accepted for parity with <see cref="DelegateAsync"/>
+    /// and recorded for audit, but does not affect which tools the delegated agent gets.
+    /// </param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<DelegationResult> DelegateToNamedAgentAsync(
+        string targetAgentId,
+        string taskDescription,
+        string? callingAgentId,
+        int currentDelegationDepth = 0,
+        IReadOnlyList<string>? toolOverrides = null,
+        CancellationToken ct = default);
+
     /// <summary>Gets the latest state for a specific delegation.</summary>
     Task<DelegationRecord?> GetDelegationStatusAsync(Guid delegationId, CancellationToken ct = default);
 

--- a/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextFormatter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextFormatter.cs
@@ -54,13 +54,22 @@ public static class PeerAgentContextFormatter
     /// </summary>
     /// <param name="registry">Discovers the full set of registered agents.</param>
     /// <param name="owningAgentId">
-    /// The calling agent's own id, excluded from its own peer list. <see langword="null"/> excludes
-    /// nothing — a caller with no owning agent (a bare skill invocation) is not itself a registered
-    /// peer, so there is nothing of its own to filter out.
+    /// The calling agent's own id, excluded from its own peer list. <see langword="null"/> yields
+    /// <em>no peers at all</em>, not "exclude nothing" — a caller with no owning id has no verified
+    /// self to filter out, and several real paths reach here with one (an orchestrator built via
+    /// <c>SkillAgentOptions</c> with no <c>OwningAgentId</c>, the parameterless
+    /// <c>CreateAgentFromSkillAsync(skillId)</c> overload). Injecting the full registry for those
+    /// callers reopens exactly the gap #518 exists to close — text the prompt receives that the
+    /// <c>Agents</c> lane never charges for, since <c>BuildRegistrationSnapshot</c> already treats a
+    /// null owning agent as zero sub-agents. Failing closed here keeps both sides of that agreement.
     /// </param>
-    public static List<AgentRegistration> GetPeers(IAgentMetadataRegistry registry, string? owningAgentId) =>
-        registry.GetAll()
+    public static List<AgentRegistration> GetPeers(IAgentMetadataRegistry registry, string? owningAgentId)
+    {
+        if (owningAgentId is null) return [];
+
+        return registry.GetAll()
             .Where(a => !string.Equals(a.Id, owningAgentId, StringComparison.OrdinalIgnoreCase))
             .Select(a => new AgentRegistration(a.Id, a.Name, a.Description))
             .ToList();
+    }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextFormatter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextFormatter.cs
@@ -1,0 +1,66 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Context;
+
+namespace Application.AI.Common.Services.Agent;
+
+/// <summary>
+/// Formats one delegatable peer agent's description for injection into a turn's instructions —
+/// the single formatter <see cref="PeerAgentContextProvider"/> (to build the actual prompt text) and
+/// <see cref="Categorization.RegistrationBreakdownCalculator"/> (to size the <c>Agents</c> lane) both
+/// call, so the two numbers describing one turn cannot drift apart into two independent estimates of
+/// "how many tokens is this description" that happen to agree by coincidence (#518).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Deliberately no separate section header.</strong> Each entry is self-contained — id, name,
+/// description, one line — with no wrapping title the provider would prepend once. A header would
+/// read a little more polished, but its cost would sit entirely outside this formatter and therefore
+/// outside <c>Categorization.RegistrationBreakdownCalculator.TokensFor(AgentRegistration)</c>'s per-entry sum,
+/// reopening the exact gap #518 exists to close: text the model receives that no lane charges for.
+/// The model already learns how to use an id from here — <c>delegate_task</c>'s own tool description
+/// (Tools lane, already charged) explains the <c>target_agent</c> parameter once; this block only
+/// needs to enumerate which ids are valid.
+/// </para>
+/// </remarks>
+public static class PeerAgentContextFormatter
+{
+    /// <summary>
+    /// Formats one peer's entry: its id (the value <c>delegate_task</c>'s <c>target_agent</c> parameter
+    /// accepts), name, and description. Also what
+    /// <c>Categorization.RegistrationBreakdownCalculator.TokensFor(AgentRegistration)</c> sizes.
+    /// </summary>
+    public static string FormatEntry(AgentRegistration agent) =>
+        $"- \"{agent.Id}\" ({agent.Name}): {agent.Description}";
+
+    /// <summary>
+    /// Formats the full peer-agent block for injection — one line per peer, in the order given.
+    /// </summary>
+    /// <param name="peers">The delegatable peers for this turn, already self-excluded by the caller.</param>
+    /// <returns>
+    /// The joined block, or <see langword="null"/> when <paramref name="peers"/> is empty — meaning
+    /// "contribute nothing", which <see cref="PeerAgentContextProvider"/> turns into an empty
+    /// <c>AIContext</c> rather than injecting a block describing zero peers.
+    /// </returns>
+    public static string? FormatBlock(IReadOnlyList<AgentRegistration> peers) =>
+        peers.Count == 0 ? null : string.Join("\n", peers.Select(FormatEntry));
+
+    /// <summary>
+    /// Resolves the delegatable peers for <paramref name="owningAgentId"/> from the full registry,
+    /// self-excluded — the shared "who are this agent's peers" projection used by both
+    /// <see cref="PeerAgentContextProvider"/> (to build the prompt block) and
+    /// <c>ExecuteAgentTurnCommandHandler.BuildRegistrationSnapshot</c> (to size the context bar's
+    /// <c>Agents</c> lane from the same registrations), so the self-exclusion rule lives in one place
+    /// rather than two independently-written copies of the same filter.
+    /// </summary>
+    /// <param name="registry">Discovers the full set of registered agents.</param>
+    /// <param name="owningAgentId">
+    /// The calling agent's own id, excluded from its own peer list. <see langword="null"/> excludes
+    /// nothing — a caller with no owning agent (a bare skill invocation) is not itself a registered
+    /// peer, so there is nothing of its own to filter out.
+    /// </param>
+    public static List<AgentRegistration> GetPeers(IAgentMetadataRegistry registry, string? owningAgentId) =>
+        registry.GetAll()
+            .Where(a => !string.Equals(a.Id, owningAgentId, StringComparison.OrdinalIgnoreCase))
+            .Select(a => new AgentRegistration(a.Id, a.Name, a.Description))
+            .ToList();
+}

--- a/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextProvider.cs
@@ -37,8 +37,9 @@ public sealed class PeerAgentContextProvider : AIContextProvider
     /// <param name="owningAgentId">
     /// This agent's own id — excluded from its own peer list so an agent is never offered itself as a
     /// delegation target. <see langword="null"/> when this agent has no owning <c>AGENT.md</c> (a bare
-    /// skill invocation), in which case nothing is excluded — such an agent is not itself a registered
-    /// peer, so there is nothing of its own to filter out.
+    /// skill invocation or a caller-curated orchestrator), in which case this provider injects
+    /// <em>nothing</em> — see <see cref="PeerAgentContextFormatter.GetPeers"/>'s own remarks for why
+    /// "exclude nothing" is unsafe here (it was this provider's own #518 correctness-review defect).
     /// </param>
     public PeerAgentContextProvider(IAgentMetadataRegistry agentRegistry, string? owningAgentId)
     {

--- a/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/PeerAgentContextProvider.cs
@@ -1,0 +1,66 @@
+using Application.AI.Common.Interfaces;
+using Microsoft.Agents.AI;
+
+namespace Application.AI.Common.Services.Agent;
+
+/// <summary>
+/// An <see cref="AIContextProvider"/> that injects the descriptions of this agent's delegatable peers
+/// into its instructions every turn — closing #518: before this provider, the context bar's
+/// <c>Agents</c> lane charged tokens for peer descriptions no prompt ever contained, because nothing
+/// put them there.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Why a provider, not the static system prompt.</strong> Baking peer text into the assembled
+/// instruction string would charge it to the <c>System</c> lane and require subtracting it back out
+/// of that lane's arithmetic — the same delicate machinery <c>RegistrationBreakdownCalculator</c>
+/// already carries for skills — and would freeze the peer list at agent-construction time, which is
+/// cached and never invalidated for the life of the process. A provider re-evaluates every turn (a
+/// peer registered after this agent was built is picked up for free) and keeps the accounting
+/// entirely inside the <c>Agents</c> lane, which already exists for exactly this content.
+/// </para>
+/// <para>
+/// Resolves <see cref="IAgentMetadataRegistry"/> at construction, not per turn — it is a singleton
+/// (discovery happens once, at host startup) with no per-request state, so unlike the two recall
+/// providers this needs no <see cref="IAmbientRequestScope"/> bridge.
+/// </para>
+/// </remarks>
+public sealed class PeerAgentContextProvider : AIContextProvider
+{
+    private readonly IAgentMetadataRegistry _agentRegistry;
+    private readonly string? _owningAgentId;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PeerAgentContextProvider"/> class.
+    /// </summary>
+    /// <param name="agentRegistry">Discovers the full set of registered peer agents.</param>
+    /// <param name="owningAgentId">
+    /// This agent's own id — excluded from its own peer list so an agent is never offered itself as a
+    /// delegation target. <see langword="null"/> when this agent has no owning <c>AGENT.md</c> (a bare
+    /// skill invocation), in which case nothing is excluded — such an agent is not itself a registered
+    /// peer, so there is nothing of its own to filter out.
+    /// </param>
+    public PeerAgentContextProvider(IAgentMetadataRegistry agentRegistry, string? owningAgentId)
+    {
+        ArgumentNullException.ThrowIfNull(agentRegistry);
+
+        _agentRegistry = agentRegistry;
+        _owningAgentId = owningAgentId;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns <em>only</em> the peer block, never the incoming instructions or tools — this hook is
+    /// contractually additive (see <c>AIContextProviderMergeContractTests</c>): the base merge appends
+    /// whatever this returns onto the input, so echoing the input back here would duplicate it.
+    /// </remarks>
+    protected override ValueTask<AIContext> ProvideAIContextAsync(
+        InvokingContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var peers = PeerAgentContextFormatter.GetPeers(_agentRegistry, _owningAgentId);
+        var block = PeerAgentContextFormatter.FormatBlock(peers);
+
+        return ValueTask.FromResult(block is null ? new AIContext() : new AIContext { Instructions = block });
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -684,17 +684,12 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			}
 		}
 
-		// Sub-agents: only AGENT.md-discoverable peers count for the Agents lane today.
-		// Self is excluded so the agent doesn't show up as a delegation target on itself.
-		var subAgents = new List<AgentRegistration>();
-		if (agentDef is not null)
-		{
-			foreach (var peer in _agentRegistry.GetAll())
-			{
-				if (string.Equals(peer.Id, agentDef.Id, StringComparison.OrdinalIgnoreCase)) continue;
-				subAgents.Add(new AgentRegistration(peer.Id, peer.Name, peer.Description));
-			}
-		}
+		// Sub-agents: only AGENT.md-discoverable peers count for the Agents lane today. Self-exclusion
+		// is the same rule PeerAgentContextProvider applies to the prompt injection itself (#518) —
+		// shared via PeerAgentContextFormatter.GetPeers so the two never drift into different filters.
+		var subAgents = agentDef is null
+			? []
+			: Application.AI.Common.Services.Agent.PeerAgentContextFormatter.GetPeers(_agentRegistry, agentDef.Id);
 
 		return new RegistrationSnapshot(
 			SystemPromptText: ctx.Instruction,

--- a/src/Content/Domain/Domain.AI/Agents/SubagentType.cs
+++ b/src/Content/Domain/Domain.AI/Agents/SubagentType.cs
@@ -19,5 +19,16 @@ public enum SubagentType
     Execute,
 
     /// <summary>General purpose — balanced tool access, moderate turn budget.</summary>
-    General
+    General,
+
+    /// <summary>
+    /// Not a built-in profile. Marks a delegation that targeted a specific, named
+    /// <c>AGENT.md</c>-registered peer agent by id (#518) — <c>AgentCandidate.AgentId</c> /
+    /// <c>DelegationRecord.DelegateAgentId</c> carry that id, and the delegation bypassed
+    /// <c>ISupervisorStrategy</c>'s scoring entirely (the caller already named its target).
+    /// <c>ISubagentProfileRegistry.GetProfile</c> has no entry for this value — a candidate or record
+    /// carrying it is built and run through <c>ISupervisor</c> directly, never resolved from that
+    /// registry.
+    /// </summary>
+    NamedAgent
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services;
@@ -320,7 +321,23 @@ public sealed partial class CapabilityMatchSupervisor
                 // (AllowedTools = agentDef?.AllowedTools). AgentDefinition.AllowedTools is empty, not
                 // null, when the agent declares no ceiling, so this assignment is a direct 1:1 mapping
                 // of the same "empty means unrestricted" contract that path already relies on.
-                AllowedTools = target.AllowedTools
+                AllowedTools = target.AllowedTools,
+                // #518 correctness-review finding: without this, AgentExecutionContextFactory still
+                // stamps a prerequisite map whenever any of target's skills declares prerequisites, but
+                // ResolvePrerequisiteScope throws when no conversation scope is present — deterministic
+                // InvalidOperationException on every delegation to such a target. The ordinary-turn path
+                // this branch mirrors always supplies one via AgentConversationCache.WithConversationScope.
+                // Using the caller's real conversation id (IAgentExecutionContext.ConversationId) is
+                // deliberately avoided here — that property documents three different meanings across its
+                // callers (see its own remarks), and reusing it for a new purpose is the exact mistake
+                // that already forced a dedicated CallOnceScopeId property elsewhere in this codebase.
+                // target.Id is stable (bounded by the registered-agent count, not a fresh value per call)
+                // and scopes prerequisite unlock state to "this named target, delegated to by anyone" —
+                // the natural analogue of a conversation for a stateless, one-shot delegation call.
+                AdditionalProperties = new Dictionary<string, object>
+                {
+                    [AgentFactory.ConversationIdPropertyKey] = target.Id
+                }
             };
             var built = await _agentFactory.CreateAgentWithContextFromSkillsAsync(skillIds, options, ct);
             agent = built.Agent;

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Application.AI.Common.Factories;
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Traces;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Application.AI.Common.Services;
 using Application.AI.Common.Services.Tools;
@@ -303,6 +304,8 @@ public sealed partial class CapabilityMatchSupervisor
         // provider rail — including PeerAgentContextProvider, so a delegated agent sees ITS OWN
         // peers too) rather than the profile path's lightweight, skill-free CreateFromDelegation.
         AIAgent agent;
+        AgentExecutionContext? namedDelegationContext = null;
+        string? namedDelegationScope = null;
         if (selection.SelectedAgent.AgentType == SubagentType.NamedAgent)
         {
             var target = _agentRegistry.TryGet(selection.SelectedAgent.AgentId)
@@ -310,6 +313,16 @@ public sealed partial class CapabilityMatchSupervisor
                     $"Named delegation target '{selection.SelectedAgent.AgentId}' was validated at "
                     + "selection time but is no longer registered.");
             var skillIds = target.Skills is { Count: > 0 } ? target.Skills : [target.Id];
+            // #518 security-review finding: this scope gates SkillPrerequisiteMiddleware's tool
+            // withholding — a capability gate, not a hint. An earlier version of this fix scoped it to
+            // target.Id, stable but shared by EVERY caller who ever delegates to this agent — one
+            // tenant unlocking a gated skill permanently unlocked it for every other tenant, forever,
+            // breaking the exact cross-caller isolation AgentConversationCache.Evict's
+            // ClearConversation call exists to guarantee for ordinary conversations. The delegation id
+            // is unique per call, so no two callers ever share it, and it is explicitly cleared in
+            // FinalizeNamedDelegationScopeAsync once this run completes, so it never outlives the one
+            // delegation it was minted for.
+            namedDelegationScope = pendingRecord.DelegationId.ToString();
             var options = new SkillAgentOptions
             {
                 AgentNameOverride = target.Id,
@@ -327,20 +340,18 @@ public sealed partial class CapabilityMatchSupervisor
                 // ResolvePrerequisiteScope throws when no conversation scope is present — deterministic
                 // InvalidOperationException on every delegation to such a target. The ordinary-turn path
                 // this branch mirrors always supplies one via AgentConversationCache.WithConversationScope.
-                // Using the caller's real conversation id (IAgentExecutionContext.ConversationId) is
-                // deliberately avoided here — that property documents three different meanings across its
-                // callers (see its own remarks), and reusing it for a new purpose is the exact mistake
-                // that already forced a dedicated CallOnceScopeId property elsewhere in this codebase.
-                // target.Id is stable (bounded by the registered-agent count, not a fresh value per call)
-                // and scopes prerequisite unlock state to "this named target, delegated to by anyone" —
-                // the natural analogue of a conversation for a stateless, one-shot delegation call.
                 AdditionalProperties = new Dictionary<string, object>
                 {
-                    [AgentFactory.ConversationIdPropertyKey] = target.Id
+                    [AgentFactory.ConversationIdPropertyKey] = namedDelegationScope
                 }
             };
             var built = await _agentFactory.CreateAgentWithContextFromSkillsAsync(skillIds, options, ct);
             agent = built.Agent;
+            // #518 correctness-review finding: the profile branch's CreateFromDelegation context never
+            // holds a trace writer, but this path can — AgentExecutionContextFactory stamps one
+            // whenever execution tracing is enabled, and nothing else on a one-shot delegation's path
+            // ever completes/disposes it. Held here so the finally below can finalize it after the run.
+            namedDelegationContext = built.Context;
         }
         else
         {
@@ -373,6 +384,8 @@ public sealed partial class CapabilityMatchSupervisor
         finally
         {
             LlmUsageCapture.Current = previousUsage;
+            if (namedDelegationContext is not null)
+                await FinalizeNamedDelegationScopeAsync(namedDelegationContext, namedDelegationScope!, ct);
         }
 
         stopwatch.Stop();
@@ -402,6 +415,50 @@ public sealed partial class CapabilityMatchSupervisor
 
         var output = response.Text ?? string.Empty;
         return DelegationResult.Success(output, usage.InputTokens + usage.OutputTokens, durationMs);
+    }
+
+    /// <summary>
+    /// Finalizes a named delegation's one-shot execution scope once its run completes, success or
+    /// failure (#518, two review findings on the same code path). Completes and disposes the run's
+    /// <see cref="ITraceWriter"/> if execution tracing stamped one into the built context — a
+    /// one-shot delegation has no <c>AgentConversationCache</c> eviction to drive that, unlike an
+    /// ordinary turn, so it must happen explicitly here or the manifest is permanently left
+    /// <c>write_completed: false</c> and the writer's handle/semaphore never released. Then clears the
+    /// skill-prerequisite unlock state recorded under this delegation's scope id — that scope gates
+    /// real tool withholding (<c>SkillPrerequisiteMiddleware</c>), so it must never outlive the single
+    /// delegation it was minted for, or one caller's unlock silently persists for the next caller to
+    /// delegate to the same target.
+    /// </summary>
+    private async Task FinalizeNamedDelegationScopeAsync(
+        AgentExecutionContext context, string scope, CancellationToken ct)
+    {
+        if (context.AdditionalProperties is not null
+            && context.AdditionalProperties.TryGetValue(ITraceWriter.AdditionalPropertiesKey, out var stashed)
+            && stashed is ITraceWriter writer)
+        {
+            try
+            {
+                // CancellationToken.None: this finalization must not be skipped just because the
+                // delegation's own token was cancelled or timed out — matches
+                // AgentConversationCache.CompleteTraceWriter's identical reasoning for the ordinary-turn
+                // path this mirrors.
+                await writer.CompleteAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                // Swallowed, but logged: a run whose manifest was never stamped complete is
+                // indistinguishable on disk from one still in flight, so silence would hide the gap.
+                _logger.LogWarning(ex,
+                    "Failed to finalize the execution trace for delegation {DelegationId} — its "
+                    + "manifest will stay marked incomplete.", scope);
+            }
+            finally
+            {
+                await writer.DisposeAsync();
+            }
+        }
+
+        _completionTracker.ClearConversation(scope);
     }
 
     private async Task RecordCompletion(DelegationRecord pendingRecord, CancellationToken ct)

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.Escalation.cs
@@ -8,6 +8,7 @@ using Domain.AI.Agents;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.AI.Orchestration;
+using Domain.AI.Skills;
 using Domain.AI.Telemetry.Conventions;
 using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
@@ -295,9 +296,41 @@ public sealed partial class CapabilityMatchSupervisor
         Stopwatch stopwatch,
         CancellationToken ct)
     {
-        var definition = _profileRegistry.GetProfile(selection.SelectedAgent.AgentType);
-        var agentContext = _contextFactory.CreateFromDelegation(definition, toolOverrides, currentDepth + 1, pendingRecord.DelegationId);
-        var agent = await _agentFactory.CreateAgentAsync(agentContext, ct);
+        // #518: a named-agent delegation (SubagentType.NamedAgent) has no ISubagentProfileRegistry
+        // entry — GetProfile only knows the built-in profiles. Build the runnable agent the same way
+        // an ordinary turn does for an AGENT.md-registered agent (skill resolution, full context
+        // provider rail — including PeerAgentContextProvider, so a delegated agent sees ITS OWN
+        // peers too) rather than the profile path's lightweight, skill-free CreateFromDelegation.
+        AIAgent agent;
+        if (selection.SelectedAgent.AgentType == SubagentType.NamedAgent)
+        {
+            var target = _agentRegistry.TryGet(selection.SelectedAgent.AgentId)
+                ?? throw new InvalidOperationException(
+                    $"Named delegation target '{selection.SelectedAgent.AgentId}' was validated at "
+                    + "selection time but is no longer registered.");
+            var skillIds = target.Skills is { Count: > 0 } ? target.Skills : [target.Id];
+            var options = new SkillAgentOptions
+            {
+                AgentNameOverride = target.Id,
+                OwningAgentId = target.Id,
+                AgentInstructions = target.Instructions,
+                // #518 correctness-review finding: omitting this let a named delegation bypass the
+                // target's own AGENT.md tool ceiling entirely — ExecuteAgentTurnCommandHandler's
+                // ordinary-turn path this branch claims to mirror always passes it
+                // (AllowedTools = agentDef?.AllowedTools). AgentDefinition.AllowedTools is empty, not
+                // null, when the agent declares no ceiling, so this assignment is a direct 1:1 mapping
+                // of the same "empty means unrestricted" contract that path already relies on.
+                AllowedTools = target.AllowedTools
+            };
+            var built = await _agentFactory.CreateAgentWithContextFromSkillsAsync(skillIds, options, ct);
+            agent = built.Agent;
+        }
+        else
+        {
+            var definition = _profileRegistry.GetProfile(selection.SelectedAgent.AgentType);
+            var agentContext = _contextFactory.CreateFromDelegation(definition, toolOverrides, currentDepth + 1, pendingRecord.DelegationId);
+            agent = await _agentFactory.CreateAgentAsync(agentContext, ct);
+        }
 
         // Run the delegated subagent on the task, isolating its usage accounting from the parent turn.
         // Creating the agent alone does no work — the task description must be sent as the subagent's

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.cs
@@ -39,6 +39,7 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
     private readonly IGovernanceAuditService _auditService;
     private readonly AgentExecutionContextFactory _contextFactory;
     private readonly IAgentFactory _agentFactory;
+    private readonly IAgentMetadataRegistry _agentRegistry;
     private readonly IModelRouter? _modelRouter;
     private readonly IEscalationService? _escalationService;
     private readonly IOptionsMonitor<AppConfig> _options;
@@ -57,6 +58,10 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
     /// <param name="auditService">Governance audit chain for delegation decisions.</param>
     /// <param name="contextFactory">Factory for building agent execution contexts.</param>
     /// <param name="agentFactory">Factory for creating configured AI agent instances.</param>
+    /// <param name="agentRegistry">
+    /// Discovers <c>AGENT.md</c>-registered peer agents for <see cref="DelegateToNamedAgentAsync"/>
+    /// (#518) — resolving and validating the target the caller named.
+    /// </param>
     /// <param name="options">Application configuration for orchestration settings.</param>
     /// <param name="logger">Logger instance.</param>
     /// <param name="modelRouter">Optional model router for complexity-aware agent selection.</param>
@@ -70,6 +75,7 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
         IGovernanceAuditService auditService,
         AgentExecutionContextFactory contextFactory,
         IAgentFactory agentFactory,
+        IAgentMetadataRegistry agentRegistry,
         IOptionsMonitor<AppConfig> options,
         ILogger<CapabilityMatchSupervisor> logger,
         IModelRouter? modelRouter = null,
@@ -83,6 +89,7 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
         _auditService = auditService;
         _contextFactory = contextFactory;
         _agentFactory = agentFactory;
+        _agentRegistry = agentRegistry;
         _options = options;
         _logger = logger;
         _modelRouter = modelRouter;
@@ -129,6 +136,77 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
             return DelegationResult.Fail("No capable agent found for the requested task and tier requirements.");
         }
 
+        return await RecordAndExecuteAsync(
+            selection, taskDescription, requiredCapabilities, toolOverrides, currentDelegationDepth,
+            subagentConfig?.DelegationTimeoutSeconds ?? 300,
+            $"selected (score: {selection.ConfidenceScore:F2}, reason: {selection.Reasoning})",
+            ct);
+    }
+
+    /// <inheritdoc />
+    public async Task<DelegationResult> DelegateToNamedAgentAsync(
+        string targetAgentId,
+        string taskDescription,
+        string? callingAgentId,
+        int currentDelegationDepth = 0,
+        IReadOnlyList<string>? toolOverrides = null,
+        CancellationToken ct = default)
+    {
+        var subagentConfig = _options.CurrentValue.AI?.Orchestration?.Subagent;
+        var maxDepth = subagentConfig?.MaxDelegationDepth ?? 3;
+
+        if (currentDelegationDepth >= maxDepth)
+            return DelegationResult.Fail($"Delegation depth limit ({maxDepth}) exceeded.");
+
+        if (string.Equals(targetAgentId, callingAgentId, StringComparison.OrdinalIgnoreCase))
+            return DelegationResult.Fail("Cannot delegate to self.");
+
+        var target = _agentRegistry.TryGet(targetAgentId);
+        if (target is null)
+            return DelegationResult.Fail($"No registered agent with id '{targetAgentId}'.");
+
+        // No autonomy tier to resolve from an AgentDefinition (it carries none) and no floor to
+        // enforce against one — see DelegateToNamedAgentAsync's own remarks on ISupervisor for why.
+        // Recorded, not enforced: DelegateToSubagentTool's own DefaultMinimumTier for the same reason
+        // — a caller-facing record needs a value, and this is the same default every other call on
+        // this tool falls back to when it does not name one.
+        var selection = new AgentSelection
+        {
+            SelectedAgent = new AgentCandidate
+            {
+                AgentId = target.Id,
+                AgentType = SubagentType.NamedAgent,
+                AutonomyLevel = AutonomyLevel.Supervised,
+                AvailableTools = []
+            },
+            ConfidenceScore = 1.0,
+            Reasoning = "explicit target agent named by the caller"
+        };
+
+        return await RecordAndExecuteAsync(
+            selection, taskDescription, [], toolOverrides, currentDelegationDepth,
+            subagentConfig?.DelegationTimeoutSeconds ?? 300,
+            $"named target (reason: {selection.Reasoning})",
+            ct);
+    }
+
+    /// <summary>
+    /// Records the pending delegation and runs it to completion — the shared tail of
+    /// <see cref="DelegateAsync"/> and <see cref="DelegateToNamedAgentAsync"/> once each has built
+    /// its own <see cref="AgentSelection"/> by whatever means fits (strategy-scored vs. named-target
+    /// lookup). Only the audit message differs between callers, since the two selection paths mean
+    /// different things by "why this agent."
+    /// </summary>
+    private async Task<DelegationResult> RecordAndExecuteAsync(
+        AgentSelection selection,
+        string taskDescription,
+        IReadOnlyList<string> requiredCapabilities,
+        IReadOnlyList<string>? toolOverrides,
+        int currentDelegationDepth,
+        int delegationTimeoutSeconds,
+        string auditMessage,
+        CancellationToken ct)
+    {
         var delegationId = Guid.NewGuid();
         var stopwatch = Stopwatch.StartNew();
 
@@ -146,11 +224,11 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
         _auditService.Log(
             SupervisorId,
             $"delegate:{selection.SelectedAgent.AgentId}",
-            $"selected (score: {selection.ConfidenceScore:F2}, reason: {selection.Reasoning})");
+            auditMessage);
 
         return await ExecuteAndTrack(
             delegationId, pendingRecord, selection, toolOverrides, currentDelegationDepth,
-            subagentConfig?.DelegationTimeoutSeconds ?? 300, stopwatch, ct);
+            delegationTimeoutSeconds, stopwatch, ct);
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/CapabilityMatchSupervisor.cs
@@ -6,6 +6,7 @@ using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Routing;
+using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Domain.AI.Agents;
 using Domain.AI.Escalation;
@@ -40,6 +41,7 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
     private readonly AgentExecutionContextFactory _contextFactory;
     private readonly IAgentFactory _agentFactory;
     private readonly IAgentMetadataRegistry _agentRegistry;
+    private readonly ISkillCompletionTracker _completionTracker;
     private readonly IModelRouter? _modelRouter;
     private readonly IEscalationService? _escalationService;
     private readonly IOptionsMonitor<AppConfig> _options;
@@ -62,6 +64,12 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
     /// Discovers <c>AGENT.md</c>-registered peer agents for <see cref="DelegateToNamedAgentAsync"/>
     /// (#518) — resolving and validating the target the caller named.
     /// </param>
+    /// <param name="completionTracker">
+    /// Clears the per-delegation skill-prerequisite unlock scope after a named delegation finishes
+    /// (#518 security-review finding) — see <see cref="ExecuteAgent"/>'s remarks for why the scope is
+    /// the delegation id, not the target agent's id, and must be explicitly cleared here since a
+    /// one-shot delegation has no cache eviction to hang the clear off.
+    /// </param>
     /// <param name="options">Application configuration for orchestration settings.</param>
     /// <param name="logger">Logger instance.</param>
     /// <param name="modelRouter">Optional model router for complexity-aware agent selection.</param>
@@ -76,6 +84,7 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
         AgentExecutionContextFactory contextFactory,
         IAgentFactory agentFactory,
         IAgentMetadataRegistry agentRegistry,
+        ISkillCompletionTracker completionTracker,
         IOptionsMonitor<AppConfig> options,
         ILogger<CapabilityMatchSupervisor> logger,
         IModelRouter? modelRouter = null,
@@ -90,6 +99,7 @@ public sealed partial class CapabilityMatchSupervisor : ISupervisor, IDisposable
         _contextFactory = contextFactory;
         _agentFactory = agentFactory;
         _agentRegistry = agentRegistry;
+        _completionTracker = completionTracker;
         _options = options;
         _logger = logger;
         _modelRouter = modelRouter;

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -116,6 +116,7 @@ public static partial class DependencyInjection
         services.AddKeyedSingleton<ITool>(DelegateToSubagentTool.ToolName, (sp, _) =>
             new DelegateToSubagentTool(
                 sp.GetRequiredService<Application.AI.Common.Interfaces.Agents.ISupervisor>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IAmbientRequestScope>(),
                 sp.GetRequiredService<ILogger<DelegateToSubagentTool>>()));
 
         // Dashboard control tool — acts on the connected dashboard UI (read view, set time range,

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/DelegateToSubagentTool.cs
@@ -1,3 +1,5 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
@@ -7,6 +9,7 @@ using Domain.AI.Governance;
 using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Governance;
 using Domain.AI.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Tools;
@@ -51,14 +54,25 @@ public sealed class DelegateToSubagentTool : ITool
     private static readonly IReadOnlyList<string> Operations = ["delegate"];
 
     private readonly ISupervisor _supervisor;
+    private readonly IAmbientRequestScope _ambientScope;
     private readonly ILogger<DelegateToSubagentTool> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DelegateToSubagentTool"/> class.
     /// </summary>
-    public DelegateToSubagentTool(ISupervisor supervisor, ILogger<DelegateToSubagentTool> logger)
+    /// <param name="supervisor">Runs the delegation, either capability-matched or to a named target.</param>
+    /// <param name="ambientScope">
+    /// Bridges to the calling request's own scope so <c>target_agent</c> (#518) can resolve the
+    /// calling agent's own id for self-exclusion — see <c>.claude/rules/tools-and-mcp.md</c> for why
+    /// this keyed-singleton tool resolves scoped state this way instead of taking it as a constructor
+    /// dependency.
+    /// </param>
+    /// <param name="logger">Records delegation diagnostics.</param>
+    public DelegateToSubagentTool(
+        ISupervisor supervisor, IAmbientRequestScope ambientScope, ILogger<DelegateToSubagentTool> logger)
     {
         _supervisor = supervisor;
+        _ambientScope = ambientScope;
         _logger = logger;
     }
 
@@ -67,8 +81,12 @@ public sealed class DelegateToSubagentTool : ITool
 
     /// <inheritdoc />
     public string Description =>
-        "Delegate a self-contained subtask to the best-fit specialized subagent (the supervisor picks it). " +
-        "Returns the subagent's result. Parameters: 'task' (required) — what to do; " +
+        "Delegate a self-contained subtask to a subagent. Returns the subagent's result. " +
+        "Parameters: 'task' (required) — what to do; " +
+        "'target_agent' (optional) — the id of a specific registered peer agent to delegate to " +
+        "directly, if your instructions list one whose description fits this task; when supplied, " +
+        "'capabilities' and 'minimum_tier' are ignored and the named agent handles the task itself. " +
+        "Without 'target_agent', the best-fit specialized subagent is chosen automatically: " +
         "'capabilities' (optional) — comma-separated tool names the subagent needs (e.g. \"file_system,document_search\"); " +
         "'minimum_tier' (optional) — one of Restricted, Supervised, Autonomous (default Supervised). " +
         "Use this to hand off a well-scoped piece of work rather than doing it inline.";
@@ -131,6 +149,7 @@ public sealed class DelegateToSubagentTool : ITool
             return ToolResult.Fail(
                 $"Delegation depth limit ({MaxDelegationDepth}) reached; refusing to delegate further.");
 
+        var targetAgent = GetString(parameters, "target_agent");
         var capabilities = ParseCapabilities(GetString(parameters, "capabilities"));
         var minimumTier = ParseTier(GetString(parameters, "minimum_tier"));
 
@@ -139,13 +158,23 @@ public sealed class DelegateToSubagentTool : ITool
         s_delegationDepth.Value = depth + 1;
         try
         {
-            var result = await _supervisor.DelegateAsync(
-                task,
-                capabilities,
-                minimumTier,
-                currentDelegationDepth: depth,
-                toolOverrides: null,
-                cancellationToken);
+            // #518: 'target_agent' takes over entirely when supplied — capabilities/minimum_tier
+            // are meaningless once the caller has already named a specific peer.
+            var result = !string.IsNullOrWhiteSpace(targetAgent)
+                ? await _supervisor.DelegateToNamedAgentAsync(
+                    targetAgent,
+                    task,
+                    callingAgentId: ResolveCallingAgentId(),
+                    currentDelegationDepth: depth,
+                    toolOverrides: null,
+                    cancellationToken)
+                : await _supervisor.DelegateAsync(
+                    task,
+                    capabilities,
+                    minimumTier,
+                    currentDelegationDepth: depth,
+                    toolOverrides: null,
+                    cancellationToken);
 
             if (result.IsSuccess)
             {
@@ -167,6 +196,16 @@ public sealed class DelegateToSubagentTool : ITool
             s_delegationDepth.Value = depth;
         }
     }
+
+    /// <summary>
+    /// Resolves the calling agent's own id for <c>target_agent</c>'s self-exclusion (#518), best
+    /// effort. <see langword="null"/> when no request scope is ambient — a direct invocation, or any
+    /// caller outside a governed turn — in which case <see cref="ISupervisor.DelegateToNamedAgentAsync"/>
+    /// skips self-exclusion rather than refusing the call; see that method's own remarks for why a
+    /// missing identity is not treated as a self-delegation risk.
+    /// </summary>
+    private string? ResolveCallingAgentId()
+        => _ambientScope.Current?.GetService<IAgentExecutionContext>()?.AgentId;
 
     private static string? GetString(IReadOnlyDictionary<string, object?> parameters, string key)
         => parameters.TryGetValue(key, out var value) ? value?.ToString() : null;

--- a/src/Content/Tests/Application.AI.Common.Tests/Categorization/RegistrationBreakdownCalculatorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Categorization/RegistrationBreakdownCalculatorTests.cs
@@ -47,7 +47,11 @@ public sealed class RegistrationBreakdownCalculatorTests
         breakdown.Skills.Should().Be(Est(skill));
         breakdown.Tools.Should().Be(Est(schema));
         breakdown.Mcp.Should().Be(Est(mcpSchema));
-        breakdown.Agents.Should().Be(Est(peer));
+        // #518: sized from the same formatted entry PeerAgentContextProvider actually injects — id,
+        // name, and description wrapped in the entry format — not the raw description alone.
+        breakdown.Agents.Should().Be(
+            Est(Application.AI.Common.Services.Agent.PeerAgentContextFormatter.FormatEntry(
+                new AgentRegistration("a1", "Peer", peer))));
         breakdown.System.Should().Be(Est(instruction) - Est(skill));
 
         breakdown.Messages.Should().Be(0,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryBundleGovernanceTests.cs
@@ -8,6 +8,7 @@ using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
 using Application.AI.Common.Tests.Governance;
+using Domain.AI.Agents;
 using Application.AI.Common.Tests.Helpers;
 using Domain.AI.Bundles;
 using Domain.AI.Governance;
@@ -146,7 +147,8 @@ public sealed class AgentExecutionContextFactoryBundleGovernanceTests : IDisposa
             // #480: GoverningToolContextProvider now resolves a sanitizer to scrub load_skill/
             // read_skill_resource output — this fixture builds bundle agents through the real
             // AIContextProvider rail, so it needs one, matching every real composition.
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<AgentDefinition>()));
     }
 
     /// <summary>

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryDualModeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryDualModeTests.cs
@@ -64,7 +64,8 @@ public class AgentExecutionContextFactoryDualModeTests
             toolChainBuilder,
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<AgentDefinition>()));
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryGovernanceTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryGovernanceTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Agents;
 using Application.AI.Common.Services.Skills;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Skills;
@@ -67,7 +68,8 @@ public sealed class AgentExecutionContextFactoryGovernanceTests
             // #480: GoverningToolContextProvider now resolves a sanitizer to scrub load_skill/
             // read_skill_resource output — this fixture builds agents through the real
             // AIContextProvider rail, so it needs one, matching every real composition.
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<AgentDefinition>()));
     }
 
     private void SetupMcpTools(params (string server, string[] tools)[] servers)

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryProgressiveDisclosureTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Factories;
 using Application.AI.Common.Helpers;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Telemetry;
@@ -126,6 +127,7 @@ public sealed class AgentExecutionContextFactoryProgressiveDisclosureTests : IDi
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
             budgetTracker);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryPromptComposerTests.cs
@@ -70,7 +70,8 @@ public sealed class AgentExecutionContextFactoryPromptComposerTests
                 NullLogger<ToolChainBuilder>.Instance, serviceProvider),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()));
 
     /// <summary>
     /// Builds a root provider containing the full prompt-composition graph plus the ambient request

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -145,6 +145,7 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
             budgetTracker
                 ? new ContextBudgetTracker(
                     Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()),
@@ -164,6 +165,7 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 
         RailTypes(context).Should().Equal(
             [
+                typeof(PeerAgentContextProvider),         // instructions only; unconditional, no config gate
                 typeof(AgentSkillsProvider),              // contributes the framework's skill tools
                 typeof(ToolPermissionFilter),             // everything above it is filtered; nothing below is
                 typeof(KnowledgeMemoryContextProvider),   // instructions only
@@ -246,7 +248,7 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
 
         // Control: the two rows really do differ, so this is not the same case asserted twice. Without
         // it, a factory that ignored the flag would satisfy both.
-        rail.Count.Should().Be(4 + (recall ? 2 : 0));
+        rail.Count.Should().Be(5 + (recall ? 2 : 0));
 
         rail[^1].Should().BeOfType<PerTurnBudgetContextProvider>(
             "the measurer charges the difference between what it is handed and the baseline it was built "

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryTests.cs
@@ -83,6 +83,7 @@ public class AgentExecutionContextFactoryTests
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<AgentDefinition>()),
             budgetTracker: budgetTracker,
             traceStore: traceStore);
     }
@@ -207,7 +208,8 @@ public class AgentExecutionContextFactoryTests
             new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Mock.Of<IAgentMetadataRegistry>(r => r.GetAll() == new List<AgentDefinition>()));
 
         var context = await factory.MapToAgentContextAsync(SimpleSkill(), new SkillAgentOptions());
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolCeilingTests.cs
@@ -53,7 +53,9 @@ public sealed class AgentExecutionContextFactoryToolCeilingTests
                 NullLogger<ToolChainBuilder>.Instance, sp),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()));
     }
 
     private static SkillDefinition Skill(string id, params string[] allowedTools) => new()

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryToolEnforcementTests.cs
@@ -55,7 +55,9 @@ public class AgentExecutionContextFactoryToolEnforcementTests
                 NullLogger<ToolChainBuilder>.Instance, sp),
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()));
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryAgentOwnedSkillTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryAgentOwnedSkillTests.cs
@@ -73,7 +73,10 @@ public sealed class AgentFactoryAgentOwnedSkillTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         _contextFactory
             .Setup(f => f.MapToAgentContextAsync(

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryCompactionWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryCompactionWiringTests.cs
@@ -76,7 +76,10 @@ public sealed class AgentFactoryCompactionWiringTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         var services = new ServiceCollection();
         services.AddSingleton(compactionService);

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryEphemeralOverlayTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryEphemeralOverlayTests.cs
@@ -60,7 +60,10 @@ public sealed class AgentFactoryEphemeralOverlayTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         _contextFactory
             .Setup(f => f.MapToAgentContextAsync(

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryFoundryResponsesTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryFoundryResponsesTests.cs
@@ -60,7 +60,10 @@ public class AgentFactoryFoundryResponsesTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         return new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryPrerequisiteScopeSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryPrerequisiteScopeSolutionReviewFixTests.cs
@@ -67,7 +67,10 @@ public class AgentFactoryPrerequisiteScopeSolutionReviewFixTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         _factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryRedactorWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryRedactorWiringTests.cs
@@ -59,7 +59,10 @@ public sealed class AgentFactoryRedactorWiringTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         var services = new ServiceCollection();
         services.AddSingleton(redactor);

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryResilienceWiringTests.cs
@@ -75,7 +75,10 @@ public sealed class AgentFactoryResilienceWiringTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         var factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,
@@ -249,6 +252,8 @@ public sealed class AgentFactoryResilienceWiringTests
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
             resilientChatClientProvider: resilientProvider);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactorySolutionReviewFixTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactorySolutionReviewFixTests.cs
@@ -60,7 +60,10 @@ public class AgentFactorySolutionReviewFixTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         _factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTests.cs
@@ -72,7 +72,10 @@ public class AgentFactoryTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         _factory = new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTraceWriterWiringTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentFactoryTraceWriterWiringTests.cs
@@ -105,7 +105,10 @@ public sealed class AgentFactoryTraceWriterWiringTests
             monitor,
             new ServiceCollection().BuildServiceProvider(),
             NullLoggerFactory.Instance,
-            null!, null!, new UnsandboxedSkillFileReader(), null!, null!, null!, null!, null!);
+            null!, null!, new UnsandboxedSkillFileReader(), null!,
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
+            null!, null!, null!, null!);
 
         return new AgentFactory(
             NullLogger<AgentFactory>.Instance,

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
@@ -84,6 +84,7 @@ public sealed class AIContextProviderMergeContractTests
                 Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer()),
         [nameof(KnowledgeMemoryContextProvider)] = BuildKnowledgeMemory,
         [nameof(LearningsRecallContextProvider)] = BuildLearningsRecall,
+        [nameof(PeerAgentContextProvider)] = BuildPeerAgentContext,
         [nameof(PerTurnBudgetContextProvider)] = () => new PerTurnBudgetContextProvider(
             "MergeContractAgent",
             new Mock<IContextBudgetTracker>().Object,
@@ -187,6 +188,31 @@ public sealed class AIContextProviderMergeContractTests
             NullLogger<LearningsRecallContextProvider>.Instance);
     }
 
+    private static PeerAgentContextProvider BuildPeerAgentContext()
+    {
+        var registry = new Mock<Application.AI.Common.Interfaces.IAgentMetadataRegistry>();
+        registry.Setup(r => r.GetAll()).Returns(new List<Domain.AI.Agents.AgentDefinition>
+        {
+            new()
+            {
+                Id = "peer-agent",
+                Name = "Peer Agent",
+                Description = "Handles peer-shaped work."
+            },
+            new()
+            {
+                Id = "self-agent",
+                Name = "Self Agent",
+                Description = "Must not appear — this is the owning agent's own id."
+            }
+        });
+
+        // owningAgentId "self-agent" proves self-exclusion is exercised, not just the happy path of
+        // an agent with no peers at all — the active configuration for this provider is "at least one
+        // OTHER peer visible, and the caller's own entry filtered out."
+        return new PeerAgentContextProvider(registry.Object, owningAgentId: "self-agent");
+    }
+
     // ── the guard: no subclass may escape this suite ─────────────────────────
 
     [Fact]
@@ -254,6 +280,18 @@ public sealed class AIContextProviderMergeContractTests
 
         CountOccurrences(result.Instructions, "Lessons from past work").Should().Be(1);
         result.Instructions.Should().Contain("Prefer batching related fixes.");
+    }
+
+    [Fact]
+    public async Task PeerAgentContext_StillInjectsThePeerBlockExactlyOnceAndExcludesSelf()
+    {
+        var result = await Create(nameof(PeerAgentContextProvider))
+            .InvokingAsync(MakeContext(ActiveInput()));
+
+        CountOccurrences(result.Instructions, "peer-agent").Should().Be(1);
+        result.Instructions.Should().Contain("Handles peer-shaped work.");
+        result.Instructions.Should().NotContain("self-agent",
+            "the owning agent's own id must never appear as one of its own delegation targets");
     }
 
     [Theory]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
@@ -294,6 +294,28 @@ public sealed class AIContextProviderMergeContractTests
             "the owning agent's own id must never appear as one of its own delegation targets");
     }
 
+    [Fact]
+    public async Task PeerAgentContext_NoOwningAgentId_InjectsNothing()
+    {
+        // #518 correctness-review regression: a caller with no owning agent id (an orchestrator built
+        // with no OwningAgentId, or the parameterless CreateAgentFromSkillAsync(skillId) overload) used
+        // to have "nothing excluded" read as "inject the whole registry" — while
+        // ExecuteAgentTurnCommandHandler.BuildRegistrationSnapshot already treats a null owning agent as
+        // zero sub-agents, so the Agents lane charged nothing for what this provider injected in full.
+        var registry = new Mock<Application.AI.Common.Interfaces.IAgentMetadataRegistry>();
+        registry.Setup(r => r.GetAll()).Returns(new List<Domain.AI.Agents.AgentDefinition>
+        {
+            new() { Id = "peer-agent", Name = "Peer Agent", Description = "Handles peer-shaped work." }
+        });
+        var provider = new PeerAgentContextProvider(registry.Object, owningAgentId: null);
+
+        var result = await provider.InvokingAsync(MakeContext(ActiveInput()));
+
+        result.Instructions.Should().NotContain("peer-agent",
+            "a caller with no owning agent id has no verified self to exclude, so nothing should be " +
+            "injected at all rather than the full registry");
+    }
+
     [Theory]
     [InlineData(PlanCapabilities.LlmCall)]
     [InlineData(PlanCapabilities.Retrieval)]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/PeerAgentContextFormatterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/PeerAgentContextFormatterTests.cs
@@ -1,0 +1,50 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Services.Agent;
+using Domain.AI.Agents;
+using FluentAssertions;
+using Moq;
+
+namespace Application.AI.Common.Tests.Services.Agent;
+
+/// <summary>
+/// Regression coverage for the #518 correctness-review defect: a null <c>owningAgentId</c> used to
+/// mean "exclude nothing," so an agent built with no owning identity (an orchestrator built via
+/// <c>SkillAgentOptions</c> with no <c>OwningAgentId</c>, or the parameterless
+/// <c>CreateAgentFromSkillAsync(skillId)</c> overload) got the entire agent registry injected into its
+/// instructions while the context bar's <c>Agents</c> lane — which relies on the same null check via
+/// <c>ExecuteAgentTurnCommandHandler.BuildRegistrationSnapshot</c> — charged zero for it. The
+/// provider-level case (nothing actually injected) is covered in
+/// <c>AIContextProviderMergeContractTests.PeerAgentContext_NoOwningAgentId_InjectsNothing</c>.
+/// </summary>
+public sealed class PeerAgentContextFormatterTests
+{
+    private static Mock<IAgentMetadataRegistry> BuildRegistry(params AgentDefinition[] agents)
+    {
+        var registry = new Mock<IAgentMetadataRegistry>();
+        registry.Setup(r => r.GetAll()).Returns(agents);
+        return registry;
+    }
+
+    private static AgentDefinition Agent(string id) =>
+        new() { Id = id, Name = id, Description = $"{id} description" };
+
+    [Fact]
+    public void GetPeers_NullOwningAgentId_ReturnsNoPeers()
+    {
+        var registry = BuildRegistry(Agent("peer-a"), Agent("peer-b"));
+
+        var peers = PeerAgentContextFormatter.GetPeers(registry.Object, owningAgentId: null);
+
+        peers.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetPeers_KnownOwningAgentId_ReturnsEveryOtherRegisteredAgent()
+    {
+        var registry = BuildRegistry(Agent("self"), Agent("peer-a"), Agent("peer-b"));
+
+        var peers = PeerAgentContextFormatter.GetPeers(registry.Object, owningAgentId: "self");
+
+        peers.Select(p => p.Id).Should().BeEquivalentTo("peer-a", "peer-b");
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/AgentConversationCacheTests.cs
@@ -71,7 +71,9 @@ public sealed class AgentConversationCacheTests
             // #480: GoverningToolContextProvider now resolves a sanitizer to scrub load_skill/
             // read_skill_resource output, so the live-agent-build path this fixture exercises needs
             // one, matching what every real composition already provides unconditionally.
-            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer());
+            Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()));
 
         // Registry returns a two-skill graph where "deploy" depends on "validate".
         var registry = new Mock<ISkillMetadataRegistry>();
@@ -261,6 +263,8 @@ public sealed class AgentConversationCacheTraceLifecycleTests
             new SkillPrerequisiteResolver(),
             new UnsandboxedSkillFileReader(),
             Application.AI.Common.Tests.Governance.AdmissionHarness.PermissiveSanitizer(),
+            Moq.Mock.Of<Application.AI.Common.Interfaces.IAgentMetadataRegistry>(
+                r => r.GetAll() == new List<Domain.AI.Agents.AgentDefinition>()),
             traceStore: traceStore.Object);
 
         var registry = new Mock<ISkillMetadataRegistry>();

--- a/src/Content/Tests/Domain.AI.Tests/Agents/SubagentTypeTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Agents/SubagentTypeTests.cs
@@ -15,14 +15,15 @@ public sealed class SubagentTypeTests
     [InlineData(SubagentType.Verify, 2)]
     [InlineData(SubagentType.Execute, 3)]
     [InlineData(SubagentType.General, 4)]
+    [InlineData(SubagentType.NamedAgent, 5)]
     public void Values_HaveExpectedUnderlyingIntegers(SubagentType value, int expected)
     {
         ((int)value).Should().Be(expected);
     }
 
     [Fact]
-    public void Enum_HasExactlyFiveValues()
+    public void Enum_HasExactlySixValues()
     {
-        Enum.GetValues<SubagentType>().Should().HaveCount(5);
+        Enum.GetValues<SubagentType>().Should().HaveCount(6);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
@@ -38,6 +38,7 @@ public sealed class CapabilityMatchSupervisorEscalationTests : IDisposable
     private readonly Mock<IAutonomyTierResolver> _tierResolverMock = new();
     private readonly Mock<IGovernanceAuditService> _auditServiceMock = new();
     private readonly Mock<IAgentFactory> _agentFactoryMock = new();
+    private readonly Mock<IAgentMetadataRegistry> _agentRegistryMock = new();
     private readonly Mock<IEscalationService> _escalationServiceMock = new();
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly CapabilityMatchSupervisor _supervisor;
@@ -77,6 +78,7 @@ public sealed class CapabilityMatchSupervisorEscalationTests : IDisposable
             }
         };
         _options = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == config);
+        _agentRegistryMock.Setup(r => r.GetAll()).Returns(new List<AgentDefinition>());
 
         SetupDefaults();
 
@@ -88,7 +90,8 @@ public sealed class CapabilityMatchSupervisorEscalationTests : IDisposable
             Mock.Of<IToolChainBuilder>(),
             Mock.Of<ISkillPrerequisiteResolver>(),
             new UnsandboxedSkillFileReader(),
-            Infrastructure.AI.Tests.Planner.StepExecutors.PermissiveAdmission.PermissiveSanitizer());
+            Infrastructure.AI.Tests.Planner.StepExecutors.PermissiveAdmission.PermissiveSanitizer(),
+            _agentRegistryMock.Object);
 
         _supervisor = new CapabilityMatchSupervisor(
             _strategyMock.Object,
@@ -99,6 +102,7 @@ public sealed class CapabilityMatchSupervisorEscalationTests : IDisposable
             _auditServiceMock.Object,
             contextFactory,
             _agentFactoryMock.Object,
+            _agentRegistryMock.Object,
             _options,
             NullLogger<CapabilityMatchSupervisor>.Instance,
             modelRouter: null,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorEscalationTests.cs
@@ -103,6 +103,7 @@ public sealed class CapabilityMatchSupervisorEscalationTests : IDisposable
             contextFactory,
             _agentFactoryMock.Object,
             _agentRegistryMock.Object,
+            Mock.Of<ISkillCompletionTracker>(),
             _options,
             NullLogger<CapabilityMatchSupervisor>.Instance,
             modelRouter: null,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
@@ -438,6 +438,39 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
     }
 
     [Fact]
+    public async Task DelegateToNamedAgentAsync_TargetHasSkillsWithPrerequisites_SuppliesAConversationScope()
+    {
+        // Correctness-review finding: AgentExecutionContextFactory stamps a prerequisite map whenever
+        // any of the target's skills declares prerequisites, and AgentFactory.ChatClient's
+        // ResolvePrerequisiteScope throws InvalidOperationException when no conversation scope is
+        // present in SkillAgentOptions.AdditionalProperties[AgentFactory.ConversationIdPropertyKey].
+        // The ordinary-turn path always supplies one (AgentConversationCache.WithConversationScope);
+        // this branch must too, or every named delegation to a peer with prerequisite-declaring
+        // skills fails deterministically.
+        var target = new AgentDefinition
+        {
+            Id = "prerequisite-agent",
+            Name = "Prerequisite Agent",
+            Description = "d"
+        };
+        _agentRegistryMock.Setup(r => r.TryGet("prerequisite-agent")).Returns(target);
+
+        SkillAgentOptions? capturedOptions = null;
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<string>, SkillAgentOptions, CancellationToken>(
+                (_, options, _) => capturedOptions = options)
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("out"), new AgentExecutionContext()));
+
+        await _supervisor.DelegateToNamedAgentAsync("prerequisite-agent", "test task", "caller-agent");
+
+        capturedOptions!.AdditionalProperties.Should().NotBeNull();
+        capturedOptions.AdditionalProperties!.Should().ContainKey(AgentFactory.ConversationIdPropertyKey)
+            .WhoseValue.Should().Be("prerequisite-agent");
+    }
+
+    [Fact]
     public async Task DelegateToNamedAgentAsync_TargetHasNoDeclaredSkills_FallsBackToItsOwnIdAsTheSkillId()
     {
         var target = new AgentDefinition { Id = "peer-agent", Name = "Peer Agent", Description = "d" };

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Agents;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Interfaces.Traces;
 using Domain.AI.Agents;
 using Domain.AI.Governance;
 using Domain.AI.Orchestration;
@@ -34,6 +35,7 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
     private readonly Mock<IGovernanceAuditService> _auditServiceMock = new();
     private readonly Mock<IAgentFactory> _agentFactoryMock = new();
     private readonly Mock<IAgentMetadataRegistry> _agentRegistryMock = new();
+    private readonly Mock<ISkillCompletionTracker> _completionTrackerMock = new();
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly CapabilityMatchSupervisor _supervisor;
 
@@ -102,6 +104,7 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
             contextFactory,
             _agentFactoryMock.Object,
             _agentRegistryMock.Object,
+            _completionTrackerMock.Object,
             _options,
             NullLogger<CapabilityMatchSupervisor>.Instance);
     }
@@ -466,8 +469,90 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
         await _supervisor.DelegateToNamedAgentAsync("prerequisite-agent", "test task", "caller-agent");
 
         capturedOptions!.AdditionalProperties.Should().NotBeNull();
-        capturedOptions.AdditionalProperties!.Should().ContainKey(AgentFactory.ConversationIdPropertyKey)
-            .WhoseValue.Should().Be("prerequisite-agent");
+        capturedOptions.AdditionalProperties!.Should().ContainKey(AgentFactory.ConversationIdPropertyKey);
+        var scope = (string)capturedOptions.AdditionalProperties[AgentFactory.ConversationIdPropertyKey];
+        Guid.TryParse(scope, out _).Should().BeTrue(
+            "the scope must be the per-delegation id, not the target agent's own (stable, shared) id");
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_TwoDelegationsToTheSameTarget_GetIsolatedPrerequisiteScopes()
+    {
+        // #518 security-review finding: scoping to target.Id (constant for every caller) let one
+        // tenant's unlocked prerequisite skill permanently unlock the gated tools for every other
+        // caller who later delegates to the same target. Two separate delegations to the same target
+        // must never share a scope value.
+        var target = new AgentDefinition { Id = "shared-target", Name = "Shared Target", Description = "d" };
+        _agentRegistryMock.Setup(r => r.TryGet("shared-target")).Returns(target);
+
+        var capturedScopes = new List<string>();
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<string>, SkillAgentOptions, CancellationToken>(
+                (_, options, _) => capturedScopes.Add(
+                    (string)options.AdditionalProperties![AgentFactory.ConversationIdPropertyKey]))
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("out"), new AgentExecutionContext()));
+
+        await _supervisor.DelegateToNamedAgentAsync("shared-target", "task one", "caller-a");
+        await _supervisor.DelegateToNamedAgentAsync("shared-target", "task two", "caller-b");
+
+        capturedScopes.Should().HaveCount(2);
+        capturedScopes[0].Should().NotBe(capturedScopes[1],
+            "two different delegations to the same target must never share prerequisite-unlock scope");
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_RunCompletes_ClearsThePrerequisiteScope()
+    {
+        // #518 security-review finding: the delegation-scoped unlock state must not outlive the
+        // delegation it was created for, or it accumulates forever with nothing to clear it.
+        var target = new AgentDefinition { Id = "cleared-target", Name = "Cleared Target", Description = "d" };
+        _agentRegistryMock.Setup(r => r.TryGet("cleared-target")).Returns(target);
+
+        string? capturedScope = null;
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<string>, SkillAgentOptions, CancellationToken>(
+                (_, options, _) => capturedScope =
+                    (string)options.AdditionalProperties![AgentFactory.ConversationIdPropertyKey])
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("out"), new AgentExecutionContext()));
+
+        await _supervisor.DelegateToNamedAgentAsync("cleared-target", "test task", "caller-agent");
+
+        capturedScope.Should().NotBeNull();
+        _completionTrackerMock.Verify(t => t.ClearConversation(capturedScope!), Times.Once);
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_ExecutionTracingStampedAWriter_CompletesAndDisposesIt()
+    {
+        // Correctness-review finding: the profile branch's CreateFromDelegation context never holds a
+        // trace writer, but CreateAgentWithContextFromSkillsAsync's context can when execution tracing
+        // is enabled — and nothing on a one-shot delegation's path completed or disposed it, silently
+        // leaving the run's manifest.json permanently stamped write_completed: false and its
+        // SemaphoreSlim/file handle unreleased.
+        var target = new AgentDefinition { Id = "traced-target", Name = "Traced Target", Description = "d" };
+        _agentRegistryMock.Setup(r => r.TryGet("traced-target")).Returns(target);
+
+        var writerMock = new Mock<ITraceWriter>();
+        var builtContext = new AgentExecutionContext
+        {
+            AdditionalProperties = new Dictionary<string, object>
+            {
+                [ITraceWriter.AdditionalPropertiesKey] = writerMock.Object
+            }
+        };
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("out"), builtContext));
+
+        await _supervisor.DelegateToNamedAgentAsync("traced-target", "test task", "caller-agent");
+
+        writerMock.Verify(w => w.CompleteAsync(It.IsAny<CancellationToken>()), Times.Once);
+        writerMock.Verify(w => w.DisposeAsync(), Times.Once);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/CapabilityMatchSupervisorTests.cs
@@ -7,6 +7,7 @@ using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Agents;
 using Domain.AI.Governance;
 using Domain.AI.Orchestration;
+using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Orchestration;
@@ -32,6 +33,7 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
     private readonly Mock<IAutonomyTierResolver> _tierResolverMock = new();
     private readonly Mock<IGovernanceAuditService> _auditServiceMock = new();
     private readonly Mock<IAgentFactory> _agentFactoryMock = new();
+    private readonly Mock<IAgentMetadataRegistry> _agentRegistryMock = new();
     private readonly IOptionsMonitor<AppConfig> _options;
     private readonly CapabilityMatchSupervisor _supervisor;
 
@@ -60,6 +62,7 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
             }
         };
         _options = Mock.Of<IOptionsMonitor<AppConfig>>(o => o.CurrentValue == config);
+        _agentRegistryMock.Setup(r => r.GetAll()).Returns(new List<AgentDefinition>());
 
         _defaultSelection = new AgentSelection
         {
@@ -84,7 +87,8 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
             Mock.Of<IToolChainBuilder>(),
             Mock.Of<ISkillPrerequisiteResolver>(),
             new UnsandboxedSkillFileReader(),
-            Infrastructure.AI.Tests.Planner.StepExecutors.PermissiveAdmission.PermissiveSanitizer());
+            Infrastructure.AI.Tests.Planner.StepExecutors.PermissiveAdmission.PermissiveSanitizer(),
+            _agentRegistryMock.Object);
 
         SetupDefaults();
 
@@ -97,6 +101,7 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
             _auditServiceMock.Object,
             contextFactory,
             _agentFactoryMock.Object,
+            _agentRegistryMock.Object,
             _options,
             NullLogger<CapabilityMatchSupervisor>.Instance);
     }
@@ -313,6 +318,153 @@ public sealed class CapabilityMatchSupervisorTests : IDisposable
                     && !r.FailureReason.Contains("Agent creation failed")),
                 It.IsAny<CancellationToken>()),
             Times.Once());
+    }
+
+    // ── DelegateToNamedAgentAsync (#518) ──────────────────────────────────────
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_UnregisteredTarget_ReturnsFailWithoutCallingAgentFactory()
+    {
+        _agentRegistryMock.Setup(r => r.TryGet("no-such-agent")).Returns((AgentDefinition?)null);
+
+        var result = await _supervisor.DelegateToNamedAgentAsync("no-such-agent", "test task", "caller-agent");
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Contain("no-such-agent");
+        _agentFactoryMock.Verify(
+            f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()),
+            Times.Never(),
+            "an unregistered target must be refused before any agent is built");
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_TargetIsTheCallingAgentItself_ReturnsFailWithoutLookup()
+    {
+        var result = await _supervisor.DelegateToNamedAgentAsync(
+            "same-agent", "test task", callingAgentId: "same-agent");
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Contain("self");
+        _agentRegistryMock.Verify(r => r.TryGet(It.IsAny<string>()), Times.Never(),
+            "self-exclusion is a name comparison — it must not need a registry lookup to catch this case");
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_NoCallingAgentId_SkipsSelfExclusionAndStillDelegates()
+    {
+        // A caller with no resolvable identity (no ambient request scope) is not refused — self-
+        // delegation by name is wasteful, not unsafe, and is still bounded by MaxDelegationDepth.
+        var target = new AgentDefinition { Id = "peer-agent", Name = "Peer Agent", Description = "d" };
+        _agentRegistryMock.Setup(r => r.TryGet("peer-agent")).Returns(target);
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("NAMED_OUTPUT"), new AgentExecutionContext()));
+
+        var result = await _supervisor.DelegateToNamedAgentAsync(
+            "peer-agent", "test task", callingAgentId: null);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Output.Should().Be("NAMED_OUTPUT");
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_RegisteredTarget_BuildsFromTheTargetsOwnSkillsAndRunsIt()
+    {
+        var target = new AgentDefinition
+        {
+            Id = "peer-agent",
+            Name = "Peer Agent",
+            Description = "d",
+            Skills = ["peer-skill-a", "peer-skill-b"]
+        };
+        _agentRegistryMock.Setup(r => r.TryGet("peer-agent")).Returns(target);
+
+        IReadOnlyList<string>? capturedSkillIds = null;
+        SkillAgentOptions? capturedOptions = null;
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<string>, SkillAgentOptions, CancellationToken>(
+                (skillIds, options, _) =>
+                {
+                    capturedSkillIds = skillIds;
+                    capturedOptions = options;
+                })
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("NAMED_OUTPUT"), new AgentExecutionContext()));
+
+        var result = await _supervisor.DelegateToNamedAgentAsync(
+            "peer-agent", "UNIQUE_NAMED_TASK", callingAgentId: "caller-agent");
+
+        result.IsSuccess.Should().BeTrue();
+        result.Output.Should().Be("NAMED_OUTPUT");
+        // Bypasses ISubagentProfileRegistry entirely — it is built from the TARGET's own AGENT.md
+        // skills, exactly like an ordinary turn for that agent, not a built-in profile's fixed set.
+        capturedSkillIds.Should().Equal("peer-skill-a", "peer-skill-b");
+        capturedOptions!.OwningAgentId.Should().Be("peer-agent");
+        _profileRegistryMock.Verify(r => r.GetProfile(It.IsAny<SubagentType>()), Times.Never());
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_TargetHasAToolCeiling_PassesItThroughToTheBuiltAgent()
+    {
+        // Correctness-review finding on this PR: named delegation must not bypass the target's own
+        // AGENT.md tool ceiling. ExecuteAgentTurnCommandHandler's ordinary-turn path always passes
+        // AllowedTools = agentDef?.AllowedTools — this branch must mirror that exactly, or an operator
+        // who locked an agent down to read-only tools via allowed-tools: sees that ceiling silently
+        // ignored whenever the agent is reached through delegate_task's target_agent instead of a
+        // normal turn.
+        var target = new AgentDefinition
+        {
+            Id = "locked-down-agent",
+            Name = "Locked Down Agent",
+            Description = "d",
+            AllowedTools = ["read_file", "list_files"]
+        };
+        _agentRegistryMock.Setup(r => r.TryGet("locked-down-agent")).Returns(target);
+
+        SkillAgentOptions? capturedOptions = null;
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<string>, SkillAgentOptions, CancellationToken>(
+                (_, options, _) => capturedOptions = options)
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("out"), new AgentExecutionContext()));
+
+        await _supervisor.DelegateToNamedAgentAsync("locked-down-agent", "test task", "caller-agent");
+
+        capturedOptions!.AllowedTools.Should().Equal("read_file", "list_files");
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_TargetHasNoDeclaredSkills_FallsBackToItsOwnIdAsTheSkillId()
+    {
+        var target = new AgentDefinition { Id = "peer-agent", Name = "Peer Agent", Description = "d" };
+        _agentRegistryMock.Setup(r => r.TryGet("peer-agent")).Returns(target);
+
+        IReadOnlyList<string>? capturedSkillIds = null;
+        _agentFactoryMock
+            .Setup(f => f.CreateAgentWithContextFromSkillsAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<SkillAgentOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyList<string>, SkillAgentOptions, CancellationToken>(
+                (skillIds, _, _) => capturedSkillIds = skillIds)
+            .ReturnsAsync(new AgentBuildResult(new TestableAIAgent("out"), new AgentExecutionContext()));
+
+        await _supervisor.DelegateToNamedAgentAsync("peer-agent", "test task", "caller-agent");
+
+        capturedSkillIds.Should().Equal("peer-agent");
+    }
+
+    [Fact]
+    public async Task DelegateToNamedAgentAsync_DepthLimitReached_ReturnsFailWithoutAnyLookup()
+    {
+        var result = await _supervisor.DelegateToNamedAgentAsync(
+            "peer-agent", "test task", "caller-agent", currentDelegationDepth: 3);
+
+        result.IsSuccess.Should().BeFalse();
+        result.FailureReason.Should().Contain("depth");
+        _agentRegistryMock.Verify(r => r.TryGet(It.IsAny<string>()), Times.Never());
     }
 
     private static DelegationRecord BuildStoreRecord(DelegationState state) => new()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/DelegateToSubagentToolTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/DelegateToSubagentToolTests.cs
@@ -1,8 +1,11 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Agents;
 using Domain.AI.Governance;
 using Domain.AI.Orchestration;
 using FluentAssertions;
 using Infrastructure.AI.Tools;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -13,8 +16,32 @@ public class DelegateToSubagentToolTests
 {
     private readonly Mock<ISupervisor> _supervisor = new();
 
+    /// <summary>
+    /// No ambient scope by default (<c>Current == null</c>) — matches a direct invocation or any
+    /// caller outside a governed turn. Tests exercising self-exclusion build their own scope via
+    /// <see cref="BuildToolWithCallingAgentId"/>.
+    /// </summary>
+    private readonly Mock<IAmbientRequestScope> _ambientScope = new();
+
     private DelegateToSubagentTool BuildTool() =>
-        new(_supervisor.Object, NullLogger<DelegateToSubagentTool>.Instance);
+        new(_supervisor.Object, _ambientScope.Object, NullLogger<DelegateToSubagentTool>.Instance);
+
+    /// <summary>
+    /// Builds a tool whose ambient scope resolves an <see cref="IAgentExecutionContext"/> reporting
+    /// <paramref name="callingAgentId"/> — what a real governed turn establishes before invoking a
+    /// tool, and what <c>target_agent</c>'s self-exclusion (#518) reads.
+    /// </summary>
+    private DelegateToSubagentTool BuildToolWithCallingAgentId(string callingAgentId)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Mock.Of<IAgentExecutionContext>(c => c.AgentId == callingAgentId));
+        var scope = services.BuildServiceProvider();
+
+        return new DelegateToSubagentTool(
+            _supervisor.Object,
+            Mock.Of<IAmbientRequestScope>(a => a.Current == (IServiceProvider)scope),
+            NullLogger<DelegateToSubagentTool>.Instance);
+    }
 
     private static Dictionary<string, object?> Params(params (string Key, object? Value)[] entries)
         => entries.ToDictionary(e => e.Key, e => e.Value);
@@ -180,5 +207,129 @@ public class DelegateToSubagentToolTests
         tool.SupportedOperations.Should().ContainSingle().Which.Should().Be("delegate");
         tool.IsReadOnly.Should().BeFalse();
         tool.IsConcurrencySafe.Should().BeFalse();
+    }
+
+    // ── target_agent (#518) ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_TargetAgentSupplied_RoutesToNamedDelegationNotCapabilityMatch()
+    {
+        _supervisor
+            .Setup(s => s.DelegateToNamedAgentAsync(
+                "peer-agent", "do the thing", It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DelegationResult.Success("named agent output", tokensUsed: 10, durationMs: 5));
+
+        var result = await BuildTool().ExecuteAsync(
+            "delegate", Params(("task", "do the thing"), ("target_agent", "peer-agent")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Be("named agent output");
+        _supervisor.Verify(
+            s => s.DelegateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<AutonomyLevel>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "target_agent must take over entirely, not run alongside the capability-match path");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TargetAgentSupplied_IgnoresCapabilitiesAndMinimumTier()
+    {
+        IReadOnlyList<string>? unused = null;
+        _supervisor
+            .Setup(s => s.DelegateToNamedAgentAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string?, int, IReadOnlyList<string>?, CancellationToken>(
+                (_, _, _, _, overrides, _) => unused = overrides)
+            .ReturnsAsync(DelegationResult.Success("ok", 1, 1));
+
+        await BuildTool().ExecuteAsync("delegate", Params(
+            ("task", "do it"),
+            ("target_agent", "peer-agent"),
+            ("capabilities", "file_system"),
+            ("minimum_tier", "Autonomous")));
+
+        // capabilities/minimum_tier are simply never read on this path — DelegateToNamedAgentAsync's
+        // own signature has no capabilities parameter and no tier floor to receive them.
+        unused.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TargetAgentSupplied_ResolvesCallingAgentIdFromAmbientScopeForSelfExclusion()
+    {
+        string? capturedCallingId = "not-set";
+        _supervisor
+            .Setup(s => s.DelegateToNamedAgentAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string?, int, IReadOnlyList<string>?, CancellationToken>(
+                (_, _, callingId, _, _, _) => capturedCallingId = callingId)
+            .ReturnsAsync(DelegationResult.Success("ok", 1, 1));
+
+        await BuildToolWithCallingAgentId("this-agent").ExecuteAsync(
+            "delegate", Params(("task", "do it"), ("target_agent", "peer-agent")));
+
+        capturedCallingId.Should().Be("this-agent");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TargetAgentSupplied_NoAmbientScope_PassesNullCallingIdRatherThanThrowing()
+    {
+        string? capturedCallingId = "not-set";
+        _supervisor
+            .Setup(s => s.DelegateToNamedAgentAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, string?, int, IReadOnlyList<string>?, CancellationToken>(
+                (_, _, callingId, _, _, _) => capturedCallingId = callingId)
+            .ReturnsAsync(DelegationResult.Success("ok", 1, 1));
+
+        // Default BuildTool() has _ambientScope.Current == null (no request scope established) — a
+        // direct invocation or any caller outside a governed turn. This must degrade gracefully.
+        var result = await BuildTool().ExecuteAsync(
+            "delegate", Params(("task", "do it"), ("target_agent", "peer-agent")));
+
+        result.Success.Should().BeTrue();
+        capturedCallingId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_TargetAgentFails_SurfacesFailureReason()
+    {
+        _supervisor
+            .Setup(s => s.DelegateToNamedAgentAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DelegationResult.Fail("No registered agent with id 'peer-agent'."));
+
+        var result = await BuildTool().ExecuteAsync(
+            "delegate", Params(("task", "do it"), ("target_agent", "peer-agent")));
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().Be("No registered agent with id 'peer-agent'.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoTargetAgent_StillRoutesThroughCapabilityMatch()
+    {
+        // Control for every test above: without target_agent, nothing about the existing
+        // capability-match path may change.
+        _supervisor
+            .Setup(s => s.DelegateAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>(), It.IsAny<AutonomyLevel>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DelegationResult.Success("capability-matched output", 1, 1));
+
+        var result = await BuildTool().ExecuteAsync("delegate", Params(("task", "do it")));
+
+        result.Success.Should().BeTrue();
+        result.Output.Should().Be("capability-matched output");
+        _supervisor.Verify(
+            s => s.DelegateToNamedAgentAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(),
+                It.IsAny<int>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
## Summary

Package 9 of the tool-output pipeline cluster. Closes #518.

The context bar's `Agents` lane charged tokens for registered peer-agent descriptions that no prompt ever contained, and `delegate_task` could only route to five fixed built-in worker profiles — not a named `AGENT.md` peer — so even a model told about its peers had no way to reach one. Full fix, per the approved scope: inject the descriptions **and** make delegation able to actually reach a named agent.

- New `PeerAgentContextProvider` (an `AIContextProvider`) injects each agent's delegatable-peer descriptions into its own instructions every turn, additive-only per this repo's provider contract.
- `PeerAgentContextFormatter` is the single formatter both the provider and `RegistrationBreakdownCalculator` use, so the charged and injected text agree by construction — also now the shared "who are this agent's peers" projection for `ExecuteAgentTurnCommandHandler.BuildRegistrationSnapshot`.
- `SubagentType.NamedAgent` + `ISupervisor.DelegateToNamedAgentAsync` let `CapabilityMatchSupervisor` delegate straight to a named `AGENT.md` peer, bypassing capability-match scoring, self-excluded and depth-bounded the same way as ordinary delegation.
- `delegate_task` gained an optional `target_agent` parameter routing to the above.

### Four review rounds, three real defects caught and fixed before this PR existed as a single commit
This branch's history is deliberately left as four commits because each one is a distinct, verified finding from `run-gates.sh`'s automated review gates (opus correctness + security), not squashed busywork:

1. **Governance bypass**: named delegation built the target agent without its own `AllowedTools` ceiling, letting a delegated agent ignore an operator's `allowed-tools:` restriction.
2. **Accounting leak**: an agent with no owning identity (an orchestrator, or the parameterless skill-invocation overload) got the *entire* agent registry injected into its prompt while the `Agents` lane charged zero for it.
3. **Missing conversation scope**: named delegation to any peer whose skills declare prerequisites threw `InvalidOperationException` deterministically, since nothing supplied `AgentFactory.ConversationIdPropertyKey`.
4. **Security HIGH — cross-tenant prerequisite-unlock leak**: the fix for (3) initially scoped that conversation id to the *target agent's own id*, which is constant for every caller. `SkillPrerequisiteMiddleware` treats that scope as a real capability gate (it withholds tools until seen), so one tenant unlocking a gated skill on a named delegation permanently unlocked it for every other tenant delegating to the same target, forever. Fixed by scoping to the delegation's own id and explicitly clearing it on completion.
5. **Resource leak** (same commit as 4, same review round): the named-delegation branch discarded the built `AgentExecutionContext`, silently abandoning the run's `ITraceWriter` whenever execution tracing was enabled — same defect class as #505, reintroduced on a new path.

Every fix above was mutation-tested (a disabled/reverted version of the fix confirmed to make its regression test fail, then restored and reconfirmed passing) before moving to the next round.

## Test plan

- [x] Full solution build (Release) — 0 errors
- [x] Full solution test suite (Release, matching `run-gates.sh` exactly) — all green, one unrelated pre-existing flake (`EfCoreEscalationStateStoreTests`, tracked as #537) confirmed clean on isolated rerun
- [x] `run-gates.sh` full local pass: build, test, owasp, grader, correctness, security, docs-drift all green
- [x] Mutation-tested every fix (5 rounds total across the branch's 4 commits)
- [x] `AIContextProviderMergeContractTests` — additive-hook contract verified for the new provider
- [x] `mcp__gitnexus__detect_changes` reconciled after every commit — no unexpected blast radius

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj