### PR TITLE
feat: per-frame streaming invariants for AgentTelemetryHub (#328)

### DIFF
--- a/src/Content/Presentation/Presentation.AgentHub/DTOs/TurnOutcome.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/DTOs/TurnOutcome.cs
@@ -13,8 +13,13 @@ public sealed record TurnOutcome
     public string? ErrorMessage { get; init; }
 
     /// <summary>
-    /// When non-null, indicates the conversation was truncated before dispatch (retry/edit).
-    /// The transport should emit a truncation event with this count before streaming the response.
+    /// When non-null, indicates the conversation was truncated before dispatch (retry/edit) —
+    /// carried here for callers that only see the final outcome (logging, telemetry, tests). The
+    /// live client notification does NOT read this field: it already went out before this turn was
+    /// even dispatched, via <see cref="Interfaces.IConversationOrchestrator.RetryFromMessageAsync"/>'s
+    /// and <see cref="Interfaces.IConversationOrchestrator.EditAndResubmitAsync"/>'s
+    /// <c>onHistoryTruncated</c> callback (see their remarks) — waiting for this outcome to emit the
+    /// notification is exactly the #328 ordering bug that callback exists to prevent.
     /// </summary>
     public int? HistoryKeepCount { get; init; }
 

--- a/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
@@ -460,9 +460,10 @@ public sealed class AgentTelemetryHub : Hub
     /// history was truncated. A bare <see cref="HubException"/> only surfaces to the caller's RPC
     /// promise, never through the client's <c>Error</c> event handler — leaving it showing a
     /// truncated transcript with no explanation and no retried response. Called only from the
-    /// generic <c>catch (Exception) when (historyTruncatedSignaled)</c> clause in
-    /// <see cref="RetryFromMessage"/> and <see cref="EditAndResubmit"/>, which then rethrows so the
-    /// RPC caller still observes the failure too.
+    /// <c>catch (Exception ex)</c> block's <c>if (historyTruncatedSignaled)</c> guard in
+    /// <see cref="RetryFromMessage"/> and <see cref="EditAndResubmit"/>, before that same block
+    /// rethrows (or maps to a <see cref="HubException"/>) so the RPC caller still observes the
+    /// failure too.
     /// </summary>
     private Task EmitPostTruncationFailureAsync(string conversationId, CancellationToken ct) =>
         Clients.Caller.SendAsync(EventError,

--- a/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
@@ -195,15 +195,40 @@ public sealed class AgentTelemetryHub : Hub
                 ct,
                 EmitHistoryTruncatedAsync(conversationId, () => historyTruncatedSignaled = true));
         }
-        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
+        catch (Exception ex)
         {
-            throw new HubException(ex is UnauthorizedAccessException
-                ? "Access denied."
-                : ex.Message.Contains("retry") ? ex.Message : "Conversation not found.");
-        }
-        catch (Exception) when (historyTruncatedSignaled)
-        {
-            await EmitPostTruncationFailureAsync(conversationId, ct);
+            // Runs for EVERY exception type — not just the two mapped below — because the client
+            // may already have acted on the truncation notice regardless of what failed afterward.
+            // This must be checked before, not after, the typed-exception mapping: a bare
+            // `catch (Exception) when (historyTruncatedSignaled)` placed below the typed clause
+            // would never run for InvalidOperationException/UnauthorizedAccessException, since C#
+            // matches catch clauses top-down and the typed clause (which matches nearly everything
+            // this method actually throws — a stolen turn lease, ConversationAccessDeniedException)
+            // would win first, silently defeating this guard for the exact failures it exists for.
+            if (historyTruncatedSignaled)
+            {
+                try
+                {
+                    // Best-effort: ct may already be cancelled if ex itself is the client
+                    // disconnecting, in which case this send can throw too — that must not replace
+                    // or hide the original ex, which the rethrow below still needs to surface.
+                    await EmitPostTruncationFailureAsync(conversationId, ct);
+                }
+                catch (Exception notifyEx)
+                {
+                    _logger.LogWarning(notifyEx,
+                        "Failed to notify the client of a post-truncation failure for conversation {ConversationId}.",
+                        conversationId);
+                }
+            }
+
+            if (ex is InvalidOperationException or UnauthorizedAccessException)
+            {
+                throw new HubException(ex is UnauthorizedAccessException
+                    ? "Access denied."
+                    : ex.Message.Contains("retry") ? ex.Message : "Conversation not found.");
+            }
+
             throw;
         }
 
@@ -231,13 +256,32 @@ public sealed class AgentTelemetryHub : Hub
                 ct,
                 EmitHistoryTruncatedAsync(conversationId, () => historyTruncatedSignaled = true));
         }
-        catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
+        catch (Exception ex)
         {
-            throw new HubException(ex is UnauthorizedAccessException ? "Access denied." : "Conversation not found.");
-        }
-        catch (Exception) when (historyTruncatedSignaled)
-        {
-            await EmitPostTruncationFailureAsync(conversationId, ct);
+            // See RetryFromMessage's identical structure and comment for why this must run before,
+            // not after, the typed-exception mapping below.
+            if (historyTruncatedSignaled)
+            {
+                try
+                {
+                    // Best-effort: ct may already be cancelled if ex itself is the client
+                    // disconnecting, in which case this send can throw too — that must not replace
+                    // or hide the original ex, which the rethrow below still needs to surface.
+                    await EmitPostTruncationFailureAsync(conversationId, ct);
+                }
+                catch (Exception notifyEx)
+                {
+                    _logger.LogWarning(notifyEx,
+                        "Failed to notify the client of a post-truncation failure for conversation {ConversationId}.",
+                        conversationId);
+                }
+            }
+
+            if (ex is InvalidOperationException or UnauthorizedAccessException)
+            {
+                throw new HubException(ex is UnauthorizedAccessException ? "Access denied." : "Conversation not found.");
+            }
+
             throw;
         }
 

--- a/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
@@ -197,38 +197,8 @@ public sealed class AgentTelemetryHub : Hub
         }
         catch (Exception ex)
         {
-            // Runs for EVERY exception type — not just the two mapped below — because the client
-            // may already have acted on the truncation notice regardless of what failed afterward.
-            // This must be checked before, not after, the typed-exception mapping: a bare
-            // `catch (Exception) when (historyTruncatedSignaled)` placed below the typed clause
-            // would never run for InvalidOperationException/UnauthorizedAccessException, since C#
-            // matches catch clauses top-down and the typed clause (which matches nearly everything
-            // this method actually throws — a stolen turn lease, ConversationAccessDeniedException)
-            // would win first, silently defeating this guard for the exact failures it exists for.
-            if (historyTruncatedSignaled)
-            {
-                try
-                {
-                    // Best-effort: ct may already be cancelled if ex itself is the client
-                    // disconnecting, in which case this send can throw too — that must not replace
-                    // or hide the original ex, which the rethrow below still needs to surface.
-                    await EmitPostTruncationFailureAsync(conversationId, ct);
-                }
-                catch (Exception notifyEx)
-                {
-                    _logger.LogWarning(notifyEx,
-                        "Failed to notify the client of a post-truncation failure for conversation {ConversationId}.",
-                        conversationId);
-                }
-            }
-
-            if (ex is InvalidOperationException or UnauthorizedAccessException)
-            {
-                throw new HubException(ex is UnauthorizedAccessException
-                    ? "Access denied."
-                    : ex.Message.Contains("retry") ? ex.Message : "Conversation not found.");
-            }
-
+            var mapped = await NotifyPostTruncationFailureAndMapAsync(ex, conversationId, historyTruncatedSignaled, ct);
+            if (mapped is not null) throw mapped;
             throw;
         }
 
@@ -258,30 +228,8 @@ public sealed class AgentTelemetryHub : Hub
         }
         catch (Exception ex)
         {
-            // See RetryFromMessage's identical structure and comment for why this must run before,
-            // not after, the typed-exception mapping below.
-            if (historyTruncatedSignaled)
-            {
-                try
-                {
-                    // Best-effort: ct may already be cancelled if ex itself is the client
-                    // disconnecting, in which case this send can throw too — that must not replace
-                    // or hide the original ex, which the rethrow below still needs to surface.
-                    await EmitPostTruncationFailureAsync(conversationId, ct);
-                }
-                catch (Exception notifyEx)
-                {
-                    _logger.LogWarning(notifyEx,
-                        "Failed to notify the client of a post-truncation failure for conversation {ConversationId}.",
-                        conversationId);
-                }
-            }
-
-            if (ex is InvalidOperationException or UnauthorizedAccessException)
-            {
-                throw new HubException(ex is UnauthorizedAccessException ? "Access denied." : "Conversation not found.");
-            }
-
+            var mapped = await NotifyPostTruncationFailureAndMapAsync(ex, conversationId, historyTruncatedSignaled, ct);
+            if (mapped is not null) throw mapped;
             throw;
         }
 
@@ -459,11 +407,8 @@ public sealed class AgentTelemetryHub : Hub
     /// Emits an <c>Error</c> event for a turn that failed AFTER the client was already told its
     /// history was truncated. A bare <see cref="HubException"/> only surfaces to the caller's RPC
     /// promise, never through the client's <c>Error</c> event handler — leaving it showing a
-    /// truncated transcript with no explanation and no retried response. Called only from the
-    /// <c>catch (Exception ex)</c> block's <c>if (historyTruncatedSignaled)</c> guard in
-    /// <see cref="RetryFromMessage"/> and <see cref="EditAndResubmit"/>, before that same block
-    /// rethrows (or maps to a <see cref="HubException"/>) so the RPC caller still observes the
-    /// failure too.
+    /// truncated transcript with no explanation and no retried response. Called only from
+    /// <see cref="NotifyPostTruncationFailureAndMapAsync"/>.
     /// </summary>
     private Task EmitPostTruncationFailureAsync(string conversationId, CancellationToken ct) =>
         Clients.Caller.SendAsync(EventError,
@@ -473,6 +418,59 @@ public sealed class AgentTelemetryHub : Hub
                 message = "The turn could not be completed after truncating history. Reload the conversation to resynchronize.",
                 code = "AGENT_ERROR",
             }, ct);
+
+    /// <summary>
+    /// Shared failure handling for <see cref="RetryFromMessage"/> and <see cref="EditAndResubmit"/>:
+    /// best-effort-notifies the client of a post-truncation failure when it may already have acted
+    /// on the truncation notice, then returns the <see cref="HubException"/> the caller should throw
+    /// for a recognised failure type, or <see langword="null"/> when the caller should instead
+    /// rethrow <paramref name="ex"/> itself via a bare <c>throw;</c> (which must stay in the
+    /// caller's own catch block to preserve the original stack trace — this helper cannot do that
+    /// rethrow on the caller's behalf).
+    /// </summary>
+    /// <remarks>
+    /// The notify runs for EVERY exception type, not just the two mapped to a
+    /// <see cref="HubException"/> below — the client may already have acted on the truncation
+    /// notice regardless of what failed afterward. This must happen before, not conditioned on,
+    /// the typed-exception mapping: if a caller instead used a bare
+    /// <c>catch (Exception) when (historyTruncatedSignaled)</c> clause placed below a typed catch
+    /// clause, C#'s top-down clause matching would let the typed clause win first for
+    /// <see cref="InvalidOperationException"/>/<see cref="UnauthorizedAccessException"/> — which are
+    /// exactly the types this path actually throws (a stolen turn lease,
+    /// <c>ConversationAccessDeniedException</c>) — silently defeating the guard for the failures it
+    /// exists for. This shape was shipped once and caught by CI's correctness-review gate.
+    /// </remarks>
+    private async Task<HubException?> NotifyPostTruncationFailureAndMapAsync(
+        Exception ex, string conversationId, bool historyTruncatedSignaled, CancellationToken ct)
+    {
+        if (historyTruncatedSignaled)
+        {
+            try
+            {
+                // Best-effort: ct may already be cancelled if ex itself is the client
+                // disconnecting, in which case this send can throw too — that must not replace or
+                // hide ex, which the caller still needs to map or rethrow after this returns.
+                await EmitPostTruncationFailureAsync(conversationId, ct);
+            }
+            catch (Exception notifyEx)
+            {
+                _logger.LogWarning(notifyEx,
+                    "Failed to notify the client of a post-truncation failure for conversation {ConversationId}.",
+                    conversationId);
+            }
+        }
+
+        return ex switch
+        {
+            UnauthorizedAccessException => new HubException("Access denied."),
+            // The "retry" substring check only ever matches RetryFromMessage's own
+            // "Cannot retry: no preceding user message found." — EditAndResubmit has no failure
+            // path producing that text, so sharing this check between both callers is safe.
+            InvalidOperationException when ex.Message.Contains("retry") => new HubException(ex.Message),
+            InvalidOperationException => new HubException("Conversation not found."),
+            _ => null,
+        };
+    }
 
     /// <summary>
     /// Emits the standard post-turn events to the caller: either (final TokenReceived +

--- a/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
@@ -183,6 +183,7 @@ public sealed class AgentTelemetryHub : Hub
     {
         var ct = Context.ConnectionAborted;
         var callerId = GetCallerId();
+        var historyTruncatedSignaled = false;
 
         TurnOutcome outcome;
         try
@@ -191,13 +192,19 @@ public sealed class AgentTelemetryHub : Hub
                 Context.ConnectionId, conversationId, assistantMessageId, callerId,
                 (chunk, cct) => Clients.Caller.SendAsync(EventTokenReceived,
                     new { conversationId, token = chunk, isComplete = false }, cct),
-                ct);
+                ct,
+                EmitHistoryTruncatedAsync(conversationId, () => historyTruncatedSignaled = true));
         }
         catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
         {
             throw new HubException(ex is UnauthorizedAccessException
                 ? "Access denied."
                 : ex.Message.Contains("retry") ? ex.Message : "Conversation not found.");
+        }
+        catch (Exception) when (historyTruncatedSignaled)
+        {
+            await EmitPostTruncationFailureAsync(conversationId, ct);
+            throw;
         }
 
         await EmitTurnEventsAsync(conversationId, outcome, ct);
@@ -212,6 +219,7 @@ public sealed class AgentTelemetryHub : Hub
     {
         var ct = Context.ConnectionAborted;
         var callerId = GetCallerId();
+        var historyTruncatedSignaled = false;
 
         TurnOutcome outcome;
         try
@@ -220,11 +228,17 @@ public sealed class AgentTelemetryHub : Hub
                 Context.ConnectionId, conversationId, userMessageId, newUserMessageId, newContent, callerId,
                 (chunk, cct) => Clients.Caller.SendAsync(EventTokenReceived,
                     new { conversationId, token = chunk, isComplete = false }, cct),
-                ct);
+                ct,
+                EmitHistoryTruncatedAsync(conversationId, () => historyTruncatedSignaled = true));
         }
         catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)
         {
             throw new HubException(ex is UnauthorizedAccessException ? "Access denied." : "Conversation not found.");
+        }
+        catch (Exception) when (historyTruncatedSignaled)
+        {
+            await EmitPostTruncationFailureAsync(conversationId, ct);
+            throw;
         }
 
         await EmitTurnEventsAsync(conversationId, outcome, ct);
@@ -378,17 +392,50 @@ public sealed class AgentTelemetryHub : Hub
         ?? throw new HubException("Unable to determine caller identity.");
 
     /// <summary>
-    /// Emits the standard post-turn events to the caller: optional HistoryTruncated,
-    /// then either (final TokenReceived + TurnComplete) or Error.
+    /// Builds the callback <see cref="IConversationOrchestrator.RetryFromMessageAsync"/> and
+    /// <see cref="IConversationOrchestrator.EditAndResubmitAsync"/> invoke immediately after
+    /// truncating history, before dispatching the turn — see those methods' remarks on why
+    /// <c>HistoryTruncated</c> must reach the client before this turn's own streamed deltas do (#328).
+    /// </summary>
+    /// <param name="onInvoked">
+    /// Called synchronously, before the SignalR send, purely to record that truncation was
+    /// signalled — regardless of whether the send itself succeeds. The orchestrator swallows a
+    /// failed send (see <c>ConversationOrchestrator.SignalHistoryTruncatedAsync</c>) rather than
+    /// aborting the turn, but the caller still needs to know a client may already have acted on the
+    /// notice, so a later failure in this same turn can be surfaced rather than left as a silent gap.
+    /// </param>
+    private Func<int, CancellationToken, Task> EmitHistoryTruncatedAsync(string conversationId, Action onInvoked) =>
+        (keepCount, cct) =>
+        {
+            onInvoked();
+            return Clients.Caller.SendAsync(EventHistoryTruncated, new { conversationId, keepCount }, cct);
+        };
+
+    /// <summary>
+    /// Emits an <c>Error</c> event for a turn that failed AFTER the client was already told its
+    /// history was truncated. A bare <see cref="HubException"/> only surfaces to the caller's RPC
+    /// promise, never through the client's <c>Error</c> event handler — leaving it showing a
+    /// truncated transcript with no explanation and no retried response. Called only from the
+    /// generic <c>catch (Exception) when (historyTruncatedSignaled)</c> clause in
+    /// <see cref="RetryFromMessage"/> and <see cref="EditAndResubmit"/>, which then rethrows so the
+    /// RPC caller still observes the failure too.
+    /// </summary>
+    private Task EmitPostTruncationFailureAsync(string conversationId, CancellationToken ct) =>
+        Clients.Caller.SendAsync(EventError,
+            new
+            {
+                conversationId,
+                message = "The turn could not be completed after truncating history. Reload the conversation to resynchronize.",
+                code = "AGENT_ERROR",
+            }, ct);
+
+    /// <summary>
+    /// Emits the standard post-turn events to the caller: either (final TokenReceived +
+    /// TurnComplete) or Error. <c>HistoryTruncated</c>, when this turn truncated history, was
+    /// already emitted before dispatch via <see cref="EmitHistoryTruncatedAsync"/> — never here.
     /// </summary>
     private async Task EmitTurnEventsAsync(string conversationId, TurnOutcome outcome, CancellationToken ct)
     {
-        if (outcome.HistoryKeepCount.HasValue)
-        {
-            await Clients.Caller.SendAsync(EventHistoryTruncated,
-                new { conversationId, keepCount = outcome.HistoryKeepCount.Value }, ct);
-        }
-
         if (outcome.Success)
         {
             await Clients.Caller.SendAsync(EventTokenReceived,

--- a/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Hubs/AgentTelemetryHub.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Models.Conversations;
 using Presentation.AgentHub.DTOs;
 using Presentation.Common.Extensions;
 using Presentation.AgentHub.Interfaces;
+using Presentation.AgentHub.Services;
 
 namespace Presentation.AgentHub.Hubs;
 
@@ -463,10 +464,12 @@ public sealed class AgentTelemetryHub : Hub
         return ex switch
         {
             UnauthorizedAccessException => new HubException("Access denied."),
-            // The "retry" substring check only ever matches RetryFromMessage's own
-            // "Cannot retry: no preceding user message found." — EditAndResubmit has no failure
-            // path producing that text, so sharing this check between both callers is safe.
-            InvalidOperationException when ex.Message.Contains("retry") => new HubException(ex.Message),
+            // Exact match against the one known constant, not a substring check on arbitrary
+            // InvalidOperationException text (the shape a prior version of this had — any exception
+            // message merely containing "retry", including one from EF Core or the store beneath
+            // this call, would have been echoed to the client verbatim).
+            InvalidOperationException when ex.Message == ConversationRetryNotice.NoPrecedingUserMessage
+                => new HubException(ex.Message),
             InvalidOperationException => new HubException("Conversation not found."),
             _ => null,
         };

--- a/src/Content/Presentation/Presentation.AgentHub/Interfaces/IConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Interfaces/IConversationOrchestrator.cs
@@ -37,17 +37,39 @@ public interface IConversationOrchestrator
     /// <summary>
     /// Truncates from the specified assistant message and re-dispatches the preceding user message.
     /// </summary>
+    /// <param name="onHistoryTruncated">
+    /// Invoked once with the surviving message count immediately after truncation, BEFORE
+    /// dispatching the retried turn — so a caller streaming <paramref name="onChunk"/> can tell a
+    /// client to drop its stale local tail before any of this turn's own deltas arrive. Emitting
+    /// the truncation signal only after the turn completes (via the returned
+    /// <see cref="TurnOutcome.HistoryKeepCount"/>) would let a client append this turn's streamed
+    /// response onto its still-untruncated message list first — the ordering bug this parameter
+    /// exists to prevent (#328). A failure calling this delegate is caught and logged by the
+    /// implementation, never propagated — the truncation it announces has already committed
+    /// durably, so a failed notification must not abort the turn.
+    /// </param>
     Task<TurnOutcome> RetryFromMessageAsync(
         string sessionKey, string conversationId, Guid assistantMessageId, string callerId,
-        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct);
+        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct,
+        Func<int, CancellationToken, Task>? onHistoryTruncated = null);
 
     /// <summary>
     /// Truncates from the specified user message, appends edited content, and re-dispatches.
     /// </summary>
+    /// <param name="onHistoryTruncated">
+    /// Invoked once with the surviving message count, after the edited message is durably appended
+    /// and immediately before dispatching the resubmitted turn — see
+    /// <see cref="RetryFromMessageAsync"/>'s remarks on this parameter for why the ordering
+    /// relative to dispatch matters, and on why a delegate failure is caught rather than propagated.
+    /// The append happens first here specifically (unlike <see cref="RetryFromMessageAsync"/>, which
+    /// has no equivalent append) so a client acting on this notice — typically by optimistically
+    /// re-inserting the edited message — never does so before the edit is actually persisted.
+    /// </param>
     Task<TurnOutcome> EditAndResubmitAsync(
         string sessionKey, string conversationId, Guid userMessageId, Guid newUserMessageId,
         string newContent, string callerId,
-        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct);
+        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct,
+        Func<int, CancellationToken, Task>? onHistoryTruncated = null);
 
     /// <summary>
     /// Validates that <paramref name="callerId"/> owns the conversation. Throws

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -135,10 +135,42 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         }, ct);
     }
 
+    /// <summary>
+    /// Invokes <paramref name="onHistoryTruncated"/>, if provided, with the surviving message
+    /// count — swallowing (and logging) any exception it throws.
+    /// </summary>
+    /// <remarks>
+    /// The truncation this signals has already committed durably in <see cref="_conversationStore"/>
+    /// by the time this runs. A transport failure delivering the notice (a dropped connection, a
+    /// slow client) must not abort the turn that follows — the caller already dispatched the store
+    /// mutation that made this notice worth sending, so treating the notice itself as best-effort is
+    /// what keeps a client hiccup from turning a durable truncation into a turn that never
+    /// dispatches and a user message that silently vanishes. See #328 (why this fires before
+    /// dispatch, not after) and its follow-up hardening (this swallow, and the ordering of this call
+    /// relative to any local mutation that must NOT be reported as done before it actually is).
+    /// </remarks>
+    private async Task SignalHistoryTruncatedAsync(
+        Func<int, CancellationToken, Task>? onHistoryTruncated, int keepCount, CancellationToken ct)
+    {
+        if (onHistoryTruncated is null) return;
+
+        try
+        {
+            await onHistoryTruncated(keepCount, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex,
+                "Failed to notify the client of a history truncation to {KeepCount} messages — " +
+                "the truncation itself already committed and the turn continues.", keepCount);
+        }
+    }
+
     /// <inheritdoc />
     public async Task<TurnOutcome> RetryFromMessageAsync(
         string sessionKey, string conversationId, Guid assistantMessageId, string callerId,
-        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct)
+        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct,
+        Func<int, CancellationToken, Task>? onHistoryTruncated = null)
     {
         var record = await _conversationStore.GetAsync(conversationId, callerId, ct)
             ?? throw new InvalidOperationException("Conversation not found.");
@@ -153,6 +185,11 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
             if (last is null || last.Role != MessageRole.User)
                 throw new InvalidOperationException("Cannot retry: no preceding user message found.");
 
+            // Signal the truncation BEFORE dispatching — see the interface's remarks (#328): a
+            // caller streaming onChunk must be able to tell its client to drop the stale local
+            // tail before this turn's own deltas arrive, not after the whole turn completes.
+            await SignalHistoryTruncatedAsync(onHistoryTruncated, truncated.Messages.Count, turnCt);
+
             var outcome = await DispatchTurnAsync(
                 sessionKey, conversationId, record.AgentName, last.Content, callerId, onChunk, turnCt);
 
@@ -164,7 +201,8 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
     public async Task<TurnOutcome> EditAndResubmitAsync(
         string sessionKey, string conversationId, Guid userMessageId, Guid newUserMessageId,
         string newContent, string callerId,
-        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct)
+        Func<string, CancellationToken, Task>? onChunk, CancellationToken ct,
+        Func<int, CancellationToken, Task>? onHistoryTruncated = null)
     {
         var record = await _conversationStore.GetAsync(conversationId, callerId, ct)
             ?? throw new InvalidOperationException("Conversation not found.");
@@ -179,6 +217,14 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
                 newUserMessageId == Guid.Empty ? Guid.NewGuid() : newUserMessageId,
                 MessageRole.User, newContent, DateTimeOffset.UtcNow);
             await _conversationStore.AppendMessageAsync(conversationId, callerId, newUserMsg, turnCt);
+
+            // The new user message is appended BEFORE the truncation notice goes out, not after:
+            // the notice is what the client acts on (it optimistically re-inserts the edited
+            // message), so telling it "truncated to N" before the edit itself is durably stored
+            // would let a subsequent AppendMessageAsync failure leave the client showing an edit
+            // the server never persisted, with nothing to roll it back. Still before dispatch —
+            // see RetryFromMessageAsync's comment and the interface's remarks (#328) for why.
+            await SignalHistoryTruncatedAsync(onHistoryTruncated, truncated.Messages.Count, turnCt);
 
             var outcome = await DispatchTurnAsync(
                 sessionKey, conversationId, record.AgentName, newContent, callerId, onChunk, turnCt);

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -167,8 +167,12 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
         {
             await onHistoryTruncated(keepCount, ct);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
         {
+            // The filter checks ct.IsCancellationRequested, not just the exception's type: an
+            // OperationCanceledException from some OTHER token (an internal timeout, not this
+            // turn's own connection going away) must still be swallowed like any other transient
+            // failure — only a cancellation that actually matches ct signals a real disconnect.
             _logger.LogWarning(ex,
                 "Failed to notify the client of a history truncation to {KeepCount} messages — " +
                 "the truncation itself already committed and the turn continues.", keepCount);

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -196,7 +196,7 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
 
             var last = truncated.Messages.LastOrDefault();
             if (last is null || last.Role != MessageRole.User)
-                throw new InvalidOperationException("Cannot retry: no preceding user message found.");
+                throw new InvalidOperationException(ConversationRetryNotice.NoPrecedingUserMessage);
 
             // Signal the truncation BEFORE dispatching — see the interface's remarks (#328): a
             // caller streaming onChunk must be able to tell its client to drop the stale local

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationOrchestrator.cs
@@ -137,17 +137,26 @@ public sealed class ConversationOrchestrator : IConversationOrchestrator
 
     /// <summary>
     /// Invokes <paramref name="onHistoryTruncated"/>, if provided, with the surviving message
-    /// count — swallowing (and logging) any exception it throws.
+    /// count — swallowing (and logging) any exception it throws, EXCEPT a cancellation matching
+    /// <paramref name="ct"/> itself, which is let through rather than swallowed.
     /// </summary>
     /// <remarks>
     /// The truncation this signals has already committed durably in <see cref="_conversationStore"/>
-    /// by the time this runs. A transport failure delivering the notice (a dropped connection, a
-    /// slow client) must not abort the turn that follows — the caller already dispatched the store
-    /// mutation that made this notice worth sending, so treating the notice itself as best-effort is
-    /// what keeps a client hiccup from turning a durable truncation into a turn that never
-    /// dispatches and a user message that silently vanishes. See #328 (why this fires before
-    /// dispatch, not after) and its follow-up hardening (this swallow, and the ordering of this call
-    /// relative to any local mutation that must NOT be reported as done before it actually is).
+    /// by the time this runs. A generic transport failure delivering the notice (a slow client, a
+    /// transient send error) must not abort the turn that follows — the caller already dispatched
+    /// the store mutation that made this notice worth sending, so treating the notice itself as
+    /// best-effort is what keeps that kind of hiccup from turning a durable truncation into a turn
+    /// that never dispatches and a user message that silently vanishes.
+    /// <para>
+    /// A cancellation is different: it means the client's own connection is gone, not that the send
+    /// merely failed. There is no one left to stream deltas to, so letting it propagate and abort —
+    /// rather than swallowing it and dispatching a turn for a vanished client — is the routine
+    /// disconnect handling this codebase already uses elsewhere (see <c>DispatchTurnAsync</c>'s
+    /// <c>OperationCanceledException when (ct.IsCancellationRequested)</c> handling).
+    /// </para>
+    /// See #328 (why this fires before dispatch, not after) and its follow-up hardening (this
+    /// swallow, and the ordering of this call relative to any local mutation that must NOT be
+    /// reported as done before it actually is).
     /// </remarks>
     private async Task SignalHistoryTruncatedAsync(
         Func<int, CancellationToken, Task>? onHistoryTruncated, int keepCount, CancellationToken ct)

--- a/src/Content/Presentation/Presentation.AgentHub/Services/ConversationRetryNotice.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Services/ConversationRetryNotice.cs
@@ -1,0 +1,15 @@
+namespace Presentation.AgentHub.Services;
+
+/// <summary>
+/// Single source of the user-facing copy shown when a retry is refused because the conversation has
+/// no preceding user message to retry. Mirrors <see cref="ConversationLeaseNotice"/>'s shape: a
+/// dedicated notice type rather than a hand-typed literal at both the throw site
+/// (<see cref="ConversationOrchestrator"/>) and the hub's exact-match check
+/// (<c>AgentTelemetryHub.NotifyPostTruncationFailureAndMapAsync</c>), so the two cannot drift and a
+/// substring check against arbitrary <see cref="InvalidOperationException"/> text is never needed.
+/// </summary>
+internal static class ConversationRetryNotice
+{
+    /// <summary>The message returned when a retry has no preceding user message to resubmit.</summary>
+    public const string NoPrecedingUserMessage = "Cannot retry: no preceding user message found.";
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Moq" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -503,6 +503,45 @@ public class ConversationOrchestratorTests
     }
 
     [Fact]
+    public async Task RetryFromMessage_OnHistoryTruncatedFiresBeforeOnChunk()
+    {
+        // #328: a client appending streamed deltas onto its still-untruncated local message list
+        // before being told to drop the stale tail is a real ordering bug this callback exists to
+        // prevent (caught by AgentTelemetryHubStreamingInvariantTests' I3 check). Proves the REAL
+        // orchestrator — not just the hub's own wiring — calls onHistoryTruncated before any
+        // onChunk delta, and with the correct surviving-message count.
+        var userMsg = new ConversationMessage(Guid.NewGuid(), MessageRole.User, "Original", DateTimeOffset.UtcNow);
+        var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow,
+            [userMsg]);
+        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _store.Setup(s => s.TruncateFromMessageAsync("c1", "user1", It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [userMsg]));
+        _store.Setup(s => s.GetHistoryForDispatch("c1", "user1", 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConversationMessage> { userMsg });
+        _obsStore.Setup(s => s.StartSessionAsync("c1", "agent", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+
+        var events = new List<string>();
+        _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                events.Add("dispatch"); // the model call itself happens strictly after truncation
+                return new AgentTurnResult { Success = true, Response = "Retried", UpdatedHistory = [] };
+            });
+
+        var orchestrator = CreateOrchestrator();
+        var outcome = await orchestrator.RetryFromMessageAsync(
+            "conn1", "c1", Guid.NewGuid(), "user1",
+            onChunk: (_, _) => { events.Add("chunk"); return Task.CompletedTask; },
+            CancellationToken.None,
+            onHistoryTruncated: (keepCount, _) => { events.Add($"truncated:{keepCount}"); return Task.CompletedTask; });
+
+        outcome.HistoryKeepCount.Should().Be(1);
+        events.Should().StartWith("truncated:1",
+            "onHistoryTruncated must fire before the turn (and therefore before any streamed delta) dispatches");
+    }
+
+    [Fact]
     public async Task RetryFromMessage_NoUserMessage_ThrowsInvalidOperationException()
     {
         var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, []);
@@ -541,6 +580,71 @@ public class ConversationOrchestratorTests
 
         outcome.Success.Should().BeTrue();
         outcome.HistoryKeepCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task EditAndResubmit_AppendsTheEditedMessageBeforeSignalingTruncation()
+    {
+        // Code-review finding: unlike RetryFromMessageAsync, this method's onHistoryTruncated is
+        // what the client acts on to optimistically re-insert the edited message — so if it fired
+        // before the edit was durably appended, an append failure would leave the client showing
+        // an edit the server never persisted, with nothing to roll it back. Proves the real
+        // orchestrator appends first.
+        var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, []);
+        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _store.Setup(s => s.TruncateFromMessageAsync("c1", "user1", It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, []));
+        _store.Setup(s => s.GetHistoryForDispatch("c1", "user1", 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConversationMessage>());
+        _obsStore.Setup(s => s.StartSessionAsync("c1", "agent", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentTurnResult { Success = true, Response = "Edited", UpdatedHistory = [] });
+
+        var events = new List<string>();
+        _store.Setup(s => s.AppendMessageAsync("c1", "user1", It.IsAny<ConversationMessage>(), It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("append"))
+            .Returns(Task.CompletedTask);
+
+        var orchestrator = CreateOrchestrator();
+        await orchestrator.EditAndResubmitAsync(
+            "conn1", "c1", Guid.NewGuid(), Guid.NewGuid(), "New content", "user1",
+            onChunk: null, CancellationToken.None,
+            onHistoryTruncated: (_, _) => { events.Add("truncated"); return Task.CompletedTask; });
+
+        // DispatchTurnAsync appends the assistant's own response afterward — a second, unrelated
+        // "append" this test isn't about — so check relative order of the first two events rather
+        // than asserting the full sequence.
+        events.Take(2).Should().Equal("append", "truncated");
+    }
+
+    [Fact]
+    public async Task RetryFromMessage_OnHistoryTruncatedFailure_IsSwallowedAndTheTurnStillDispatches()
+    {
+        // The truncation this signals already committed durably in the store — a transport failure
+        // delivering the notice (dropped connection, slow client) must not abort a turn whose
+        // underlying mutation already succeeded.
+        var userMsg = new ConversationMessage(Guid.NewGuid(), MessageRole.User, "Original", DateTimeOffset.UtcNow);
+        var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow,
+            [userMsg]);
+        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _store.Setup(s => s.TruncateFromMessageAsync("c1", "user1", It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [userMsg]));
+        _store.Setup(s => s.GetHistoryForDispatch("c1", "user1", 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConversationMessage> { userMsg });
+        _obsStore.Setup(s => s.StartSessionAsync("c1", "agent", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentTurnResult { Success = true, Response = "Retried", UpdatedHistory = [] });
+
+        var orchestrator = CreateOrchestrator();
+        var outcome = await orchestrator.RetryFromMessageAsync(
+            "conn1", "c1", Guid.NewGuid(), "user1",
+            onChunk: null, CancellationToken.None,
+            onHistoryTruncated: (_, _) => throw new IOException("client connection dropped"));
+
+        outcome.Success.Should().BeTrue("a failed notification must not abort a turn whose truncation already committed");
+        outcome.HistoryKeepCount.Should().Be(1);
     }
 
     // ── ValidateAccess ───────────────────────────────────────────────────

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Services/ConversationOrchestratorTests.cs
@@ -647,6 +647,61 @@ public class ConversationOrchestratorTests
         outcome.HistoryKeepCount.Should().Be(1);
     }
 
+    [Fact]
+    public async Task RetryFromMessage_OnHistoryTruncatedThrowsCancellationMatchingCt_PropagatesRatherThanSwallowed()
+    {
+        // A cancellation matching the turn's own token means the client's connection is gone —
+        // there is no one left to stream deltas to, so unlike a generic transport failure this must
+        // propagate and abort rather than be swallowed.
+        var userMsg = new ConversationMessage(Guid.NewGuid(), MessageRole.User, "Original", DateTimeOffset.UtcNow);
+        var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [userMsg]);
+        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _store.Setup(s => s.TruncateFromMessageAsync("c1", "user1", It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [userMsg]));
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var orchestrator = CreateOrchestrator();
+        var act = () => orchestrator.RetryFromMessageAsync(
+            "conn1", "c1", Guid.NewGuid(), "user1",
+            onChunk: null, cts.Token,
+            onHistoryTruncated: (_, ct) => throw new OperationCanceledException(ct));
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task RetryFromMessage_OnHistoryTruncatedThrowsCancellationFromUnrelatedToken_IsSwallowed()
+    {
+        // A cancellation from some OTHER token (an internal timeout, not the turn's own connection
+        // token going away) must be swallowed like any other transient notification failure, not
+        // treated as this turn's own disconnect.
+        var userMsg = new ConversationMessage(Guid.NewGuid(), MessageRole.User, "Original", DateTimeOffset.UtcNow);
+        var record = new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [userMsg]);
+        _store.Setup(s => s.GetAsync("c1", "user1", It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        _store.Setup(s => s.TruncateFromMessageAsync("c1", "user1", It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ConversationRecord("c1", "agent", "user1", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, [userMsg]));
+        _store.Setup(s => s.GetHistoryForDispatch("c1", "user1", 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ConversationMessage> { userMsg });
+        _obsStore.Setup(s => s.StartSessionAsync("c1", "agent", null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Guid.NewGuid());
+        _mediator.Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AgentTurnResult { Success = true, Response = "Retried", UpdatedHistory = [] });
+
+        using var unrelatedCts = new CancellationTokenSource();
+        unrelatedCts.Cancel();
+
+        var orchestrator = CreateOrchestrator();
+        var outcome = await orchestrator.RetryFromMessageAsync(
+            "conn1", "c1", Guid.NewGuid(), "user1",
+            onChunk: null, CancellationToken.None,
+            onHistoryTruncated: (_, _) => throw new OperationCanceledException(unrelatedCts.Token));
+
+        outcome.Success.Should().BeTrue(
+            "a cancellation from an unrelated token must be swallowed, not treated as this turn's own disconnect");
+    }
+
     // ── ValidateAccess ───────────────────────────────────────────────────
 
     [Fact]

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/AgentTelemetryHubStreamingInvariantTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/AgentTelemetryHubStreamingInvariantTests.cs
@@ -261,6 +261,44 @@ public sealed class AgentTelemetryHubStreamingInvariantTests
     }
 
     [Fact]
+    public async Task RetryFromMessage_TypedExceptionAfterTruncationWasSignaled_StillEmitsErrorFrame()
+    {
+        // THE CONTROL for the exact gap `run-gates`' correctness reviewer caught: the first version
+        // of this fix put `catch (Exception) when (historyTruncatedSignaled)` BELOW the pre-existing
+        // `catch (Exception ex) when (ex is InvalidOperationException or UnauthorizedAccessException)`
+        // — C# matches catch clauses top-down, so for InvalidOperationException/UnauthorizedAccessException
+        // (a stolen turn lease, a mid-flight ConversationAccessDeniedException — the types this
+        // method actually throws on this path) the typed clause won FIRST and the new guard never
+        // ran, silently defeating it for the exact failures it exists for. This test uses the same
+        // exception type ConversationOrchestrator's own lease-conflict path throws
+        // (InvalidOperationException(ConversationLeaseNotice.Message)) rather than an arbitrary one,
+        // specifically so it cannot pass by accident the way the IOException-based test above could.
+        var fixture = Build();
+        fixture.Orchestrator
+            .Setup(o => o.RetryFromMessageAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task>?>(), It.IsAny<CancellationToken>(),
+                It.IsAny<Func<int, CancellationToken, Task>?>()))
+            .Returns(async (string _, string _, Guid _, string _,
+                Func<string, CancellationToken, Task>? _, CancellationToken ct,
+                Func<int, CancellationToken, Task>? onHistoryTruncated) =>
+            {
+                if (onHistoryTruncated is not null)
+                    await onHistoryTruncated(4, ct);
+                throw new InvalidOperationException("Another host now owns this conversation's turn.");
+            });
+
+        var act = () => fixture.Hub.RetryFromMessage("conv-1", Guid.NewGuid());
+
+        // Still wrapped as a HubException — existing typed-exception behaviour for RPC callers is
+        // unchanged — but the Error frame must ALSO have gone out first, unlike before the fix.
+        await act.Should().ThrowAsync<HubException>();
+        fixture.Captured.Should().ContainSingle(f => f.EventName == AgentTelemetryHub.EventHistoryTruncated);
+        fixture.Captured.Should().Contain(f => f.EventName == AgentTelemetryHub.EventError,
+            "an InvalidOperationException after truncation must not silently skip the Error frame");
+    }
+
+    [Fact]
     public void AssertHistoryTruncatedPrecedesTokens_TruncatedAfterFirstDelta_Throws()
     {
         // The check itself, proven against a synthetic violation — production code always emits

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/AgentTelemetryHubStreamingInvariantTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/AgentTelemetryHubStreamingInvariantTests.cs
@@ -269,10 +269,12 @@ public sealed class AgentTelemetryHubStreamingInvariantTests
         // — C# matches catch clauses top-down, so for InvalidOperationException/UnauthorizedAccessException
         // (a stolen turn lease, a mid-flight ConversationAccessDeniedException — the types this
         // method actually throws on this path) the typed clause won FIRST and the new guard never
-        // ran, silently defeating it for the exact failures it exists for. This test uses the same
-        // exception type ConversationOrchestrator's own lease-conflict path throws
-        // (InvalidOperationException(ConversationLeaseNotice.Message)) rather than an arbitrary one,
-        // specifically so it cannot pass by accident the way the IOException-based test above could.
+        // ran, silently defeating it for the exact failures it exists for. This test throws the same
+        // exception TYPE ConversationOrchestrator's own lease-conflict path throws
+        // (InvalidOperationException — see ConversationLeaseNotice, internal to Presentation.AgentHub
+        // and not referenced by literal here) rather than an arbitrary one, specifically so it cannot
+        // pass by accident the way the IOException-based test above could. The message text below is
+        // this test's own stand-in, not the production literal.
         var fixture = Build();
         fixture.Orchestrator
             .Setup(o => o.RetryFromMessageAsync(

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/AgentTelemetryHubStreamingInvariantTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/AgentTelemetryHubStreamingInvariantTests.cs
@@ -1,0 +1,342 @@
+using System.Diagnostics;
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Presentation.AgentHub.DTOs;
+using Presentation.AgentHub.Hubs;
+using Presentation.AgentHub.Interfaces;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Streaming;
+
+/// <summary>
+/// #328's hub-level streaming invariants (I1, I2, I3, I5) — checked against real SignalR wire
+/// frames captured off a directly-constructed <see cref="AgentTelemetryHub"/> (mocked
+/// <see cref="IHubCallerClients"/>/<see cref="HubCallerContext"/>, real hub code). I4/I6/I7 are
+/// covered separately in <c>StreamFrameRecorderInvariantTests</c> — see <see cref="StreamInvariants"/>'s
+/// remarks for why the split follows the seam, not the invariant numbering.
+/// </summary>
+public sealed class AgentTelemetryHubStreamingInvariantTests
+{
+    // Matches the JsonHubProtocol default in ASP.NET Core SignalR — same policy
+    // SignalRContextSnapshotNotifierTests uses for the identical reason.
+    private static readonly JsonSerializerOptions WireJson = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    private sealed record Fixture(
+        AgentTelemetryHub Hub,
+        Mock<IConversationOrchestrator> Orchestrator,
+        List<HubFrame> Captured,
+        CancellationTokenSource ConnectionAborted);
+
+    private static Fixture Build()
+    {
+        var orchestrator = new Mock<IConversationOrchestrator>();
+        var clientProxy = new Mock<ISingleClientProxy>();
+        var callerClients = new Mock<IHubCallerClients>();
+        callerClients.SetupGet(c => c.Caller).Returns(clientProxy.Object);
+
+        var captured = new List<HubFrame>();
+        var gate = new object();
+        var stopwatch = Stopwatch.StartNew();
+        clientProxy
+            .Setup(c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
+            .Returns((string method, object?[] args, CancellationToken _) =>
+            {
+                var frame = new HubFrame(method, JsonSerializer.SerializeToElement(args[0], WireJson), stopwatch.Elapsed);
+                lock (gate) captured.Add(frame);
+                return Task.CompletedTask;
+            });
+
+        var connectionAborted = new CancellationTokenSource();
+        var context = new Mock<HubCallerContext>();
+        context.SetupGet(c => c.ConnectionAborted).Returns(connectionAborted.Token);
+        context.SetupGet(c => c.ConnectionId).Returns("conn-1");
+        context.SetupGet(c => c.User).Returns(
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim("sub", "test-user")], "test")));
+
+        var hub = new AgentTelemetryHub(orchestrator.Object, NullLogger<AgentTelemetryHub>.Instance)
+        {
+            Clients = callerClients.Object,
+            Context = context.Object,
+        };
+
+        return new Fixture(hub, orchestrator, captured, connectionAborted);
+    }
+
+    /// <summary>Scripts the mocked orchestrator to stream <paramref name="deltas"/> via <c>onChunk</c>
+    /// (mirroring what <c>ExecuteAgentTurnCommandHandler.RunStreamingTurnAsync</c> really does through
+    /// this seam) before returning <paramref name="outcome"/>.</summary>
+    private static void ScriptSuccessfulStream(Mock<IConversationOrchestrator> orchestrator, IReadOnlyList<string> deltas, TurnOutcome outcome)
+    {
+        orchestrator
+            .Setup(o => o.SendMessageAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task>?>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, string _, Guid _, string _, string _,
+                Func<string, CancellationToken, Task>? onChunk, CancellationToken ct) =>
+            {
+                if (onChunk is not null)
+                {
+                    foreach (var delta in deltas)
+                        await onChunk(delta, ct);
+                }
+                return outcome;
+            });
+    }
+
+    /// <summary>Scripts the mocked orchestrator to return a failed outcome directly (no streaming).</summary>
+    private static void ScriptErrorOutcome(Mock<IConversationOrchestrator> orchestrator, string errorMessage)
+    {
+        orchestrator
+            .Setup(o => o.SendMessageAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TurnOutcome { Success = false, ErrorMessage = errorMessage });
+    }
+
+    // ── I1 — exactly one terminal frame, and it is last ─────────────────────
+
+    [Fact]
+    public async Task SuccessfulTurn_TerminalFrameIsTurnCompleteAndIsLast()
+    {
+        var fixture = Build();
+        ScriptSuccessfulStream(fixture.Orchestrator, ["Hello, ", "world!"],
+            new TurnOutcome { Success = true, Response = "Hello, world!", FinalTurnNumber = 1 });
+
+        await fixture.Hub.SendMessage("conv-1", Guid.NewGuid(), "Hi");
+
+        var act = () => StreamInvariants.AssertExactlyOneTerminalFrame(fixture.Captured);
+        act.Should().NotThrow();
+        fixture.Captured[^1].EventName.Should().Be(AgentTelemetryHub.EventTurnComplete);
+    }
+
+    [Fact]
+    public async Task FailedTurn_TerminalFrameIsErrorAndIsLast()
+    {
+        var fixture = Build();
+        ScriptErrorOutcome(fixture.Orchestrator, "model unavailable");
+
+        await fixture.Hub.SendMessage("conv-1", Guid.NewGuid(), "Hi");
+
+        var act = () => StreamInvariants.AssertExactlyOneTerminalFrame(fixture.Captured);
+        act.Should().NotThrow();
+        fixture.Captured[^1].EventName.Should().Be(AgentTelemetryHub.EventError);
+    }
+
+    [Fact]
+    public void AssertExactlyOneTerminalFrame_FrameAfterTerminal_Throws()
+    {
+        // The check itself, proven against a synthetic violation — production code never emits
+        // anything after TurnComplete, so this cannot be driven through the real hub.
+        var frames = new List<HubFrame>
+        {
+            new(AgentTelemetryHub.EventTurnComplete, JsonDocument.Parse("{}").RootElement, TimeSpan.FromMilliseconds(10)),
+            new(AgentTelemetryHub.EventTokenReceived, JsonDocument.Parse("{}").RootElement, TimeSpan.FromMilliseconds(20)),
+        };
+
+        var act = () => StreamInvariants.AssertExactlyOneTerminalFrame(frames);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not the last frame*");
+    }
+
+    // ── I2 — exactly one isComplete=true TokenReceived on success, zero on error ────
+
+    [Fact]
+    public async Task SuccessfulTurn_ExactlyOneCompletionToken()
+    {
+        var fixture = Build();
+        ScriptSuccessfulStream(fixture.Orchestrator, ["a", "b", "c"],
+            new TurnOutcome { Success = true, Response = "abc", FinalTurnNumber = 1 });
+
+        await fixture.Hub.SendMessage("conv-1", Guid.NewGuid(), "Hi");
+
+        var act = () => StreamInvariants.AssertExactlyOneCompletionToken(fixture.Captured);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task FailedTurn_ZeroCompletionTokens()
+    {
+        var fixture = Build();
+        ScriptErrorOutcome(fixture.Orchestrator, "boom");
+
+        await fixture.Hub.SendMessage("conv-1", Guid.NewGuid(), "Hi");
+
+        var act = () => StreamInvariants.AssertExactlyOneCompletionToken(fixture.Captured);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AssertExactlyOneCompletionToken_TwoCompletionFrames_Throws()
+    {
+        var frames = new List<HubFrame>
+        {
+            new(AgentTelemetryHub.EventTokenReceived, JsonDocument.Parse("""{"isComplete":true}""").RootElement, TimeSpan.FromMilliseconds(10)),
+            new(AgentTelemetryHub.EventTokenReceived, JsonDocument.Parse("""{"isComplete":true}""").RootElement, TimeSpan.FromMilliseconds(20)),
+            new(AgentTelemetryHub.EventTurnComplete, JsonDocument.Parse("{}").RootElement, TimeSpan.FromMilliseconds(30)),
+        };
+
+        var act = () => StreamInvariants.AssertExactlyOneCompletionToken(frames);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*found 2*");
+    }
+
+    // ── I3 — HistoryTruncated precedes every TokenReceived ───────────────────
+
+    [Fact]
+    public async Task RetryFromMessage_HistoryTruncatedPrecedesEveryTokenReceived()
+    {
+        // Must run the retry path: HistoryKeepCount is only ever set on retry/edit, so the plain
+        // SendMessage path never emits HistoryTruncated at all and a version of this test using it
+        // would prove nothing (the plan's own stated trap for I3).
+        //
+        // THE CONTROL for I3: first run of this test (before the fix landed) caught a real bug —
+        // AgentTelemetryHub.EmitTurnEventsAsync emitted HistoryTruncated only AFTER the whole turn
+        // completed, so a retry/edit's own streamed deltas (emitted via onChunk DURING
+        // IConversationOrchestrator.RetryFromMessageAsync/EditAndResubmitAsync, before that method
+        // returns) always arrived first — a client could append the new response onto its still-
+        // untruncated message list before being told to drop the stale tail. Fixed by threading an
+        // onHistoryTruncated callback through the orchestrator interface, invoked immediately after
+        // truncation and before dispatch (ConversationOrchestrator.cs), and moving the hub's own
+        // emission out of the post-turn EmitTurnEventsAsync into that callback (#328).
+        var fixture = Build();
+        fixture.Orchestrator
+            .Setup(o => o.RetryFromMessageAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task>?>(), It.IsAny<CancellationToken>(),
+                It.IsAny<Func<int, CancellationToken, Task>?>()))
+            .Returns(async (string _, string _, Guid _, string _,
+                Func<string, CancellationToken, Task>? onChunk, CancellationToken ct,
+                Func<int, CancellationToken, Task>? onHistoryTruncated) =>
+            {
+                if (onHistoryTruncated is not null)
+                    await onHistoryTruncated(4, ct);
+                if (onChunk is not null)
+                    await onChunk("Recovered", ct);
+                return new TurnOutcome { Success = true, Response = "Recovered", FinalTurnNumber = 2, HistoryKeepCount = 4 };
+            });
+
+        await fixture.Hub.RetryFromMessage("conv-1", Guid.NewGuid());
+
+        fixture.Captured.Should().Contain(f => f.EventName == AgentTelemetryHub.EventHistoryTruncated);
+        fixture.Captured[0].EventName.Should().Be(AgentTelemetryHub.EventHistoryTruncated,
+            "the truncation signal must reach the client before this turn's own streamed deltas");
+        var act = () => StreamInvariants.AssertHistoryTruncatedPrecedesTokens(fixture.Captured);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task RetryFromMessage_FailsAfterTruncationWasSignaled_EmitsErrorFrameNotBareRpcRejection()
+    {
+        // Code-review finding: moving HistoryTruncated before dispatch (the #328 fix above) opened
+        // a narrower gap — if something fails AFTER the client was told to drop its stale tail but
+        // BEFORE a real TurnComplete/Error frame would normally follow, a bare HubException only
+        // reaches the RPC caller's own .catch(), never the client's dedicated Error event handler,
+        // leaving the transcript truncated with no explanation. AgentTelemetryHub now tracks whether
+        // the truncation notice was signalled and, if so, emits a real Error frame before rethrowing.
+        var fixture = Build();
+        fixture.Orchestrator
+            .Setup(o => o.RetryFromMessageAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task>?>(), It.IsAny<CancellationToken>(),
+                It.IsAny<Func<int, CancellationToken, Task>?>()))
+            .Returns(async (string _, string _, Guid _, string _,
+                Func<string, CancellationToken, Task>? _, CancellationToken ct,
+                Func<int, CancellationToken, Task>? onHistoryTruncated) =>
+            {
+                if (onHistoryTruncated is not null)
+                    await onHistoryTruncated(4, ct);
+                throw new IOException("store write failed after truncation");
+            });
+
+        var act = () => fixture.Hub.RetryFromMessage("conv-1", Guid.NewGuid());
+
+        await act.Should().ThrowAsync<IOException>("the failure still propagates to the RPC caller too");
+        fixture.Captured.Should().ContainSingle(f => f.EventName == AgentTelemetryHub.EventHistoryTruncated);
+        fixture.Captured.Should().Contain(f => f.EventName == AgentTelemetryHub.EventError,
+            "the client already acted on the truncation notice and must be told the turn failed");
+    }
+
+    [Fact]
+    public void AssertHistoryTruncatedPrecedesTokens_TruncatedAfterFirstDelta_Throws()
+    {
+        // The check itself, proven against a synthetic violation — production code always emits
+        // HistoryTruncated unconditionally first when present, so this cannot be driven through
+        // the real hub either.
+        var frames = new List<HubFrame>
+        {
+            new(AgentTelemetryHub.EventTokenReceived, JsonDocument.Parse("""{"isComplete":false}""").RootElement, TimeSpan.FromMilliseconds(10)),
+            new(AgentTelemetryHub.EventHistoryTruncated, JsonDocument.Parse("{}").RootElement, TimeSpan.FromMilliseconds(20)),
+        };
+
+        var act = () => StreamInvariants.AssertHistoryTruncatedPrecedesTokens(frames);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*arrived AFTER*");
+    }
+
+    // ── I5 — every frame carries the same conversationId ────────────────────
+
+    [Fact]
+    public async Task SuccessfulTurn_EveryFrameCarriesTheSameConversationId()
+    {
+        var fixture = Build();
+        ScriptSuccessfulStream(fixture.Orchestrator, ["a", "b"],
+            new TurnOutcome { Success = true, Response = "ab", FinalTurnNumber = 1 });
+
+        await fixture.Hub.SendMessage("conv-42", Guid.NewGuid(), "Hi");
+
+        var act = () => StreamInvariants.AssertSameConversationId(fixture.Captured, "conv-42");
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AssertSameConversationId_MismatchedFrame_Throws()
+    {
+        var frames = new List<HubFrame>
+        {
+            new(AgentTelemetryHub.EventTokenReceived, JsonDocument.Parse("""{"conversationId":"conv-1"}""").RootElement, TimeSpan.FromMilliseconds(10)),
+            new(AgentTelemetryHub.EventTurnComplete, JsonDocument.Parse("""{"conversationId":"conv-WRONG"}""").RootElement, TimeSpan.FromMilliseconds(20)),
+        };
+
+        var act = () => StreamInvariants.AssertSameConversationId(frames, "conv-1");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*conv-WRONG*");
+    }
+
+    // ── Mid-stream interruption (ConversationOrchestrator.cs:409-420 behaviour) ─────
+
+    [Fact]
+    public async Task ClientDisconnectMidStream_StopsWithNoTerminalFrame()
+    {
+        // Pins ConversationOrchestrator.SendMessageAsync's documented behaviour: a cancelled
+        // connection token mid-turn is a routine disconnect, rethrown WITHOUT ever reaching
+        // EmitTurnEventsAsync — no TurnComplete, no Error, just the deltas that streamed before
+        // the disconnect.
+        var fixture = Build();
+        fixture.Orchestrator
+            .Setup(o => o.SendMessageAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<string, CancellationToken, Task>?>(), It.IsAny<CancellationToken>()))
+            .Returns(async (string _, string _, Guid _, string _, string _,
+                Func<string, CancellationToken, Task>? onChunk, CancellationToken ct) =>
+            {
+                if (onChunk is not null)
+                {
+                    await onChunk("Partial before disconnect", ct);
+                }
+
+                fixture.ConnectionAborted.Cancel();
+                throw new OperationCanceledException(ct);
+            });
+
+        var act = () => fixture.Hub.SendMessage("conv-1", Guid.NewGuid(), "Hi");
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        fixture.Captured.Should().ContainSingle(f => f.EventName == AgentTelemetryHub.EventTokenReceived);
+        fixture.Captured.Should().NotContain(f => f.EventName == AgentTelemetryHub.EventTurnComplete);
+        fixture.Captured.Should().NotContain(f => f.EventName == AgentTelemetryHub.EventError);
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamFrameRecorder.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamFrameRecorder.cs
@@ -1,0 +1,110 @@
+using Application.AI.Common.Interfaces;
+
+namespace Presentation.AgentHub.Tests.Streaming;
+
+/// <summary>The kind of one captured <see cref="StreamFrame"/>.</summary>
+public enum StreamFrameKind
+{
+    /// <summary>An assistant text delta from <see cref="IAgentTurnStreamSink.EmitAsync"/>.</summary>
+    TokenDelta,
+
+    /// <summary>A tool call start from <see cref="IAgentTurnStreamSink.EmitToolCallAsync"/>.</summary>
+    ToolCallStart,
+
+    /// <summary>A tool call result from <see cref="IAgentTurnStreamSink.EmitToolCallResultAsync"/>.</summary>
+    ToolCallResult,
+}
+
+/// <summary>
+/// One frame captured by <see cref="StreamFrameRecorder"/>: its kind, the frame's own identifying
+/// text (the delta text for <see cref="StreamFrameKind.TokenDelta"/>, the tool-call id for the two
+/// tool-call kinds), and elapsed time since the recorder was constructed.
+/// </summary>
+public sealed record StreamFrame(StreamFrameKind Kind, string Payload, TimeSpan Elapsed);
+
+/// <summary>
+/// Records every call made through it as an ordered, timestamped <see cref="StreamFrame"/> —
+/// the direct <see cref="IAgentTurnStreamSink"/>-seam half of #328's per-frame streaming
+/// invariants. Not a fake of the transport: it IS a real sink implementation, usable standalone to
+/// prove <see cref="StreamInvariants.AssertPrefix"/>/<see cref="StreamInvariants.AssertNonDecreasingElapsed"/>,
+/// or wrapped by the real <c>ToolCallOrderingSink</c> to prove that decorator's protection holds
+/// under this recorder rather than under a hand-rolled substitute.
+/// </summary>
+/// <remarks>
+/// For a mutation test proving <see cref="StreamInvariants.AssertToolCallOrdering"/> is a live
+/// check (not dead code), the recorder must be exercised DIRECTLY — never behind
+/// <c>ToolCallOrderingSink</c> — since that decorator silently drops an out-of-order call before it
+/// ever reaches an inner sink. Wrapped, the invariant can never observe a violation and the test
+/// would prove nothing about this type's own check.
+/// </remarks>
+public sealed class StreamFrameRecorder : IAgentTurnStreamSink
+{
+    private readonly Lock _gate = new();
+    private readonly List<StreamFrame> _frames = [];
+    private readonly TimeProvider _timeProvider;
+    private readonly long _startTimestamp;
+
+    /// <summary>Creates a recorder whose <see cref="StreamFrame.Elapsed"/> values are measured
+    /// from construction time using <paramref name="timeProvider"/>.</summary>
+    public StreamFrameRecorder(TimeProvider? timeProvider = null)
+    {
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _startTimestamp = _timeProvider.GetTimestamp();
+    }
+
+    /// <summary>All frames recorded so far, in call order.</summary>
+    public IReadOnlyList<StreamFrame> Frames
+    {
+        get { lock (_gate) return [.. _frames]; }
+    }
+
+    /// <summary>The concatenation of every <see cref="StreamFrameKind.TokenDelta"/> payload, in order.</summary>
+    public string ConcatenatedDeltas
+    {
+        get
+        {
+            var builder = new System.Text.StringBuilder();
+            lock (_gate)
+            {
+                foreach (var frame in _frames)
+                {
+                    if (frame.Kind == StreamFrameKind.TokenDelta)
+                        builder.Append(frame.Payload);
+                }
+            }
+            return builder.ToString();
+        }
+    }
+
+    /// <inheritdoc />
+    public Task EmitAsync(string delta, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(delta)) return Task.CompletedTask;
+        Record(StreamFrameKind.TokenDelta, delta);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task EmitToolCallAsync(string toolCallId, string toolCallName, StreamedToolCallArguments args, CancellationToken cancellationToken)
+    {
+        Record(StreamFrameKind.ToolCallStart, toolCallId);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task EmitToolCallResultAsync(string toolCallId, StreamedToolCallResult result, CancellationToken cancellationToken)
+    {
+        Record(StreamFrameKind.ToolCallResult, toolCallId);
+        return Task.CompletedTask;
+    }
+
+    private void Record(StreamFrameKind kind, string payload)
+    {
+        // Elapsed must be sampled INSIDE the lock, atomically with the Add — sampling it outside
+        // lets two racing calls capture their timestamps in one order but get inserted in the
+        // other, producing a frame list whose position order doesn't match its own Elapsed order.
+        // That would make AssertNonDecreasingElapsed (I7) fail on a race in this recorder, not on
+        // a real production ordering violation.
+        lock (_gate) _frames.Add(new StreamFrame(kind, payload, _timeProvider.GetElapsedTime(_startTimestamp)));
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamFrameRecorderInvariantTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamFrameRecorderInvariantTests.cs
@@ -1,0 +1,167 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.Streaming;
+
+/// <summary>
+/// #328's sink-level streaming invariants (I4, I6, I7) — checked directly against a
+/// <see cref="StreamFrameRecorder"/>, the <c>IAgentTurnStreamSink</c> seam. The hub-level
+/// invariants (I1/I2/I3/I5) are covered separately in
+/// <c>AgentTelemetryHubStreamingInvariantTests</c>, since their subject has no sink-level
+/// representation (see <see cref="StreamInvariants"/>'s remarks).
+/// </summary>
+public sealed class StreamFrameRecorderInvariantTests
+{
+    // ── I4 — prefix, not equality ──────────────────────────────────────────
+
+    [Fact]
+    public async Task AssertPrefix_DeltasConcatenateToExactlyTheFinalText_Passes()
+    {
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+        await recorder.EmitAsync("Hello, ", CancellationToken.None);
+        await recorder.EmitAsync("world!", CancellationToken.None);
+
+        var act = () => StreamInvariants.AssertPrefix(recorder, "Hello, world!");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task AssertPrefix_FinalTextRepeatsTheWholeResponseOnTopOfDeltas_StillPasses()
+    {
+        // Mirrors the real shape: AgentTelemetryHub.EmitTurnEventsAsync re-sends the full response
+        // as one more frame, and ConversationOrchestrator builds the final assistant message
+        // independently of what streamed — so "final text == concatenated deltas" is NOT the
+        // invariant; "concatenated deltas is a prefix of final text" is.
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+        await recorder.EmitAsync("Partial", CancellationToken.None);
+
+        var act = () => StreamInvariants.AssertPrefix(recorder, "Partial answer, fully assembled.");
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task AssertPrefix_DeltasDivergeFromFinalTextMidStream_ThrowsEvenThoughFinalTextIsCorrect()
+    {
+        // THE CONTROL for I4 (per the plan's mutation-test table): a run whose final text is
+        // exactly right but whose deltas diverge mid-stream MUST fail here. If this test passes,
+        // the invariant is checking only the end state and #328 is not actually closed.
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+        await recorder.EmitAsync("Helxo, ", CancellationToken.None); // typo mid-stream
+        await recorder.EmitAsync("world!", CancellationToken.None);
+
+        var act = () => StreamInvariants.AssertPrefix(recorder, "Hello, world!");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*diverged from the authoritative final text*");
+    }
+
+    [Fact]
+    public async Task AssertPrefix_EmptyDeltasAreIgnored_NeverAppearAsFrames()
+    {
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+        await recorder.EmitAsync(string.Empty, CancellationToken.None);
+        await recorder.EmitAsync("real", CancellationToken.None);
+
+        recorder.Frames.Should().ContainSingle();
+        StreamInvariants.AssertPrefix(recorder, "real deal");
+    }
+
+    // ── I7 — non-decreasing elapsed ────────────────────────────────────────
+
+    [Fact]
+    public async Task AssertNonDecreasingElapsed_RealClockFrames_Passes()
+    {
+        var time = new FakeTimeProvider();
+        var recorder = new StreamFrameRecorder(time);
+        await recorder.EmitAsync("a", CancellationToken.None);
+        time.Advance(TimeSpan.FromMilliseconds(10));
+        await recorder.EmitAsync("b", CancellationToken.None);
+
+        var act = () => StreamInvariants.AssertNonDecreasingElapsed(recorder.Frames);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void AssertNonDecreasingElapsed_OutOfOrderFrames_Throws()
+    {
+        var frames = new List<StreamFrame>
+        {
+            new(StreamFrameKind.TokenDelta, "a", TimeSpan.FromMilliseconds(50)),
+            new(StreamFrameKind.TokenDelta, "b", TimeSpan.FromMilliseconds(10)),
+        };
+
+        var act = () => StreamInvariants.AssertNonDecreasingElapsed(frames);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Frame 1*");
+    }
+
+    // ── I6 — tool-call correlation ─────────────────────────────────────────
+
+    [Fact]
+    public async Task AssertToolCallOrdering_StartThenResult_Passes()
+    {
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+        await recorder.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await recorder.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("ok", false), CancellationToken.None);
+
+        var act = () => StreamInvariants.AssertToolCallOrdering(recorder.Frames);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public async Task AssertToolCallOrdering_ResultWithNoPriorStart_ThrowsWhenRecorderIsExercisedDirectly()
+    {
+        // Exercises StreamFrameRecorder DIRECTLY, bypassing ToolCallOrderingSink — see this file's
+        // class remarks and StreamFrameRecorder's own remarks for why that placement matters: the
+        // decorator would silently drop this exact call before the recorder ever saw it, and the
+        // invariant could never fire.
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+
+        await recorder.EmitToolCallResultAsync("orphan-call", new StreamedToolCallResult("ok", false), CancellationToken.None);
+
+        var act = () => StreamInvariants.AssertToolCallOrdering(recorder.Frames);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*orphan-call*no prior ToolCallStart*");
+    }
+
+    [Fact]
+    public async Task AssertToolCallOrdering_DuplicateStart_ThrowsWhenRecorderIsExercisedDirectly()
+    {
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+        await recorder.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+
+        await recorder.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+
+        var act = () => StreamInvariants.AssertToolCallOrdering(recorder.Frames);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*duplicate start*call-1*");
+    }
+
+    [Fact]
+    public async Task AssertToolCallOrdering_TheSameViolation_IsSilentlyPreventedWhenWrappedByTheRealDecorator()
+    {
+        // THE CONTROL proving the recorder sits at the right layer in production: the identical
+        // violation from the previous test never reaches this recorder, and therefore never fires
+        // the invariant, when wrapped by the real ToolCallOrderingSink — because that decorator's
+        // job is to prevent exactly this. Both this test and the two above must pass together, or
+        // the recorder is either not catching real violations, or not proving the decorator works.
+        var recorder = new StreamFrameRecorder(new FakeTimeProvider());
+        IAgentTurnStreamSink protectedSink = new ToolCallOrderingSink(recorder);
+
+        await protectedSink.EmitToolCallResultAsync("orphan-call", new StreamedToolCallResult("ok", false), CancellationToken.None);
+        await protectedSink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await protectedSink.EmitToolCallAsync("call-1", "search", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await protectedSink.EmitToolCallResultAsync("call-1", new StreamedToolCallResult("ok", false), CancellationToken.None);
+
+        recorder.Frames.Should().HaveCount(2, "the orphaned result and the duplicate start were both dropped by the decorator");
+        var act = () => StreamInvariants.AssertToolCallOrdering(recorder.Frames);
+        act.Should().NotThrow();
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamInvariants.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamInvariants.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using Presentation.AgentHub.Hubs;
+
+namespace Presentation.AgentHub.Tests.Streaming;
+
+/// <summary>
+/// One captured SignalR wire frame from <see cref="AgentTelemetryHub"/>: the event name, its
+/// deserialized JSON payload, and elapsed time since capture began.
+/// </summary>
+public sealed record HubFrame(string EventName, JsonElement Payload, TimeSpan Elapsed);
+
+/// <summary>
+/// #328's per-frame streaming invariants. Split by seam: I4/I6/I7 are checked directly against a
+/// <see cref="StreamFrameRecorder"/> (the <c>IAgentTurnStreamSink</c> level); I1/I2/I3/I5 are
+/// checked against captured <see cref="HubFrame"/>s (the SignalR wire level) because their subject
+/// — <c>TurnComplete</c>, <c>Error</c>, <c>HistoryTruncated</c>, and <c>isComplete</c> — has no
+/// representation at the sink level at all: <c>IAgentTurnStreamSink</c> carries text deltas and
+/// tool-call activity only, and <c>AgentTelemetryHub</c> never streams tool-call frames over this
+/// transport (see <see cref="AgentTelemetryHub.SendMessage"/> — its <c>onChunk</c> callback is the
+/// sink's only wired delegate; tool-call activity reaches clients via a separate OTel bridge, not
+/// this interface). Every failure names the offending frame's index, kind/event, and elapsed time.
+/// </summary>
+public static class StreamInvariants
+{
+    /// <summary>
+    /// I4 — the concatenation of every streamed delta must be a PREFIX of the authoritative final
+    /// text, never required to equal it. Equality is false by design here:
+    /// <c>ConversationOrchestrator.SendMessageAsync</c> constructs its own final assistant message
+    /// independent of what was streamed, and <c>AgentTelemetryHub.EmitTurnEventsAsync</c> re-sends
+    /// the entire response as one more frame before <c>TurnComplete</c>.
+    /// </summary>
+    public static void AssertPrefix(StreamFrameRecorder recorder, string authoritativeFinalText)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+        var concatenated = recorder.ConcatenatedDeltas;
+        if (!authoritativeFinalText.StartsWith(concatenated, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Streamed deltas diverged from the authoritative final text: concatenated deltas " +
+                $"\"{concatenated}\" is not a prefix of \"{authoritativeFinalText}\".");
+        }
+    }
+
+    /// <summary>I7 — every recorded frame's elapsed time is >= the previous frame's.</summary>
+    public static void AssertNonDecreasingElapsed(IReadOnlyList<StreamFrame> frames)
+    {
+        for (var i = 1; i < frames.Count; i++)
+        {
+            if (frames[i].Elapsed < frames[i - 1].Elapsed)
+            {
+                throw new InvalidOperationException(
+                    $"Frame {i} ({frames[i].Kind}, elapsed {frames[i].Elapsed}) has a smaller elapsed " +
+                    $"time than frame {i - 1} ({frames[i - 1].Kind}, elapsed {frames[i - 1].Elapsed}).");
+            }
+        }
+    }
+
+    /// <summary>
+    /// I6 — no <see cref="StreamFrameKind.ToolCallResult"/> without a prior
+    /// <see cref="StreamFrameKind.ToolCallStart"/> for the same id, and no id started twice.
+    /// </summary>
+    public static void AssertToolCallOrdering(IReadOnlyList<StreamFrame> frames)
+    {
+        var started = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < frames.Count; i++)
+        {
+            var frame = frames[i];
+            if (frame.Kind == StreamFrameKind.ToolCallStart)
+            {
+                if (!started.Add(frame.Payload))
+                {
+                    throw new InvalidOperationException(
+                        $"Frame {i} (ToolCallStart, elapsed {frame.Elapsed}): duplicate start for id " +
+                        $"'{frame.Payload}', already started earlier in this turn.");
+                }
+            }
+            else if (frame.Kind == StreamFrameKind.ToolCallResult && !started.Contains(frame.Payload))
+            {
+                throw new InvalidOperationException(
+                    $"Frame {i} (ToolCallResult, elapsed {frame.Elapsed}): result for id '{frame.Payload}' " +
+                    "with no prior ToolCallStart in this turn.");
+            }
+        }
+    }
+
+    /// <summary>I1 — exactly one terminal frame (TurnComplete XOR Error) and it is the last frame.</summary>
+    public static void AssertExactlyOneTerminalFrame(IReadOnlyList<HubFrame> frames)
+    {
+        var terminal = frames
+            .Select((f, i) => (Frame: f, Index: i))
+            .Where(t => t.Frame.EventName is AgentTelemetryHub.EventTurnComplete or AgentTelemetryHub.EventError)
+            .ToList();
+
+        if (terminal.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected exactly one terminal frame (TurnComplete XOR Error); found {terminal.Count}: " +
+                string.Join(", ", terminal.Select(t => $"[{t.Index}] {t.Frame.EventName}@{t.Frame.Elapsed}")));
+        }
+
+        var (frame, index) = terminal[0];
+        if (index != frames.Count - 1)
+        {
+            throw new InvalidOperationException(
+                $"Terminal frame at index {index} ({frame.EventName}, elapsed {frame.Elapsed}) is not the " +
+                $"last frame — {frames.Count - 1 - index} frame(s) followed it.");
+        }
+    }
+
+    /// <summary>
+    /// I2 — exactly one <c>TokenReceived</c> frame with <c>isComplete=true</c> on a successful turn
+    /// (zero on an errored one). Uniqueness alone is what's checked: once at most one such frame is
+    /// confirmed to exist, there is nothing earlier in the list left to also be one.
+    /// </summary>
+    public static void AssertExactlyOneCompletionToken(IReadOnlyList<HubFrame> frames)
+    {
+        var hasError = false;
+        var completionIndices = new List<int>();
+        for (var i = 0; i < frames.Count; i++)
+        {
+            if (frames[i].EventName == AgentTelemetryHub.EventError)
+                hasError = true;
+            else if (frames[i].EventName == AgentTelemetryHub.EventTokenReceived
+                && frames[i].Payload.GetProperty("isComplete").GetBoolean())
+                completionIndices.Add(i);
+        }
+
+        if (hasError)
+        {
+            if (completionIndices.Count != 0)
+            {
+                throw new InvalidOperationException(
+                    $"Errored turn emitted {completionIndices.Count} isComplete=true TokenReceived frame(s) " +
+                    $"(first at index {completionIndices[0]}, elapsed {frames[completionIndices[0]].Elapsed}); expected zero.");
+            }
+            return;
+        }
+
+        if (completionIndices.Count != 1)
+        {
+            throw new InvalidOperationException(
+                $"Expected exactly one isComplete=true TokenReceived frame on a successful turn; found {completionIndices.Count}: " +
+                string.Join(", ", completionIndices.Select(i => $"[{i}]@{frames[i].Elapsed}")));
+        }
+    }
+
+    /// <summary>Returns the index of the first frame with the given event name, or -1 if none.</summary>
+    private static int FindFirstIndex(IReadOnlyList<HubFrame> frames, string eventName)
+    {
+        for (var i = 0; i < frames.Count; i++)
+        {
+            if (frames[i].EventName == eventName) return i;
+        }
+        return -1;
+    }
+
+    /// <summary>I3 — <c>HistoryTruncated</c>, when present, precedes every <c>TokenReceived</c> frame.</summary>
+    public static void AssertHistoryTruncatedPrecedesTokens(IReadOnlyList<HubFrame> frames)
+    {
+        var truncatedIndex = FindFirstIndex(frames, AgentTelemetryHub.EventHistoryTruncated);
+        if (truncatedIndex < 0) return;
+
+        var firstTokenIndex = FindFirstIndex(frames, AgentTelemetryHub.EventTokenReceived);
+        if (firstTokenIndex >= 0 && firstTokenIndex < truncatedIndex)
+        {
+            throw new InvalidOperationException(
+                $"HistoryTruncated at index {truncatedIndex} (elapsed {frames[truncatedIndex].Elapsed}) " +
+                $"arrived AFTER the first TokenReceived at index {firstTokenIndex} " +
+                $"(elapsed {frames[firstTokenIndex].Elapsed}).");
+        }
+    }
+
+    /// <summary>I5 — every frame in the turn carries the same <c>conversationId</c>.</summary>
+    public static void AssertSameConversationId(IReadOnlyList<HubFrame> frames, string expectedConversationId)
+    {
+        for (var i = 0; i < frames.Count; i++)
+        {
+            var actual = frames[i].Payload.GetProperty("conversationId").GetString();
+            if (actual != expectedConversationId)
+            {
+                throw new InvalidOperationException(
+                    $"Frame {i} ({frames[i].EventName}, elapsed {frames[i].Elapsed}) carries conversationId " +
+                    $"'{actual}', expected '{expectedConversationId}'.");
+            }
+        }
+    }
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamInvariants.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/Streaming/StreamInvariants.cs
@@ -32,6 +32,7 @@ public static class StreamInvariants
     public static void AssertPrefix(StreamFrameRecorder recorder, string authoritativeFinalText)
     {
         ArgumentNullException.ThrowIfNull(recorder);
+        ArgumentNullException.ThrowIfNull(authoritativeFinalText);
         var concatenated = recorder.ConcatenatedDeltas;
         if (!authoritativeFinalText.StartsWith(concatenated, StringComparison.Ordinal))
         {


### PR DESCRIPTION
## Summary
- Closes #328: `StreamFrameRecorder`/`StreamInvariants` prove I1–I7 (terminal-frame exclusivity, single completion token, `HistoryTruncated` ordering, delta-prefix, same-conversation-id, tool-call correlation, non-decreasing elapsed) — split across the two seams that actually carry them: `IAgentTurnStreamSink` (I4/I6/I7) and the SignalR wire (I1/I2/I3/I5). Full rationale for the split is in `StreamInvariants`'s own remarks.
- Writing the I3 test caught a real production bug: `AgentTelemetryHub.EmitTurnEventsAsync` emitted `HistoryTruncated` only after the whole turn completed, but a retry/edit's own streamed deltas arrive on the wire *during* the turn — so a client appending tokens to its message list as they streamed could append the new response before being told to drop its stale, pre-truncation tail.
- Fixed by threading an `onHistoryTruncated` callback through `IConversationOrchestrator`, invoked by `ConversationOrchestrator` immediately after truncation and before dispatch.

## Hardening found across 6 review rounds (`run-gates.sh`: grader/correctness/security, each run to completion)
- **Catch-clause ordering bug**: the new post-truncation `Error`-frame guard sat below the pre-existing typed catch for `InvalidOperationException`/`UnauthorizedAccessException` — exactly the types the orchestrator actually throws (a stolen turn lease, `ConversationAccessDeniedException`) — so it never ran for the failures it existed to catch. Fixed and mutation-tested (reverted the ordering, confirmed the regression test goes red, restored).
- **`EditAndResubmitAsync` reordered** to append the edited message before signaling truncation, so a store failure can't leave the client showing an edit the server never persisted.
- **Failed notifications are now best-effort**: a transport failure delivering the truncation notice no longer aborts a turn whose underlying mutation already committed durably.
- **Duplicated notify-then-map logic** extracted into `NotifyPostTruncationFailureAndMapAsync`, used by both hub methods.
- **Real information-disclosure gap closed**: the retry-failure passthrough checked `ex.Message.Contains("retry")` — any `InvalidOperationException` merely containing that substring (e.g. from EF Core) would have been echoed to the client verbatim. Tightened to an exact match against a named constant (`ConversationRetryNotice`).
- **Cancellation-filter test coverage**: added dedicated tests for both branches (a cancellation matching the turn's own token propagates as a real disconnect; one from an unrelated token is swallowed), mutation-tested.
- `StreamFrameRecorder`'s lock-ordering bug fixed (timestamp was sampled outside the lock, could produce spurious non-decreasing-elapsed failures under concurrency).

## Test plan
- [x] `dotnet build src/AgenticHarness.slnx` clean, 0 warnings
- [x] `dotnet test src/Content/Tests/Presentation.AgentHub.Tests/Presentation.AgentHub.Tests.csproj` — 481/481 passed
- [x] `mcp__gitnexus__detect_changes` — GitNexus flagged "critical" risk via line-drift false positives on untouched methods (`ValidateAccessAsync`, `HandleDisconnectAsync`, `InvokeToolViaAgent`); independently verified zero actual diff on each via `git diff`
- [x] `/code-review` + `/simplify` + a dedicated `security-reviewer` pass — all findings fixed, receipts recorded
- [x] `scripts/rails/run-gates.sh` — build/test/owasp/grader/correctness/security all pass clean on the final commit

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj