### PR TITLE
feat: reconcile the context bar against real per-turn prompt tokens (#517)

### DIFF
--- a/documentation/design/foresight-dashboard-spec.md
+++ b/documentation/design/foresight-dashboard-spec.md
@@ -272,6 +272,9 @@ type Turn = {
   }>
   ctxAfter:  CategoryBreakdown         // snapshot immediately AFTER this turn lands
   loaded:    LoadedItem[]              // what this turn added — the per-turn delta
+  unattributedTokens?: number | null   // signed reconciliation gap vs. the last model call's real
+                                        // prompt (#517); positive = unattributed context, negative =
+                                        // estimate overshoot; null when no model call landed this turn
 }
 
 type LoadedItem = {

--- a/src/Content/Application/Application.AI.Common/Categorization/DefaultContextSnapshotComputer.cs
+++ b/src/Content/Application/Application.AI.Common/Categorization/DefaultContextSnapshotComputer.cs
@@ -16,8 +16,9 @@ namespace Application.AI.Common.Categorization;
 /// (<see cref="ContextCategory.System"/>, <see cref="ContextCategory.Skills"/>,
 /// <see cref="ContextCategory.Tools"/>, <see cref="ContextCategory.Mcp"/>,
 /// <see cref="ContextCategory.Agents"/>) arrive already summed from the real system-prompt, skill,
-/// tool-schema and peer-agent text; <see cref="ContextCategory.Messages"/> is estimated over the
-/// post-turn transcript.
+/// tool-schema and peer-agent text; <see cref="ContextCategory.Messages"/> is estimated over
+/// <c>history</c> as the caller passes it — the turn's own not-yet-sent response must not be in
+/// there (#517; see <see cref="IContextSnapshotComputer.Compute"/>'s remarks on <c>history</c>).
 /// </para>
 /// <para>
 /// <b>What changed, and why it was wrong before (#507).</b> This class used to compute
@@ -30,11 +31,11 @@ namespace Application.AI.Common.Categorization;
 /// has always shown two of its six lanes.
 /// </para>
 /// <para>
-/// The provider's reported total is no longer consulted at all. Reconciling against it would need a
-/// measurement of this turn's <em>prompt</em>, and what the harness records is input tokens
-/// accumulated across every model call in the turn — see <see cref="ContextSnapshot"/>'s remarks. The
-/// breakdown now stands on its own measurements rather than on a subtraction from a number that means
-/// something else.
+/// The provider's reported total feeds exactly one figure now, computed against operands pinned to
+/// the same side of the turn boundary (#517): <see cref="ContextSnapshot.UnattributedTokens"/>. It
+/// does not feed any <see cref="ContextCategory"/> — those remain pure measurements of what was
+/// actually loaded, never a subtraction from a billed total. See that property's remarks for why this
+/// is safe where #507's original, removed attempt was not.
 /// </para>
 /// </remarks>
 public sealed class DefaultContextSnapshotComputer : IContextSnapshotComputer
@@ -47,7 +48,8 @@ public sealed class DefaultContextSnapshotComputer : IContextSnapshotComputer
         IReadOnlyList<ChatMessage> history,
         CategoryBreakdown registrations,
         IReadOnlyList<LoadedItem> turnLoaded,
-        DateTimeOffset capturedAtUtc)
+        DateTimeOffset capturedAtUtc,
+        int? lastCallPromptTokens = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(conversationId);
         ArgumentException.ThrowIfNullOrEmpty(turnId);
@@ -70,6 +72,7 @@ public sealed class DefaultContextSnapshotComputer : IContextSnapshotComputer
             TurnId: turnId,
             CtxAfter: ctxAfter,
             Loaded: turnLoaded,
-            CapturedAtUtc: capturedAtUtc);
+            CapturedAtUtc: capturedAtUtc,
+            UnattributedTokens: lastCallPromptTokens is { } prompt ? prompt - ctxAfter.Total : null);
     }
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Context/IContextSnapshotComputer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Context/IContextSnapshotComputer.cs
@@ -22,8 +22,14 @@ namespace Application.AI.Common.Interfaces.Context;
 /// <c>registrations</c>, computed from the text actually loaded into the agent;
 /// <see cref="ContextCategory.Messages"/> is estimated from the transcript. Nothing is derived by
 /// subtracting from the provider's reported usage, which is what let one overshooting estimate floor
-/// the whole system-prompt segment to zero (#507) — and is why this contract no longer takes that
-/// figure at all.
+/// the whole system-prompt segment to zero (#507).
+/// </para>
+/// <para>
+/// <strong><see cref="ContextSnapshot.UnattributedTokens"/> is the one figure that IS a subtraction</strong>,
+/// and deliberately so (#517) — it exists to surface exactly the gap between the measured categories
+/// and what the provider actually billed, not to replace any of them. It is safe now in a way #507's
+/// original attempt was not: both operands are pinned to the same model call and the same side of the
+/// turn boundary — see <c>Compute</c>'s <c>lastCallPromptTokens</c> and <c>history</c> parameters below.
 /// </para>
 /// </remarks>
 public interface IContextSnapshotComputer
@@ -34,7 +40,14 @@ public interface IContextSnapshotComputer
     /// <param name="conversationId">Stable conversation identifier (matches the SignalR group).</param>
     /// <param name="turnIndex">Zero-based turn index within the conversation.</param>
     /// <param name="turnId">Stable turn identifier (e.g. <c>t-04</c>).</param>
-    /// <param name="history">The full message history including the user message and assistant response that landed this turn.</param>
+    /// <param name="history">
+    /// The message history as it stood for the turn's last model call — the user message and any
+    /// prior-turn messages, but <strong>not</strong> this turn's own assistant response. That response
+    /// is the call's <em>output</em>, never part of what was billed as input, so including it here
+    /// would misalign <see cref="ContextCategory.Messages"/> against <paramref name="lastCallPromptTokens"/>
+    /// by exactly one message every turn (#517) — the caller is responsible for passing the pre-response
+    /// history, not appending the response first.
+    /// </param>
     /// <param name="registrations">
     /// Cumulative, measured token totals for everything registered into the agent's context — the
     /// system prompt, each loaded skill, native tool schemas, MCP tool surfaces, and peer agents.
@@ -46,6 +59,13 @@ public interface IContextSnapshotComputer
     /// </param>
     /// <param name="turnLoaded">Per-turn delta items (user message, assistant message, tool results) the timeline should show under this turn.</param>
     /// <param name="capturedAtUtc">Server clock at capture time (stamped on the snapshot).</param>
+    /// <param name="lastCallPromptTokens">
+    /// The turn's last model call's own prompt size (input + cache-read + cache-write tokens for that
+    /// one call — never the turn's accumulated total, which answers a different question; see
+    /// <see cref="ContextSnapshot.UnattributedTokens"/>'s remarks). <see langword="null"/> when no
+    /// model call landed this turn, in which case <see cref="ContextSnapshot.UnattributedTokens"/> is
+    /// also null — there is nothing to reconcile against.
+    /// </param>
     ContextSnapshot Compute(
         string conversationId,
         int turnIndex,
@@ -53,5 +73,6 @@ public interface IContextSnapshotComputer
         IReadOnlyList<ChatMessage> history,
         CategoryBreakdown registrations,
         IReadOnlyList<LoadedItem> turnLoaded,
-        DateTimeOffset capturedAtUtc);
+        DateTimeOffset capturedAtUtc,
+        int? lastCallPromptTokens = null);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/ILlmUsageCapture.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/ILlmUsageCapture.cs
@@ -99,4 +99,17 @@ public record LlmUsageSnapshot(
     /// context window as it stood for the call that just ran."
     /// </summary>
     public IReadOnlyList<LlmCallUsage> Calls { get; init; } = Array.Empty<LlmCallUsage>();
+
+    /// <summary>
+    /// The turn's last model call's own prompt size — input, cache-read, and cache-write tokens for
+    /// that one call, all three real prompt content (<c>LlmCostCalculator</c> prices them identically).
+    /// This is the figure a context-bar reconciliation needs (#517), never <see cref="InputTokens"/>
+    /// above, which accumulates across every call in the turn and answers "what did the whole turn
+    /// cost," not "how big was the context window for the call that just ran." Null when no call
+    /// landed this turn.
+    /// </summary>
+    public int? LastCallPromptTokens =>
+        Calls.Count > 0
+            ? Calls[^1].InputTokens + Calls[^1].CacheRead + Calls[^1].CacheWrite
+            : null;
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/ILlmUsageCapture.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/ILlmUsageCapture.cs
@@ -58,6 +58,20 @@ public record ToolInvocationCapture(
     string? Stdout);
 
 /// <summary>
+/// Token usage from a single LLM call, in the order <see cref="ILlmUsageCapture.Record"/> saw it.
+/// Unlike <see cref="LlmUsageSnapshot"/>'s totals — accumulated across every call in the turn — this
+/// is what one specific call's prompt actually cost, which is what a context-bar reconciliation
+/// needs to compare against (#517): the accumulated total answers "how much did this turn cost
+/// altogether," not "how big was the context window for the call that just ran."
+/// </summary>
+public record LlmCallUsage(
+    int InputTokens,
+    int OutputTokens,
+    int CacheRead,
+    int CacheWrite,
+    string? Model);
+
+/// <summary>
 /// Immutable snapshot of accumulated LLM usage for a single agent turn.
 /// </summary>
 public record LlmUsageSnapshot(
@@ -76,4 +90,13 @@ public record LlmUsageSnapshot(
     /// </summary>
     public IReadOnlyList<ToolInvocationCapture> ToolInvocations { get; init; } =
         Array.Empty<ToolInvocationCapture>();
+
+    /// <summary>
+    /// Each individual model call's usage, in call order, alongside the totals above that sum them.
+    /// Empty when no call landed this turn (e.g. a turn that failed before any LLM call completed).
+    /// The last entry is the call whose prompt the context bar's per-turn reconciliation compares
+    /// against (#517) — the most recent model call is the closest available measurement of "the
+    /// context window as it stood for the call that just ran."
+    /// </summary>
+    public IReadOnlyList<LlmCallUsage> Calls { get; init; } = Array.Empty<LlmCallUsage>();
 }

--- a/src/Content/Application/Application.AI.Common/Services/LlmUsageCapture.cs
+++ b/src/Content/Application/Application.AI.Common/Services/LlmUsageCapture.cs
@@ -39,6 +39,12 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
     private readonly HashSet<string> _toolNames = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Per-call usage in call order — see <see cref="LlmUsageSnapshot.Calls"/> for why this exists
+    /// alongside the accumulated totals above (#517).
+    /// </summary>
+    private readonly List<LlmCallUsage> _calls = new();
+
+    /// <summary>
     /// Per-CallId invocation capture. Tool call requests land here keyed by their
     /// LLM-supplied call id; the matching result message updates the same entry
     /// on the next turn (when the FunctionResultContent is submitted back).
@@ -73,6 +79,7 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
             _cacheRead += cacheRead;
             _cacheWrite += cacheWrite;
             _model ??= model;
+            _calls.Add(new LlmCallUsage(inputTokens, outputTokens, cacheRead, cacheWrite, model));
         }
     }
 
@@ -160,11 +167,16 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
                     .ToList()
                 : Array.Empty<ToolInvocationCapture>();
 
+            IReadOnlyList<LlmCallUsage> calls = _calls.Count > 0
+                ? _calls.ToList()
+                : Array.Empty<LlmCallUsage>();
+
             var snapshot = new LlmUsageSnapshot(
                 _inputTokens, _outputTokens, _cacheRead, _cacheWrite,
                 model, cost, Math.Round(cacheHitPct, 4), toolNames)
             {
-                ToolInvocations = invocations
+                ToolInvocations = invocations,
+                Calls = calls
             };
 
             _inputTokens = 0;
@@ -174,6 +186,7 @@ public sealed class LlmUsageCapture : ILlmUsageCapture
             _model = null;
             _toolNames.Clear();
             _invocations.Clear();
+            _calls.Clear();
 
             return snapshot;
         }

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -273,16 +273,6 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 					request.UserMessage,
 					responseText,
 					toolsInvoked);
-				// #517: the last call's own prompt tokens — never usage's accumulated total, which
-				// sums every model call in the turn and would misrepresent a multi-round-trip turn
-				// as having a context window several times its real end-of-turn size. Includes
-				// cache-read/cache-write alongside plain input tokens because all three are real
-				// prompt content for that one call (LlmCostCalculator prices them the same way).
-				var lastCall = usage.Calls.Count > 0 ? usage.Calls[^1] : null;
-				var lastCallPromptTokens = lastCall is not null
-					? lastCall.InputTokens + lastCall.CacheRead + lastCall.CacheWrite
-					: (int?)null;
-
 				var snapshot = _snapshotComputer.Compute(
 					conversationId: request.ConversationId,
 					turnIndex: request.TurnNumber,
@@ -290,12 +280,12 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 					// #517: pre-response history — the state the last call's prompt actually saw.
 					// updatedHistory (below) additionally carries this turn's own assistant reply,
 					// which is output, never billed as input, and would misalign Messages against
-					// lastCallPromptTokens by exactly one message.
+					// usage.LastCallPromptTokens by exactly one message.
 					history: messages,
 					registrations: registrations,
 					turnLoaded: turnLoaded,
 					capturedAtUtc: _timeProvider.GetUtcNow(),
-					lastCallPromptTokens: lastCallPromptTokens);
+					lastCallPromptTokens: usage.LastCallPromptTokens);
 
 				// RecordLoadedBodiesAsync writes to the context_snapshot_loaded_bodies
 				// sidecar table — keeps the snapshot row + SignalR wire small (just

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -273,14 +273,29 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 					request.UserMessage,
 					responseText,
 					toolsInvoked);
+				// #517: the last call's own prompt tokens — never usage's accumulated total, which
+				// sums every model call in the turn and would misrepresent a multi-round-trip turn
+				// as having a context window several times its real end-of-turn size. Includes
+				// cache-read/cache-write alongside plain input tokens because all three are real
+				// prompt content for that one call (LlmCostCalculator prices them the same way).
+				var lastCall = usage.Calls.Count > 0 ? usage.Calls[^1] : null;
+				var lastCallPromptTokens = lastCall is not null
+					? lastCall.InputTokens + lastCall.CacheRead + lastCall.CacheWrite
+					: (int?)null;
+
 				var snapshot = _snapshotComputer.Compute(
 					conversationId: request.ConversationId,
 					turnIndex: request.TurnNumber,
 					turnId: $"t-{request.TurnNumber:D2}",
-					history: updatedHistory,
+					// #517: pre-response history — the state the last call's prompt actually saw.
+					// updatedHistory (below) additionally carries this turn's own assistant reply,
+					// which is output, never billed as input, and would misalign Messages against
+					// lastCallPromptTokens by exactly one message.
+					history: messages,
 					registrations: registrations,
 					turnLoaded: turnLoaded,
-					capturedAtUtc: _timeProvider.GetUtcNow());
+					capturedAtUtc: _timeProvider.GetUtcNow(),
+					lastCallPromptTokens: lastCallPromptTokens);
 
 				// RecordLoadedBodiesAsync writes to the context_snapshot_loaded_bodies
 				// sidecar table — keeps the snapshot row + SignalR wire small (just

--- a/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
+++ b/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
@@ -10,7 +10,12 @@ namespace Domain.AI.Context;
 /// <param name="ConversationId">Stable conversation identifier; matches the SignalR group name.</param>
 /// <param name="TurnIndex">Zero-based index of the turn within the conversation.</param>
 /// <param name="TurnId">Stable id of the turn (e.g. "t-01") for cross-reference with stored messages.</param>
-/// <param name="CtxAfter">Cumulative breakdown after this turn lands.</param>
+/// <param name="CtxAfter">
+/// Cumulative breakdown after this turn lands. Its <c>Messages</c> lane is measured over the
+/// pre-response history the turn's last model call actually saw (#517) — this turn's own assistant
+/// reply is not folded in until the next turn's snapshot, since it was never part of a billed prompt
+/// at the moment this snapshot is taken.
+/// </param>
 /// <param name="Loaded">Artifacts added by this turn (the per-turn delta).</param>
 /// <param name="CapturedAtUtc">Server clock at capture; clients show this in the timeline.</param>
 /// <param name="UnattributedTokens">

--- a/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
+++ b/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
@@ -35,6 +35,16 @@ namespace Domain.AI.Context;
 /// includes this turn's own not-yet-sent assistant reply. Both were the two "same side of the turn
 /// boundary" gaps #517 tracked.
 /// </para>
+/// <para>
+/// One real, known gap still shows up here as a nonzero figure rather than a false one: intra-turn
+/// tool-round-trip messages (a tool call and its result, exchanged mid-turn) are invisible to
+/// <see cref="CategoryBreakdown.Messages"/> the same way they are to
+/// <c>RegistrationBreakdownCalculator.TokensFor(SkillRegistration)</c>'s own remarks — whether they
+/// ever land in the estimated transcript depends on the durable tool-call replay path, not on
+/// anything this turn does. On a tool-heavy turn that content genuinely was billed as input, so a
+/// positive <see cref="UnattributedTokens"/> there is a true reconciliation signal, not noise —
+/// exactly the "context reached the model that no lane explains" case this field exists to surface.
+/// </para>
 /// </remarks>
 public sealed record ContextSnapshot(
     string ConversationId,

--- a/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
+++ b/src/Content/Domain/Domain.AI/Context/ContextSnapshot.cs
@@ -13,15 +13,27 @@ namespace Domain.AI.Context;
 /// <param name="CtxAfter">Cumulative breakdown after this turn lands.</param>
 /// <param name="Loaded">Artifacts added by this turn (the per-turn delta).</param>
 /// <param name="CapturedAtUtc">Server clock at capture; clients show this in the timeline.</param>
+/// <param name="UnattributedTokens">
+/// Signed reconciliation gap between what the bar attributed and what the provider actually billed
+/// for the turn's last model call (#517): <c>lastCallPromptTokens - CtxAfter.Total</c>. Positive means
+/// context reached the model that no lane explains; negative means the bar's own estimates overshot
+/// the real prompt. <see langword="null"/> when no model call landed this turn (a failed turn, or one
+/// with only local work) — there is nothing to reconcile against. <strong>Deliberately not a seventh
+/// <see cref="ContextCategory"/></strong>: a category is an additive token count and cannot represent
+/// an overshoot, and adding one would drag in every hand-maintained mirror of the enum the same way
+/// adding a <c>RedactionCategory</c> member did (see <c>CLAUDE.md</c>'s Common Mistakes).
+/// </param>
 /// <remarks>
 /// <para>
-/// <strong>There is deliberately no "unaccounted" figure here</strong>, though #507 originally called
-/// for one. Reconciling the breakdown against what the provider actually billed needs a measurement of
-/// <em>this turn's prompt</em>, and the harness does not have one: <c>ILlmUsageCapture</c> accumulates
-/// input tokens across every model call in a turn, so a turn with two tool round-trips reports roughly
-/// three prompts' worth. Subtracting a single post-turn context total from that produces a large
-/// positive number with no meaning — a confidently wrong figure on a dashboard, which is precisely the
-/// defect #507 exists to remove. Tracked as a follow-up; it needs per-call prompt sizing first.
+/// #507 originally called for a reconciliation figure and removed it before merge: the only usage
+/// measurement then available was <c>ILlmUsageCapture</c>'s accumulated total across every model call
+/// in the turn, so a turn with two tool round-trips reported roughly three prompts' worth — subtracted
+/// against a single post-turn context total, that produced a large positive number with no meaning.
+/// <see cref="UnattributedTokens"/> exists now because that gap is closed on both operands: it compares
+/// the <em>last</em> call's own prompt tokens (not the accumulated total) against <see cref="CtxAfter"/>
+/// computed from the same pre-response history that call actually saw, not the post-turn history that
+/// includes this turn's own not-yet-sent assistant reply. Both were the two "same side of the turn
+/// boundary" gaps #517 tracked.
 /// </para>
 /// </remarks>
 public sealed record ContextSnapshot(
@@ -30,4 +42,5 @@ public sealed record ContextSnapshot(
     string TurnId,
     CategoryBreakdown CtxAfter,
     IReadOnlyList<LoadedItem> Loaded,
-    DateTimeOffset CapturedAtUtc);
+    DateTimeOffset CapturedAtUtc,
+    int? UnattributedTokens = null);

--- a/src/Content/Infrastructure/Infrastructure.Observability/Migrations/006_context_snapshots_unattributed_tokens.sql
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Migrations/006_context_snapshots_unattributed_tokens.sql
@@ -1,0 +1,10 @@
+-- =============================================================================
+-- Foresight context-bar reconciliation (#517) — adds the signed unattributed-
+-- tokens gap to context_snapshots. Nullable: a turn with no model call (a
+-- failed turn, or one with only local work) has nothing to reconcile against.
+-- Applied by PostgresMigrationRunner. ADD is guarded with IF NOT EXISTS so
+-- re-applying is a no-op, same convention as 004_message_and_tool_bodies.sql.
+-- =============================================================================
+
+ALTER TABLE context_snapshots
+    ADD COLUMN IF NOT EXISTS unattributed_tokens INTEGER;

--- a/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.Context.cs
+++ b/src/Content/Infrastructure/Infrastructure.Observability/Persistence/PostgresObservabilityStore.Context.cs
@@ -7,8 +7,8 @@ namespace Infrastructure.Observability.Persistence;
 
 /// <summary>
 /// Foresight context-snapshot persistence. Schema lives in
-/// <c>Migrations/002_context_snapshots.sql</c>, embedded in this assembly and applied by the
-/// migration runner.
+/// <c>Migrations/002_context_snapshots.sql</c> plus <c>006_context_snapshots_unattributed_tokens.sql</c>
+/// (#517), embedded in this assembly and applied by the migration runner.
 /// </summary>
 public sealed partial class PostgresObservabilityStore
 {
@@ -40,19 +40,20 @@ public sealed partial class PostgresObservabilityStore
             INSERT INTO context_snapshots (
                 conversation_id, turn_index, turn_id,
                 cat_system, cat_agents, cat_skills, cat_tools, cat_mcp, cat_messages,
-                loaded_json, captured_at
+                loaded_json, captured_at, unattributed_tokens
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12)
             ON CONFLICT (conversation_id, turn_index) DO UPDATE SET
-                turn_id      = EXCLUDED.turn_id,
-                cat_system   = EXCLUDED.cat_system,
-                cat_agents   = EXCLUDED.cat_agents,
-                cat_skills   = EXCLUDED.cat_skills,
-                cat_tools    = EXCLUDED.cat_tools,
-                cat_mcp      = EXCLUDED.cat_mcp,
-                cat_messages = EXCLUDED.cat_messages,
-                loaded_json  = EXCLUDED.loaded_json,
-                captured_at  = EXCLUDED.captured_at
+                turn_id             = EXCLUDED.turn_id,
+                cat_system          = EXCLUDED.cat_system,
+                cat_agents          = EXCLUDED.cat_agents,
+                cat_skills          = EXCLUDED.cat_skills,
+                cat_tools           = EXCLUDED.cat_tools,
+                cat_mcp             = EXCLUDED.cat_mcp,
+                cat_messages        = EXCLUDED.cat_messages,
+                loaded_json         = EXCLUDED.loaded_json,
+                captured_at         = EXCLUDED.captured_at,
+                unattributed_tokens = EXCLUDED.unattributed_tokens
             """;
 
         try
@@ -78,6 +79,7 @@ public sealed partial class PostgresObservabilityStore
             cmd.Parameters.AddWithValue(snapshot.CtxAfter.Messages);
             cmd.Parameters.AddWithValue(loadedJson);
             cmd.Parameters.AddWithValue(snapshot.CapturedAtUtc);
+            cmd.Parameters.AddWithValue((object?)snapshot.UnattributedTokens ?? DBNull.Value);
 
             await cmd.ExecuteNonQueryAsync(cancellationToken);
         }
@@ -98,7 +100,7 @@ public sealed partial class PostgresObservabilityStore
         const string sql = """
             SELECT conversation_id, turn_index, turn_id,
                    cat_system, cat_agents, cat_skills, cat_tools, cat_mcp, cat_messages,
-                   loaded_json, captured_at
+                   loaded_json, captured_at, unattributed_tokens
             FROM context_snapshots
             WHERE conversation_id = $1
             ORDER BY turn_index DESC
@@ -132,7 +134,7 @@ public sealed partial class PostgresObservabilityStore
         const string sql = """
             SELECT conversation_id, turn_index, turn_id,
                    cat_system, cat_agents, cat_skills, cat_tools, cat_mcp, cat_messages,
-                   loaded_json, captured_at
+                   loaded_json, captured_at, unattributed_tokens
             FROM context_snapshots
             WHERE conversation_id = $1
             ORDER BY turn_index ASC
@@ -226,6 +228,7 @@ public sealed partial class PostgresObservabilityStore
             Messages: reader.GetInt32(8));
         var loadedJson = reader.GetString(9);
         var capturedAt = reader.GetFieldValue<DateTimeOffset>(10);
+        var unattributedTokens = reader.IsDBNull(11) ? (int?)null : reader.GetInt32(11);
 
         var loadedWire = JsonSerializer.Deserialize<LoadedItemWire[]>(loadedJson, s_loadedJson)
                          ?? Array.Empty<LoadedItemWire>();
@@ -234,6 +237,6 @@ public sealed partial class PostgresObservabilityStore
             .ToList();
 
         return new ContextSnapshot(
-            conversationId, turnIndex, turnId, ctxAfter, loaded, capturedAt);
+            conversationId, turnIndex, turnId, ctxAfter, loaded, capturedAt, unattributedTokens);
     }
 }

--- a/src/Content/Presentation/Presentation.AgentHub/DTOs/ContextSnapshotDto.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DTOs/ContextSnapshotDto.cs
@@ -12,10 +12,15 @@ namespace Presentation.AgentHub.DTOs;
 /// <param name="CtxAfter">Cumulative per-category breakdown after this turn.</param>
 /// <param name="Loaded">Per-turn delta items.</param>
 /// <param name="CapturedAtUtc">Server clock at capture.</param>
+/// <param name="UnattributedTokens">
+/// Signed reconciliation gap (#517) — see <see cref="Domain.AI.Context.ContextSnapshot.UnattributedTokens"/>
+/// for the full contract. <see langword="null"/> when no model call landed this turn.
+/// </param>
 public sealed record ContextSnapshotDto(
     string ConversationId,
     int TurnIndex,
     string TurnId,
     CategoryBreakdownDto CtxAfter,
     IReadOnlyList<LoadedItemDto> Loaded,
-    DateTimeOffset CapturedAtUtc);
+    DateTimeOffset CapturedAtUtc,
+    int? UnattributedTokens);

--- a/src/Content/Presentation/Presentation.AgentHub/Extensions/ContextSnapshotMappingExtensions.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Extensions/ContextSnapshotMappingExtensions.cs
@@ -45,6 +45,7 @@ public static class ContextSnapshotMappingExtensions
             snapshot.TurnId,
             snapshot.CtxAfter.ToDto(),
             [.. snapshot.Loaded.Select(ToDto)],
-            snapshot.CapturedAtUtc);
+            snapshot.CapturedAtUtc,
+            snapshot.UnattributedTokens);
     }
 }

--- a/src/Content/Presentation/Presentation.Dashboard/src/api/types.ts
+++ b/src/Content/Presentation/Presentation.Dashboard/src/api/types.ts
@@ -89,6 +89,14 @@ export interface ContextSnapshotEvent {
   ctxAfter: CategoryBreakdown;
   loaded: LoadedItem[];
   capturedAtUtc: string;
+  /**
+   * Signed reconciliation gap between what ctxAfter attributed and what the
+   * provider actually billed for this turn's last model call (#517).
+   * Positive: context reached the model that no category explains. Negative:
+   * the bar's own estimates overshot the real prompt. `null` when no model
+   * call landed this turn.
+   */
+  unattributedTokens?: number | null;
 }
 
 export interface SessionRecord {

--- a/src/Content/Tests/Application.AI.Common.Tests/Categorization/DefaultContextSnapshotComputerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Categorization/DefaultContextSnapshotComputerTests.cs
@@ -193,4 +193,76 @@ public sealed class DefaultContextSnapshotComputerTests
 
         act.Should().Throw<ArgumentNullException>();
     }
+
+    [Fact]
+    public void Compute_LastCallPromptTokensOmitted_UnattributedTokensIsNull()
+    {
+        // A turn with no model call (a failed turn, or one with only local work) has nothing to
+        // reconcile against — every existing test above omits this parameter and must keep passing.
+        var snapshot = _sut.Compute(
+            conversationId: "conv-1",
+            turnIndex: 0,
+            turnId: "t-00",
+            history: [],
+            registrations: CategoryBreakdown.Empty,
+            turnLoaded: [],
+            capturedAtUtc: _now);
+
+        snapshot.UnattributedTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public void Compute_LastCallPromptTokensExceedsCtxAfter_UnattributedTokensIsPositive()
+    {
+        // #517: context reached the model that no lane explains — the case the original,
+        // removed #507 attempt existed to surface, now computed against operands pinned to the
+        // same call and the same side of the turn boundary instead of an accumulated total.
+        var snapshot = _sut.Compute(
+            conversationId: "conv-1",
+            turnIndex: 0,
+            turnId: "t-00",
+            history: [],
+            registrations: Registrations(system: 1_000),
+            turnLoaded: [],
+            capturedAtUtc: _now,
+            lastCallPromptTokens: 1_500);
+
+        snapshot.CtxAfter.Total.Should().Be(1_000);
+        snapshot.UnattributedTokens.Should().Be(500);
+    }
+
+    [Fact]
+    public void Compute_LastCallPromptTokensUndershootsCtxAfter_UnattributedTokensIsNegative()
+    {
+        // The bar's own estimates overshot the real prompt — a signed value is what makes this
+        // direction distinguishable from the positive case, which a seventh additive ContextCategory
+        // could never represent.
+        var snapshot = _sut.Compute(
+            conversationId: "conv-1",
+            turnIndex: 0,
+            turnId: "t-00",
+            history: [],
+            registrations: Registrations(system: 2_000),
+            turnLoaded: [],
+            capturedAtUtc: _now,
+            lastCallPromptTokens: 1_700);
+
+        snapshot.UnattributedTokens.Should().Be(-300);
+    }
+
+    [Fact]
+    public void Compute_LastCallPromptTokensExactlyMatchesCtxAfter_UnattributedTokensIsZero()
+    {
+        var snapshot = _sut.Compute(
+            conversationId: "conv-1",
+            turnIndex: 0,
+            turnId: "t-00",
+            history: [],
+            registrations: Registrations(system: 900),
+            turnLoaded: [],
+            capturedAtUtc: _now,
+            lastCallPromptTokens: 900);
+
+        snapshot.UnattributedTokens.Should().Be(0);
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/LlmUsageCaptureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/LlmUsageCaptureTests.cs
@@ -249,4 +249,29 @@ public class LlmUsageCaptureTests
 
         second.Calls.Should().BeEmpty();
     }
+
+    [Fact]
+    public void LastCallPromptTokens_NoCalls_IsNull()
+    {
+        var sut = CreateSut();
+
+        var snapshot = sut.TakeSnapshot();
+
+        snapshot.LastCallPromptTokens.Should().BeNull();
+    }
+
+    [Fact]
+    public void LastCallPromptTokens_SumsInputCacheReadAndCacheWrite_ForTheLastCallOnly()
+    {
+        var sut = CreateSut();
+
+        sut.Record(inputTokens: 1_000, outputTokens: 0, cacheRead: 0, cacheWrite: 0, model: "test-model");
+        sut.Record(inputTokens: 8_450, outputTokens: 0, cacheRead: 100, cacheWrite: 50, model: "test-model");
+
+        var snapshot = sut.TakeSnapshot();
+
+        snapshot.LastCallPromptTokens.Should().Be(8_450 + 100 + 50,
+            "the first call's 1,000 tokens must not fold into the reconciliation figure — only the " +
+            "last call's own prompt matters for #517");
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/LlmUsageCaptureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/LlmUsageCaptureTests.cs
@@ -199,4 +199,54 @@ public class LlmUsageCaptureTests
         snapshot.Model.Should().Be("claude-haiku-4-5", "an explicitly recorded model must not be overridden by the default");
         snapshot.CostUsd.Should().Be(0.80m);
     }
+
+    // ── #517: per-call usage, distinct from the accumulated totals above ──
+    // The context-bar reconciliation needs one specific call's prompt size, not the turn's
+    // accumulated total across every model call — a turn with two tool round-trips would
+    // otherwise report roughly three prompts' worth against a snapshot of one.
+
+    [Fact]
+    public void TakeSnapshot_NoActivity_CallsIsEmpty()
+    {
+        var sut = CreateSut();
+
+        var snapshot = sut.TakeSnapshot();
+
+        snapshot.Calls.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TakeSnapshot_MultipleCalls_RecordsEachSeparatelyInOrder()
+    {
+        var sut = CreateSut();
+
+        sut.Record(inputTokens: 1_000, outputTokens: 50, cacheRead: 0, cacheWrite: 0, model: "test-model");
+        sut.Record(inputTokens: 8_000, outputTokens: 200, cacheRead: 100, cacheWrite: 0, model: "test-model");
+        sut.Record(inputTokens: 9_500, outputTokens: 300, cacheRead: 0, cacheWrite: 50, model: "test-model");
+
+        var snapshot = sut.TakeSnapshot();
+
+        snapshot.Calls.Should().HaveCount(3,
+            "the accumulated total folds three calls into one number; reconciliation needs each on its own");
+        snapshot.Calls[0].InputTokens.Should().Be(1_000);
+        snapshot.Calls[1].InputTokens.Should().Be(8_000);
+        snapshot.Calls[1].CacheRead.Should().Be(100);
+        snapshot.Calls[2].InputTokens.Should().Be(9_500);
+        snapshot.Calls[2].CacheWrite.Should().Be(50);
+
+        // The accumulated totals must still be correct and independent of the per-call list.
+        snapshot.InputTokens.Should().Be(1_000 + 8_000 + 9_500);
+    }
+
+    [Fact]
+    public void TakeSnapshot_ResetsCalls()
+    {
+        var sut = CreateSut();
+        sut.Record(inputTokens: 1_000, outputTokens: 0, cacheRead: 0, cacheWrite: 0, model: "test-model");
+
+        _ = sut.TakeSnapshot();
+        var second = sut.TakeSnapshot();
+
+        second.Calls.Should().BeEmpty();
+    }
 }

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_SnapshotTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ExecuteAgentTurnCommandHandler_SnapshotTests.cs
@@ -27,7 +27,18 @@ public class ExecuteAgentTurnCommandHandler_SnapshotTests
     private readonly Mock<IContextSnapshotNotifier> _notifier = new();
     private readonly Mock<IObservabilityStore> _store = new();
 
-    private ExecuteAgentTurnCommandHandler BuildHandler(IContextSnapshotNotifier notifier)
+    private static readonly LlmUsageSnapshot DefaultUsageSnapshot = new(
+        InputTokens: 5_000,
+        OutputTokens: 200,
+        CacheRead: 0,
+        CacheWrite: 0,
+        Model: "test-model",
+        CostUsd: 0m,
+        CacheHitPct: 0m,
+        ToolNames: Array.Empty<string>());
+
+    private ExecuteAgentTurnCommandHandler BuildHandler(
+        IContextSnapshotNotifier notifier, LlmUsageSnapshot? usageSnapshot = null)
     {
         _agentRegistry
             .Setup(r => r.TryGet(It.IsAny<string>()))
@@ -36,15 +47,7 @@ public class ExecuteAgentTurnCommandHandler_SnapshotTests
         var usageCapture = new Mock<ILlmUsageCapture>();
         usageCapture
             .Setup(c => c.TakeSnapshot())
-            .Returns(new LlmUsageSnapshot(
-                InputTokens: 5_000,
-                OutputTokens: 200,
-                CacheRead: 0,
-                CacheWrite: 0,
-                Model: "test-model",
-                CostUsd: 0m,
-                CacheHitPct: 0m,
-                ToolNames: Array.Empty<string>()));
+            .Returns(usageSnapshot ?? DefaultUsageSnapshot);
 
         return new ExecuteAgentTurnCommandHandler(
             _agentCache.Object,
@@ -181,5 +184,59 @@ public class ExecuteAgentTurnCommandHandler_SnapshotTests
         captured.Loaded.Should().Contain(li => li.What == "User message");
         captured.Loaded.Should().Contain(li => li.What == "Assistant message");
         captured.Loaded.All(li => li.Category == ContextCategory.Messages).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_UsesLastCallNotAccumulatedTotal_ForUnattributedTokens()
+    {
+        // #517: a turn with two tool round-trips (three model calls) must reconcile against the
+        // LAST call's own prompt, not the accumulated total across all three — the exact confusion
+        // that got #507's original reconciliation attempt pulled before merge.
+        SetupAgent("ok");
+        var usage = DefaultUsageSnapshot with
+        {
+            Calls =
+            [
+                new LlmCallUsage(InputTokens: 8_000, OutputTokens: 50, CacheRead: 0, CacheWrite: 0, Model: "test-model"),
+                new LlmCallUsage(InputTokens: 8_200, OutputTokens: 60, CacheRead: 0, CacheWrite: 0, Model: "test-model"),
+                new LlmCallUsage(InputTokens: 8_450, OutputTokens: 70, CacheRead: 100, CacheWrite: 0, Model: "test-model"),
+            ]
+        };
+        ContextSnapshot? captured = null;
+        _notifier
+            .Setup(n => n.NotifyAsync(It.IsAny<ContextSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<ContextSnapshot, CancellationToken>((s, _) => captured = s)
+            .Returns(Task.CompletedTask);
+
+        var handler = BuildHandler(_notifier.Object, usage);
+        await handler.Handle(Command(), CancellationToken.None);
+
+        // Nothing is registered in this fixture, so CtxAfter.Total is just the measured Messages
+        // lane; UnattributedTokens is the last call's prompt (8,450 + 100 cache-read) minus that.
+        captured!.UnattributedTokens.Should().Be(
+            8_450 + 100 - captured.CtxAfter.Total,
+            "reconciliation must key off Calls[^1], not the 24,650-token accumulated total across all three calls");
+    }
+
+    [Fact]
+    public async Task Handle_MessagesEstimate_ExcludesThisTurnsOwnAssistantResponse()
+    {
+        // #517's second, smaller gap: the assistant's own reply is this call's OUTPUT, never part
+        // of what was billed as input, so it must not inflate the Messages lane used to reconcile
+        // against the last call's prompt tokens.
+        var longResponse = new string('a', 4_000);
+        SetupAgent(longResponse);
+        ContextSnapshot? captured = null;
+        _notifier
+            .Setup(n => n.NotifyAsync(It.IsAny<ContextSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<ContextSnapshot, CancellationToken>((s, _) => captured = s)
+            .Returns(Task.CompletedTask);
+
+        var handler = BuildHandler(_notifier.Object);
+        await handler.Handle(Command(), CancellationToken.None);
+
+        captured!.CtxAfter.Messages.Should().BeLessThan(1_000,
+            "the 4,000-char assistant response must not be estimated into Messages — only the short " +
+            "user message this turn's last call actually saw as input belongs there");
     }
 }

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Integration/RoundTrip/ContextSnapshotsTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Integration/RoundTrip/ContextSnapshotsTests.cs
@@ -188,4 +188,44 @@ public sealed class ContextSnapshotsTests
 
         result.Should().BeEmpty();
     }
+
+    [SkippableFact]
+    public async Task RoundTrip_SignedUnattributedTokens_PersistsAndReadsBackExactly()
+    {
+        // #517: the field must survive exactly as stored — including negative (estimate overshoot),
+        // not just positive (unattributed context) — the bug the original attempt shipped with was
+        // the live SignalR stream carrying a real value while a page reload returned zero for the
+        // same turn because the store neither persisted nor rehydrated it.
+        _fixture.SkipIfUnavailable();
+        await EnsureSchemaAsync();
+
+        using var store = new PostgresObservabilityStore(_fixture.ConnectionString, _fixture.StoreLogger);
+        var convId = _fixture.NewConversationId();
+        var snapshot = MakeSnapshot(convId, turnIndex: 0, messages: 1200, system: 8200)
+            with
+        { UnattributedTokens = -350 };
+
+        await store.RecordContextSnapshotAsync(snapshot);
+        var read = await store.GetLatestSnapshotAsync(convId);
+
+        read!.UnattributedTokens.Should().Be(-350);
+    }
+
+    [SkippableFact]
+    public async Task RoundTrip_NoUnattributedTokens_PersistsAndReadsBackAsNull()
+    {
+        // The common case — a turn with no model call has nothing to reconcile against. Must read
+        // back as null, not 0, since 0 is a real (if unlikely) reconciliation result on its own.
+        _fixture.SkipIfUnavailable();
+        await EnsureSchemaAsync();
+
+        using var store = new PostgresObservabilityStore(_fixture.ConnectionString, _fixture.StoreLogger);
+        var convId = _fixture.NewConversationId();
+        var snapshot = MakeSnapshot(convId, turnIndex: 0, messages: 1200, system: 8200);
+
+        await store.RecordContextSnapshotAsync(snapshot);
+        var read = await store.GetLatestSnapshotAsync(convId);
+
+        read!.UnattributedTokens.Should().BeNull();
+    }
 }

--- a/src/Content/Tests/Infrastructure.Observability.Tests/Integration/RoundTrip/ContextSnapshotsTests.cs
+++ b/src/Content/Tests/Infrastructure.Observability.Tests/Integration/RoundTrip/ContextSnapshotsTests.cs
@@ -202,8 +202,7 @@ public sealed class ContextSnapshotsTests
         using var store = new PostgresObservabilityStore(_fixture.ConnectionString, _fixture.StoreLogger);
         var convId = _fixture.NewConversationId();
         var snapshot = MakeSnapshot(convId, turnIndex: 0, messages: 1200, system: 8200)
-            with
-        { UnattributedTokens = -350 };
+            with { UnattributedTokens = -350 };
 
         await store.RecordContextSnapshotAsync(snapshot);
         var read = await store.GetLatestSnapshotAsync(convId);

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/EmbeddedSqlMigrationSourceTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/EmbeddedSqlMigrationSourceTests.cs
@@ -35,10 +35,11 @@ public sealed class EmbeddedSqlMigrationSourceTests
                 "003_loaded_bodies",
                 "004_message_and_tool_bodies",
                 "005_sessions_status_cancelled",
+                "006_context_snapshots_unattributed_tokens",
             },
             scripts.Select(s => s.Id));
 
-        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, scripts.Select(s => s.Ordinal));
+        Assert.Equal(new[] { 1, 2, 3, 4, 5, 6 }, scripts.Select(s => s.Ordinal));
         Assert.All(scripts, s => Assert.False(string.IsNullOrWhiteSpace(s.Sql)));
     }
 

--- a/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
+++ b/src/Content/Tests/Infrastructure.Postgres.Tests/ObservabilitySchemaUpgradeTests.cs
@@ -197,7 +197,7 @@ public sealed class ObservabilitySchemaUpgradeTests
 
         // ---- Treatment: the same database, brought forward by the runner.
         var applied = await schema.ApplyAsync(all, Ledger);
-        Assert.Equal(1, applied); // only 005 was outstanding
+        Assert.Equal(all.Count - previousRelease.Length, applied); // every migration after 004 was outstanding
 
         Assert.Null(await schema.TryExecuteAsync(InsertCancelledSession));
         Assert.Equal("cancelled", await schema.ScalarAsync<string>(

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Notifications/SignalRContextSnapshotNotifierTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Notifications/SignalRContextSnapshotNotifierTests.cs
@@ -99,6 +99,7 @@ public sealed class SignalRContextSnapshotNotifierTests
             "ctxAfter",
             "loaded",
             "capturedAtUtc",
+            "unattributedTokens",
         ]);
     }
 


### PR DESCRIPTION
## Summary

Package 10 — the last package in the tool-output-pipeline cluster. Closes #517.

#507's original reconciliation attempt was pulled before merge: its two operands answered different questions. `LlmUsageCapture.Record` accumulates across every model call in a turn, so a turn with two tool round-trips reported roughly three prompts' worth, subtracted against `ContextSnapshot.CtxAfter` — a single post-turn snapshot. The result was a large, confidently wrong "unattributed context" figure. A second, smaller mismatch: `CtxAfter.Messages` was estimated over history that included the turn's own just-generated assistant response — output, never billed as input.

Both gaps are closed on the same operands now:

- `LlmUsageCapture.Record` already runs exactly once per model call — it now also appends each call's usage to an ordered `Calls` list alongside the existing accumulated totals, exposed as `LlmUsageSnapshot.LastCallPromptTokens` (input + cache-read + cache-write for the last call only).
- `ExecuteAgentTurnCommandHandler` passes the pre-response history (not the version with this turn's own assistant reply appended) into `DefaultContextSnapshotComputer`, alongside the last call's prompt size.
- `ContextSnapshot` gains a new, deliberately **signed** `UnattributedTokens` field (`lastCallPromptTokens - CtxAfter.Total`) — not a seventh `ContextCategory`, which is additive by design and can't represent an estimate overshoot (the `RedactionCategory` lesson already in this repo's `CLAUDE.md`).
- Persistence shipped in the same change: migration `006` adds the column, and all 5 hand-spelled sites in `PostgresObservabilityStore.Context.cs` (insert, on-conflict update, params, two selects, positional reader) are updated together — closing the exact gap that made the original attempt's live SignalR stream disagree with a page reload for the same turn.
- DTO, mapping, and the dashboard's `ContextSnapshotEvent` TS type carry the field through to the wire, nullable throughout since a turn with no model call has nothing to reconcile against.

## Review

One code-review pass (correctness + security + quality, full 17-file diff) found zero functional defects — one low-severity doc-only suggestion (cross-reference a known, pre-existing gap so a nonzero reconciliation on tool-heavy turns reads as a true signal), applied. `/simplify`'s 4-angle pass found one real improvement (extract `LastCallPromptTokens` as a computed property instead of an inline derivation at its one call site, per this repo's "second-caller-of-a-fixed-pattern" lesson) and one cosmetic nit, both applied. `run-gates.sh` passed all 7 gates (build, test, owasp, grader, correctness, security, docs-drift) on the **first attempt** — the cleanest run of any package in this cluster, matching GitNexus's own `risk_level: low` assessment (0 affected processes, changes fully contained to the reconciliation path).

## Test plan

- [x] Full solution build (Release) — 0 errors
- [x] Full solution test suite (Release) — all green
- [x] `run-gates.sh` full local pass — all 7 gates green on first attempt
- [x] Mutation-tested every new code path: per-call tracking, `UnattributedTokens` sign correctness (positive/negative/zero), pre-response `Messages` estimation, last-call-vs-accumulated-total selection, `LastCallPromptTokens` extraction
- [x] New Postgres round-trip tests for signed and null `UnattributedTokens` (skip when no local Postgres; will run in CI)
- [x] `mcp__gitnexus__detect_changes` reconciled after every commit — 0 affected processes, low risk

## Cluster complete

This closes the 10-package tool-output-pipeline cluster (#487, #489–491, #493, #494, #495, #488, #512, #513, #515, #521, #522, #518, #517).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj