### PR TITLE
Packages A+B: shared chat-client fake + structured-output contract (#323)

### DIFF
--- a/src/AgenticHarness.slnx
+++ b/src/AgenticHarness.slnx
@@ -180,6 +180,11 @@
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
     </Project>
+    <Project Path="Content/Tests/Tests.AI.Fakes/Tests.AI.Fakes.csproj">
+      <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
+    </Project>
     <Project Path="Content/Tests/Presentation.FoundryHost.Tests/Presentation.FoundryHost.Tests.csproj">
       <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -232,6 +232,10 @@ public static class DependencyInjection
         // Context budget tracking
         services.AddSingleton<IContextBudgetTracker, ContextBudgetTracker>();
 
+        // Structured-output contract layer (#323) — schema-out, validated-parse-back, one repair
+        // round-trip. Stateless; holds no per-request state.
+        services.AddSingleton<Interfaces.AI.IStructuredOutputInvoker, StructuredOutput.StructuredOutputInvoker>();
+
         // LLM usage capture — scoped so middleware and handler share the same instance per turn
         services.AddScoped<ILlmUsageCapture, Services.LlmUsageCapture>();
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/AI/IStructuredOutputInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/AI/IStructuredOutputInvoker.cs
@@ -1,0 +1,41 @@
+using Application.AI.Common.StructuredOutput;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Interfaces.AI;
+
+/// <summary>
+/// Sends a chat request with a JSON-schema hint attached, parses the reply against the target
+/// type, and runs one bounded repair round-trip on a malformed first attempt.
+/// </summary>
+/// <remarks>
+/// The one place in the codebase that owns "ask the model for JSON, validate what comes back,
+/// retry once with a stricter instruction." <c>Infrastructure.AI.Planner.LlmPlanGeneratorService</c>
+/// and <c>Infrastructure.AI.RAG.Evaluation.CragEvaluator</c> are its first two callers, replacing
+/// hand-rolled single-shot parse-and-fail logic that had no repair attempt at all.
+/// </remarks>
+public interface IStructuredOutputInvoker
+{
+    /// <summary>
+    /// Sends <paramref name="messages"/> with <paramref name="contract"/>'s schema attached as a
+    /// <see cref="ChatResponseFormat"/> hint, and parses the reply as <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">The response shape.</typeparam>
+    /// <param name="chatClient">The client to invoke. Not resolved by this method — the caller
+    /// already knows which provider/deployment it wants.</param>
+    /// <param name="contract">The contract built via <see cref="StructuredOutputSchema.Build{T}"/>.</param>
+    /// <param name="messages">The conversation to send. A repair attempt appends to the system
+    /// prompt rather than replaying the model's own prior output — see the implementation's remarks.</param>
+    /// <param name="chatOptions">
+    /// Caller-supplied options (temperature, max tokens). <see cref="ChatOptions.ResponseFormat"/>
+    /// is set by this method from <paramref name="contract"/> and must not be pre-populated by the
+    /// caller.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<StructuredOutputResult<T>> InvokeAsync<T>(
+        IChatClient chatClient,
+        StructuredOutputContract contract,
+        IReadOnlyList<ChatMessage> messages,
+        ChatOptions? chatOptions,
+        CancellationToken cancellationToken)
+        where T : class;
+}

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutcome.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutcome.cs
@@ -4,33 +4,31 @@ namespace Application.AI.Common.StructuredOutput;
 /// Why a call to <see cref="Interfaces.AI.IStructuredOutputInvoker"/>'s invoke method terminated.
 /// </summary>
 /// <remarks>
-/// Modelled on <c>Evaluation.Outcomes.LlmJudgeOutcome</c> — the same distinct-failure-mode shape,
-/// so a bad parse (<see cref="Malformed"/>) is never confused with a repair attempt that itself
-/// failed (<see cref="RepairFailed"/>) or with a transport failure (<see cref="InvocationFailed"/>).
+/// Modelled on <c>Evaluation.Outcomes.LlmJudgeOutcome</c>'s distinct-failure-mode shape, adapted to
+/// this invoker's actual control flow. There is deliberately no separate "malformed, no repair
+/// attempted" value: the two-attempt loop unconditionally schedules a repair after any parse
+/// failure on the first attempt, so by the time a call can fail on unparseable JSON, a repair
+/// always already happened — <see cref="RepairFailed"/> is reached, never a bare "malformed."
+/// Modelling a value that no code path can produce is the "outcomes collapsed by construction"
+/// defect shape this codebase's own history tracks — cheaper to not add the value than to add a
+/// test proving it's unreachable.
 /// </remarks>
 public enum StructuredOutcome
 {
     /// <summary>The model returned JSON that parsed and deserialized into the target type.</summary>
     Parsed = 0,
 
-    /// <summary>
-    /// Both attempts (first + repair) returned JSON that either did not parse or failed to
-    /// deserialize into the target type (including a missing <see langword="required"/> member).
-    /// </summary>
-    Malformed = 1,
-
     /// <summary>An infrastructure exception escaped the call (network, provider, etc.).</summary>
-    InvocationFailed = 2,
+    InvocationFailed = 1,
 
     /// <summary>
-    /// The first attempt was malformed and the repair round-trip itself failed — distinct from
-    /// <see cref="Malformed"/> so a caller can tell "never got valid JSON" apart from "got it wrong
-    /// once, then the repair attempt errored rather than merely being malformed again" (see
-    /// <see cref="InvocationFailed"/> for the latter's actual value if it also carries an exception).
+    /// Both attempts (first + the one repair round-trip) returned JSON that either did not parse
+    /// or failed to deserialize into the target type (including a missing
+    /// <see langword="required"/> member).
     /// </summary>
-    RepairFailed = 3,
+    RepairFailed = 2,
 
     /// <summary>The model returned an empty or whitespace-only body. No repair is attempted —
     /// a stricter format instruction cannot fix "the model said nothing."</summary>
-    EmptyResponse = 4,
+    EmptyResponse = 3,
 }

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutcome.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutcome.cs
@@ -1,0 +1,36 @@
+namespace Application.AI.Common.StructuredOutput;
+
+/// <summary>
+/// Why a call to <see cref="Interfaces.AI.IStructuredOutputInvoker"/>'s invoke method terminated.
+/// </summary>
+/// <remarks>
+/// Modelled on <c>Evaluation.Outcomes.LlmJudgeOutcome</c> — the same distinct-failure-mode shape,
+/// so a bad parse (<see cref="Malformed"/>) is never confused with a repair attempt that itself
+/// failed (<see cref="RepairFailed"/>) or with a transport failure (<see cref="InvocationFailed"/>).
+/// </remarks>
+public enum StructuredOutcome
+{
+    /// <summary>The model returned JSON that parsed and deserialized into the target type.</summary>
+    Parsed = 0,
+
+    /// <summary>
+    /// Both attempts (first + repair) returned JSON that either did not parse or failed to
+    /// deserialize into the target type (including a missing <see langword="required"/> member).
+    /// </summary>
+    Malformed = 1,
+
+    /// <summary>An infrastructure exception escaped the call (network, provider, etc.).</summary>
+    InvocationFailed = 2,
+
+    /// <summary>
+    /// The first attempt was malformed and the repair round-trip itself failed — distinct from
+    /// <see cref="Malformed"/> so a caller can tell "never got valid JSON" apart from "got it wrong
+    /// once, then the repair attempt errored rather than merely being malformed again" (see
+    /// <see cref="InvocationFailed"/> for the latter's actual value if it also carries an exception).
+    /// </summary>
+    RepairFailed = 3,
+
+    /// <summary>The model returned an empty or whitespace-only body. No repair is attempted —
+    /// a stricter format instruction cannot fix "the model said nothing."</summary>
+    EmptyResponse = 4,
+}

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputContract.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputContract.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+
+namespace Application.AI.Common.StructuredOutput;
+
+/// <summary>
+/// The single description of "what shape does this call's response take" — attached to the model
+/// request as a schema hint via <see cref="StructuredOutputSchema"/>, and used to validate the
+/// parsed reply on the way back. One object serving both directions, by construction, so the
+/// schema sent to the model and the schema checked against its reply can never independently drift
+/// (the failure shape recorded against <c>RegistrationBreakdownCalculator</c> — two estimates of
+/// the same thing computed twice, agreeing only by luck).
+/// </summary>
+/// <remarks>
+/// Build via <see cref="StructuredOutputSchema.Build{T}"/> — never construct a schema for
+/// <see cref="ResponseType"/> any other way; see that type's remarks for why it must be the sole
+/// owner of the schema-generation posture.
+/// </remarks>
+public sealed record StructuredOutputContract
+{
+    /// <summary>The CLR type a successful call deserializes into.</summary>
+    public required Type ResponseType { get; init; }
+
+    /// <summary>The schema's name, sent to the model as <c>ChatResponseFormatJson.SchemaName</c>.</summary>
+    public required string SchemaName { get; init; }
+
+    /// <summary>Optional human-readable description of the schema, sent alongside the name.</summary>
+    public string? SchemaDescription { get; init; }
+
+    /// <summary>The generated JSON Schema for <see cref="ResponseType"/>.</summary>
+    public required JsonElement Schema { get; init; }
+
+    /// <summary>
+    /// The <see cref="JsonSerializerOptions"/> used both to generate <see cref="Schema"/> and to
+    /// deserialize the model's reply — the same reflection pass drives both, which is what makes
+    /// the drift guard meaningful rather than tautological.
+    /// </summary>
+    public required JsonSerializerOptions SerializerOptions { get; init; }
+}

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputInvoker.cs
@@ -76,9 +76,13 @@ public sealed class StructuredOutputInvoker(ILogger<StructuredOutputInvoker> log
                 retryAddendum = MalformedJsonAddendum;
             }
 
-            var outcome = retryAddendum is null ? StructuredOutcome.Malformed : StructuredOutcome.RepairFailed;
+            // Always RepairFailed, never a bare "Malformed": retryAddendum is set at the end of
+            // attempt 0's iteration on any parse failure, so reaching here (both attempts
+            // exhausted) means a repair was necessarily attempted. There is no code path in this
+            // two-attempt loop that fails without one.
             return StructuredOutputResult<T>.Fail(
-                outcome, $"Model did not return valid '{contract.SchemaName}' JSON after a repair attempt.", lastRaw);
+                StructuredOutcome.RepairFailed,
+                $"Model did not return valid '{contract.SchemaName}' JSON after a repair attempt.", lastRaw);
         }
         catch (OperationCanceledException)
         {

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputInvoker.cs
@@ -1,0 +1,104 @@
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Json;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.StructuredOutput;
+
+/// <inheritdoc cref="IStructuredOutputInvoker" />
+public sealed class StructuredOutputInvoker(ILogger<StructuredOutputInvoker> logger) : IStructuredOutputInvoker
+{
+    // Generic — works regardless of what the caller's own system prompt said, since this layer
+    // doesn't know the specific validation failure beyond "it didn't parse." Deliberately does NOT
+    // say "return the same JSON object": the retry never shows the model its own prior attempt
+    // (only the raw text is captured, never appended as an assistant message), so an instruction
+    // implying continuity is unsatisfiable — mirrors JudgeCallCore's identical reasoning.
+    private const string MalformedJsonAddendum =
+        "Your previous reply was not valid JSON, or was missing a required field. You MUST return " +
+        "exactly one JSON object matching the requested schema, no fences, no commentary, and every " +
+        "required field populated.";
+
+    /// <inheritdoc />
+    public async Task<StructuredOutputResult<T>> InvokeAsync<T>(
+        IChatClient chatClient,
+        StructuredOutputContract contract,
+        IReadOnlyList<ChatMessage> messages,
+        ChatOptions? chatOptions,
+        CancellationToken cancellationToken)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(chatClient);
+        ArgumentNullException.ThrowIfNull(contract);
+        ArgumentNullException.ThrowIfNull(messages);
+
+        if (contract.ResponseType != typeof(T))
+            throw new ArgumentException(
+                $"Contract is for '{contract.ResponseType.Name}' but InvokeAsync<{typeof(T).Name}> was called.",
+                nameof(contract));
+
+        var responseFormat = ChatResponseFormat.ForJsonSchema(contract.Schema, contract.SchemaName, contract.SchemaDescription);
+        var options = chatOptions?.Clone() ?? new ChatOptions();
+        options.ResponseFormat = responseFormat;
+
+        string? lastRaw = null;
+        string? retryAddendum = null;
+
+        try
+        {
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var attemptMessages = BuildMessages(messages, retryAddendum);
+                var response = await chatClient
+                    .GetResponseAsync(attemptMessages, options, cancellationToken)
+                    .ConfigureAwait(false);
+                lastRaw = response.Text ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(lastRaw))
+                {
+                    // An empty body isn't a JSON-format problem; a stricter format instruction
+                    // can't fix "the model said nothing" — abort the retry budget early, matching
+                    // JudgeCallCore's identical reasoning for the same case.
+                    logger.LogWarning(
+                        "Structured output call for '{Schema}' returned an empty body on attempt {Attempt}; skipping repair.",
+                        contract.SchemaName, attempt + 1);
+                    return StructuredOutputResult<T>.Fail(
+                        StructuredOutcome.EmptyResponse, "Model returned an empty response.", lastRaw);
+                }
+
+                if (LlmJsonResponseParser.TryParseObject<T>(lastRaw, contract.SerializerOptions, out var parsed) && parsed is not null)
+                    return StructuredOutputResult<T>.Success(parsed, lastRaw);
+
+                logger.LogWarning(
+                    "Structured output call for '{Schema}' returned malformed output on attempt {Attempt}.",
+                    contract.SchemaName, attempt + 1);
+                retryAddendum = MalformedJsonAddendum;
+            }
+
+            var outcome = retryAddendum is null ? StructuredOutcome.Malformed : StructuredOutcome.RepairFailed;
+            return StructuredOutputResult<T>.Fail(
+                outcome, $"Model did not return valid '{contract.SchemaName}' JSON after a repair attempt.", lastRaw);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Structured output invocation failed for '{Schema}'.", contract.SchemaName);
+            return StructuredOutputResult<T>.Fail(
+                StructuredOutcome.InvocationFailed, $"Invocation failed: {ex.Message}", lastRaw);
+        }
+    }
+
+    private static IList<ChatMessage> BuildMessages(IReadOnlyList<ChatMessage> messages, string? retryAddendum)
+    {
+        if (retryAddendum is null) return [.. messages];
+
+        // Appended as an additional system message rather than mutating the caller's original
+        // system message text, and never as an assistant message replaying the prior (bad) output
+        // — see the class remarks on MalformedJsonAddendum.
+        return [.. messages, new ChatMessage(ChatRole.System, retryAddendum)];
+    }
+}

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputResult.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputResult.cs
@@ -1,0 +1,43 @@
+namespace Application.AI.Common.StructuredOutput;
+
+/// <summary>
+/// The outcome of one structured-output invocation — never throws for an expected failure; see
+/// <see cref="Outcome"/>.
+/// </summary>
+/// <typeparam name="T">The response shape requested.</typeparam>
+public sealed record StructuredOutputResult<T>
+{
+    /// <summary>Why the call terminated.</summary>
+    public required StructuredOutcome Outcome { get; init; }
+
+    /// <summary><see langword="true"/> only when <see cref="Outcome"/> is <see cref="StructuredOutcome.Parsed"/>.</summary>
+    public bool IsSuccess => Outcome == StructuredOutcome.Parsed;
+
+    /// <summary>The deserialized value on success; <see langword="default"/> otherwise.</summary>
+    public T? Value { get; init; }
+
+    /// <summary>
+    /// The raw text of the last attempt, whether or not it parsed — useful for diagnosing why a
+    /// call failed without needing to re-run it.
+    /// </summary>
+    public string? RawOutput { get; init; }
+
+    /// <summary>Human-readable failure reason. <see langword="null"/> on success.</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Builds a successful result.</summary>
+    public static StructuredOutputResult<T> Success(T value, string? rawOutput) => new()
+    {
+        Outcome = StructuredOutcome.Parsed,
+        Value = value,
+        RawOutput = rawOutput,
+    };
+
+    /// <summary>Builds a failed result with the given outcome and reason.</summary>
+    public static StructuredOutputResult<T> Fail(StructuredOutcome outcome, string errorMessage, string? rawOutput = null) => new()
+    {
+        Outcome = outcome,
+        ErrorMessage = errorMessage,
+        RawOutput = rawOutput,
+    };
+}

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputSchema.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputSchema.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.StructuredOutput;
+
+/// <summary>
+/// The sole owner of the schema-generation posture used across every structured-output contract.
+/// No other code in this codebase may call <see cref="AIJsonUtilities.CreateJsonSchema"/> directly
+/// — enforced by <c>StructuredOutputSchemaChokepointTests</c>, in the shape of
+/// <c>ToolCallAdmissionChokepointTests</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Posture: <c>RequireAllProperties = false</c>, <c>DisallowAdditionalProperties = false</c>,
+/// <c>UseNullableKeyword = false</c>, <c>MoveDefaultKeywordToDescription = true</c>.</strong> The C#
+/// type is the single source of truth for what "required" means — a member is required if and only
+/// if it carries <see langword="required"/> or <c>[JsonRequired]</c>; nothing else marks a schema
+/// property required, and nothing marks the schema strict.
+/// </para>
+/// <para>
+/// This deliberately does <em>not</em> reproduce OpenAI's "strict mode" semantics
+/// (<c>RequireAllProperties = true</c> + <c>additionalProperties: false</c> everywhere). Three
+/// reasons: (1) it is wrong for a type built mostly from defaulted members — requiring them forces
+/// the model to restate a value it already knows on every call, and makes any genuinely optional
+/// member mandatory, rejecting a model that correctly omits it; (2) it cannot even be expressed for
+/// a type carrying a deliberately open <see cref="JsonElement"/> blob (polymorphic per-instance
+/// configuration) — strict mode forbids unconstrained objects outright; (3) it is not this layer's
+/// job to apply — the OpenAI adapter already performs this exact transformation itself, correctly,
+/// when a caller opts in, so hand-rolling it here would be a second, worse copy of a transform that
+/// ships in a package this repo already depends on, applied even to providers (Anthropic, Azure AI
+/// Inference) that would silently discard it.
+/// </para>
+/// <para>
+/// <strong>The schema is advisory, not enforcement, on every provider.</strong> Anthropic's Messages
+/// API has no JSON-schema request parameter at all — <see cref="ChatOptions.ResponseFormat"/> is
+/// silently dropped on that path. The OpenAI adapter's own strict-schema transform is opt-in. So
+/// receive-side validation and the repair round-trip in <see cref="StructuredOutputInvoker"/> are
+/// not a nicety layered on top of structured output — on this provider matrix they ARE the
+/// enforcement, and the schema attached to the request is only ever a hint the model may ignore.
+/// </para>
+/// </remarks>
+public static class StructuredOutputSchema
+{
+    private static readonly AIJsonSchemaCreateOptions InferenceOptions = new()
+    {
+        TransformOptions = new AIJsonSchemaTransformOptions
+        {
+            RequireAllProperties = false,
+            DisallowAdditionalProperties = false,
+            UseNullableKeyword = false,
+            MoveDefaultKeywordToDescription = true,
+        },
+    };
+
+    /// <summary>
+    /// Builds the <see cref="StructuredOutputContract"/> for <typeparamref name="T"/> — the schema
+    /// generated under this type's fixed posture, and the serializer options used to both generate
+    /// it and later parse a reply against it.
+    /// </summary>
+    /// <typeparam name="T">The response shape.</typeparam>
+    /// <param name="schemaName">The schema's name (sent to the model).</param>
+    /// <param name="schemaDescription">Optional description, sent alongside the name.</param>
+    /// <param name="serializerOptions">
+    /// Options to reflect over <typeparamref name="T"/> with. Defaults to
+    /// <see cref="AIJsonUtilities.DefaultOptions"/> — camelCase, matching the shape most LLM JSON
+    /// output arrives in.
+    /// </param>
+    public static StructuredOutputContract Build<T>(
+        string schemaName, string? schemaDescription = null, JsonSerializerOptions? serializerOptions = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaName);
+
+        var options = serializerOptions ?? AIJsonUtilities.DefaultOptions;
+        var schema = AIJsonUtilities.CreateJsonSchema(
+            type: typeof(T),
+            description: schemaDescription,
+            hasDefaultValue: false,
+            defaultValue: null,
+            serializerOptions: options,
+            inferenceOptions: InferenceOptions);
+
+        return new StructuredOutputContract
+        {
+            ResponseType = typeof(T),
+            SchemaName = schemaName,
+            SchemaDescription = schemaDescription,
+            Schema = schema,
+            SerializerOptions = options,
+        };
+    }
+}

--- a/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputSchemaValidation.cs
+++ b/src/Content/Application/Application.AI.Common/StructuredOutput/StructuredOutputSchemaValidation.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Application.AI.Common.StructuredOutput;
+
+/// <summary>
+/// Generic guards over a <see cref="StructuredOutputContract"/>'s schema against its own
+/// <see cref="StructuredOutputContract.ResponseType"/> — usable from any test project that can see
+/// the response type (first-party contracts live in <c>Application.AI.Common.Tests</c>; a contract
+/// for an <see langword="internal"/> DTO in another assembly is tested from that assembly's own
+/// test project, which already has <c>InternalsVisibleTo</c> access to build the contract in the
+/// first place).
+/// </summary>
+public static class StructuredOutputSchemaValidation
+{
+    /// <summary>
+    /// Compares <paramref name="contract"/>'s schema <c>properties</c> and <c>required</c> sets
+    /// against <see cref="StructuredOutputContract.ResponseType"/>'s serializable members, in both
+    /// directions. Returns a human-readable drift description per mismatch; an empty list means no
+    /// drift. Checking both directions matters — a schema property with no CLR member, and a CLR
+    /// member with no schema property, are different bugs and neither implies the other.
+    /// </summary>
+    public static IReadOnlyList<string> FindDrift(StructuredOutputContract contract)
+    {
+        ArgumentNullException.ThrowIfNull(contract);
+
+        var drift = new List<string>();
+        var members = GetSerializableMembers(contract.ResponseType, contract.SerializerOptions);
+        var memberNames = members.Select(m => m.JsonName).ToHashSet(StringComparer.Ordinal);
+        var requiredMemberNames = members.Where(m => m.IsRequired).Select(m => m.JsonName)
+            .ToHashSet(StringComparer.Ordinal);
+
+        if (!contract.Schema.TryGetProperty("properties", out var propertiesElement)
+            || propertiesElement.ValueKind != JsonValueKind.Object)
+        {
+            if (members.Count > 0)
+                drift.Add($"{contract.ResponseType.Name}: schema has no 'properties' object, but the type has {members.Count} serializable member(s).");
+            return drift;
+        }
+
+        var schemaPropertyNames = propertiesElement.EnumerateObject().Select(p => p.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var schemaName in schemaPropertyNames)
+            if (!memberNames.Contains(schemaName))
+                drift.Add($"{contract.ResponseType.Name}: schema property '{schemaName}' has no matching CLR member.");
+
+        foreach (var member in members)
+            if (!schemaPropertyNames.Contains(member.JsonName))
+                drift.Add($"{contract.ResponseType.Name}: CLR member '{member.ClrName}' (JSON '{member.JsonName}') has no matching schema property.");
+
+        var schemaRequired = contract.Schema.TryGetProperty("required", out var requiredElement)
+                && requiredElement.ValueKind == JsonValueKind.Array
+            ? requiredElement.EnumerateArray().Select(e => e.GetString()!).ToHashSet(StringComparer.Ordinal)
+            : [];
+
+        foreach (var name in schemaRequired)
+            if (!requiredMemberNames.Contains(name))
+                drift.Add($"{contract.ResponseType.Name}: schema marks '{name}' required, but the CLR member is not `required`/[JsonRequired].");
+
+        foreach (var name in requiredMemberNames)
+            if (!schemaRequired.Contains(name))
+                drift.Add($"{contract.ResponseType.Name}: CLR member '{name}' is `required`/[JsonRequired], but the schema does not mark it required.");
+
+        return drift;
+    }
+
+    /// <summary>
+    /// Depth-first walk of <paramref name="schema"/> returning the JSON pointer of every node whose
+    /// <c>"type"</c> is <c>"array"</c> and which declares no <c>"items"</c> schema — the single
+    /// shape a model most reliably mis-fills when a schema under-constrains it.
+    /// </summary>
+    public static IReadOnlyList<string> FindArraysWithoutItems(JsonElement schema)
+    {
+        var offenders = new List<string>();
+        Walk(schema, "#", offenders);
+        return offenders;
+    }
+
+    private static void Walk(JsonElement node, string pointer, List<string> offenders)
+    {
+        if (node.ValueKind != JsonValueKind.Object)
+            return;
+
+        if (node.TryGetProperty("type", out var typeElement)
+            && typeElement.ValueKind == JsonValueKind.String
+            && typeElement.GetString() == "array"
+            && !node.TryGetProperty("items", out _))
+        {
+            offenders.Add(pointer);
+        }
+
+        foreach (var property in node.EnumerateObject())
+            Walk(property.Value, $"{pointer}/{property.Name}", offenders);
+    }
+
+    private static IReadOnlyList<SerializableMember> GetSerializableMembers(Type type, JsonSerializerOptions options)
+    {
+        var namingPolicy = options.PropertyNamingPolicy;
+        var members = new List<SerializableMember>();
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var ignore = property.GetCustomAttribute<JsonIgnoreAttribute>();
+            if (ignore is not null && ignore.Condition == JsonIgnoreCondition.Always)
+                continue;
+            if (property.GetIndexParameters().Length > 0)
+                continue;
+
+            var explicitName = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name;
+            var jsonName = explicitName ?? namingPolicy?.ConvertName(property.Name) ?? property.Name;
+
+            var isRequired = property.GetCustomAttribute<JsonRequiredAttribute>() is not null
+                || IsRequiredMember(property);
+
+            members.Add(new SerializableMember(property.Name, jsonName, isRequired));
+        }
+
+        return members;
+    }
+
+    // `required` (the C# keyword, not [JsonRequired]) shows up to reflection as
+    // System.Runtime.CompilerServices.RequiredMemberAttribute on the property.
+    private static bool IsRequiredMember(PropertyInfo property) =>
+        property.GetCustomAttributes(inherit: false)
+            .Any(a => a.GetType().FullName == "System.Runtime.CompilerServices.RequiredMemberAttribute");
+
+    private sealed record SerializableMember(string ClrName, string JsonName, bool IsRequired);
+}

--- a/src/Content/Application/Application.Core/Workflows/Rag/VectorRetrievalExecutor.cs
+++ b/src/Content/Application/Application.Core/Workflows/Rag/VectorRetrievalExecutor.cs
@@ -136,6 +136,16 @@ public sealed class VectorRetrievalExecutor : Executor<ClassifiedQuery, VectorRe
                     return new VectorRetrievalOutput(
                         message.Query, [], WasRefined: attempt > 1, AttemptCount: attempt);
 
+                case CorrectionAction.EvaluationUnavailable:
+                    // The gate did not run — falls through to the same "best available" path as
+                    // an exhausted Refine or WebFallback, never treated as Accept. Kept as its own
+                    // case (rather than relying on `default` below) so this is an audited decision,
+                    // not an incidental one — see the enum member's own remarks.
+                    _logger.LogWarning(
+                        "CRAG evaluation unavailable on attempt {Attempt}: {Reason}",
+                        attempt, evaluation.Reasoning);
+                    goto default;
+
                 default:
                     _logger.LogInformation(
                         "CRAG {Action} after {Attempt} attempts; returning best available",

--- a/src/Content/Domain/Domain.AI/RAG/Enums/CorrectionAction.cs
+++ b/src/Content/Domain/Domain.AI/RAG/Enums/CorrectionAction.cs
@@ -30,5 +30,15 @@ public enum CorrectionAction
     /// entirely and respond with an explicit "I don't have this information"
     /// rather than hallucinating from poor context.
     /// </summary>
-    Reject
+    Reject,
+
+    /// <summary>
+    /// The CRAG gate itself did not run — the evaluation call threw, or the model's response could
+    /// not be parsed even after a repair attempt. This is <em>not</em> a relevance judgment and
+    /// must never be treated as equivalent to <see cref="Accept"/>: a gate that cannot read its own
+    /// output must not silently green-light the retrieval it exists to check. Every consumer of
+    /// <c>CragEvaluation.Action</c> must handle this explicitly rather than falling through to
+    /// whatever the default branch happens to do for an unrecognised value.
+    /// </summary>
+    EvaluationUnavailable,
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/CragEvaluator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/CragEvaluator.cs
@@ -1,9 +1,8 @@
 using System.Diagnostics;
 using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Application.AI.Common.Interfaces.RAG;
 using Application.AI.Common.Interfaces.Routing;
+using Application.AI.Common.StructuredOutput;
 using Domain.AI.RAG.Enums;
 using Domain.AI.RAG.Models;
 using Domain.AI.Telemetry.Conventions;
@@ -25,12 +24,14 @@ public sealed class CragEvaluator : ICragEvaluator
 {
     private static readonly ActivitySource ActivitySource = new("AgenticHarness.RAG.Evaluation");
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
+    // Built once — the same contract both attaches the schema to the request and validates the
+    // reply against, so the two can never independently drift. See StructuredOutputSchema's remarks
+    // for why its posture never marks a member required unless the CLR type does.
+    private static readonly StructuredOutputContract Contract =
+        StructuredOutputSchema.Build<CragResponse>("crag_evaluation", "Corrective RAG relevance evaluation");
 
     private readonly IModelRouter _modelRouter;
+    private readonly Application.AI.Common.Interfaces.AI.IStructuredOutputInvoker _structuredOutput;
     private readonly IOptionsMonitor<AppConfig> _configMonitor;
     private readonly ILogger<CragEvaluator> _logger;
 
@@ -38,14 +39,17 @@ public sealed class CragEvaluator : ICragEvaluator
     /// Initializes a new instance of the <see cref="CragEvaluator"/> class.
     /// </summary>
     /// <param name="modelRouter">Model router for selecting the standard-tier chat client.</param>
+    /// <param name="structuredOutput">Schema-out, validated-parse-back, one-repair invoker.</param>
     /// <param name="configMonitor">Configuration monitor for CRAG threshold values.</param>
     /// <param name="logger">Logger for recording evaluation outcomes and failures.</param>
     public CragEvaluator(
         IModelRouter modelRouter,
+        Application.AI.Common.Interfaces.AI.IStructuredOutputInvoker structuredOutput,
         IOptionsMonitor<AppConfig> configMonitor,
         ILogger<CragEvaluator> logger)
     {
         _modelRouter = modelRouter;
+        _structuredOutput = structuredOutput;
         _configMonitor = configMonitor;
         _logger = logger;
     }
@@ -69,8 +73,11 @@ public sealed class CragEvaluator : ICragEvaluator
 
         try
         {
-            var response = await chatClient.GetResponseAsync(prompt, cancellationToken: cancellationToken);
-            var evaluation = ParseResponse(response.Text ?? "{}", cragConfig);
+            var messages = new List<ChatMessage> { new(ChatRole.User, prompt) };
+            var parseResult = await _structuredOutput.InvokeAsync<CragResponse>(
+                chatClient, Contract, messages, chatOptions: null, cancellationToken);
+
+            var evaluation = BuildEvaluation(parseResult, cragConfig);
 
             activity?.SetTag(RagConventions.CragAction, evaluation.Action.ToString().ToLowerInvariant());
             activity?.SetTag(RagConventions.CragScore, evaluation.RelevanceScore);
@@ -81,17 +88,48 @@ public sealed class CragEvaluator : ICragEvaluator
 
             return evaluation;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogWarning(ex, "CRAG evaluation failed; defaulting to Accept to avoid blocking pipeline");
-            return new CragEvaluation
-            {
-                Action = CorrectionAction.Accept,
-                RelevanceScore = 0.5,
-                Reasoning = $"Evaluation failed: {ex.Message}"
-            };
+            // A gate that cannot read its own output must never silently green-light the
+            // retrieval it exists to check — EvaluationUnavailable, never Accept. See that enum
+            // member's remarks; every consumer of CorrectionAction handles this explicitly.
+            _logger.LogWarning(ex, "CRAG evaluation failed; the gate did not run for this retrieval");
+            return UnavailableEvaluation($"Evaluation failed: {ex.Message}");
         }
     }
+
+    /// <summary>
+    /// Converts the invoker's result into a <see cref="CragEvaluation"/>: a successful parse
+    /// derives the action from the score against configured thresholds (never from the model's own
+    /// <see cref="CragResponse.Action"/> label — see that type's remarks); any non-success outcome
+    /// becomes <see cref="CorrectionAction.EvaluationUnavailable"/>, never a passing score.
+    /// </summary>
+    private static CragEvaluation BuildEvaluation(
+        StructuredOutputResult<CragResponse> parseResult,
+        Domain.Common.Config.AI.RAG.CragConfig cragConfig)
+    {
+        if (!parseResult.IsSuccess || parseResult.Value is null)
+            return UnavailableEvaluation(parseResult.ErrorMessage ?? "CRAG response could not be parsed.");
+
+        var parsed = parseResult.Value;
+        var score = Math.Clamp(parsed.Score, 0.0, 1.0);
+        var action = DetermineAction(score, cragConfig);
+
+        return new CragEvaluation
+        {
+            Action = action,
+            RelevanceScore = score,
+            Reasoning = parsed.Reasoning,
+            WeakChunkIds = parsed.WeakChunkIds ?? [],
+        };
+    }
+
+    private static CragEvaluation UnavailableEvaluation(string reason) => new()
+    {
+        Action = CorrectionAction.EvaluationUnavailable,
+        RelevanceScore = 0.5,
+        Reasoning = reason,
+    };
 
     private static string BuildPrompt(
         string query,
@@ -119,43 +157,7 @@ public sealed class CragEvaluator : ICragEvaluator
             - "Reject" if score < {{cragConfig.RefineThreshold}}
 
             Also list IDs of any weak/irrelevant passages.
-
-            Respond as JSON: {"action": "...", "score": 0.0, "reasoning": "...", "weak_chunk_ids": [...]}
             """;
-    }
-
-    private CragEvaluation ParseResponse(
-        string responseText,
-        Domain.Common.Config.AI.RAG.CragConfig cragConfig)
-    {
-        try
-        {
-            var jsonStart = responseText.IndexOf('{');
-            var jsonEnd = responseText.LastIndexOf('}');
-            if (jsonStart < 0 || jsonEnd < 0)
-                return FallbackEvaluation("No JSON found in response");
-
-            var json = responseText[jsonStart..(jsonEnd + 1)];
-            var parsed = JsonSerializer.Deserialize<CragResponseDto>(json, JsonOptions);
-            if (parsed is null)
-                return FallbackEvaluation("Failed to deserialize CRAG response");
-
-            var score = Math.Clamp(parsed.Score, 0.0, 1.0);
-            var action = DetermineAction(score, cragConfig);
-
-            return new CragEvaluation
-            {
-                Action = action,
-                RelevanceScore = score,
-                Reasoning = parsed.Reasoning,
-                WeakChunkIds = parsed.WeakChunkIds ?? []
-            };
-        }
-        catch (JsonException ex)
-        {
-            _logger.LogWarning(ex, "Failed to parse CRAG JSON response");
-            return FallbackEvaluation("JSON parse error");
-        }
     }
 
     private static CorrectionAction DetermineAction(
@@ -169,24 +171,5 @@ public sealed class CragEvaluator : ICragEvaluator
         return cragConfig.AllowWebFallback
             ? CorrectionAction.WebFallback
             : CorrectionAction.Reject;
-    }
-
-    private static CragEvaluation FallbackEvaluation(string reason) =>
-        new()
-        {
-            Action = CorrectionAction.Accept,
-            RelevanceScore = 0.5,
-            Reasoning = $"Fallback: {reason}"
-        };
-
-    /// <summary>DTO for deserializing the LLM's JSON response.</summary>
-    private sealed class CragResponseDto
-    {
-        public string? Action { get; set; }
-        public double Score { get; set; }
-        public string? Reasoning { get; set; }
-
-        [JsonPropertyName("weak_chunk_ids")]
-        public List<string>? WeakChunkIds { get; set; }
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/CragResponse.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Evaluation/CragResponse.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.AI.RAG.Evaluation;
+
+/// <summary>
+/// The model's structured CRAG evaluation response. Promoted to a top-level internal type (out of
+/// <see cref="CragEvaluator"/>, where it previously lived as a private nested class) so the
+/// structured-output drift guard — which needs <c>InternalsVisibleTo</c> visibility to enumerate a
+/// type's serializable members — can see it.
+/// </summary>
+/// <remarks>
+/// <see cref="Action"/> is accepted for schema fidelity with what the prompt asks the model for,
+/// but is not itself authoritative: <see cref="CragEvaluator.DetermineAction"/> derives the actual
+/// <c>CorrectionAction</c> from <see cref="Score"/> against configured thresholds, not from
+/// whatever label the model chose to put here — a model's own action label could disagree with
+/// where its score actually falls relative to threshold configuration it may not know precisely.
+/// </remarks>
+internal sealed record CragResponse
+{
+    /// <summary>The model's own action label. See remarks — not authoritative.</summary>
+    [JsonPropertyName("action")]
+    public string? Action { get; init; }
+
+    /// <summary>Overall relevance score, 0.0–1.0. Defaults to 0.0 (treated as low relevance) when
+    /// the model omits it — a safe default, so this is deliberately not <see langword="required"/>.</summary>
+    [JsonPropertyName("score")]
+    public double Score { get; init; }
+
+    /// <summary>The model's stated reasoning for the score.</summary>
+    [JsonPropertyName("reasoning")]
+    public string? Reasoning { get; init; }
+
+    /// <summary>IDs of passages the model judged weak or irrelevant.</summary>
+    [JsonPropertyName("weak_chunk_ids")]
+    public IReadOnlyList<string>? WeakChunkIds { get; init; }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.MultiHop.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.MultiHop.cs
@@ -63,6 +63,10 @@ public sealed partial class RagOrchestrator
                 var cragEval = await _cragEvaluator.EvaluateAsync(
                     query, iterativeResult.AggregatedResults, cancellationToken);
 
+                // Allowlist, not a blocklist: EvaluationUnavailable — like Reject and WebFallback —
+                // already falls through to the conservative "return the already-assembled context"
+                // path below rather than being silently treated as a pass. A new CorrectionAction
+                // value defaults safe here by construction.
                 if (cragEval.Action == CorrectionAction.Accept || cragEval.Action == CorrectionAction.Refine)
                 {
                     var filtered = FilterWeakChunks(reranked, cragEval.WeakChunkIds);

--- a/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.RAG/Orchestration/RagOrchestrator.cs
@@ -404,6 +404,17 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
                         augmented, DefaultMaxTokens, cancellationToken);
                 }
 
+                case CorrectionAction.EvaluationUnavailable:
+                    // The gate did not run — never treated as a confident Accept. Falls through to
+                    // the same degraded "assemble best available" path as an exhausted Refine,
+                    // which is the explicit, audited version of what an unhandled enum value would
+                    // already do via `default` below — kept as its own case so this decision is
+                    // visible rather than incidental.
+                    _logger.LogWarning(
+                        "CRAG evaluation unavailable: {Reason}; assembling best available without a relevance judgment",
+                        evaluation.Reasoning);
+                    goto default;
+
                 default:
                     // Refine exhausted or WebFallback — assemble what we have
                     _logger.LogInformation(
@@ -532,8 +543,12 @@ public sealed partial class RagOrchestrator : IRagOrchestrator
                 evaluation.Reasoning ?? "Multi-source content not relevant to the query.");
         }
 
-        if (evaluation.Action == CorrectionAction.Refine)
+        if (evaluation.Action is CorrectionAction.Refine or CorrectionAction.EvaluationUnavailable)
         {
+            // EvaluationUnavailable joins Refine here rather than falling through to the
+            // unconditional Accept-shaped return below — the gate did not run, so this path must
+            // not be indistinguishable from a confident Accept. FilterWeakChunks is a no-op when
+            // the gate never produced weak-chunk ids, which is the correct degraded behavior.
             var filtered = FilterWeakChunks(reranked, evaluation.WeakChunkIds);
             return await _contextAssembler.AssembleAsync(filtered, DefaultMaxTokens, cancellationToken);
         }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/LlmPlanGeneratorService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/LlmPlanGeneratorService.cs
@@ -1,8 +1,9 @@
-using System.Text.Json;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Prompts.Exceptions;
 using Application.AI.Common.Prompts.Interfaces;
+using Application.AI.Common.StructuredOutput;
 using Domain.AI.Planner;
 using Domain.AI.Prompts;
 using Domain.Common;
@@ -24,7 +25,13 @@ public sealed class LlmPlanGeneratorService : IPlanGenerator
     private const string PromptName = "plan-generator-system";
     private const string MetricKey = "plan_generation";
 
+    // Built once — the schema attached to the request and the schema the reply is validated
+    // against are the same object, so they can never independently drift.
+    private static readonly StructuredOutputContract Contract =
+        StructuredOutputSchema.Build<LlmPlanOutput>("plan_generation", "A generated agentic plan graph");
+
     private readonly IChatClientFactory _chatClientFactory;
+    private readonly IStructuredOutputInvoker _structuredOutput;
     private readonly IPromptRegistry _promptRegistry;
     private readonly IPromptRenderer _promptRenderer;
     private readonly IPromptUsageRecorder _usageRecorder;
@@ -32,15 +39,10 @@ public sealed class LlmPlanGeneratorService : IPlanGenerator
     private readonly IOptionsMonitor<PlannerOptions> _options;
     private readonly ILogger<LlmPlanGeneratorService> _logger;
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     /// <summary>Initializes a new instance.</summary>
     public LlmPlanGeneratorService(
         IChatClientFactory chatClientFactory,
+        IStructuredOutputInvoker structuredOutput,
         IPromptRegistry promptRegistry,
         IPromptRenderer promptRenderer,
         IPromptUsageRecorder usageRecorder,
@@ -49,6 +51,7 @@ public sealed class LlmPlanGeneratorService : IPlanGenerator
         ILogger<LlmPlanGeneratorService> logger)
     {
         ArgumentNullException.ThrowIfNull(chatClientFactory);
+        ArgumentNullException.ThrowIfNull(structuredOutput);
         ArgumentNullException.ThrowIfNull(promptRegistry);
         ArgumentNullException.ThrowIfNull(promptRenderer);
         ArgumentNullException.ThrowIfNull(usageRecorder);
@@ -57,6 +60,7 @@ public sealed class LlmPlanGeneratorService : IPlanGenerator
         ArgumentNullException.ThrowIfNull(logger);
 
         _chatClientFactory = chatClientFactory;
+        _structuredOutput = structuredOutput;
         _promptRegistry = promptRegistry;
         _promptRenderer = promptRenderer;
         _usageRecorder = usageRecorder;
@@ -119,28 +123,21 @@ public sealed class LlmPlanGeneratorService : IPlanGenerator
                 MaxOutputTokens = opts.GenerationMaxTokens
             };
 
-            var response = await chatClient.GetResponseAsync(messages, chatOptions, ct);
-            var responseText = SanitizeJsonResponse(response.Text ?? string.Empty);
+            var parseResult = await _structuredOutput.InvokeAsync<LlmPlanOutput>(
+                chatClient, Contract, messages, chatOptions, ct);
 
-            if (string.IsNullOrWhiteSpace(responseText))
+            if (!parseResult.IsSuccess || parseResult.Value is null)
             {
-                _logger.LogWarning("LLM returned empty response for plan generation");
-                return Result<PlanGraph>.Fail("LLM returned an empty response.");
+                _logger.LogWarning(
+                    "Plan generation structured-output call failed: {Outcome} — {Reason}",
+                    parseResult.Outcome, parseResult.ErrorMessage);
+                return Result<PlanGraph>.Fail(
+                    $"Plan generation failed ({parseResult.Outcome}): {parseResult.ErrorMessage}");
             }
 
-            LlmPlanOutput? planOutput;
-            try
-            {
-                planOutput = JsonSerializer.Deserialize<LlmPlanOutput>(responseText, JsonOptions);
-            }
-            catch (JsonException ex)
-            {
-                _logger.LogWarning(ex, "Failed to deserialize LLM plan output as JSON");
-                return Result<PlanGraph>.Fail($"LLM did not return valid JSON: {ex.Message}");
-            }
-
-            if (planOutput is null || planOutput.Steps.Count == 0)
-                return Result<PlanGraph>.Fail("LLM returned an empty or null plan.");
+            var planOutput = parseResult.Value;
+            if (planOutput.Steps.Count == 0)
+                return Result<PlanGraph>.Fail("LLM returned a plan with no steps.");
 
             PlanGraph graph;
             try
@@ -214,10 +211,4 @@ public sealed class LlmPlanGeneratorService : IPlanGenerator
 
         return $"Task: {taskDescription}";
     }
-
-    /// <summary>
-    /// Strips markdown code fences that LLMs frequently add despite instructions not to.
-    /// </summary>
-    private static string SanitizeJsonResponse(string response)
-        => Application.AI.Common.Json.LlmJsonResponseParser.StripFences(response);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/LlmPlanOutput.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/LlmPlanOutput.cs
@@ -13,8 +13,13 @@ internal sealed record LlmPlanOutput
     [JsonPropertyName("name")]
     public string Name { get; init; } = "";
 
+    // Required: a plan with no steps is meaningless, and GenerateAsync's own empty-plan check
+    // (Steps.Count == 0) becomes redundant with the schema itself once this is required — a model
+    // that omits "steps" now fails to parse rather than sailing through Deserialize as {} and
+    // failing two statements later. See LlmStepOutput.Name/Type and LlmEdgeOutput.From/To for the
+    // same reasoning applied one level down.
     [JsonPropertyName("steps")]
-    public IReadOnlyList<LlmStepOutput> Steps { get; init; } = [];
+    public required IReadOnlyList<LlmStepOutput> Steps { get; init; }
 
     [JsonPropertyName("edges")]
     public IReadOnlyList<LlmEdgeOutput> Edges { get; init; } = [];
@@ -25,11 +30,15 @@ internal sealed record LlmPlanOutput
 
 internal sealed record LlmStepOutput
 {
+    // Required: LlmPlanOutputMapper.MapToPlanGraph indexes steps by Name (nameToId dictionary) and
+    // ParseStepType throws InvalidOperationException on any Type it doesn't recognise, including
+    // the empty string the old default silently produced. Both are already-mandatory-in-practice;
+    // this makes the schema say so instead of letting a missing value surface as a mapper crash.
     [JsonPropertyName("name")]
-    public string Name { get; init; } = "";
+    public required string Name { get; init; }
 
     [JsonPropertyName("type")]
-    public string Type { get; init; } = "";
+    public required string Type { get; init; }
 
     [JsonPropertyName("configuration")]
     public JsonElement Configuration { get; init; }
@@ -43,11 +52,14 @@ internal sealed record LlmStepOutput
 
 internal sealed record LlmEdgeOutput
 {
+    // Required: LlmPlanOutputMapper.MapEdges throws InvalidOperationException if From/To don't
+    // resolve against the step-name map — an edge with a missing endpoint was already unusable,
+    // this just moves the failure to schema validation instead of a mapper-level exception.
     [JsonPropertyName("from")]
-    public string From { get; init; } = "";
+    public required string From { get; init; }
 
     [JsonPropertyName("to")]
-    public string To { get; init; } = "";
+    public required string To { get; init; }
 
     [JsonPropertyName("type")]
     public string Type { get; init; } = "ControlFlow";

--- a/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
+++ b/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
@@ -36,6 +36,8 @@
          repair-round-trip tests that need to script fail-then-succeed responses and assert
          whether ChatOptions.ResponseFormat was populated on each call. -->
     <ProjectReference Include="../Tests.AI.Fakes/Tests.AI.Fakes.csproj" />
+    <!-- RepoRoot/SourceScan for the structured-output schema-generation chokepoint test. -->
+    <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
+++ b/src/Content/Tests/Application.AI.Common.Tests/Application.AI.Common.Tests.csproj
@@ -32,6 +32,10 @@
          ToolChainBuilder's merge step so the collision/shadowing/drift tests prove the withhold
          decision end-to-end, not just that a mocked scanner was called correctly. -->
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.Governance/Infrastructure.AI.Governance.csproj" />
+    <!-- The shared role-aware chat-client fake (Tests.AI.Fakes) — used by structured-output
+         repair-round-trip tests that need to script fail-then-succeed responses and assert
+         whether ChatOptions.ResponseFormat was populated on each call. -->
+    <ProjectReference Include="../Tests.AI.Fakes/Tests.AI.Fakes.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Application.AI.Common.Tests/Fakes/ChatResponseStreamingTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Fakes/ChatResponseStreamingTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Tests.AI.Fakes;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Fakes;
+
+/// <summary>
+/// Proves <see cref="ChatResponseStreaming.ToUpdatesAsync"/> carries response-level metadata onto
+/// every emitted frame (M5 of Package A's review) — without it, a scripted response with a real
+/// <c>ResponseId</c>/<c>ConversationId</c>/<c>ModelId</c>/<c>MessageId</c>/<c>FinishReason</c> would
+/// look metadata-less on the streaming path while carrying those values on the blocking path,
+/// disagreeing with production's <c>ChatResponseUpdateExtensions.ToChatResponse()</c> coalescing,
+/// which reads those fields off the updates rather than the original response.
+/// </summary>
+public sealed class ChatResponseStreamingTests
+{
+    private static ChatResponse BuildResponse(params ChatMessage[] messages)
+    {
+        var response = new ChatResponse(messages)
+        {
+            ResponseId = "resp-1",
+            ConversationId = "conv-1",
+            ModelId = "model-x",
+            CreatedAt = DateTimeOffset.UnixEpoch,
+            FinishReason = ChatFinishReason.Stop,
+        };
+        return response;
+    }
+
+    [Fact]
+    public async Task ToUpdatesAsync_CopiesResponseLevelMetadataOntoEveryFrame()
+    {
+        var message = new ChatMessage(ChatRole.Assistant, "hello") { MessageId = "msg-1" };
+        var response = BuildResponse(message);
+
+        var frames = new List<ChatResponseUpdate>();
+        await foreach (var frame in ChatResponseStreaming.ToUpdatesAsync(response))
+            frames.Add(frame);
+
+        frames.Should().NotBeEmpty();
+        frames.Should().OnlyContain(f =>
+            f.ResponseId == "resp-1" && f.ConversationId == "conv-1" && f.ModelId == "model-x"
+            && f.CreatedAt == DateTimeOffset.UnixEpoch);
+    }
+
+    [Fact]
+    public async Task ToUpdatesAsync_PropagatesEachMessagesOwnMessageId()
+    {
+        var first = new ChatMessage(ChatRole.Assistant, "part one") { MessageId = "msg-1" };
+        var second = new ChatMessage(ChatRole.Assistant, "part two") { MessageId = "msg-2" };
+        var response = BuildResponse(first, second);
+
+        var frames = new List<ChatResponseUpdate>();
+        await foreach (var frame in ChatResponseStreaming.ToUpdatesAsync(response))
+            frames.Add(frame);
+
+        frames.Should().HaveCount(2);
+        frames[0].MessageId.Should().Be("msg-1");
+        frames[1].MessageId.Should().Be("msg-2");
+    }
+
+    [Fact]
+    public async Task ToUpdatesAsync_SetsFinishReasonOnlyOnTheLastFrame()
+    {
+        var message = new ChatMessage(ChatRole.Assistant, new List<AIContent> { new TextContent("a"), new TextContent("b") })
+        {
+            MessageId = "msg-1",
+        };
+        var response = BuildResponse(message);
+
+        var frames = new List<ChatResponseUpdate>();
+        await foreach (var frame in ChatResponseStreaming.ToUpdatesAsync(response))
+            frames.Add(frame);
+
+        frames.Should().HaveCount(2);
+        frames[0].FinishReason.Should().BeNull();
+        frames[^1].FinishReason.Should().Be(ChatFinishReason.Stop);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Fakes/FakeChatClient.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Fakes/FakeChatClient.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
+using Tests.AI.Fakes;
 
 namespace Application.AI.Common.Tests.Fakes;
 
@@ -81,15 +82,11 @@ public sealed class FakeChatClient : IChatClient
     {
         var response = await GetResponseAsync(messages, options, cancellationToken);
 
-        // Stream each content item (text, tool calls) as its own update so middleware
-        // reconstructing via ToChatResponse() sees the same shape as the blocking path.
-        foreach (var message in response.Messages)
-            foreach (var content in message.Contents)
-                yield return new ChatResponseUpdate(message.Role, new List<AIContent> { content });
-
-        // Mirror real providers: token usage arrives as a UsageContent item in a final chunk.
-        if (response.Usage is { } usage)
-            yield return new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent> { new UsageContent(usage) });
+        // Delegates to the shared helper (Tests.AI.Fakes) so this fake's streaming semantics can't
+        // drift from the other chat-client fakes' — which is exactly what happened to the sibling
+        // copy in Presentation.AgentHub.Tests before this package fixed it.
+        await foreach (var update in ChatResponseStreaming.ToUpdatesAsync(response, cancellationToken))
+            yield return update;
     }
 
     /// <inheritdoc />

--- a/src/Content/Tests/Application.AI.Common.Tests/Fakes/ScriptedChatClientFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Fakes/ScriptedChatClientFactoryTests.cs
@@ -1,0 +1,173 @@
+using Application.AI.Common.Services.Agent;
+using Domain.Common.Config.AI;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Tests.AI.Fakes;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Fakes;
+
+/// <summary>
+/// Proves the shared <see cref="ScriptedChatClientFactory"/>/<see cref="RecordingChatClient"/> fake
+/// (Tests.AI.Fakes) actually does what Packages B, C, and D of the verification cluster depend on:
+/// role selection by ambient agent identity, a fail-loud unscripted-role path, per-call invocation
+/// recording (including whether a structured-output schema was attached), and correct multi-frame
+/// streaming. Drives the real <see cref="AgentExecutionContext"/> rather than a mock — the fake's
+/// whole point is to sit downstream of the real ambient-context wiring.
+/// </summary>
+public sealed class ScriptedChatClientFactoryTests
+{
+    private static AgentExecutionContext ContextFor(string agentId)
+    {
+        var context = new AgentExecutionContext();
+        context.Initialize(agentId, conversationId: "conv-1", turnNumber: 1);
+        return context;
+    }
+
+    [Fact]
+    public async Task GetChatClientAsync_UnscriptedRole_ThrowsNamingUnmatchedIdAndKnownRoles()
+    {
+        var log = new ChatInvocationLog();
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), log);
+        factory.ForRole("verifier").Enqueue("known role response");
+
+        var act = () => factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+        exception.Which.Message.Should().Contain("planner").And.Contain("verifier");
+    }
+
+    [Fact]
+    public async Task GetChatClientAsync_NoRolesRegisteredAtAll_ThrowsNamingNoneRegistered()
+    {
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+
+        var act = () => factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+        exception.Which.Message.Should().Contain("none registered");
+    }
+
+    [Fact]
+    public async Task ForAnyUnscriptedRole_ExplicitOptIn_AcceptsAnyUnmatchedRole()
+    {
+        var log = new ChatInvocationLog();
+        var factory = new ScriptedChatClientFactory(ContextFor("some-other-agent"), log);
+        factory.ForAnyUnscriptedRole().WithDefaultResponse("fallback content");
+
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+        var response = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "hi")]);
+
+        response.Text.Should().Be("fallback content");
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_RecordsAgentIdMessageCountAndResponseFormatPresence()
+    {
+        var log = new ChatInvocationLog();
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), log);
+        factory.ForRole("planner").Enqueue("plan output");
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+
+        var options = new ChatOptions { ResponseFormat = ChatResponseFormat.Json };
+        await client.GetResponseAsync(
+            [new ChatMessage(ChatRole.System, "sys"), new ChatMessage(ChatRole.User, "go")],
+            options);
+
+        log.Invocations.Should().ContainSingle();
+        var invocation = log.Invocations[0];
+        invocation.AgentId.Should().Be("planner");
+        invocation.MessageCount.Should().Be(2);
+        invocation.HadResponseFormat.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_NoResponseFormatSupplied_RecordsFalse()
+    {
+        var log = new ChatInvocationLog();
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), log);
+        factory.ForRole("planner").Enqueue("plan output");
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+
+        await client.GetResponseAsync([new ChatMessage(ChatRole.User, "go")]);
+
+        log.Invocations[0].HadResponseFormat.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RoleSequence_AcrossMultipleAgents_PreservesCallOrder()
+    {
+        var log = new ChatInvocationLog();
+
+        var plannerFactory = new ScriptedChatClientFactory(ContextFor("planner"), log);
+        plannerFactory.ForRole("planner").Enqueue("plan");
+        var plannerClient = await plannerFactory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+        await plannerClient.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
+
+        var verifierFactory = new ScriptedChatClientFactory(ContextFor("verifier"), log);
+        verifierFactory.ForRole("verifier").Enqueue("verified");
+        var verifierClient = await verifierFactory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+        await verifierClient.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+
+        log.RoleSequence.Should().Equal("planner", "verifier");
+    }
+
+    [Fact]
+    public async Task RoleScript_QueueExhausted_FallsBackToDefaultResponse()
+    {
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        factory.ForRole("planner").Enqueue("first").WithDefaultResponse("steady state");
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+
+        var first = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
+        var second = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+
+        first.Text.Should().Be("first");
+        second.Text.Should().Be("steady state");
+    }
+
+    [Fact]
+    public async Task EnqueueThrow_ThrowsTheScriptedExceptionOnThatCall()
+    {
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        factory.ForRole("planner").EnqueueThrow(new InvalidOperationException("provider unavailable"));
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+
+        var act = () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
+
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("provider unavailable");
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_EmitsOneFramePerContentItemThenTrailingUsage()
+    {
+        // The control this fake exists to satisfy: a real streaming sequence, not one collapsed
+        // frame — Package D's per-frame invariants would pass vacuously against a single-frame fake.
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        factory.ForRole("planner").EnqueueWithUsage("hello world", inputTokens: 10, outputTokens: 5);
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+
+        var frames = new List<ChatResponseUpdate>();
+        await foreach (var frame in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "go")]))
+            frames.Add(frame);
+
+        frames.Should().HaveCount(2, "one text content frame, then one trailing usage frame");
+        frames[0].Contents.Should().ContainSingle().Which.Should().BeOfType<TextContent>();
+        frames[1].Contents.Should().ContainSingle().Which.Should().BeOfType<UsageContent>();
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ToolCallResponse_StreamsTheFunctionCallAsItsOwnFrame()
+    {
+        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        factory.ForRole("planner").EnqueueToolCall("search", "call-1");
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+
+        var frames = new List<ChatResponseUpdate>();
+        await foreach (var frame in client.GetStreamingResponseAsync([new ChatMessage(ChatRole.User, "go")]))
+            frames.Add(frame);
+
+        frames.Should().ContainSingle().Which.Contents.Should().ContainSingle()
+            .Which.Should().BeOfType<FunctionCallContent>();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Fakes/ScriptedChatClientFactoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Fakes/ScriptedChatClientFactoryTests.cs
@@ -1,7 +1,11 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Services;
 using Application.AI.Common.Services.Agent;
 using Domain.Common.Config.AI;
 using FluentAssertions;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using Tests.AI.Fakes;
 using Xunit;
 
@@ -12,23 +16,45 @@ namespace Application.AI.Common.Tests.Fakes;
 /// (Tests.AI.Fakes) actually does what Packages B, C, and D of the verification cluster depend on:
 /// role selection by ambient agent identity, a fail-loud unscripted-role path, per-call invocation
 /// recording (including whether a structured-output schema was attached), and correct multi-frame
-/// streaming. Drives the real <see cref="AgentExecutionContext"/> rather than a mock — the fake's
-/// whole point is to sit downstream of the real ambient-context wiring.
+/// streaming.
 /// </summary>
+/// <remarks>
+/// Drives the real <see cref="AgentExecutionContext"/> and the real <see cref="AmbientRequestScope"/>
+/// — the same <see cref="IAmbientRequestScope"/> bridge production singletons use to reach per-request
+/// scoped services — rather than a mock, since the fake's whole point is to sit downstream of that
+/// real ambient-scope wiring, not a shortcut around it.
+/// </remarks>
 public sealed class ScriptedChatClientFactoryTests
 {
-    private static AgentExecutionContext ContextFor(string agentId)
+    /// <summary>
+    /// Establishes the ambient request scope a real <c>AmbientRequestScopeBehavior&lt;,&gt;</c> would
+    /// set up for one request, with a real <see cref="AgentExecutionContext"/> registered as the
+    /// scope would have it (matching production's <c>AddScoped&lt;IAgentExecutionContext,
+    /// AgentExecutionContext&gt;()</c>). The returned token must be disposed to clear the ambient
+    /// value — callers use <see langword="using"/>.
+    /// </summary>
+    private static (ScriptedChatClientFactory Factory, ChatInvocationLog Log, IDisposable ScopeToken) CreateForAgent(string agentId)
     {
         var context = new AgentExecutionContext();
         context.Initialize(agentId, conversationId: "conv-1", turnNumber: 1);
-        return context;
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IAgentExecutionContext>(context);
+        var provider = services.BuildServiceProvider();
+
+        var ambientScope = new AmbientRequestScope();
+        var token = ambientScope.BeginScope(provider);
+
+        var log = new ChatInvocationLog();
+        var factory = new ScriptedChatClientFactory(ambientScope, log);
+        return (factory, log, token);
     }
 
     [Fact]
     public async Task GetChatClientAsync_UnscriptedRole_ThrowsNamingUnmatchedIdAndKnownRoles()
     {
-        var log = new ChatInvocationLog();
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), log);
+        var (factory, _, scope) = CreateForAgent("planner");
+        using var _ = scope;
         factory.ForRole("verifier").Enqueue("known role response");
 
         var act = () => factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
@@ -40,7 +66,8 @@ public sealed class ScriptedChatClientFactoryTests
     [Fact]
     public async Task GetChatClientAsync_NoRolesRegisteredAtAll_ThrowsNamingNoneRegistered()
     {
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        var (factory, _, scope) = CreateForAgent("planner");
+        using var _ = scope;
 
         var act = () => factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
 
@@ -49,10 +76,36 @@ public sealed class ScriptedChatClientFactoryTests
     }
 
     [Fact]
+    public async Task GetChatClientAsync_NoAmbientScopeEstablished_ThrowsDistinctlyFromUnscriptedRole()
+    {
+        // A factory that is never handed an active ambient scope — distinct misconfiguration from
+        // "scope exists but no script matches", and must say so, not report agent id '<null>'.
+        var factory = new ScriptedChatClientFactory(new AmbientRequestScope(), new ChatInvocationLog());
+
+        var act = () => factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+        exception.Which.Message.Should().Contain("no ambient request scope is established");
+    }
+
+    [Fact]
+    public async Task GetChatClientAsync_AmbientScopeWithNoExecutionContextRegistered_ThrowsDistinctly()
+    {
+        var ambientScope = new AmbientRequestScope();
+        using var token = ambientScope.BeginScope(new ServiceCollection().BuildServiceProvider());
+        var factory = new ScriptedChatClientFactory(ambientScope, new ChatInvocationLog());
+
+        var act = () => factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+        exception.Which.Message.Should().Contain("no IAgentExecutionContext registered");
+    }
+
+    [Fact]
     public async Task ForAnyUnscriptedRole_ExplicitOptIn_AcceptsAnyUnmatchedRole()
     {
-        var log = new ChatInvocationLog();
-        var factory = new ScriptedChatClientFactory(ContextFor("some-other-agent"), log);
+        var (factory, _, scope) = CreateForAgent("some-other-agent");
+        using var _ = scope;
         factory.ForAnyUnscriptedRole().WithDefaultResponse("fallback content");
 
         var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
@@ -62,10 +115,26 @@ public sealed class ScriptedChatClientFactoryTests
     }
 
     [Fact]
+    public async Task ForAnyUnscriptedRole_CalledTwice_ReturnsSameScriptRatherThanDiscardingQueuedItems()
+    {
+        var (factory, _, scope) = CreateForAgent("some-other-agent");
+        using var _ = scope;
+        factory.ForAnyUnscriptedRole().Enqueue("first queued");
+        factory.ForAnyUnscriptedRole().Enqueue("second queued");
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
+
+        var first = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
+        var second = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+
+        first.Text.Should().Be("first queued");
+        second.Text.Should().Be("second queued");
+    }
+
+    [Fact]
     public async Task GetResponseAsync_RecordsAgentIdMessageCountAndResponseFormatPresence()
     {
-        var log = new ChatInvocationLog();
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), log);
+        var (factory, log, scope) = CreateForAgent("planner");
+        using var _ = scope;
         factory.ForRole("planner").Enqueue("plan output");
         var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
 
@@ -84,8 +153,8 @@ public sealed class ScriptedChatClientFactoryTests
     [Fact]
     public async Task GetResponseAsync_NoResponseFormatSupplied_RecordsFalse()
     {
-        var log = new ChatInvocationLog();
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), log);
+        var (factory, log, scope) = CreateForAgent("planner");
+        using var _ = scope;
         factory.ForRole("planner").Enqueue("plan output");
         var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "deployment");
 
@@ -99,43 +168,90 @@ public sealed class ScriptedChatClientFactoryTests
     {
         var log = new ChatInvocationLog();
 
-        var plannerFactory = new ScriptedChatClientFactory(ContextFor("planner"), log);
-        plannerFactory.ForRole("planner").Enqueue("plan");
-        var plannerClient = await plannerFactory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
-        await plannerClient.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
+        var (plannerFactory, _, plannerScope) = CreateForAgentSharingLog("planner", log);
+        using (plannerScope)
+        {
+            plannerFactory.ForRole("planner").Enqueue("plan");
+            var plannerClient = await plannerFactory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+            await plannerClient.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
+        }
 
-        var verifierFactory = new ScriptedChatClientFactory(ContextFor("verifier"), log);
-        verifierFactory.ForRole("verifier").Enqueue("verified");
-        var verifierClient = await verifierFactory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
-        await verifierClient.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+        var (verifierFactory, _, verifierScope) = CreateForAgentSharingLog("verifier", log);
+        using (verifierScope)
+        {
+            verifierFactory.ForRole("verifier").Enqueue("verified");
+            var verifierClient = await verifierFactory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+            await verifierClient.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+        }
 
         log.RoleSequence.Should().Equal("planner", "verifier");
+    }
+
+    private static (ScriptedChatClientFactory Factory, ChatInvocationLog Log, IDisposable ScopeToken) CreateForAgentSharingLog(
+        string agentId, ChatInvocationLog log)
+    {
+        var context = new AgentExecutionContext();
+        context.Initialize(agentId, conversationId: "conv-1", turnNumber: 1);
+        var services = new ServiceCollection();
+        services.AddSingleton<IAgentExecutionContext>(context);
+        var provider = services.BuildServiceProvider();
+        var ambientScope = new AmbientRequestScope();
+        var token = ambientScope.BeginScope(provider);
+        return (new ScriptedChatClientFactory(ambientScope, log), log, token);
     }
 
     [Fact]
     public async Task RoleScript_QueueExhausted_FallsBackToDefaultResponse()
     {
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        var (factory, _, scope) = CreateForAgent("planner");
+        using var _ = scope;
         factory.ForRole("planner").Enqueue("first").WithDefaultResponse("steady state");
         var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
 
         var first = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
         var second = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+        var third = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "3")]);
 
         first.Text.Should().Be("first");
         second.Text.Should().Be("steady state");
+        third.Text.Should().Be("steady state");
+        // The control for L4: the default response must be a fresh object each time, not one
+        // shared mutable instance a caller's middleware could mutate and leak into the next call.
+        ReferenceEquals(second.Messages, third.Messages).Should().BeFalse();
     }
 
     [Fact]
-    public async Task EnqueueThrow_ThrowsTheScriptedExceptionOnThatCall()
+    public async Task EnqueueThrow_ThrowsOnceThenFallsThroughToWhateverIsNext()
     {
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
-        factory.ForRole("planner").EnqueueThrow(new InvalidOperationException("provider unavailable"));
+        // EnqueueThrow is documented as non-sticky: it consumes its queue slot like any other
+        // scripted item. A caller that needs every call to fail uses AlwaysThrow instead.
+        var (factory, _, scope) = CreateForAgent("planner");
+        using var _ = scope;
+        factory.ForRole("planner")
+            .EnqueueThrow(new InvalidOperationException("provider unavailable"))
+            .Enqueue("recovered");
         var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
 
         var act = () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
-
         await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("provider unavailable");
+
+        var recovered = await client.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+        recovered.Text.Should().Be("recovered");
+    }
+
+    [Fact]
+    public async Task AlwaysThrow_FailsEveryCallIncludingAfterQueueExhaustion()
+    {
+        var (factory, _, scope) = CreateForAgent("planner");
+        using var _ = scope;
+        factory.ForRole("planner").AlwaysThrow(new InvalidOperationException("total failure"));
+        var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
+
+        var first = () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "1")]);
+        var second = () => client.GetResponseAsync([new ChatMessage(ChatRole.User, "2")]);
+
+        await first.Should().ThrowAsync<InvalidOperationException>();
+        await second.Should().ThrowAsync<InvalidOperationException>();
     }
 
     [Fact]
@@ -143,7 +259,8 @@ public sealed class ScriptedChatClientFactoryTests
     {
         // The control this fake exists to satisfy: a real streaming sequence, not one collapsed
         // frame — Package D's per-frame invariants would pass vacuously against a single-frame fake.
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        var (factory, _, scope) = CreateForAgent("planner");
+        using var _ = scope;
         factory.ForRole("planner").EnqueueWithUsage("hello world", inputTokens: 10, outputTokens: 5);
         var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
 
@@ -159,7 +276,8 @@ public sealed class ScriptedChatClientFactoryTests
     [Fact]
     public async Task GetStreamingResponseAsync_ToolCallResponse_StreamsTheFunctionCallAsItsOwnFrame()
     {
-        var factory = new ScriptedChatClientFactory(ContextFor("planner"), new ChatInvocationLog());
+        var (factory, _, scope) = CreateForAgent("planner");
+        using var _ = scope;
         factory.ForRole("planner").EnqueueToolCall("search", "call-1");
         var client = await factory.GetChatClientAsync(AIAgentFrameworkClientType.AzureOpenAI, "d");
 

--- a/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputInvokerTests.cs
@@ -78,10 +78,16 @@ public sealed class StructuredOutputInvokerTests
     }
 
     [Fact]
-    public async Task InvokeAsync_MalformedOnFirstAttemptOnly_NeverAborted_StillReachesSecondAttempt()
+    public async Task InvokeAsync_NeverReachesTheUnreachableMalformedShape()
     {
-        // Distinguishes RepairFailed (both attempts malformed) from Malformed (first-attempt-only
-        // shape doesn't exist in this loop — control proving the outcome differs by attempt count).
+        // THE CONTROL for a real defect a code-review fan-out caught: retryAddendum is set at the
+        // end of attempt 0's iteration on ANY parse failure, so the post-loop branch can only ever
+        // be reached after a repair was already attempted — there is no code path that fails
+        // without one. StructuredOutcome intentionally has no separate "malformed, no repair
+        // attempted" value because this loop can never produce it. This test scripts only ONE
+        // malformed response (the queue then falls back to RoleScript's default, itself malformed)
+        // and asserts two invocations happened and the outcome is RepairFailed — proving a repair
+        // was actually attempted, not skipped.
         var (invoker, script, log) = CreateSut();
         script.EnqueueMalformed();
         var client = ClientFor(script, log);
@@ -89,9 +95,7 @@ public sealed class StructuredOutputInvokerTests
         var result = await invoker.InvokeAsync<Plan>(
             client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
 
-        // Queue exhausted after attempt 1 falls back to RoleScript's default ("fake response"),
-        // which is itself malformed — so this still exercises exactly 2 attempts.
-        log.Invocations.Should().HaveCount(2);
+        log.Invocations.Should().HaveCount(2, "a repair is always attempted before giving up");
         result.Outcome.Should().Be(StructuredOutcome.RepairFailed);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputInvokerTests.cs
@@ -1,0 +1,173 @@
+using Application.AI.Common.StructuredOutput;
+using FluentAssertions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Tests.AI.Fakes;
+using Xunit;
+
+namespace Application.AI.Common.Tests.StructuredOutput;
+
+/// <summary>
+/// Proves <see cref="StructuredOutputInvoker"/>'s repair round-trip: attaches the schema, retries
+/// once on malformed output, aborts early on an empty body, and never shows the model its own prior
+/// bad attempt. Uses the real <see cref="RecordingChatClient"/> (via <see cref="RoleScript"/>) so
+/// the invocation count and <c>ChatOptions.ResponseFormat</c> presence are asserted against what
+/// actually reached the fake client, not a mocked expectation.
+/// </summary>
+public sealed class StructuredOutputInvokerTests
+{
+    private sealed record Plan(string Name, int StepCount);
+
+    private static readonly StructuredOutputContract Contract =
+        StructuredOutputSchema.Build<Plan>("test_plan");
+
+    private static (StructuredOutputInvoker Invoker, RoleScript Script, ChatInvocationLog Log) CreateSut()
+    {
+        var log = new ChatInvocationLog();
+        var script = new RoleScript();
+        var invoker = new StructuredOutputInvoker(NullLogger<StructuredOutputInvoker>.Instance);
+        return (invoker, script, log);
+    }
+
+    private static IChatClient ClientFor(RoleScript script, ChatInvocationLog log) =>
+        new RecordingChatClient(agentId: "test", script, log);
+
+    [Fact]
+    public async Task InvokeAsync_ValidJsonFirstAttempt_ReturnsParsedSuccessWithoutRepair()
+    {
+        var (invoker, script, log) = CreateSut();
+        script.Enqueue("""{"name":"build api","stepCount":3}""");
+        var client = ClientFor(script, log);
+
+        var result = await invoker.InvokeAsync<Plan>(
+            client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(new Plan("build api", 3));
+        log.Invocations.Should().ContainSingle("no repair needed on a valid first attempt");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MalformedThenValid_RepairsAndSucceeds()
+    {
+        var (invoker, script, log) = CreateSut();
+        script.EnqueueMalformed().Enqueue("""{"name":"recovered","stepCount":1}""");
+        var client = ClientFor(script, log);
+
+        var result = await invoker.InvokeAsync<Plan>(
+            client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(new Plan("recovered", 1));
+        log.Invocations.Should().HaveCount(2, "the repair round-trip took a second call");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MalformedOnBothAttempts_ReturnsRepairFailed()
+    {
+        var (invoker, script, log) = CreateSut();
+        script.EnqueueMalformed().EnqueueMalformed();
+        var client = ClientFor(script, log);
+
+        var result = await invoker.InvokeAsync<Plan>(
+            client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Outcome.Should().Be(StructuredOutcome.RepairFailed);
+        log.Invocations.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MalformedOnFirstAttemptOnly_NeverAborted_StillReachesSecondAttempt()
+    {
+        // Distinguishes RepairFailed (both attempts malformed) from Malformed (first-attempt-only
+        // shape doesn't exist in this loop — control proving the outcome differs by attempt count).
+        var (invoker, script, log) = CreateSut();
+        script.EnqueueMalformed();
+        var client = ClientFor(script, log);
+
+        var result = await invoker.InvokeAsync<Plan>(
+            client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        // Queue exhausted after attempt 1 falls back to RoleScript's default ("fake response"),
+        // which is itself malformed — so this still exercises exactly 2 attempts.
+        log.Invocations.Should().HaveCount(2);
+        result.Outcome.Should().Be(StructuredOutcome.RepairFailed);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_EmptyBody_AbortsWithoutARepairAttempt()
+    {
+        var (invoker, script, log) = CreateSut();
+        script.EnqueueEmpty();
+        var client = ClientFor(script, log);
+
+        var result = await invoker.InvokeAsync<Plan>(
+            client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        result.Outcome.Should().Be(StructuredOutcome.EmptyResponse);
+        // THE CONTROL: an empty body must not burn the repair attempt — a stricter format
+        // instruction cannot fix "the model said nothing."
+        log.Invocations.Should().ContainSingle("empty body aborts the retry budget early");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ProviderThrows_ReturnsInvocationFailed()
+    {
+        var (invoker, script, log) = CreateSut();
+        script.EnqueueThrow(new InvalidOperationException("provider unavailable"));
+        var client = ClientFor(script, log);
+
+        var result = await invoker.InvokeAsync<Plan>(
+            client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        result.Outcome.Should().Be(StructuredOutcome.InvocationFailed);
+        result.ErrorMessage.Should().Contain("provider unavailable");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_AttachesResponseFormatOnEveryAttempt()
+    {
+        var (invoker, script, log) = CreateSut();
+        script.EnqueueMalformed().Enqueue("""{"name":"x","stepCount":1}""");
+        var client = ClientFor(script, log);
+
+        await invoker.InvokeAsync<Plan>(
+            client, Contract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        log.Invocations.Should().HaveCount(2);
+        log.Invocations.Should().OnlyContain(i => i.HadResponseFormat, "both the first attempt and the repair must carry the schema");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_RepairAttempt_DoesNotReplayTheModelsOwnPriorOutput()
+    {
+        // The retry appends a system-level addendum, never an assistant message echoing the bad
+        // first attempt — verified via message count growth (system+user -> system+user+system).
+        var (invoker, script, log) = CreateSut();
+        script.EnqueueMalformed().Enqueue("""{"name":"x","stepCount":1}""");
+        var client = ClientFor(script, log);
+
+        await invoker.InvokeAsync<Plan>(
+            client, Contract,
+            [new ChatMessage(ChatRole.System, "sys"), new ChatMessage(ChatRole.User, "go")],
+            chatOptions: null, CancellationToken.None);
+
+        log.Invocations.Should().HaveCount(2);
+        log.Invocations[0].MessageCount.Should().Be(2);
+        log.Invocations[1].MessageCount.Should().Be(3, "the retry appends one addendum message, never the model's own prior output");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_ContractForWrongType_Throws()
+    {
+        var (invoker, script, log) = CreateSut();
+        var client = ClientFor(script, log);
+        var wrongContract = StructuredOutputSchema.Build<string>("wrong_type");
+
+        var act = () => invoker.InvokeAsync<Plan>(
+            client, wrongContract, [new ChatMessage(ChatRole.User, "go")], chatOptions: null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputSchemaChokepointTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputSchemaChokepointTests.cs
@@ -1,0 +1,57 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Tests.Common;
+using Xunit;
+
+namespace Application.AI.Common.Tests.StructuredOutput;
+
+/// <summary>
+/// Asserts that <c>StructuredOutputSchema</c> is the <strong>only</strong> caller of
+/// <c>AIJsonUtilities.CreateJsonSchema</c> — the same source-scan shape as
+/// <c>ToolCallAdmissionChokepointTests</c>, for the same reason: the defect this guards against is a
+/// new call site choosing its own schema-generation posture (required/nullable/additionalProperties)
+/// independently, which is exactly how a schema can silently reject valid model output — not a wrong
+/// answer from the one component that has it right.
+/// </summary>
+public sealed class StructuredOutputSchemaChokepointTests
+{
+    private static readonly HashSet<string> Allowed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "StructuredOutputSchema.cs",
+    };
+
+    [Fact]
+    public void StructuredOutputSchema_IsTheOnlyCallerOfCreateJsonSchema()
+    {
+        var contentRoot = Path.Combine(RepoRoot.Path, "src", "Content");
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(contentRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            if (SourceScan.IsExcluded(file, contentRoot) || Allowed.Contains(Path.GetFileName(file)))
+                continue;
+
+            var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(file));
+            if (Regex.IsMatch(code, @"\bAIJsonUtilities\.CreateJsonSchema\b"))
+                offenders.Add(Path.GetRelativePath(contentRoot, file));
+        }
+
+        offenders.Should().BeEmpty(
+            "every structured-output schema must be generated under StructuredOutputSchema's fixed "
+            + "posture — a second call site choosing its own required/nullable/additionalProperties "
+            + "settings is how a schema silently starts rejecting valid model output. Offenders:\n"
+            + string.Join("\n", offenders));
+    }
+
+    [Fact]
+    public void TheGuardWouldActuallyFire()
+    {
+        var violating = SourceScan.StripCommentsAndStrings(
+            "var schema = AIJsonUtilities.CreateJsonSchema(typeof(Foo), null, false, null, null, null);");
+        var commentOnly = SourceScan.StripCommentsAndStrings(
+            "// see AIJsonUtilities.CreateJsonSchema for the underlying call\npublic class X { }");
+
+        Regex.IsMatch(violating, @"\bAIJsonUtilities\.CreateJsonSchema\b").Should().BeTrue();
+        Regex.IsMatch(commentOnly, @"\bAIJsonUtilities\.CreateJsonSchema\b").Should().BeFalse();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputSchemaValidationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputSchemaValidationTests.cs
@@ -1,0 +1,254 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Application.AI.Common.StructuredOutput;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.StructuredOutput;
+
+/// <summary>
+/// Proves <see cref="StructuredOutputSchemaValidation"/>'s drift check catches a schema/CLR
+/// mismatch in <em>either</em> direction, and that the array-items check names the offending JSON
+/// pointer — using a local test type so this exercises the generic checker's own correctness,
+/// independent of any real DTO (those get their own drift test in the test project that can see
+/// their internal type: <c>Infrastructure.AI.Tests</c> for <c>LlmPlanOutput</c>,
+/// <c>Infrastructure.AI.RAG.Tests</c> for <c>CragResponse</c>).
+/// </summary>
+public sealed class StructuredOutputSchemaValidationTests
+{
+    private sealed record TestDto
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("count")]
+        public int Count { get; init; }
+
+        [JsonPropertyName("tags")]
+        public IReadOnlyList<string>? Tags { get; init; }
+    }
+
+    [Fact]
+    public void FindDrift_MatchingContract_ReturnsEmpty()
+    {
+        var contract = StructuredOutputSchema.Build<TestDto>("test_dto");
+
+        var drift = StructuredOutputSchemaValidation.FindDrift(contract);
+
+        drift.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindDrift_SchemaPropertyWithNoClrMember_IsReported()
+    {
+        // Build a contract, then hand-corrupt its schema to add a property the type doesn't have —
+        // simulating what a hand-written or drifted schema looks like from the checker's perspective.
+        var real = StructuredOutputSchema.Build<TestDto>("test_dto");
+        var corrupted = InjectExtraSchemaProperty(real, "phantom_field");
+
+        var drift = StructuredOutputSchemaValidation.FindDrift(corrupted);
+
+        drift.Should().Contain(d => d.Contains("phantom_field") && d.Contains("no matching CLR member"));
+    }
+
+    [Fact]
+    public void FindDrift_ClrMemberWithNoSchemaProperty_IsReported()
+    {
+        // The other direction: remove a real property from the schema, leaving the CLR member
+        // behind — simulating a type gaining a field without regenerating its schema.
+        var real = StructuredOutputSchema.Build<TestDto>("test_dto");
+        var corrupted = RemoveSchemaProperty(real, "count");
+
+        var drift = StructuredOutputSchemaValidation.FindDrift(corrupted);
+
+        drift.Should().Contain(d => d.Contains("Count") && d.Contains("no matching schema property"));
+    }
+
+    [Fact]
+    public void FindDrift_RequiredMismatch_IsReportedBothDirections()
+    {
+        var real = StructuredOutputSchema.Build<TestDto>("test_dto");
+
+        // Direction 1: schema marks something required that the CLR type doesn't.
+        var overRequired = InjectRequired(real, "count");
+        StructuredOutputSchemaValidation.FindDrift(overRequired).Should()
+            .Contain(d => d.Contains("'count'") && d.Contains("not `required`"));
+
+        // Direction 2: schema drops a requirement the CLR type actually has (Name is `required`).
+        var underRequired = RemoveAllRequired(real);
+        StructuredOutputSchemaValidation.FindDrift(underRequired).Should()
+            .Contain(d => d.Contains("'name'") && d.Contains("does not mark it required"));
+    }
+
+    [Fact]
+    public void FindArraysWithoutItems_ArrayMissingItems_ReturnsItsPointer()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "tags": { "type": "array" }
+              }
+            }
+            """).RootElement;
+
+        var offenders = StructuredOutputSchemaValidation.FindArraysWithoutItems(schema);
+
+        offenders.Should().ContainSingle().Which.Should().Be("#/properties/tags");
+    }
+
+    [Fact]
+    public void FindArraysWithoutItems_RealContractSchema_HasNoOffenders()
+    {
+        // Control: TestDto's real, correctly-generated schema (Tags: IReadOnlyList<string>?) must
+        // NOT trip this — proves the check isn't just always finding something.
+        var contract = StructuredOutputSchema.Build<TestDto>("test_dto");
+
+        var offenders = StructuredOutputSchemaValidation.FindArraysWithoutItems(contract.Schema);
+
+        offenders.Should().BeEmpty();
+    }
+
+    private sealed record DefaultedDto
+    {
+        [JsonPropertyName("required_field")]
+        public required string RequiredField { get; init; }
+
+        // Defaulted, not required — a model omitting it entirely must still parse.
+        [JsonPropertyName("with_default")]
+        public int WithDefault { get; init; } = 60;
+
+        // Genuinely optional — a model correctly omitting it must still parse.
+        [JsonPropertyName("optional")]
+        public string? Optional { get; init; }
+    }
+
+    [Fact]
+    public void Schema_OnlyMarksTheClrRequiredMemberAsRequired()
+    {
+        var contract = StructuredOutputSchema.Build<DefaultedDto>("defaulted_dto");
+
+        contract.Schema.TryGetProperty("required", out var required).Should().BeTrue();
+        var requiredNames = required.EnumerateArray().Select(e => e.GetString()).ToList();
+
+        requiredNames.Should().Contain("required_field");
+        requiredNames.Should().NotContain("with_default");
+        requiredNames.Should().NotContain("optional");
+    }
+
+    [Fact]
+    public void RoundTrip_OmittedDefaultedField_ParsesSuccessfully()
+    {
+        // The issue's stated trap: a naive reflected schema marks every field required, so a model
+        // correctly omitting a defaulted field gets rejected. This proves our posture doesn't.
+        var json = """{"required_field":"present"}""";
+
+        var parsed = JsonSerializer.Deserialize<DefaultedDto>(json, StructuredOutputSchema.Build<DefaultedDto>("x").SerializerOptions);
+
+        parsed.Should().NotBeNull();
+        parsed!.RequiredField.Should().Be("present");
+        parsed.WithDefault.Should().Be(60, "the CLR default fills in for the omitted field");
+        parsed.Optional.Should().BeNull();
+    }
+
+    [Fact]
+    public void RoundTrip_MissingRequiredField_ThrowsJsonException()
+    {
+        var json = """{"with_default":10}""";
+        var options = StructuredOutputSchema.Build<DefaultedDto>("x").SerializerOptions;
+
+        var act = () => JsonSerializer.Deserialize<DefaultedDto>(json, options);
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    public void RoundTrip_ModelVolunteersAnUnknownExtraKey_StillParsesSuccessfully()
+    {
+        // The issue's other stated trap: additionalProperties:false would reject a model that
+        // volunteers an unprompted explanatory key alongside a valid payload.
+        var json = """{"required_field":"present","confidence":0.9}""";
+        var options = StructuredOutputSchema.Build<DefaultedDto>("x").SerializerOptions;
+
+        var act = () => JsonSerializer.Deserialize<DefaultedDto>(json, options);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void FindArraysWithoutItems_ArrayWithItems_IsNotReported()
+    {
+        var schema = JsonDocument.Parse("""
+            {
+              "type": "object",
+              "properties": {
+                "tags": { "type": "array", "items": { "type": "string" } }
+              }
+            }
+            """).RootElement;
+
+        StructuredOutputSchemaValidation.FindArraysWithoutItems(schema).Should().BeEmpty();
+    }
+
+    private static StructuredOutputContract InjectExtraSchemaProperty(StructuredOutputContract source, string propertyName)
+    {
+        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
+        var mutable = new Dictionary<string, JsonElement>();
+        foreach (var prop in doc.RootElement.EnumerateObject())
+            mutable[prop.Name] = prop.Value.Clone();
+
+        using var propsDoc = JsonDocument.Parse(mutable["properties"].GetRawText());
+        var props = new Dictionary<string, JsonElement>();
+        foreach (var p in propsDoc.RootElement.EnumerateObject())
+            props[p.Name] = p.Value.Clone();
+        props[propertyName] = JsonDocument.Parse("""{"type":"string"}""").RootElement.Clone();
+
+        mutable["properties"] = ToJsonElement(props);
+        return source with { Schema = ToJsonElement(mutable) };
+    }
+
+    private static StructuredOutputContract RemoveSchemaProperty(StructuredOutputContract source, string propertyName)
+    {
+        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
+        var mutable = new Dictionary<string, JsonElement>();
+        foreach (var prop in doc.RootElement.EnumerateObject())
+            mutable[prop.Name] = prop.Value.Clone();
+
+        using var propsDoc = JsonDocument.Parse(mutable["properties"].GetRawText());
+        var props = new Dictionary<string, JsonElement>();
+        foreach (var p in propsDoc.RootElement.EnumerateObject())
+            if (p.Name != propertyName) props[p.Name] = p.Value.Clone();
+
+        mutable["properties"] = ToJsonElement(props);
+        return source with { Schema = ToJsonElement(mutable) };
+    }
+
+    private static StructuredOutputContract InjectRequired(StructuredOutputContract source, string propertyName)
+    {
+        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
+        var mutable = new Dictionary<string, JsonElement>();
+        foreach (var prop in doc.RootElement.EnumerateObject())
+            mutable[prop.Name] = prop.Value.Clone();
+
+        var existing = mutable.TryGetValue("required", out var r)
+            ? r.EnumerateArray().Select(e => e.GetString()!).ToList()
+            : [];
+        existing.Add(propertyName);
+        mutable["required"] = JsonSerializer.SerializeToElement(existing);
+
+        return source with { Schema = ToJsonElement(mutable) };
+    }
+
+    private static StructuredOutputContract RemoveAllRequired(StructuredOutputContract source)
+    {
+        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
+        var mutable = new Dictionary<string, JsonElement>();
+        foreach (var prop in doc.RootElement.EnumerateObject())
+            if (prop.Name != "required") mutable[prop.Name] = prop.Value.Clone();
+
+        return source with { Schema = ToJsonElement(mutable) };
+    }
+
+    private static JsonElement ToJsonElement(Dictionary<string, JsonElement> obj) =>
+        JsonSerializer.SerializeToElement(obj);
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputSchemaValidationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/StructuredOutput/StructuredOutputSchemaValidationTests.cs
@@ -190,63 +190,53 @@ public sealed class StructuredOutputSchemaValidationTests
         StructuredOutputSchemaValidation.FindArraysWithoutItems(schema).Should().BeEmpty();
     }
 
-    private static StructuredOutputContract InjectExtraSchemaProperty(StructuredOutputContract source, string propertyName)
+    // All four corruption helpers below reduce to the same shape — parse the schema to a mutable
+    // dictionary, change one key, re-serialize — so they share it instead of each hand-rolling the
+    // parse/rebuild dance.
+    private static StructuredOutputContract WithSchema(
+        StructuredOutputContract source, Action<Dictionary<string, JsonElement>> mutateTopLevel)
     {
-        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
-        var mutable = new Dictionary<string, JsonElement>();
-        foreach (var prop in doc.RootElement.EnumerateObject())
-            mutable[prop.Name] = prop.Value.Clone();
-
-        using var propsDoc = JsonDocument.Parse(mutable["properties"].GetRawText());
-        var props = new Dictionary<string, JsonElement>();
-        foreach (var p in propsDoc.RootElement.EnumerateObject())
-            props[p.Name] = p.Value.Clone();
-        props[propertyName] = JsonDocument.Parse("""{"type":"string"}""").RootElement.Clone();
-
-        mutable["properties"] = ToJsonElement(props);
+        var mutable = ToDictionary(source.Schema);
+        mutateTopLevel(mutable);
         return source with { Schema = ToJsonElement(mutable) };
     }
 
-    private static StructuredOutputContract RemoveSchemaProperty(StructuredOutputContract source, string propertyName)
+    private static StructuredOutputContract InjectExtraSchemaProperty(StructuredOutputContract source, string propertyName) =>
+        WithSchema(source, top =>
+        {
+            var props = ToDictionary(top["properties"]);
+            props[propertyName] = JsonDocument.Parse("""{"type":"string"}""").RootElement.Clone();
+            top["properties"] = ToJsonElement(props);
+        });
+
+    private static StructuredOutputContract RemoveSchemaProperty(StructuredOutputContract source, string propertyName) =>
+        WithSchema(source, top =>
+        {
+            var props = ToDictionary(top["properties"]);
+            props.Remove(propertyName);
+            top["properties"] = ToJsonElement(props);
+        });
+
+    private static StructuredOutputContract InjectRequired(StructuredOutputContract source, string propertyName) =>
+        WithSchema(source, top =>
+        {
+            var existing = top.TryGetValue("required", out var r)
+                ? r.EnumerateArray().Select(e => e.GetString()!).ToList()
+                : [];
+            existing.Add(propertyName);
+            top["required"] = JsonSerializer.SerializeToElement(existing);
+        });
+
+    private static StructuredOutputContract RemoveAllRequired(StructuredOutputContract source) =>
+        WithSchema(source, top => top.Remove("required"));
+
+    private static Dictionary<string, JsonElement> ToDictionary(JsonElement element)
     {
-        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
-        var mutable = new Dictionary<string, JsonElement>();
+        using var doc = JsonDocument.Parse(element.GetRawText());
+        var result = new Dictionary<string, JsonElement>();
         foreach (var prop in doc.RootElement.EnumerateObject())
-            mutable[prop.Name] = prop.Value.Clone();
-
-        using var propsDoc = JsonDocument.Parse(mutable["properties"].GetRawText());
-        var props = new Dictionary<string, JsonElement>();
-        foreach (var p in propsDoc.RootElement.EnumerateObject())
-            if (p.Name != propertyName) props[p.Name] = p.Value.Clone();
-
-        mutable["properties"] = ToJsonElement(props);
-        return source with { Schema = ToJsonElement(mutable) };
-    }
-
-    private static StructuredOutputContract InjectRequired(StructuredOutputContract source, string propertyName)
-    {
-        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
-        var mutable = new Dictionary<string, JsonElement>();
-        foreach (var prop in doc.RootElement.EnumerateObject())
-            mutable[prop.Name] = prop.Value.Clone();
-
-        var existing = mutable.TryGetValue("required", out var r)
-            ? r.EnumerateArray().Select(e => e.GetString()!).ToList()
-            : [];
-        existing.Add(propertyName);
-        mutable["required"] = JsonSerializer.SerializeToElement(existing);
-
-        return source with { Schema = ToJsonElement(mutable) };
-    }
-
-    private static StructuredOutputContract RemoveAllRequired(StructuredOutputContract source)
-    {
-        using var doc = JsonDocument.Parse(source.Schema.GetRawText());
-        var mutable = new Dictionary<string, JsonElement>();
-        foreach (var prop in doc.RootElement.EnumerateObject())
-            if (prop.Name != "required") mutable[prop.Name] = prop.Value.Clone();
-
-        return source with { Schema = ToJsonElement(mutable) };
+            result[prop.Name] = prop.Value.Clone();
+        return result;
     }
 
     private static JsonElement ToJsonElement(Dictionary<string, JsonElement> obj) =>

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/CragEvaluatorSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/CragEvaluatorSolutionReviewFixTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Routing;
+using Application.AI.Common.StructuredOutput;
 using Domain.AI.Routing.Enums;
 using Domain.AI.Routing.Models;
 using Domain.Common.Config.AI;
@@ -32,8 +33,11 @@ public sealed class CragEvaluatorSolutionReviewFixTests
             c.AI.Rag.Crag.AllowWebFallback = false;
         });
 
+        var structuredOutput = new StructuredOutputInvoker(Mock.Of<ILogger<StructuredOutputInvoker>>());
+
         return new CragEvaluator(
             _mockRouter.Object,
+            structuredOutput,
             config,
             Mock.Of<ILogger<CragEvaluator>>());
     }

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/CragEvaluatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/CragEvaluatorTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Routing;
+using Application.AI.Common.StructuredOutput;
 using Domain.AI.RAG.Enums;
 using Domain.AI.Routing.Enums;
 using Domain.AI.Routing.Models;
@@ -29,8 +30,12 @@ public sealed class CragEvaluatorTests
             c.AI.Rag.Crag.AllowWebFallback = allowWebFallback;
         });
 
+        // Real invoker, not a mock — proves the structured-output wiring works end to end.
+        var structuredOutput = new StructuredOutputInvoker(Mock.Of<ILogger<StructuredOutputInvoker>>());
+
         return new CragEvaluator(
             _mockRouter.Object,
+            structuredOutput,
             config,
             Mock.Of<ILogger<CragEvaluator>>());
     }
@@ -97,8 +102,11 @@ public sealed class CragEvaluatorTests
     }
 
     [Fact]
-    public async Task EvaluateAsync_LlmFailure_ReturnsFallbackAccept()
+    public async Task EvaluateAsync_LlmFailure_ReturnsEvaluationUnavailable_NeverAccept()
     {
+        // THE CONTROL for #323's sharpest finding: a CRAG evaluator that cannot read its own
+        // response must never silently green-light the retrieval it exists to gate. This test used
+        // to assert the opposite (CorrectionAction.Accept) — that was the bug.
         var mockChatClient = new Mock<IChatClient>();
         mockChatClient
             .Setup(c => c.GetResponseAsync(
@@ -123,9 +131,24 @@ public sealed class CragEvaluatorTests
 
         var evaluation = await evaluator.EvaluateAsync("test query", results);
 
-        evaluation.Action.Should().Be(CorrectionAction.Accept);
+        evaluation.Action.Should().Be(CorrectionAction.EvaluationUnavailable);
+        evaluation.Action.Should().NotBe(CorrectionAction.Accept);
         evaluation.RelevanceScore.Should().Be(0.5);
         evaluation.Reasoning.Should().Contain("failed");
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_MalformedResponseAfterRepairAttempt_ReturnsEvaluationUnavailable_NeverAccept()
+    {
+        // Second half of the same control: a response that never parses, even after the one
+        // repair round-trip, must degrade the same way as a thrown exception — never a passing score.
+        SetupChatResponse("this is not json at all, no braces here");
+        var evaluator = CreateEvaluator();
+        var results = RagTestData.CreateRetrievalResults(3);
+
+        var evaluation = await evaluator.EvaluateAsync("test query", results);
+
+        evaluation.Action.Should().Be(CorrectionAction.EvaluationUnavailable);
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/CragResponseSchemaDriftTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Evaluation/CragResponseSchemaDriftTests.cs
@@ -1,0 +1,37 @@
+using Application.AI.Common.StructuredOutput;
+using FluentAssertions;
+using Infrastructure.AI.RAG.Evaluation;
+using Xunit;
+
+namespace Infrastructure.AI.RAG.Tests.Evaluation;
+
+/// <summary>
+/// Proves the real <c>CragResponse</c> contract has no drift against its own CLR type, and that
+/// every array in its schema declares an <c>items</c> type. See
+/// <c>LlmPlanOutputSchemaDriftTests</c> for the same check against the other structured-output
+/// consumer; both DTOs' drift tests live in the Infrastructure test project that can see their
+/// internal type, per <see cref="StructuredOutputSchemaValidation"/>'s own remarks.
+/// </summary>
+public sealed class CragResponseSchemaDriftTests
+{
+    private static StructuredOutputContract BuildContract() =>
+        StructuredOutputSchema.Build<CragResponse>("crag_evaluation", "Corrective RAG relevance evaluation");
+
+    [Fact]
+    public void CragResponse_SchemaHasNoDriftAgainstItsClrType()
+    {
+        var drift = StructuredOutputSchemaValidation.FindDrift(BuildContract());
+
+        drift.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CragResponse_EveryArrayInTheSchemaDeclaresItems()
+    {
+        var contract = BuildContract();
+
+        var offenders = StructuredOutputSchemaValidation.FindArraysWithoutItems(contract.Schema);
+
+        offenders.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.RAG.Tests/Helpers/RagTestData.cs
+++ b/src/Content/Tests/Infrastructure.AI.RAG.Tests/Helpers/RagTestData.cs
@@ -129,6 +129,14 @@ internal static class RagTestData
             Reasoning = "Local results insufficient; recommend web fallback"
         };
 
+    public static CragEvaluation CreateEvaluationUnavailableEvaluation(string reason = "Evaluation failed: simulated failure") =>
+        new()
+        {
+            Action = CorrectionAction.EvaluationUnavailable,
+            RelevanceScore = 0.5,
+            Reasoning = reason
+        };
+
     public static TaskComplexityAssessment CreateTrivialClassification(double confidence = 0.9) =>
         new()
         {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/LlmPlanGeneratorServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/LlmPlanGeneratorServiceTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Prompts.Interfaces;
 using Application.AI.Common.Prompts.Models;
+using Application.AI.Common.StructuredOutput;
 using Domain.AI.Planner;
 using Domain.AI.Prompts;
 using Domain.Common;
@@ -75,8 +76,13 @@ public sealed class LlmPlanGeneratorServiceTests
         var optionsMonitor = Mock.Of<IOptionsMonitor<PlannerOptions>>(
             o => o.CurrentValue == _options);
 
+        // Real implementation, not a mock — drives the actual schema-out/parse-back/repair loop so
+        // these tests prove the wiring works end to end, not just that a mocked invoker was called.
+        var structuredOutput = new StructuredOutputInvoker(NullLogger<StructuredOutputInvoker>.Instance);
+
         _sut = new LlmPlanGeneratorService(
             _chatClientFactory.Object,
+            structuredOutput,
             _promptRegistry.Object,
             _promptRenderer.Object,
             _usageRecorder.Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/LlmPlanOutputSchemaDriftTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/LlmPlanOutputSchemaDriftTests.cs
@@ -1,0 +1,37 @@
+using Application.AI.Common.StructuredOutput;
+using FluentAssertions;
+using Infrastructure.AI.Planner;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Planner;
+
+/// <summary>
+/// Proves the real <c>LlmPlanOutput</c> contract — the schema actually sent to the model and
+/// validated on the way back — has no drift against its own CLR type, and that every array in its
+/// schema declares an <c>items</c> type. Uses the generic checkers in
+/// <see cref="StructuredOutputSchemaValidation"/>; this file's only job is supplying the internal
+/// type, which <c>Application.AI.Common.Tests</c> cannot see.
+/// </summary>
+public sealed class LlmPlanOutputSchemaDriftTests
+{
+    private static StructuredOutputContract BuildContract() =>
+        StructuredOutputSchema.Build<LlmPlanOutput>("plan_generation", "A generated agentic plan graph");
+
+    [Fact]
+    public void LlmPlanOutput_SchemaHasNoDriftAgainstItsClrType()
+    {
+        var drift = StructuredOutputSchemaValidation.FindDrift(BuildContract());
+
+        drift.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void LlmPlanOutput_EveryArrayInTheSchemaDeclaresItems()
+    {
+        var contract = BuildContract();
+
+        var offenders = StructuredOutputSchemaValidation.FindArraysWithoutItems(contract.Schema);
+
+        offenders.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -284,6 +284,12 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         // itself (and the unused collaborators nothing here resolves) come from the shared default.
         services.AddToolCallAdmissionChain();
         services.AddSingleton(new Mock<Application.AI.Common.Interfaces.AI.IConversationBudgetTracker>().Object);
+        // Real implementation, not a mock — LlmPlanGeneratorService's structured-output call is
+        // exactly the behaviour under test elsewhere (LlmPlanGeneratorServiceTests); here it only
+        // needs to resolve, so the cheap, stateless real StructuredOutputInvoker is simpler than
+        // mocking a generic-method interface.
+        services.AddSingleton<Application.AI.Common.Interfaces.AI.IStructuredOutputInvoker,
+            Application.AI.Common.StructuredOutput.StructuredOutputInvoker>();
         services.AddSingleton<ISender>(new Mock<ISender>().Object);
         services.AddSingleton<IPlanProgressNotifier>(new Mock<IPlanProgressNotifier>().Object);
         services.AddSingleton<ICapabilityEnforcer>(new Mock<ICapabilityEnforcer>().Object);

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Fakes/FakeChatClient.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Fakes/FakeChatClient.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.AI;
+using Tests.AI.Fakes;
 
 namespace Presentation.AgentHub.Tests.Fakes;
 
@@ -57,8 +58,14 @@ public sealed class FakeChatClient : IChatClient
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var response = await GetResponseAsync(messages, options, cancellationToken);
-        var text = string.Join("", response.Messages.Select(m => m.Text));
-        yield return new ChatResponseUpdate(ChatRole.Assistant, text);
+
+        // Streams each content item as its own update, usage as a trailing frame — mirroring what
+        // a real provider does. Collapsing to a single joined-text update (the prior behaviour
+        // here) made every response arrive as exactly one frame, which defeats any test asserting
+        // a per-frame invariant over a real streaming sequence. Shared with the other chat-client
+        // fakes via ChatResponseStreaming so this logic can't drift out of sync with them again.
+        await foreach (var update in ChatResponseStreaming.ToUpdatesAsync(response).WithCancellation(cancellationToken))
+            yield return update;
     }
 
     /// <inheritdoc />

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj
@@ -26,6 +26,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Presentation\Presentation.AgentHub\Presentation.AgentHub.csproj" />
     <ProjectReference Include="..\Tests.Common\Tests.Common.csproj" />
+    <!-- Shares ChatResponseStreaming so this project's FakeChatClient reconstructs streaming
+         updates with the same logic as the other chat-client fakes, instead of a second
+         hand-copied loop that can silently drift (as this file's previously did). -->
+    <ProjectReference Include="..\Tests.AI.Fakes\Tests.AI.Fakes.csproj" />
   </ItemGroup>
 
   <!--

--- a/src/Content/Tests/Presentation.Common.Tests/Fakes/FakeChatClientFactory.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Fakes/FakeChatClientFactory.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Models;
 using Domain.Common.Config.AI;
 using Microsoft.Extensions.AI;
+using Tests.AI.Fakes;
 
 namespace Presentation.Common.Tests.Fakes;
 
@@ -64,8 +65,8 @@ public sealed class FakeChatClientFactory : IChatClientFactory
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             var response = await GetResponseAsync(messages, options, cancellationToken);
-            foreach (var message in response.Messages)
-                yield return new ChatResponseUpdate(message.Role, message.Contents);
+            await foreach (var update in ChatResponseStreaming.ToUpdatesAsync(response, cancellationToken))
+                yield return update;
         }
 
         public object? GetService(Type serviceType, object? serviceKey = null) => null;

--- a/src/Content/Tests/Presentation.Common.Tests/Presentation.Common.Tests.csproj
+++ b/src/Content/Tests/Presentation.Common.Tests/Presentation.Common.Tests.csproj
@@ -28,6 +28,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Presentation\Presentation.Common\Presentation.Common.csproj" />
     <ProjectReference Include="..\Tests.Common\Tests.Common.csproj" />
+    <!-- Shares ChatResponseStreaming so FakeChatClientFactory's nested fake streams the same way
+         as the other chat-client fakes, instead of a fourth hand-copied loop. -->
+    <ProjectReference Include="..\Tests.AI.Fakes\Tests.AI.Fakes.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Tests.AI.Fakes/ChatInvocation.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/ChatInvocation.cs
@@ -1,0 +1,67 @@
+namespace Tests.AI.Fakes;
+
+/// <summary>
+/// One recorded call into a <see cref="RecordingChatClient"/> — the agent role that made it, the
+/// shape of what it sent, and when.
+/// </summary>
+/// <param name="AgentId">
+/// The <c>IAgentExecutionContext.AgentId</c> active when the call was made, or <c>null</c> if no
+/// agent context was in scope.
+/// </param>
+/// <param name="MessageCount">The number of messages in the request.</param>
+/// <param name="HadResponseFormat">
+/// Whether the caller populated <c>ChatOptions.ResponseFormat</c> — the signal a structured-output
+/// contract (see the invoker built for #323) attaches a schema to the request. Recording this is
+/// what makes a repair round-trip assertable end-to-end: a scenario can assert not just that the
+/// final output is correct, but that the retry attempt actually requested the schema again.
+/// </param>
+/// <param name="ElapsedFromStart">
+/// Time since the log was created, sourced from the <see cref="TimeProvider"/> the client was
+/// constructed with — never wall-clock, so tests are deterministic under a fake time provider.
+/// </param>
+public sealed record ChatInvocation(
+    string? AgentId,
+    int MessageCount,
+    bool HadResponseFormat,
+    TimeSpan ElapsedFromStart);
+
+/// <summary>
+/// Ordered, thread-safe log of every call made across every <see cref="RecordingChatClient"/>
+/// instance sharing this log. Registered singleton so it survives the scoped
+/// <see cref="ScriptedChatClientFactory"/> lifetime described on that type — a test asserting an
+/// invocation sequence needs one log for the whole run, not one per DI scope.
+/// </summary>
+public sealed class ChatInvocationLog
+{
+    private readonly List<ChatInvocation> _invocations = [];
+    private readonly Lock _gate = new();
+    private readonly TimeProvider _timeProvider;
+    private readonly long _startTimestamp;
+
+    /// <summary>Creates a log whose <see cref="ChatInvocation.ElapsedFromStart"/> values are
+    /// measured from construction time using <paramref name="timeProvider"/>.</summary>
+    public ChatInvocationLog(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _startTimestamp = _timeProvider.GetTimestamp();
+    }
+
+    /// <summary>All invocations recorded so far, in call order.</summary>
+    public IReadOnlyList<ChatInvocation> Invocations
+    {
+        get { lock (_gate) return [.. _invocations]; }
+    }
+
+    /// <summary>The ordered sequence of <see cref="ChatInvocation.AgentId"/> values recorded so far.</summary>
+    public IReadOnlyList<string?> RoleSequence => [.. Invocations.Select(i => i.AgentId)];
+
+    /// <summary>Counts how many times a given agent id was invoked.</summary>
+    public int CountFor(string? agentId) => Invocations.Count(i => i.AgentId == agentId);
+
+    /// <summary>Records one invocation. Thread-safe — parallel tool calls may invoke concurrently.</summary>
+    internal void Record(string? agentId, int messageCount, bool hadResponseFormat)
+    {
+        var elapsed = _timeProvider.GetElapsedTime(_startTimestamp);
+        lock (_gate) _invocations.Add(new ChatInvocation(agentId, messageCount, hadResponseFormat, elapsed));
+    }
+}

--- a/src/Content/Tests/Tests.AI.Fakes/ChatResponseStreaming.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/ChatResponseStreaming.cs
@@ -1,0 +1,47 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Tests.AI.Fakes;
+
+/// <summary>
+/// Reconstructs a blocking <see cref="ChatResponse"/> as the sequence of
+/// <see cref="ChatResponseUpdate"/> frames a real provider would emit for it — one frame per
+/// content item, with usage arriving as a trailing <see cref="UsageContent"/> chunk.
+/// </summary>
+/// <remarks>
+/// The single place this logic lives. It was previously copy-pasted between
+/// <c>Application.AI.Common.Tests.Fakes.FakeChatClient</c> and
+/// <c>Presentation.AgentHub.Tests.Fakes.FakeChatClient</c> — the second copy is what had silently
+/// drifted to collapsing every response into one frame, the exact bug Package A of the
+/// verification cluster exists to close. Any fake that needs to turn a canned
+/// <see cref="ChatResponse"/> into a streaming sequence should call this rather than
+/// reimplementing the loop a third time.
+/// </remarks>
+public static class ChatResponseStreaming
+{
+    /// <summary>
+    /// Converts <paramref name="response"/> into its per-content-item update sequence. Honours
+    /// <paramref name="cancellationToken"/> between frames — passed through by a caller's
+    /// <c>WithCancellation</c> via <see cref="EnumeratorCancellationAttribute"/> rather than being a
+    /// decorative parameter, since the enumeration has no other await point to observe it at.
+    /// </summary>
+    public static async IAsyncEnumerable<ChatResponseUpdate> ToUpdatesAsync(
+        ChatResponse response,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        foreach (var message in response.Messages)
+            foreach (var content in message.Contents)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return new ChatResponseUpdate(message.Role, new List<AIContent> { content });
+            }
+
+        if (response.Usage is { } usage)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent> { new UsageContent(usage) });
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/src/Content/Tests/Tests.AI.Fakes/ChatResponseStreaming.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/ChatResponseStreaming.cs
@@ -25,23 +25,54 @@ public static class ChatResponseStreaming
     /// <c>WithCancellation</c> via <see cref="EnumeratorCancellationAttribute"/> rather than being a
     /// decorative parameter, since the enumeration has no other await point to observe it at.
     /// </summary>
+    /// <remarks>
+    /// Every frame carries <paramref name="response"/>'s <see cref="ChatResponse.ResponseId"/>,
+    /// <see cref="ChatResponse.ConversationId"/>, <see cref="ChatResponse.ModelId"/> and
+    /// <see cref="ChatResponse.CreatedAt"/>, and each message's own
+    /// <see cref="ChatMessage.MessageId"/> — production coalesces a stream back with
+    /// <c>ChatResponseUpdateExtensions.ToChatResponse()</c>, which reads those fields off the
+    /// updates, not the original blocking response. Frames with none of them would make a scripted
+    /// response look metadata-less on the streaming path while carrying real values on the blocking
+    /// one, and would coalesce every message back into one (no <c>MessageId</c> to split on). The
+    /// final frame also carries <see cref="ChatResponse.FinishReason"/>, matching where a real
+    /// provider's finish reason arrives.
+    /// </remarks>
     public static async IAsyncEnumerable<ChatResponseUpdate> ToUpdatesAsync(
         ChatResponse response,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        foreach (var message in response.Messages)
-            foreach (var content in message.Contents)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                yield return new ChatResponseUpdate(message.Role, new List<AIContent> { content });
-            }
-
-        if (response.Usage is { } usage)
+        var frames = BuildFrames(response);
+        for (var i = 0; i < frames.Count; i++)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            yield return new ChatResponseUpdate(ChatRole.Assistant, new List<AIContent> { new UsageContent(usage) });
+            if (i == frames.Count - 1) frames[i].FinishReason = response.FinishReason;
+            yield return frames[i];
         }
 
         await Task.CompletedTask;
     }
+
+    private static List<ChatResponseUpdate> BuildFrames(ChatResponse response)
+    {
+        var frames = new List<ChatResponseUpdate>();
+
+        foreach (var message in response.Messages)
+            foreach (var content in message.Contents)
+                frames.Add(NewFrame(response, message.Role, message.MessageId, new List<AIContent> { content }));
+
+        if (response.Usage is { } usage)
+            frames.Add(NewFrame(response, ChatRole.Assistant, messageId: null, new List<AIContent> { new UsageContent(usage) }));
+
+        return frames;
+    }
+
+    private static ChatResponseUpdate NewFrame(ChatResponse response, ChatRole role, string? messageId, IList<AIContent> contents) =>
+        new(role, contents)
+        {
+            ResponseId = response.ResponseId,
+            MessageId = messageId,
+            ConversationId = response.ConversationId,
+            ModelId = response.ModelId,
+            CreatedAt = response.CreatedAt,
+        };
 }

--- a/src/Content/Tests/Tests.AI.Fakes/RecordingChatClient.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/RecordingChatClient.cs
@@ -1,0 +1,46 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+
+namespace Tests.AI.Fakes;
+
+/// <summary>
+/// In-memory <see cref="IChatClient"/> bound to one agent role's <see cref="RoleScript"/>, that
+/// records every call it receives into a shared <see cref="ChatInvocationLog"/>.
+/// </summary>
+/// <remarks>
+/// Streams each response's content items individually with usage arriving as a trailing
+/// <see cref="UsageContent"/> chunk — mirroring what a real provider does, so a test asserting a
+/// per-frame streaming invariant sees a real multi-frame sequence rather than one collapsed frame.
+/// Construct via <see cref="ScriptedChatClientFactory"/> rather than directly, so the invocation log
+/// and role binding stay consistent with the factory's role resolution.
+/// </remarks>
+public sealed class RecordingChatClient(string? agentId, RoleScript script, ChatInvocationLog log) : IChatClient
+{
+    /// <inheritdoc />
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        var messageList = messages.ToList();
+        log.Record(agentId, messageList.Count, options?.ResponseFormat is not null);
+        return Task.FromResult(script.Next());
+    }
+
+    /// <inheritdoc />
+    public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var response = await GetResponseAsync(messages, options, cancellationToken);
+        await foreach (var update in ChatResponseStreaming.ToUpdatesAsync(response).WithCancellation(cancellationToken))
+            yield return update;
+    }
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    /// <inheritdoc />
+    public void Dispose() { }
+}

--- a/src/Content/Tests/Tests.AI.Fakes/RoleScript.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/RoleScript.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.AI;
+
+namespace Tests.AI.Fakes;
+
+/// <summary>
+/// The scripted responses for one agent role: a FIFO queue drained on each call, falling back to
+/// a default once exhausted. Shared and mutated by every <see cref="RecordingChatClient"/> built
+/// for the same role across repeated <c>IChatClientFactory.GetChatClientAsync</c> calls, so a
+/// scenario's queue state survives agent reconstruction within one test.
+/// </summary>
+public sealed class RoleScript
+{
+    private readonly Queue<ScriptedItem> _responses = new();
+    private ChatResponse _defaultResponse = new(new ChatMessage(ChatRole.Assistant, "fake response"));
+
+    /// <summary>Sets the response returned once the queue is empty.</summary>
+    public RoleScript WithDefaultResponse(string content)
+    {
+        _defaultResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, content));
+        return this;
+    }
+
+    /// <summary>Enqueues a plain-text response.</summary>
+    public RoleScript Enqueue(string content)
+    {
+        _responses.Enqueue(ScriptedItem.Of(new ChatResponse(new ChatMessage(ChatRole.Assistant, content))));
+        return this;
+    }
+
+    /// <summary>
+    /// Enqueues a response with usage metadata, for tests asserting per-call token accounting
+    /// (e.g. <c>LlmUsageCapture.LastCallPromptTokens</c>).
+    /// </summary>
+    public RoleScript EnqueueWithUsage(string content, int inputTokens, int outputTokens)
+    {
+        var response = new ChatResponse(new ChatMessage(ChatRole.Assistant, content))
+        {
+            Usage = new UsageDetails
+            {
+                InputTokenCount = inputTokens,
+                OutputTokenCount = outputTokens,
+                TotalTokenCount = inputTokens + outputTokens,
+            },
+        };
+        _responses.Enqueue(ScriptedItem.Of(response));
+        return this;
+    }
+
+    /// <summary>
+    /// Enqueues text that is deliberately not valid JSON — for scripting the "malformed, then
+    /// repaired" half of a structured-output repair-round-trip scenario.
+    /// </summary>
+    public RoleScript EnqueueMalformed(string malformedJson = "{ this is not valid json") =>
+        Enqueue(malformedJson);
+
+    /// <summary>Enqueues a response carrying no content at all, for the empty-body abort path.</summary>
+    public RoleScript EnqueueEmpty() => Enqueue(string.Empty);
+
+    /// <summary>Enqueues a response whose assistant message carries a single tool call.</summary>
+    public RoleScript EnqueueToolCall(string toolName, string callId, IDictionary<string, object?>? arguments = null)
+    {
+        var message = new ChatMessage(ChatRole.Assistant, new List<AIContent>
+        {
+            new FunctionCallContent(callId, toolName, arguments ?? new Dictionary<string, object?>()),
+        });
+        _responses.Enqueue(ScriptedItem.Of(new ChatResponse(message)));
+        return this;
+    }
+
+    /// <summary>Enqueues a response that always throws when requested, for total-failure scenarios.</summary>
+    public RoleScript EnqueueThrow(Exception exception)
+    {
+        _responses.Enqueue(ScriptedItem.Throw(exception));
+        return this;
+    }
+
+    /// <summary>Dequeues the next scripted response, or the default if the queue is empty. Throws
+    /// the scripted exception, if one was enqueued, instead of returning.</summary>
+    internal ChatResponse Next()
+    {
+        if (_responses.Count == 0) return _defaultResponse;
+        var item = _responses.Dequeue();
+        return item.Exception is { } exception ? throw exception : item.ResponseValue!;
+    }
+
+    /// <summary>
+    /// A queued item is either a canned response or an exception to throw — kept as a plain
+    /// discriminated struct rather than subclassing <see cref="ChatResponse"/>, whose sealed-ness
+    /// is not part of its documented contract and should not be assumed.
+    /// </summary>
+    private readonly record struct ScriptedItem(ChatResponse? ResponseValue, Exception? Exception)
+    {
+        public static ScriptedItem Of(ChatResponse response) => new(response, null);
+        public static ScriptedItem Throw(Exception exception) => new(null, exception);
+    }
+}

--- a/src/Content/Tests/Tests.AI.Fakes/RoleScript.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/RoleScript.cs
@@ -8,22 +8,28 @@ namespace Tests.AI.Fakes;
 /// for the same role across repeated <c>IChatClientFactory.GetChatClientAsync</c> calls, so a
 /// scenario's queue state survives agent reconstruction within one test.
 /// </summary>
+/// <remarks>
+/// Thread-safe — <c>AgentFactory</c> sets <c>AllowConcurrentInvocation = true</c> for tool-bearing
+/// turns, and plan steps run with bounded concurrency, so two calls against the same role's script
+/// can race in a real scenario. Every mutating/reading operation takes <see cref="_gate"/>.
+/// </remarks>
 public sealed class RoleScript
 {
+    private readonly Lock _gate = new();
     private readonly Queue<ScriptedItem> _responses = new();
-    private ChatResponse _defaultResponse = new(new ChatMessage(ChatRole.Assistant, "fake response"));
+    private string _defaultResponseText = "fake response";
 
-    /// <summary>Sets the response returned once the queue is empty.</summary>
+    /// <summary>Sets the text returned (as a freshly built response) once the queue is empty.</summary>
     public RoleScript WithDefaultResponse(string content)
     {
-        _defaultResponse = new ChatResponse(new ChatMessage(ChatRole.Assistant, content));
+        lock (_gate) _defaultResponseText = content;
         return this;
     }
 
     /// <summary>Enqueues a plain-text response.</summary>
     public RoleScript Enqueue(string content)
     {
-        _responses.Enqueue(ScriptedItem.Of(new ChatResponse(new ChatMessage(ChatRole.Assistant, content))));
+        lock (_gate) _responses.Enqueue(ScriptedItem.Of(new ChatResponse(new ChatMessage(ChatRole.Assistant, content))));
         return this;
     }
 
@@ -42,7 +48,7 @@ public sealed class RoleScript
                 TotalTokenCount = inputTokens + outputTokens,
             },
         };
-        _responses.Enqueue(ScriptedItem.Of(response));
+        lock (_gate) _responses.Enqueue(ScriptedItem.Of(response));
         return this;
     }
 
@@ -63,24 +69,49 @@ public sealed class RoleScript
         {
             new FunctionCallContent(callId, toolName, arguments ?? new Dictionary<string, object?>()),
         });
-        _responses.Enqueue(ScriptedItem.Of(new ChatResponse(message)));
+        lock (_gate) _responses.Enqueue(ScriptedItem.Of(new ChatResponse(message)));
         return this;
     }
 
-    /// <summary>Enqueues a response that always throws when requested, for total-failure scenarios.</summary>
+    /// <summary>
+    /// Enqueues an exception to be thrown the one time this item is dequeued — for scripting a
+    /// single failed call within a larger sequence (e.g. "attempt one throws, attempt two
+    /// succeeds"). This is <em>not</em> sticky: once dequeued, later calls proceed to whatever is
+    /// enqueued next, or the default response if the queue is now empty. For a call that must fail
+    /// every time it is invoked, enqueue this repeatedly or use <see cref="AlwaysThrow"/>.
+    /// </summary>
     public RoleScript EnqueueThrow(Exception exception)
     {
-        _responses.Enqueue(ScriptedItem.Throw(exception));
+        lock (_gate) _responses.Enqueue(ScriptedItem.Throw(exception));
         return this;
     }
 
+    /// <summary>
+    /// Makes every call against this role throw <paramref name="exception"/>, including calls made
+    /// after the queue is otherwise exhausted — for a genuine total-failure scenario, where a
+    /// single <see cref="EnqueueThrow"/> would let a later, unscripted call fall through to the
+    /// default success response.
+    /// </summary>
+    public RoleScript AlwaysThrow(Exception exception)
+    {
+        lock (_gate) _alwaysThrow = exception;
+        return this;
+    }
+
+    private Exception? _alwaysThrow;
+
     /// <summary>Dequeues the next scripted response, or the default if the queue is empty. Throws
-    /// the scripted exception, if one was enqueued, instead of returning.</summary>
+    /// the scripted exception, if the dequeued item is one, or the sticky exception set via
+    /// <see cref="AlwaysThrow"/> if one is active.</summary>
     internal ChatResponse Next()
     {
-        if (_responses.Count == 0) return _defaultResponse;
-        var item = _responses.Dequeue();
-        return item.Exception is { } exception ? throw exception : item.ResponseValue!;
+        lock (_gate)
+        {
+            if (_alwaysThrow is { } sticky) throw sticky;
+            if (_responses.Count == 0) return new ChatResponse(new ChatMessage(ChatRole.Assistant, _defaultResponseText));
+            var item = _responses.Dequeue();
+            return item.Exception is { } exception ? throw exception : item.ResponseValue!;
+        }
     }
 
     /// <summary>

--- a/src/Content/Tests/Tests.AI.Fakes/ScriptedChatClientFactory.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/ScriptedChatClientFactory.cs
@@ -1,0 +1,109 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Models;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.AI;
+
+namespace Tests.AI.Fakes;
+
+/// <summary>
+/// Role-aware <see cref="IChatClientFactory"/> fake. Selects which <see cref="RoleScript"/> a call
+/// gets by reading <see cref="IAgentExecutionContext.AgentId"/> — the ambient identity
+/// <c>AgentContextPropagationBehavior</c> stamps before a handler runs, and which is already in
+/// scope by the time <c>AgentFactory</c> calls <c>GetChatClientAsync</c> — rather than by sniffing
+/// prompt text.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Lifetime.</strong> Must be registered <c>Scoped</c>, not the production
+/// <c>Singleton</c> lifetime <c>IChatClientFactory</c> normally has — it depends on the scoped
+/// <see cref="IAgentExecutionContext"/>. A singleton registration is only guaranteed to throw when
+/// the container has scope validation enabled (<c>ServiceProviderOptions.ValidateScopes = true</c>,
+/// on by default for an ASP.NET Core host but <em>not</em> for a bare
+/// <c>new ServiceCollection().BuildServiceProvider()</c>). Build any hand-rolled test container for
+/// this factory with <c>ValidateScopes = true</c> — otherwise a lifetime mistake here doesn't throw,
+/// it silently freezes every scope onto whichever <see cref="IAgentExecutionContext"/> was active on
+/// first resolution, which reads as role-bleed between tests rather than a lifetime bug. Register
+/// the <see cref="ChatInvocationLog"/> singleton separately so it survives across scopes and can
+/// still answer "what was the full call sequence for this test."
+/// </para>
+/// <para>
+/// <strong>Fails loudly on an unscripted role.</strong> A call whose resolved <c>AgentId</c> has no
+/// registered <see cref="RoleScript"/> and no <see cref="ForAnyUnscriptedRole"/> fallback throws,
+/// naming the unmatched id and every registered role — the same "must fail loudly, not return empty
+/// success" requirement structured-output and pipeline scenarios are built to prove.
+/// </para>
+/// </remarks>
+public sealed class ScriptedChatClientFactory(IAgentExecutionContext executionContext, ChatInvocationLog log) : IChatClientFactory
+{
+    private readonly Dictionary<string, RoleScript> _roles = new(StringComparer.Ordinal);
+    private RoleScript? _anyRoleFallback;
+
+    /// <summary>Registers (or returns the existing) script for the given agent id.</summary>
+    public RoleScript ForRole(string agentId)
+    {
+        if (_roles.TryGetValue(agentId, out var existing)) return existing;
+        var script = new RoleScript();
+        _roles[agentId] = script;
+        return script;
+    }
+
+    /// <summary>
+    /// Registers a fallback script used for any call whose agent id has no dedicated
+    /// <see cref="ForRole"/> script. An explicit opt-in, not a silent default — a test that wants
+    /// role separation enforced simply never calls this.
+    /// </summary>
+    public RoleScript ForAnyUnscriptedRole()
+    {
+        _anyRoleFallback = new RoleScript();
+        return _anyRoleFallback;
+    }
+
+    /// <inheritdoc />
+    public bool IsAvailable(AIAgentFrameworkClientType clientType) => true;
+
+    /// <inheritdoc />
+    public Task<IChatClient> GetChatClientAsync(
+        AIAgentFrameworkClientType clientType,
+        string deploymentOrAgentId,
+        CancellationToken cancellationToken = default)
+    {
+        var agentId = executionContext.AgentId;
+        var script = ResolveScript(agentId);
+        return Task.FromResult<IChatClient>(new RecordingChatClient(agentId, script, log));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>The fake has no SDK retry to disable, so this yields the same client.</remarks>
+    public Task<IChatClient> GetChatClientWithoutProviderRetryAsync(
+        AIAgentFrameworkClientType clientType,
+        string deploymentOrAgentId,
+        CancellationToken cancellationToken = default)
+        => GetChatClientAsync(clientType, deploymentOrAgentId, cancellationToken);
+
+    /// <inheritdoc />
+    public IReadOnlyDictionary<AIAgentFrameworkClientType, bool> GetAvailableProviders() =>
+        new Dictionary<AIAgentFrameworkClientType, bool> { [AIAgentFrameworkClientType.AzureOpenAI] = true };
+
+    /// <inheritdoc />
+    public AiProviderStatus GetProviderStatus() =>
+        new(AIAgentFrameworkClientType.AzureOpenAI, "fake-deployment", IsConfigured: true, MissingSettings: []);
+
+    /// <inheritdoc />
+    public Task<string> CreatePersistentAgentAsync(
+        string model, string name, string? instructions = null,
+        string? description = null, CancellationToken cancellationToken = default)
+        => Task.FromResult($"fake-agent-{Guid.NewGuid():N}");
+
+    private RoleScript ResolveScript(string? agentId)
+    {
+        if (agentId is not null && _roles.TryGetValue(agentId, out var script)) return script;
+        if (_anyRoleFallback is not null) return _anyRoleFallback;
+
+        var known = _roles.Count == 0 ? "(none registered)" : string.Join(", ", _roles.Keys);
+        throw new InvalidOperationException(
+            $"ScriptedChatClientFactory has no script for agent id '{agentId ?? "<null>"}'. " +
+            $"Registered roles: {known}. Call ForRole(agentId) to script this agent, or " +
+            $"{nameof(ForAnyUnscriptedRole)}() to accept any unmatched role.");
+    }
+}

--- a/src/Content/Tests/Tests.AI.Fakes/ScriptedChatClientFactory.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/ScriptedChatClientFactory.cs
@@ -3,60 +3,70 @@ using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Models;
 using Domain.Common.Config.AI;
 using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Tests.AI.Fakes;
 
 /// <summary>
 /// Role-aware <see cref="IChatClientFactory"/> fake. Selects which <see cref="RoleScript"/> a call
 /// gets by reading <see cref="IAgentExecutionContext.AgentId"/> — the ambient identity
-/// <c>AgentContextPropagationBehavior</c> stamps before a handler runs, and which is already in
-/// scope by the time <c>AgentFactory</c> calls <c>GetChatClientAsync</c> — rather than by sniffing
+/// <c>AgentContextPropagationBehavior</c> stamps before a handler runs — rather than by sniffing
 /// prompt text.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Lifetime.</strong> Must be registered <c>Scoped</c>, not the production
-/// <c>Singleton</c> lifetime <c>IChatClientFactory</c> normally has — it depends on the scoped
-/// <see cref="IAgentExecutionContext"/>. A singleton registration is only guaranteed to throw when
-/// the container has scope validation enabled (<c>ServiceProviderOptions.ValidateScopes = true</c>,
-/// on by default for an ASP.NET Core host but <em>not</em> for a bare
-/// <c>new ServiceCollection().BuildServiceProvider()</c>). Build any hand-rolled test container for
-/// this factory with <c>ValidateScopes = true</c> — otherwise a lifetime mistake here doesn't throw,
-/// it silently freezes every scope onto whichever <see cref="IAgentExecutionContext"/> was active on
-/// first resolution, which reads as role-bleed between tests rather than a lifetime bug. Register
-/// the <see cref="ChatInvocationLog"/> singleton separately so it survives across scopes and can
-/// still answer "what was the full call sequence for this test."
+/// <strong>Lifetime: register Singleton, matching production's real <c>IChatClientFactory</c>
+/// (<c>Infrastructure.AI/DependencyInjection.cs</c>).</strong> This type does NOT constructor-inject
+/// the scoped <see cref="IAgentExecutionContext"/> directly — doing so would either fail container
+/// validation, or, under a hand-built test container with scope validation off, silently pin every
+/// resolution to whichever scope built the factory first (role-bleed indistinguishable from a real
+/// test bug). Instead it takes the singleton <see cref="IAmbientRequestScope"/> — the same
+/// AsyncLocal-backed bridge production singletons already use to reach per-request scoped services
+/// (see <c>KnowledgeMemoryContextProvider</c>, <c>AgentExecutionContextFactory.ContextProviders</c>)
+/// — and resolves <see cref="IAgentExecutionContext"/> from <see cref="IAmbientRequestScope.Current"/>
+/// at call time. A caller must have the real <c>AmbientRequestScopeBehavior&lt;,&gt;</c> (or an
+/// equivalent manual <see cref="IAmbientRequestScope.BeginScope"/>) established for the duration of
+/// the request, exactly as production does.
 /// </para>
 /// <para>
-/// <strong>Fails loudly on an unscripted role.</strong> A call whose resolved <c>AgentId</c> has no
-/// registered <see cref="RoleScript"/> and no <see cref="ForAnyUnscriptedRole"/> fallback throws,
-/// naming the unmatched id and every registered role — the same "must fail loudly, not return empty
-/// success" requirement structured-output and pipeline scenarios are built to prove.
+/// <strong>Fails loudly, and distinguishes why.</strong> No ambient scope established, no
+/// <see cref="IAgentExecutionContext"/> registered in that scope, and an unscripted agent id are
+/// three different misconfigurations and throw three differently-worded exceptions — collapsing
+/// them would turn "you forgot to establish the ambient scope in your test container" into a
+/// confusing "no script for id '&lt;null&gt;'" message.
 /// </para>
 /// </remarks>
-public sealed class ScriptedChatClientFactory(IAgentExecutionContext executionContext, ChatInvocationLog log) : IChatClientFactory
+public sealed class ScriptedChatClientFactory(IAmbientRequestScope ambientScope, ChatInvocationLog log) : IChatClientFactory
 {
+    private readonly Lock _rolesGate = new();
     private readonly Dictionary<string, RoleScript> _roles = new(StringComparer.Ordinal);
     private RoleScript? _anyRoleFallback;
 
     /// <summary>Registers (or returns the existing) script for the given agent id.</summary>
     public RoleScript ForRole(string agentId)
     {
-        if (_roles.TryGetValue(agentId, out var existing)) return existing;
-        var script = new RoleScript();
-        _roles[agentId] = script;
-        return script;
+        lock (_rolesGate)
+        {
+            if (_roles.TryGetValue(agentId, out var existing)) return existing;
+            var script = new RoleScript();
+            _roles[agentId] = script;
+            return script;
+        }
     }
 
     /// <summary>
     /// Registers a fallback script used for any call whose agent id has no dedicated
     /// <see cref="ForRole"/> script. An explicit opt-in, not a silent default — a test that wants
-    /// role separation enforced simply never calls this.
+    /// role separation enforced simply never calls this. Idempotent: a second call returns the
+    /// same script rather than discarding whatever the first call had already queued.
     /// </summary>
     public RoleScript ForAnyUnscriptedRole()
     {
-        _anyRoleFallback = new RoleScript();
-        return _anyRoleFallback;
+        lock (_rolesGate)
+        {
+            _anyRoleFallback ??= new RoleScript();
+            return _anyRoleFallback;
+        }
     }
 
     /// <inheritdoc />
@@ -68,7 +78,7 @@ public sealed class ScriptedChatClientFactory(IAgentExecutionContext executionCo
         string deploymentOrAgentId,
         CancellationToken cancellationToken = default)
     {
-        var agentId = executionContext.AgentId;
+        var agentId = ResolveAgentId();
         var script = ResolveScript(agentId);
         return Task.FromResult<IChatClient>(new RecordingChatClient(agentId, script, log));
     }
@@ -95,15 +105,36 @@ public sealed class ScriptedChatClientFactory(IAgentExecutionContext executionCo
         string? description = null, CancellationToken cancellationToken = default)
         => Task.FromResult($"fake-agent-{Guid.NewGuid():N}");
 
+    private string? ResolveAgentId()
+    {
+        var requestServices = ambientScope.Current
+            ?? throw new InvalidOperationException(
+                "ScriptedChatClientFactory could not resolve an agent id: no ambient request scope is " +
+                "established. Wrap the call in IAmbientRequestScope.BeginScope(...) (or register the real " +
+                "AmbientRequestScopeBehavior<,> in the MediatR pipeline) before invoking anything that " +
+                "resolves IChatClientFactory.");
+
+        var executionContext = requestServices.GetService<IAgentExecutionContext>()
+            ?? throw new InvalidOperationException(
+                "ScriptedChatClientFactory could not resolve an agent id: the current ambient request " +
+                "scope has no IAgentExecutionContext registered. Register it (matching production's " +
+                "AddScoped<IAgentExecutionContext, AgentExecutionContext>()) in the test container.");
+
+        return executionContext.AgentId;
+    }
+
     private RoleScript ResolveScript(string? agentId)
     {
-        if (agentId is not null && _roles.TryGetValue(agentId, out var script)) return script;
-        if (_anyRoleFallback is not null) return _anyRoleFallback;
+        lock (_rolesGate)
+        {
+            if (agentId is not null && _roles.TryGetValue(agentId, out var script)) return script;
+            if (_anyRoleFallback is not null) return _anyRoleFallback;
 
-        var known = _roles.Count == 0 ? "(none registered)" : string.Join(", ", _roles.Keys);
-        throw new InvalidOperationException(
-            $"ScriptedChatClientFactory has no script for agent id '{agentId ?? "<null>"}'. " +
-            $"Registered roles: {known}. Call ForRole(agentId) to script this agent, or " +
-            $"{nameof(ForAnyUnscriptedRole)}() to accept any unmatched role.");
+            var known = _roles.Count == 0 ? "(none registered)" : string.Join(", ", _roles.Keys);
+            throw new InvalidOperationException(
+                $"ScriptedChatClientFactory has no script for agent id '{agentId ?? "<null>"}'. " +
+                $"Registered roles: {known}. Call ForRole(agentId) to script this agent, or " +
+                $"{nameof(ForAnyUnscriptedRole)}() to accept any unmatched role.");
+        }
     }
 }

--- a/src/Content/Tests/Tests.AI.Fakes/Tests.AI.Fakes.csproj
+++ b/src/Content/Tests/Tests.AI.Fakes/Tests.AI.Fakes.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- Not a test project: it contains no tests and must not be handed to the runner.
+         It is support code shared BY test projects that need a role-aware, invocation-logging
+         IChatClient fake — Application.AI.Common.Tests, Application.Core.Tests, and
+         Presentation.AgentHub.Tests. -->
+    <IsTestProject>false</IsTestProject>
+    <RootNamespace>Tests.AI.Fakes</RootNamespace>
+    <Configurations>Debug;Release;Debug-AgentHub-All;Debug-AgentHub-WebUI;Debug-AgentHub-Dashboard</Configurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

First two packages of the verification cluster (plan: `keen-sprouting-pillow.md`).

**Package A — shared, role-aware chat-client test fake.** Three copies of a chat-client
fake had already drifted — the `Presentation.AgentHub.Tests` copy silently collapsed
streaming to one frame, which would make any per-frame streaming test (Package D) pass
vacuously. New `Tests.AI.Fakes` project ships `RecordingChatClient`/`ScriptedChatClientFactory`,
selecting a scripted response by the ambient `IAgentExecutionContext.AgentId` (via
`IAmbientRequestScope`, the same bridge production singletons already use) rather than
prompt sniffing, with an invocation log and a fail-loud unscripted-role path.

**Package B — structured-output contract (#323).** `LlmPlanGeneratorService` and
`CragEvaluator` asked the model for JSON in prose and hoped — no schema attached, no
repair on a bad parse. `CragEvaluator` was worse: its fallback returned `Action = Accept`,
so the component whose job is gating retrieval quality silently green-lit it whenever it
couldn't read its own response. New `Application.AI.Common/StructuredOutput/` subsystem
attaches a JSON schema (via `Microsoft.Extensions.AI.Abstractions` 10.7's
`AIJsonUtilities.CreateJsonSchema`, deliberately *not* OpenAI strict-mode semantics —
that would reject a model correctly omitting a defaulted field), validates the parsed
reply, and runs one repair round-trip (generalizing `JudgeCallCore`'s battle-tested loop).
`CragEvaluator`'s fallback now returns a new `CorrectionAction.EvaluationUnavailable`,
never treated as a pass by any of its four consumers.

## Review

Two full `/code-review` + `/simplify` cycles, plus a fresh independent sanity check.
Real findings fixed: a broken scoped-vs-singleton DI lifetime assumption (H2), thread-safety
in the shared fake, a dead unreachable enum value + ternary branch, a DI-registration test
gap `run-gates.sh` caught that per-project builds didn't. Every control mutation-tested
(disabled, confirmed the paired test fails, restored) — the CRAG fail-open bug, the
required/nullable schema posture, the repair round-trip, and the empty-body-abort path.

## Test plan

- [x] Full solution build + test suite green (`dotnet build` / `dotnet test` on `AgenticHarness.slnx`)
- [x] `run-gates.sh --fast`: build, test, owasp all pass
- [x] Mutation-tested: CRAG fail-open (`Accept` restored → both control tests fail, confirmed),
      `RequireAllProperties=true` restored → drift tests name the offending member, confirmed
- [x] Mutation-tested: repair round-trip removed → repair test fails; empty-body abort disabled → empty-body test fails
- [x] New DTO drift + array-items guards pass for both `LlmPlanOutput` and `CragResponse`
- [x] Chokepoint test confirms `StructuredOutputSchema` is the only caller of `CreateJsonSchema`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj