### PR TITLE
feat: zero-LLM full-pipeline test proving the real agent turn composes (#322)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Application.AI.Common.csproj
+++ b/src/Content/Application/Application.AI.Common/Application.AI.Common.csproj
@@ -16,6 +16,10 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Application.AI.Common.Tests" />
+    <!-- ZeroLlmPipelineTests (#322) constructs the real AgentConversationCache directly, rather
+         than mocking IAgentConversationCache as AgentPipelineIntegrationTests does, so the full
+         AgentFactory graph actually runs end to end. -->
+    <InternalsVisibleTo Include="Application.Core.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Content/Tests/Application.Core.Tests/Application.Core.Tests.csproj
+++ b/src/Content/Tests/Application.Core.Tests/Application.Core.Tests.csproj
@@ -23,6 +23,9 @@
   <ItemGroup>
     <ProjectReference Include="../../Application/Application.Core/Application.Core.csproj" />
     <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
+    <!-- ZeroLlmPipelineTests (#322) scripts the real chat-client boundary via the shared
+         role-aware fake instead of mocking IAgentConversationCache away. -->
+    <ProjectReference Include="../Tests.AI.Fakes/Tests.AI.Fakes.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/AgentPipelineIntegrationTests.cs
@@ -54,104 +54,11 @@ public class AgentPipelineIntegrationTests
         // Scoped agent execution context — real implementation, not mock
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
 
-        // Tool-invocation governor — not under test here; permissive mock so the handler resolves.
-        var governorMock = new Mock<Application.AI.Common.Interfaces.Governance.IToolInvocationGovernor>();
-        governorMock
-            .Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Application.AI.Common.Interfaces.Governance.ToolInvocationDecision.Allow());
-        services.AddScoped(_ => governorMock.Object);
-
-        // Progress / spin guard — not under test here; permissive mock so the handler resolves.
-        // Evaluate is set up explicitly because a loose mock would return null and the chain assumes
-        // a verdict exists.
-        var progressMock = new Mock<Application.AI.Common.Interfaces.Governance.IProgressEvaluator>();
-        progressMock
-            .Setup(p => p.Evaluate(It.IsAny<string>(), It.IsAny<Func<string?>>()))
-            .Returns(Application.AI.Common.Interfaces.Governance.ProgressVerdict.Continue());
-        services.AddScoped(_ => progressMock.Object);
-
-        // The turn's governance trail — real, and required by the admission chain the handler resolves.
-        // Built via the shared registration below rather than by hand; it needs these two collaborators
-        // registered so DI can resolve it.
-        services.AddSingleton(Mock.Of<Microsoft.Extensions.Options.IOptionsMonitor<Domain.Common.Config.AI.GovernanceConfig>>(
-            m => m.CurrentValue == new Domain.Common.Config.AI.GovernanceConfig()));
-        services.AddSingleton(Mock.Of<Application.AI.Common.Interfaces.Tools.IToolRiskClassifier>(
-            c => c.Classify(It.IsAny<string>()) == Application.AI.Common.Interfaces.Tools.ToolRiskProfile.Default));
-
-        // Classification DLP gate — not under test here; permissive mock so the handler resolves.
-        var classificationMock = new Mock<Application.AI.Common.Interfaces.Governance.IToolClassificationGate>();
-        classificationMock
-            .Setup(g => g.EvaluateAsync(
-                It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Application.AI.Common.Interfaces.Governance.ClassificationVerdict.Allow());
-        services.AddScoped(_ => classificationMock.Object);
-
-        // Consumer tool-call observers — none registered here, matching the default composition, so
-        // the chain reports itself empty and the chokepoint skips it.
-        var observerChainMock = new Mock<Application.AI.Common.Interfaces.Governance.IToolCallObserverChain>();
-        observerChainMock.SetupGet(c => c.HasObservers).Returns(false);
-        services.AddScoped(_ => observerChainMock.Object);
-
-        // Per-agent tool RBAC — admits, which is what the real gate answers when
-        // AI.Identity.ToolAuthorization.Enabled is unset, i.e. the default composition this suite runs.
-        var authorizationMock = new Mock<Application.AI.Common.Interfaces.Governance.IAgentToolAuthorizationGate>();
-        authorizationMock
-            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Application.AI.Common.Interfaces.Governance.ToolInvocationDecision.Allow());
-        services.AddScoped(_ => authorizationMock.Object);
-
-        // Closes the approval loop for whichever call this chain approves — not under test here;
-        // permissive mock so the handler resolves.
-        services.AddScoped(_ => Mock.Of<Application.AI.Common.Interfaces.Escalation.IApprovalExecutionReporter>());
-
-        // #460: ToolCallAdmissionPipeline.ReportExecutionAsync now sanitizes and redacts a failure's
-        // reported text itself — not under test here, so permissive pass-through mocks, matching the
-        // pattern above, so DI resolution of the chain succeeds.
-        var sanitizerMock = new Mock<Application.AI.Common.Interfaces.Governance.ICompositeResponseSanitizer>();
-        sanitizerMock
-            .Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
-            .Returns((string content, string? _) => Domain.AI.Governance.SanitizationResult.Clean(content));
-        services.AddScoped(_ => sanitizerMock.Object);
-
-        var redactionFilterMock = new Mock<Application.AI.Common.Interfaces.Telemetry.IContentRedactionFilter>();
-        redactionFilterMock
-            .Setup(f => f.Redact(It.IsAny<string>(), It.IsAny<IReadOnlyList<Domain.AI.Telemetry.Redaction.RedactionCategory>>()))
-            .Returns((string content, IReadOnlyList<Domain.AI.Telemetry.Redaction.RedactionCategory> _) => content);
-        services.AddScoped(_ => redactionFilterMock.Object);
-
-        // #249 item 6: ExecuteAgentTurnCommandHandler now depends on IToolCallReplayTreatment to
-        // treat a turn's tool calls for durable replay — not under test here, so a permissive
-        // pass-through mock, matching the pattern above, so DI resolution of the handler succeeds.
-        var toolCallReplayTreatmentMock = new Mock<Application.AI.Common.Interfaces.IToolCallReplayTreatment>();
-        toolCallReplayTreatmentMock.Setup(t => t.Enabled).Returns(true);
-        toolCallReplayTreatmentMock
-            .Setup(t => t.Treat(It.IsAny<string>(), It.IsAny<string?>()))
-            .Returns((string rawText, string? _) => rawText);
-        toolCallReplayTreatmentMock.Setup(t => t.NoResultPlaceholder).Returns("[no result recorded]");
-        // Explicit, because an unconfigured Moq int property returns 0 — and a zero limit here is not
-        // "no limit", it drops every tool call.
-        toolCallReplayTreatmentMock.Setup(t => t.MaxCallsPerTurn).Returns(32);
-        toolCallReplayTreatmentMock.Setup(t => t.MaxReplayedChars).Returns(65536);
-        services.AddScoped(_ => toolCallReplayTreatmentMock.Object);
-
-        // The REAL admission chain over the five permissive gates above, not a mock of it, built the
-        // same way the production root builds it. The handler depends only on the chain now, and
-        // registering the real one keeps this an end-to-end proof that the five gates are reachable
-        // from the turn — a mocked chain would prove nothing about whether they are wired at all.
-        // #532: the admission chain bounds tool output and reads its ceiling from AppConfig,
-        // so it requires one. Registered rather than defaulted inside AddToolCallAdmissionChain:
-        // a host that forgets to bind AppConfig should fail loudly at container build, which is
-        // what ValidateOnBuildSweepTests exists to catch — a TryAdd default there would make that
-        // guard structurally unable to see it.
-        services.AddSingleton<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
-            Mock.Of<IOptionsMonitor<Domain.Common.Config.AppConfig>>(
-                m => m.CurrentValue == new Domain.Common.Config.AppConfig()));
-
-        // #521: the chain now constructor-injects IToolResultStore to spill truncated output — same
-        // "an absent registration is a composition that cannot exist in production" reasoning as
-        // every gate above. None of these tests truncate output, so a permissive stub is enough.
-        services.AddSingleton(Mock.Of<IToolResultStore>());
-        services.AddToolCallAdmissionChain();
+        // The REAL admission chain over five permissive gates, not a mock of it, built the same way
+        // the production root builds it — an end-to-end proof the gates are reachable from the turn,
+        // which a mocked chain would not prove. Shared with ZeroLlmPipelineTests (see
+        // PermissiveGovernanceChain's remarks) rather than kept as a second hand-copied block.
+        services.AddPermissiveGovernanceChain();
 
         // Conversation-lifetime budget — not under test here; permissive mock (disabled) so the
         // RunConversation handler resolves and never reports exhaustion.

--- a/src/Content/Tests/Application.Core.Tests/CQRS/ZeroLlmPipelineTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/ZeroLlmPipelineTests.cs
@@ -1,0 +1,244 @@
+using Application.AI.Common;
+using Application.AI.Common.Categorization;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Factories;
+using Application.AI.Common.MediatRBehaviors;
+using Application.AI.Common.Notifications;
+using Application.AI.Common.Services;
+using Application.AI.Common.Services.AI;
+using Application.AI.Common.Services.Context;
+using Application.AI.Common.Services.Skills;
+using Application.AI.Common.Services.Tools;
+using Application.Core.CQRS.Agents.ExecuteAgentTurn;
+using Application.Core.Tests.Helpers;
+using Domain.AI.Agents;
+using Domain.AI.Skills;
+using Domain.Common.Config;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Tests.AI.Fakes;
+using Xunit;
+using AppExecutionContext = Application.AI.Common.Services.Agent.AgentExecutionContext;
+
+namespace Application.Core.Tests.CQRS;
+
+/// <summary>
+/// Proves a full agent turn works end-to-end through the REAL pipeline — MediatR, the middleware
+/// behaviors, <see cref="AgentFactory"/>, <see cref="AgentExecutionContextFactory"/>, the admission
+/// chain, and the agent framework's own middleware pipeline — with only the model faked.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="AgentPipelineIntegrationTests"/> proved the pipeline above <c>IAgentConversationCache</c>
+/// (MediatR wiring, the double-init regression). This class moves the cut one layer lower, to
+/// <see cref="IChatClientFactory"/>, so <see cref="AgentFactory.CreateAgentWithContextFromSkillsAsync"/>
+/// actually runs and the resulting <c>AIAgent</c> is real — a genuine zero-LLM proof that the whole
+/// graph composes, not just that a mocked collaborator was called correctly.
+/// </para>
+/// <para>
+/// The scripted fake (<see cref="ScriptedChatClientFactory"/>) resolves a role by
+/// <see cref="IAgentExecutionContext.AgentId"/>, which <see cref="AgentContextPropagationBehavior{TRequest,TResponse}"/>
+/// stamps before the handler runs — this container registers that behavior, so role resolution is
+/// exercised for real, not assumed.
+/// </para>
+/// </remarks>
+public sealed class ZeroLlmPipelineTests
+{
+    private const string AgentName = "zero-llm-test-agent";
+
+    private static (ServiceProvider Provider, ChatInvocationLog Log) BuildPipeline(
+        Action<ScriptedChatClientFactory> configureScript)
+    {
+        var services = new ServiceCollection();
+
+        services.AddSingleton<ILoggerFactory>(NullLoggerFactory.Instance);
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+
+        services.AddMediatR(cfg =>
+            cfg.RegisterServicesFromAssembly(typeof(ExecuteAgentTurnCommandHandler).Assembly));
+
+        // Order matches production (Application.AI.Common/DependencyInjection.cs): the ambient
+        // scope must be established BEFORE AgentContextPropagationBehavior runs, since it is what
+        // makes IAgentExecutionContext reachable from the singleton-lifetime ScriptedChatClientFactory.
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(AmbientRequestScopeBehavior<,>));
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(AgentContextPropagationBehavior<,>));
+        services.AddScoped<IAgentExecutionContext, AppExecutionContext>();
+        services.AddSingleton<IAmbientRequestScope, AmbientRequestScope>();
+
+        // --- The real chat-client boundary (this package's whole point) ---
+        var log = new ChatInvocationLog();
+        services.AddSingleton(log);
+        services.AddScoped<IChatClientFactory>(sp =>
+        {
+            var factory = new ScriptedChatClientFactory(
+                sp.GetRequiredService<IAmbientRequestScope>(), log);
+            configureScript(factory);
+            return factory;
+        });
+
+        // --- Real AgentFactory + AgentExecutionContextFactory (the seam this package lowers the cut to) ---
+        services.AddDistributedMemoryCache();
+        services.AddMemoryCache();
+
+        var skillRegistryMock = new Mock<ISkillMetadataRegistry>();
+        skillRegistryMock
+            .Setup(r => r.TryGet(It.IsAny<string>()))
+            .Returns((string id) => new SkillDefinition
+            {
+                Id = id,
+                Name = id,
+                Instructions = "You are a test agent used only to prove the pipeline composes.",
+            });
+        services.AddSingleton(skillRegistryMock.Object);
+
+        services.AddSingleton(Mock.Of<ISkillCompletionTracker>());
+
+        // Real ToolChainBuilder with no tool converter/MCP provider registered on the resolved
+        // context — a zero-tool agent, matching this package's "prove composition" scope; tool
+        // wiring through this same chain is already covered by AgentPipelineIntegrationTests.
+        services.AddSingleton<IToolChainBuilder>(sp =>
+            new ToolChainBuilder(NullLogger<ToolChainBuilder>.Instance, sp, toolConverter: null, mcpToolProvider: null));
+
+        services.AddSingleton<ISkillPrerequisiteResolver>(new SkillPrerequisiteResolver());
+        services.AddSingleton<ISkillFileReader>(Mock.Of<ISkillFileReader>());
+
+        services.AddSingleton(Mock.Of<IAgentMetadataRegistry>(
+            r => r.TryGet(It.IsAny<string>()) == null && r.GetAll() == Array.Empty<AgentDefinition>()));
+
+        services.AddSingleton<AgentExecutionContextFactory>();
+        services.AddSingleton<IAgentFactory, AgentFactory>();
+
+        // Real conversation cache — the entry point this package's cut moves through, rather than
+        // mocking it away as AgentPipelineIntegrationTests does.
+        services.AddSingleton<IAgentConversationCache, Application.AI.Common.Services.AgentConversationCache>();
+        services.AddSingleton<IConversationRegistrationTracker, ConversationRegistrationTracker>();
+
+        // The real admission chain over five permissive gates — shared with AgentPipelineIntegrationTests
+        // (see PermissiveGovernanceChain's remarks) rather than a second hand-copied ~90-line block.
+        services.AddPermissiveGovernanceChain();
+
+        services.AddSingleton(new Mock<IObservabilityStore>().Object);
+        services.AddSingleton<IContextSnapshotComputer, DefaultContextSnapshotComputer>();
+        services.AddSingleton<IContextSnapshotNotifier, NullContextSnapshotNotifier>();
+        services.AddSingleton(TimeProvider.System);
+
+        var usageCaptureMock = new Mock<ILlmUsageCapture>();
+        usageCaptureMock.Setup(c => c.TakeSnapshot())
+            .Returns(new LlmUsageSnapshot(0, 0, 0, 0, null, 0m, 0m, Array.Empty<string>()));
+        services.AddScoped<ILlmUsageCapture>(_ => usageCaptureMock.Object);
+
+        return (services.BuildServiceProvider(), log);
+    }
+
+    private static ExecuteAgentTurnCommand Command(string agentName = AgentName, int turnNumber = 1, string userMessage = "Hello") => new()
+    {
+        AgentName = agentName,
+        UserMessage = userMessage,
+        ConversationId = $"conv-{agentName}",
+        TurnNumber = turnNumber,
+    };
+
+    [Fact]
+    public async Task Clean_SingleRoleSucceeds_AssertsInvocationSequenceNotJustFinalResponse()
+    {
+        var (provider, log) = BuildPipeline(factory =>
+            factory.ForRole(AgentName).WithDefaultResponse("Hello from the real pipeline"));
+        using var providerDisposal = provider;
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(Command());
+
+        result.Success.Should().BeTrue(result.Error);
+        result.Response.Should().Contain("Hello from the real pipeline");
+        log.RoleSequence.Should().Equal(AgentName);
+    }
+
+    [Fact]
+    public async Task MultiTurn_SecondTurnOnSameConversation_DoesNotClobberEitherTurnsOutput()
+    {
+        // #322's original scenario here was "one role returns malformed output, Package B's repair
+        // recovers it" — verified against the real ExecuteAgentTurnCommandHandler (see the type's
+        // remarks): a plain agent turn has no repair loop at all. Package B's structured-output
+        // repair is scoped to LlmPlanGeneratorService and CragEvaluator, two different CQRS commands
+        // this handler never calls; StructuredOutputInvokerTests already proves that repair loop in
+        // isolation against the same RecordingChatClient/RoleScript fakes. Re-asserting it here
+        // through a seam that cannot reach it would pass or fail for reasons unrelated to what it
+        // claims to test.
+        //
+        // The real "must not clobber good output" property THIS seam owns is conversation-cache
+        // reuse across turns (IAgentConversationCache.GetOrCreateAsync): the second turn's model
+        // response must not leak the first turn's text, and vice versa.
+        //
+        // Turns deliberately use DIFFERENT user messages. AgentFactory.BuildMiddlewarePipeline
+        // (AgentFactory.ChatClient.cs) wraps every chat client in .UseDistributedCache(...) —
+        // real, deliberate prompt-caching middleware. Two turns sending byte-identical messages
+        // would legitimately cache-hit on the second turn and never reach the chat client at all,
+        // which would make this test pass or fail on cache behaviour instead of on conversation
+        // continuity. Distinct messages per turn is also how a real multi-turn conversation looks.
+        var (provider, log) = BuildPipeline(factory =>
+            factory.ForRole(AgentName)
+                .Enqueue("First turn response")
+                .Enqueue("Second turn response"));
+        using var providerDisposal = provider;
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var first = await mediator.Send(Command(turnNumber: 1, userMessage: "Hello"));
+        var second = await mediator.Send(Command(turnNumber: 2, userMessage: "What's next?"));
+
+        first.Success.Should().BeTrue(first.Error);
+        second.Success.Should().BeTrue(second.Error);
+        first.Response.Should().Contain("First turn response");
+        second.Response.Should().Contain("Second turn response");
+        second.Response.Should().NotContain("First turn response");
+        log.CountFor(AgentName).Should().Be(2, "each of the two turns reaches the chat client exactly once");
+    }
+
+    [Fact]
+    public async Task TotalFailure_EveryCallThrows_ReturnsFailureNotAnEmptySuccess()
+    {
+        var (provider, _) = BuildPipeline(factory =>
+            factory.ForRole(AgentName).AlwaysThrow(new InvalidOperationException("model unavailable")));
+        using var providerDisposal = provider;
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(Command());
+
+        // The exact shape #322 asks not to reproduce is an empty response presented as SUCCESS.
+        // ExecuteAgentTurnCommandHandler's catch-all deliberately pairs Response = string.Empty with
+        // Success = false (see the handler's generic catch block) — that pairing is correct and is
+        // what this asserts; an empty Response is only a defect when Success is also true.
+        result.Success.Should().BeFalse();
+        result.Error.Should().NotBeNullOrWhiteSpace();
+        result.Response.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task UnrecognisedRole_FactoryFailsLoudly_TurnFailsRatherThanSilentlyDefaulting()
+    {
+        var (provider, _) = BuildPipeline(factory =>
+            factory.ForRole("some-other-agent").WithDefaultResponse("never reached"));
+        using var providerDisposal = provider;
+        using var scope = provider.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        // AgentName has no script and no ForAnyUnscriptedRole() fallback was configured.
+        var result = await mediator.Send(Command());
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().NotBeNullOrWhiteSpace();
+    }
+}

--- a/src/Content/Tests/Application.Core.Tests/Helpers/PermissiveGovernanceChain.cs
+++ b/src/Content/Tests/Application.Core.Tests/Helpers/PermissiveGovernanceChain.cs
@@ -1,0 +1,107 @@
+using Application.AI.Common;
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Context;
+using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Telemetry;
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Governance;
+using Domain.AI.Telemetry.Redaction;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Application.Core.Tests.Helpers;
+
+/// <summary>
+/// Registers the real tool-call admission chain over five permissive gates — not a mock of the
+/// chain itself — so a hand-built test container resolves <c>ExecuteAgentTurnCommandHandler</c>
+/// without asserting anything about governance behaviour.
+/// </summary>
+/// <remarks>
+/// Extracted after this exact ~90-line block was found duplicated near-verbatim between
+/// <c>AgentPipelineIntegrationTests</c> and <c>ZeroLlmPipelineTests</c> — the same
+/// recurring-duplication shape <c>PermissiveAdmission</c> (in
+/// <c>Infrastructure.AI.RAG.Tests</c>/<c>Infrastructure.AI.Tests</c>) already exists to prevent for
+/// a directly-constructed <c>ToolCallAdmissionPipeline</c>. This is the <see cref="IServiceCollection"/>
+/// DI-registration shape those two helpers don't cover, since this project builds the chain through
+/// <c>AddToolCallAdmissionChain()</c> rather than constructing it directly.
+/// </remarks>
+public static class PermissiveGovernanceChain
+{
+    /// <summary>
+    /// Registers the five admission gates as permissive mocks, plus the collaborators the real
+    /// chain requires (config defaults, tool-result spill store), then calls
+    /// <c>AddToolCallAdmissionChain()</c> so the container resolves the real chain over them.
+    /// </summary>
+    public static IServiceCollection AddPermissiveGovernanceChain(this IServiceCollection services)
+    {
+        var governorMock = new Mock<IToolInvocationGovernor>();
+        governorMock
+            .Setup(g => g.AuthorizeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<IReadOnlyDictionary<string, object?>?>()))
+            .ReturnsAsync(ToolInvocationDecision.Allow());
+        services.AddScoped(_ => governorMock.Object);
+
+        var progressMock = new Mock<IProgressEvaluator>();
+        progressMock
+            .Setup(p => p.Evaluate(It.IsAny<string>(), It.IsAny<Func<string?>>()))
+            .Returns(ProgressVerdict.Continue());
+        services.AddScoped(_ => progressMock.Object);
+
+        services.AddSingleton(Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == new GovernanceConfig()));
+        services.AddSingleton(Mock.Of<IToolRiskClassifier>(c => c.Classify(It.IsAny<string>()) == ToolRiskProfile.Default));
+
+        var classificationMock = new Mock<IToolClassificationGate>();
+        classificationMock
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, object?>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ClassificationVerdict.Allow());
+        services.AddScoped(_ => classificationMock.Object);
+
+        var observerChainMock = new Mock<IToolCallObserverChain>();
+        observerChainMock.SetupGet(c => c.HasObservers).Returns(false);
+        services.AddScoped(_ => observerChainMock.Object);
+
+        var authorizationMock = new Mock<IAgentToolAuthorizationGate>();
+        authorizationMock
+            .Setup(g => g.EvaluateAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolInvocationDecision.Allow());
+        services.AddScoped(_ => authorizationMock.Object);
+
+        services.AddScoped(_ => Mock.Of<IApprovalExecutionReporter>());
+
+        var sanitizerMock = new Mock<ICompositeResponseSanitizer>();
+        sanitizerMock
+            .Setup(s => s.Sanitize(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string content, string? _) => SanitizationResult.Clean(content));
+        services.AddScoped(_ => sanitizerMock.Object);
+
+        var redactionFilterMock = new Mock<IContentRedactionFilter>();
+        redactionFilterMock
+            .Setup(f => f.Redact(It.IsAny<string>(), It.IsAny<IReadOnlyList<RedactionCategory>>()))
+            .Returns((string content, IReadOnlyList<RedactionCategory> _) => content);
+        services.AddScoped(_ => redactionFilterMock.Object);
+
+        var toolCallReplayTreatmentMock = new Mock<IToolCallReplayTreatment>();
+        toolCallReplayTreatmentMock.Setup(t => t.Enabled).Returns(true);
+        toolCallReplayTreatmentMock
+            .Setup(t => t.Treat(It.IsAny<string>(), It.IsAny<string?>()))
+            .Returns((string rawText, string? _) => rawText);
+        toolCallReplayTreatmentMock.Setup(t => t.NoResultPlaceholder).Returns("[no result recorded]");
+        // Explicit, because an unconfigured Moq int property returns 0 — and a zero limit here is
+        // not "no limit", it drops every tool call.
+        toolCallReplayTreatmentMock.Setup(t => t.MaxCallsPerTurn).Returns(32);
+        toolCallReplayTreatmentMock.Setup(t => t.MaxReplayedChars).Returns(65536);
+        services.AddScoped(_ => toolCallReplayTreatmentMock.Object);
+
+        // The admission chain bounds tool output and reads its ceiling from AppConfig, so it
+        // requires one — registered here rather than defaulted inside AddToolCallAdmissionChain so
+        // a host that forgets to bind AppConfig fails loudly at container build (ValidateOnBuildSweepTests).
+        services.AddSingleton<IOptionsMonitor<AppConfig>>(Mock.Of<IOptionsMonitor<AppConfig>>(m => m.CurrentValue == new AppConfig()));
+        services.AddSingleton(Mock.Of<IToolResultStore>());
+        services.AddToolCallAdmissionChain();
+
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #322: `ZeroLlmPipelineTests` moves the fake boundary down to `IChatClientFactory` (via `Tests.AI.Fakes`' `ScriptedChatClientFactory`, shipped in the shared-fake package), so `ExecuteAgentTurnCommand` runs through the real MediatR pipeline, `AgentFactory`, `AgentExecutionContextFactory`, and the tool-call admission chain end to end — a genuine proof the whole graph composes, not just that a mocked collaborator was called correctly.
- 4 scenarios: clean single-role turn (asserts invocation sequence, not just final text), multi-turn conversation-cache reuse (proves turn 2 doesn't leak turn 1's response), total failure (every call throws → `Success=false` paired with empty `Response`, never an empty string presented as success), and an unrecognised role failing loudly rather than silently defaulting.
- Extracted `PermissiveGovernanceChain` (`Application.Core.Tests/Helpers/`) after review found this test's ~90-line governance/admission-chain mock block duplicated near-verbatim from the existing `AgentPipelineIntegrationTests` — both now share one helper.

## Design note recorded in-code
The plan's original scenario 2 ("malformed output → Package B's repair recovers it") assumed the plain agent-turn path retries on malformed structured output. It doesn't — that repair loop is scoped to `LlmPlanGeneratorService`/`CragEvaluator`, two different CQRS commands this handler never calls, and is already proven in isolation by `StructuredOutputInvokerTests`. Scenario 2 was redefined to test what this seam actually owns: conversation-cache reuse across turns. Full rationale is in the test's own comment.

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` clean, 0 warnings
- [x] `dotnet test src/Content/Tests/Application.Core.Tests/Application.Core.Tests.csproj` — 1163/1163 passed
- [x] `mcp__gitnexus__detect_changes` — low risk, 0 affected processes (test-only diff)
- [x] `/code-review` + `/simplify` (4 parallel angles) — all findings fixed, receipts recorded
- [x] `scripts/rails/run-gates.sh` — build/test/owasp/grader/correctness/security all pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj