### PR TITLE
Package F: artifact-grounded claim verification (#319)

### DIFF
--- a/documentation/onboarding/02-configuration.html
+++ b/documentation/onboarding/02-configuration.html
@@ -303,6 +303,7 @@
 │   ├── Resilience
 │   ├── DriftDetection
 │   ├── Learnings
+│   ├── ClaimVerification    <span class="ft-comment">// artifact-grounded claim verification (#319)</span>
 │   └── Governance           <span class="ft-comment">// tool-invocation gate + DataClassification DLP</span>
 ├── <span class="ft-dir">Azure</span>           <span class="ft-comment">// App Insights, SQL, B2C, Key Vault, Graph</span>
 ├── <span class="ft-dir">Cache</span>           <span class="ft-comment">// Memory | Redis</span>

--- a/prompts/claim-verifier/v1.md
+++ b/prompts/claim-verifier/v1.md
@@ -1,0 +1,27 @@
+---
+description: Checks whether one claim actually holds against evidence already read from the location it cites.
+owner: verification
+inputs: []
+---
+You are a claim-verification engine. You are given ONE claim — something an agent asserted about a
+specific location — and the evidence text already read from that exact location. Your job is to
+check the claim against this evidence, not to re-evaluate whether it was a good claim to raise, and
+not to go looking anywhere else.
+
+Determine whether the claim is true given the evidence you were given.
+
+Return a JSON object of the shape:
+{
+  "status": "held" | "broken" | "unverifiable",
+  "explanation": "..."
+}
+
+- "held": the evidence supports the claim as stated.
+- "broken": the evidence contradicts the claim — explain exactly what is inconsistent, quoting the
+  relevant text from the evidence.
+- "unverifiable": the evidence you were given does not contain enough information to judge the
+  claim either way. This is not the same as "broken" — do not guess, and do not assume something is
+  wrong just because the evidence does not fully address it.
+
+"explanation" is required in every case: for "held", briefly say what you confirmed; for "broken" or
+"unverifiable", explain the finding in enough detail for a reader to act on it.

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -515,26 +515,23 @@ public sealed class TrainSkillCommandHandler
         var accepted = new List<HarnessChangeSuggestion>(proposed.Count);
         foreach (var suggestion in proposed)
         {
-            var surfaced = await ValidateAndAuditSuggestionAsync(
-                suggestion, request.SkillId, finalStep, cancellationToken).ConfigureAwait(false);
+            var surfaced = ValidateAndAuditSuggestion(suggestion, request.SkillId, finalStep);
             if (surfaced is not null)
             {
                 accepted.Add(surfaced);
             }
         }
 
-        return accepted;
+        return await AnnotateWithClaimVerificationAsync(accepted, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
     /// Validates one suggestion against the config-surface constraint and audits the outcome. Returns the
-    /// suggestion to surface — with its value replaced by the scrubbed canonical form and, when the claimed
-    /// <see cref="HarnessChangeSuggestion.CurrentValue"/> could not be confirmed against live config,
-    /// annotated in <see cref="HarnessChangeSuggestion.Rationale"/> — when allowed, or
+    /// suggestion to surface — with its value replaced by the scrubbed canonical form — when allowed, or
     /// <see langword="null"/> when rejected.
     /// </summary>
-    private async Task<HarnessChangeSuggestion?> ValidateAndAuditSuggestionAsync(
-        HarnessChangeSuggestion suggestion, string skillId, int finalStep, CancellationToken cancellationToken)
+    private HarnessChangeSuggestion? ValidateAndAuditSuggestion(
+        HarnessChangeSuggestion suggestion, string skillId, int finalStep)
     {
         var validation = _suggestionValidator.Validate(suggestion);
         if (validation.IsAllowed)
@@ -547,8 +544,7 @@ public sealed class TrainSkillCommandHandler
             SafeAudit(skillId, "skill_training.harness_change_suggested",
                 $"suggest: {suggestion.Surface}.{suggestion.Field}={validation.NormalizedValue}", finalStep);
             // Surface the canonical value too, so consumers of the run result never see raw proposer text.
-            var accepted = suggestion with { ProposedValue = validation.NormalizedValue ?? suggestion.ProposedValue };
-            return await AnnotateWithClaimVerificationAsync(accepted, cancellationToken).ConfigureAwait(false);
+            return suggestion with { ProposedValue = validation.NormalizedValue ?? suggestion.ProposedValue };
         }
 
         // Audit rejections too (audit-everything guardrail). The raw, unvalidated proposer Field and value
@@ -563,45 +559,44 @@ public sealed class TrainSkillCommandHandler
     }
 
     /// <summary>
-    /// Checks the accepted suggestion's claimed <see cref="HarnessChangeSuggestion.CurrentValue"/>
-    /// against the live config it names (#319's first consumer). A claim that survives verification
-    /// (held, or genuinely unverifiable/erroring — fail-safe) surfaces the suggestion unchanged; a
-    /// claim the artifact contradicts is never dropped, only annotated — the same "revise, don't
-    /// delete" rule <see cref="ClaimVerdict"/>'s factories apply to the claim itself, extended here
-    /// to the suggestion it backs. Never throws: a faulty or unconfigured verifier must not fail an
-    /// already-completed run, matching <see cref="EmitHarnessChangeSuggestionsAsync"/>'s own
-    /// tolerance for a faulty suggester.
+    /// Checks every accepted suggestion's claimed <see cref="HarnessChangeSuggestion.CurrentValue"/>
+    /// against the live config it names (#319's first consumer), in a single batched
+    /// <see cref="ClaimVerificationRunner.RunAsync"/> call rather than one round-trip per suggestion
+    /// — the runner already dispatches its whole input concurrently, bounded by
+    /// <c>ClaimVerificationConfig.MaxParallelVerifiers</c>, so verifying suggestions one at a time
+    /// would pay N sequential round-trips for work it is built to parallelize. A claim that survives
+    /// verification (held, or genuinely unverifiable/erroring — fail-safe) surfaces its suggestion
+    /// unchanged; a claim the artifact contradicts is never dropped, only annotated — the same
+    /// "revise, don't delete" rule <see cref="ClaimVerdict"/>'s factories apply to the claim itself,
+    /// extended here to the suggestion it backs. Never throws: a faulty or unconfigured verifier
+    /// must not fail an already-completed run, matching <see cref="EmitHarnessChangeSuggestionsAsync"/>'s
+    /// own tolerance for a faulty suggester.
     /// </summary>
-    private async Task<HarnessChangeSuggestion> AnnotateWithClaimVerificationAsync(
-        HarnessChangeSuggestion suggestion, CancellationToken cancellationToken)
+    private async Task<IReadOnlyList<HarnessChangeSuggestion>> AnnotateWithClaimVerificationAsync(
+        IReadOnlyList<HarnessChangeSuggestion> suggestions, CancellationToken cancellationToken)
     {
-        var configPath = _configSurfaceConstraint.ResolveConfigPath(suggestion.Surface, suggestion.Field);
-        if (configPath is null)
+        // Positional, not suggestion-keyed: HarnessChangeSuggestion is a record with no identity
+        // field, so two accepted suggestions could compare equal — index correlation is the only
+        // reliable way to zip a verdict back to the suggestion that produced its claim.
+        var claims = new Claim?[suggestions.Count];
+        for (var i = 0; i < suggestions.Count; i++)
         {
-            // ConfigSurfaceConstraint governs this surface/field (validation above already confirmed
-            // that) but has no known live-config path for it. Nothing to verify against.
-            return suggestion;
+            var configPath = _configSurfaceConstraint.ResolveConfigPath(suggestions[i].Surface, suggestions[i].Field);
+            // ConfigSurfaceConstraint governs this surface/field (validation already confirmed that)
+            // but may have no known live-config path for it. Nothing to verify against.
+            claims[i] = configPath is null ? null : BuildCurrentValueClaim(suggestions[i], configPath);
         }
 
-        var claim = new Claim
+        var toVerify = claims.Where(c => c is not null).Select(c => c!).ToList();
+        if (toVerify.Count == 0)
         {
-            Text = $"The current value of {suggestion.Surface}.{suggestion.Field} is {suggestion.CurrentValue}.",
-            Location = $"config:{configPath}",
-            ConsequenceSignals = new ClaimConsequenceSignals
-            {
-                CausesWrite = false,
-                // The suggestion is never applied automatically, but a human's accept/reject
-                // decision on it depends on trusting CurrentValue — that dependency is what
-                // "gates a decision" means here.
-                GatesADecision = true
-            }
-        };
+            return suggestions;
+        }
 
-        ClaimVerdict verdict;
+        IReadOnlyList<ClaimVerdict> verdicts;
         try
         {
-            var verdicts = await _claimVerificationRunner.RunAsync([claim], cancellationToken).ConfigureAwait(false);
-            verdict = verdicts[0];
+            verdicts = await _claimVerificationRunner.RunAsync(toVerify, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -610,10 +605,38 @@ public sealed class TrainSkillCommandHandler
         catch (Exception ex)
         {
             _logger.LogError(ex,
-                "Claim verification threw while checking a harness-change suggestion's current value; surfacing the suggestion unannotated.");
-            return suggestion;
+                "Claim verification threw while checking harness-change suggestions' current values; surfacing all suggestions unannotated.");
+            return suggestions;
         }
 
+        var result = new List<HarnessChangeSuggestion>(suggestions.Count);
+        var verdictIndex = 0;
+        for (var i = 0; i < suggestions.Count; i++)
+        {
+            result.Add(claims[i] is null
+                ? suggestions[i]
+                : AnnotateIfContradicted(suggestions[i], verdicts[verdictIndex++]));
+        }
+
+        return result;
+    }
+
+    private static Claim BuildCurrentValueClaim(HarnessChangeSuggestion suggestion, string configPath) => new()
+    {
+        Text = $"The current value of {suggestion.Surface}.{suggestion.Field} is {suggestion.CurrentValue}.",
+        Location = $"config:{configPath}",
+        ConsequenceSignals = new ClaimConsequenceSignals
+        {
+            CausesWrite = false,
+            // The suggestion is never applied automatically, but a human's accept/reject decision
+            // on it depends on trusting CurrentValue — that dependency is what "gates a decision"
+            // means here.
+            GatesADecision = true
+        }
+    };
+
+    private HarnessChangeSuggestion AnnotateIfContradicted(HarnessChangeSuggestion suggestion, ClaimVerdict verdict)
+    {
         if (verdict.Outcome is not (ClaimVerificationOutcome.Broken or ClaimVerificationOutcome.LocationNotFound))
         {
             return suggestion;
@@ -622,9 +645,13 @@ public sealed class TrainSkillCommandHandler
         _logger.LogWarning(
             "Harness-change suggestion's claimed current value could not be confirmed against live config ({Outcome}): {Explanation}",
             verdict.Outcome, verdict.Explanation);
+        // RevisedClaim.Confidence carries the same floor ClaimVerdict.Broken/LocationNotFound apply
+        // to the claim itself — surfaced here rather than discarded, so a reader of the annotation
+        // sees the same signal the claim-verification subsystem recorded, not a re-derived summary.
         return suggestion with
         {
-            Rationale = $"[UNVERIFIED CURRENT VALUE — {verdict.Outcome}: {verdict.Explanation}] {suggestion.Rationale}"
+            Rationale = $"[UNVERIFIED CURRENT VALUE ({verdict.RevisedClaim.Confidence:F1} confidence) — " +
+                $"{verdict.Outcome}: {verdict.Explanation}] {suggestion.Rationale}"
         };
     }
 

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -613,7 +613,11 @@ public sealed class TrainSkillCommandHandler
         var verdictIndex = 0;
         for (var i = 0; i < suggestions.Count; i++)
         {
-            result.Add(claims[i] is null
+            // verdicts can be SHORTER than toVerify — ClaimVerificationRunner.MaxClaims caps the
+            // batch and produces no verdict at all for a claim beyond it (logged there, not an
+            // error here). Any claim run out of verdicts is left unannotated, exactly like a claim
+            // this loop never built in the first place.
+            result.Add(claims[i] is null || verdictIndex >= verdicts.Count
                 ? suggestions[i]
                 : AnnotateIfContradicted(suggestions[i], verdicts[verdictIndex++]));
         }
@@ -624,7 +628,7 @@ public sealed class TrainSkillCommandHandler
     private static Claim BuildCurrentValueClaim(HarnessChangeSuggestion suggestion, string configPath) => new()
     {
         Text = $"The current value of {suggestion.Surface}.{suggestion.Field} is {suggestion.CurrentValue}.",
-        Location = $"config:{configPath}",
+        Location = $"{ClaimLocationScheme.Config}:{configPath}",
         ConsequenceSignals = new ClaimConsequenceSignals
         {
             CausesWrite = false,

--- a/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
+++ b/src/Content/Application/Application.AI.Common/CQRS/SkillTraining/TrainSkill/TrainSkillCommandHandler.cs
@@ -2,8 +2,10 @@ using System.Security.Cryptography;
 using System.Text;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.SkillTraining;
+using Application.AI.Common.Services.ClaimVerification;
 using Application.AI.Common.Services.SkillTraining;
 using Application.AI.Common.Services.SkillTraining.Schedulers;
+using Domain.AI.ClaimVerification;
 using Domain.AI.SkillTraining;
 using Domain.Common;
 using MediatR;
@@ -41,6 +43,8 @@ public sealed class TrainSkillCommandHandler
     private readonly HarnessPatchValidator _fence;
     private readonly IHarnessChangeSuggester _suggester;
     private readonly HarnessChangeSuggestionValidator _suggestionValidator;
+    private readonly ConfigSurfaceConstraint _configSurfaceConstraint;
+    private readonly ClaimVerificationRunner _claimVerificationRunner;
     private readonly ISkillTrainingCheckpointStore _checkpointStore;
     private readonly IMediator _mediator;
     private readonly TimeProvider _time;
@@ -65,6 +69,8 @@ public sealed class TrainSkillCommandHandler
         HarnessPatchValidator fence,
         IHarnessChangeSuggester suggester,
         HarnessChangeSuggestionValidator suggestionValidator,
+        ConfigSurfaceConstraint configSurfaceConstraint,
+        ClaimVerificationRunner claimVerificationRunner,
         ISkillTrainingCheckpointStore checkpointStore,
         IMediator mediator,
         TimeProvider time,
@@ -80,6 +86,8 @@ public sealed class TrainSkillCommandHandler
         ArgumentNullException.ThrowIfNull(fence);
         ArgumentNullException.ThrowIfNull(suggester);
         ArgumentNullException.ThrowIfNull(suggestionValidator);
+        ArgumentNullException.ThrowIfNull(configSurfaceConstraint);
+        ArgumentNullException.ThrowIfNull(claimVerificationRunner);
         ArgumentNullException.ThrowIfNull(checkpointStore);
         ArgumentNullException.ThrowIfNull(mediator);
         ArgumentNullException.ThrowIfNull(time);
@@ -94,6 +102,8 @@ public sealed class TrainSkillCommandHandler
         _fence = fence;
         _suggester = suggester;
         _suggestionValidator = suggestionValidator;
+        _configSurfaceConstraint = configSurfaceConstraint;
+        _claimVerificationRunner = claimVerificationRunner;
         _checkpointStore = checkpointStore;
         _mediator = mediator;
         _time = time;
@@ -505,7 +515,8 @@ public sealed class TrainSkillCommandHandler
         var accepted = new List<HarnessChangeSuggestion>(proposed.Count);
         foreach (var suggestion in proposed)
         {
-            var surfaced = ValidateAndAuditSuggestion(suggestion, request.SkillId, finalStep);
+            var surfaced = await ValidateAndAuditSuggestionAsync(
+                suggestion, request.SkillId, finalStep, cancellationToken).ConfigureAwait(false);
             if (surfaced is not null)
             {
                 accepted.Add(surfaced);
@@ -517,11 +528,13 @@ public sealed class TrainSkillCommandHandler
 
     /// <summary>
     /// Validates one suggestion against the config-surface constraint and audits the outcome. Returns the
-    /// suggestion to surface — with its value replaced by the scrubbed canonical form — when allowed, or
+    /// suggestion to surface — with its value replaced by the scrubbed canonical form and, when the claimed
+    /// <see cref="HarnessChangeSuggestion.CurrentValue"/> could not be confirmed against live config,
+    /// annotated in <see cref="HarnessChangeSuggestion.Rationale"/> — when allowed, or
     /// <see langword="null"/> when rejected.
     /// </summary>
-    private HarnessChangeSuggestion? ValidateAndAuditSuggestion(
-        HarnessChangeSuggestion suggestion, string skillId, int finalStep)
+    private async Task<HarnessChangeSuggestion?> ValidateAndAuditSuggestionAsync(
+        HarnessChangeSuggestion suggestion, string skillId, int finalStep, CancellationToken cancellationToken)
     {
         var validation = _suggestionValidator.Validate(suggestion);
         if (validation.IsAllowed)
@@ -534,7 +547,8 @@ public sealed class TrainSkillCommandHandler
             SafeAudit(skillId, "skill_training.harness_change_suggested",
                 $"suggest: {suggestion.Surface}.{suggestion.Field}={validation.NormalizedValue}", finalStep);
             // Surface the canonical value too, so consumers of the run result never see raw proposer text.
-            return suggestion with { ProposedValue = validation.NormalizedValue ?? suggestion.ProposedValue };
+            var accepted = suggestion with { ProposedValue = validation.NormalizedValue ?? suggestion.ProposedValue };
+            return await AnnotateWithClaimVerificationAsync(accepted, cancellationToken).ConfigureAwait(false);
         }
 
         // Audit rejections too (audit-everything guardrail). The raw, unvalidated proposer Field and value
@@ -546,6 +560,72 @@ public sealed class TrainSkillCommandHandler
         SafeAudit(skillId, "skill_training.harness_change_rejected",
             $"deny: {suggestion.Surface} reason {validation.RejectionReason}", finalStep);
         return null;
+    }
+
+    /// <summary>
+    /// Checks the accepted suggestion's claimed <see cref="HarnessChangeSuggestion.CurrentValue"/>
+    /// against the live config it names (#319's first consumer). A claim that survives verification
+    /// (held, or genuinely unverifiable/erroring — fail-safe) surfaces the suggestion unchanged; a
+    /// claim the artifact contradicts is never dropped, only annotated — the same "revise, don't
+    /// delete" rule <see cref="ClaimVerdict"/>'s factories apply to the claim itself, extended here
+    /// to the suggestion it backs. Never throws: a faulty or unconfigured verifier must not fail an
+    /// already-completed run, matching <see cref="EmitHarnessChangeSuggestionsAsync"/>'s own
+    /// tolerance for a faulty suggester.
+    /// </summary>
+    private async Task<HarnessChangeSuggestion> AnnotateWithClaimVerificationAsync(
+        HarnessChangeSuggestion suggestion, CancellationToken cancellationToken)
+    {
+        var configPath = _configSurfaceConstraint.ResolveConfigPath(suggestion.Surface, suggestion.Field);
+        if (configPath is null)
+        {
+            // ConfigSurfaceConstraint governs this surface/field (validation above already confirmed
+            // that) but has no known live-config path for it. Nothing to verify against.
+            return suggestion;
+        }
+
+        var claim = new Claim
+        {
+            Text = $"The current value of {suggestion.Surface}.{suggestion.Field} is {suggestion.CurrentValue}.",
+            Location = $"config:{configPath}",
+            ConsequenceSignals = new ClaimConsequenceSignals
+            {
+                CausesWrite = false,
+                // The suggestion is never applied automatically, but a human's accept/reject
+                // decision on it depends on trusting CurrentValue — that dependency is what
+                // "gates a decision" means here.
+                GatesADecision = true
+            }
+        };
+
+        ClaimVerdict verdict;
+        try
+        {
+            var verdicts = await _claimVerificationRunner.RunAsync([claim], cancellationToken).ConfigureAwait(false);
+            verdict = verdicts[0];
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Claim verification threw while checking a harness-change suggestion's current value; surfacing the suggestion unannotated.");
+            return suggestion;
+        }
+
+        if (verdict.Outcome is not (ClaimVerificationOutcome.Broken or ClaimVerificationOutcome.LocationNotFound))
+        {
+            return suggestion;
+        }
+
+        _logger.LogWarning(
+            "Harness-change suggestion's claimed current value could not be confirmed against live config ({Outcome}): {Explanation}",
+            verdict.Outcome, verdict.Explanation);
+        return suggestion with
+        {
+            Rationale = $"[UNVERIFIED CURRENT VALUE — {verdict.Outcome}: {verdict.Explanation}] {suggestion.Rationale}"
+        };
     }
 
     private ILrScheduler ResolveScheduler(string key) => key.ToLowerInvariant() switch

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -278,6 +278,11 @@ public static class DependencyInjection
         // Skill-training subsystem (PatchApplier, GateEvaluator, schedulers, checkpoint store, ...)
         services.AddSkillTrainingDependencies();
 
+        // Artifact-grounded claim verification (#319) — core, judge-independent components with a
+        // fail-safe default verifier. See ClaimVerificationDependencyInjection's remarks for why this
+        // is registered unconditionally rather than gated behind the eval-only extension.
+        services.AddClaimVerificationDependencies();
+
         // Harmonic memory representation seams (Memora port) — fail-fast NotConfigured defaults, inert
         // until AppConfig:AI:HarmonicMemory:Mode is raised above Off.
         services.AddHarmonicMemoryDependencies();

--- a/src/Content/Application/Application.AI.Common/Extensions/ClaimVerificationDependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/Extensions/ClaimVerificationDependencyInjection.cs
@@ -1,0 +1,52 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Application.AI.Common.Services.ClaimVerification;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Application.AI.Common.Extensions;
+
+/// <summary>
+/// Registers the artifact-grounded claim-verification subsystem's core, judge-independent
+/// components into DI. Composition root (Presentation) calls this from
+/// <c>AddApplicationAIDependencies</c>; every host gets a resolvable
+/// <see cref="ClaimVerificationRunner"/> regardless of whether it has opted into real LLM-backed
+/// verification.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Default-registered services:
+/// <list type="bullet">
+/// <item><see cref="IClaimConsequenceClassifier"/> → <see cref="RuleBasedClaimConsequenceClassifier"/>.</item>
+/// <item><see cref="IClaimVerifier"/> → <see cref="NotConfiguredClaimVerifier"/> (fail-safe default,
+/// not fail-fast — see that type's remarks for why this subsystem departs from the sibling
+/// <c>NotConfiguredRolloutRunner</c>/<c>NotConfiguredPatchProposer</c> throw-on-use shape).</item>
+/// <item><see cref="ClaimVerificationRunner"/> — concrete orchestrator, no interface seam.</item>
+/// </list>
+/// </para>
+/// <para>
+/// A host that wants real verification calls
+/// <c>Infrastructure.AI.Evaluation.DependencyInjectionClaimVerification.AddClaimVerification</c>
+/// AFTER this method — it registers <see cref="IClaimVerifier"/> via a plain <c>AddSingleton</c>,
+/// which wins over this method's <c>TryAddSingleton</c> default by last-registration-wins, the same
+/// mechanism <c>NotConfiguredEvalRunner</c>'s own remarks document for <c>IEvalRunner</c>. The two
+/// <c>ILocatedArtifactReader</c> implementations are registered unconditionally in
+/// <c>Infrastructure.AI</c> — they depend only on <c>IFileSystemService</c>/<c>IOptionsMonitor&lt;AppConfig&gt;</c>,
+/// never on a judge model, so gating them behind the eval-only extension would be scope creep.
+/// </para>
+/// </remarks>
+public static class ClaimVerificationDependencyInjection
+{
+    /// <summary>Registers the claim-verification subsystem's core services.</summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddClaimVerificationDependencies(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<IClaimConsequenceClassifier, RuleBasedClaimConsequenceClassifier>();
+        services.TryAddSingleton<IClaimVerifier, NotConfiguredClaimVerifier>();
+        services.TryAddSingleton<ClaimVerificationRunner>();
+
+        return services;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Changes/PolicyFinding.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Changes/PolicyFinding.cs
@@ -41,4 +41,24 @@ public sealed record PolicyFinding
     /// fix to the originating agent.
     /// </summary>
     public string? Remediation { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, this finding blocks the gate regardless of
+    /// <see cref="Severity"/> or the configured threshold. Defaults to <see langword="false"/>, so
+    /// every existing policy is unaffected by this field's mere existence. A policy sets this only
+    /// for a finding it has independently confirmed, not merely suspected — see
+    /// <see cref="RequiresVerification"/> for the complementary case.
+    /// </summary>
+    public bool Blocking { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/>, this finding's own <see cref="Severity"/> is not trusted to
+    /// block the gate on its own — the severity was assigned by a model, not confirmed against the
+    /// artifact the finding is about. <c>PolicyGate</c> excludes such a finding from its severity
+    /// comparison entirely (it neither blocks nor "passes below threshold"; it is simply not counted
+    /// toward the gate decision) unless a verifier has independently confirmed it and the policy
+    /// re-emits it with <see cref="Blocking"/> set instead. Defaults to <see langword="false"/>, so
+    /// every existing policy's findings gate exactly as they always have.
+    /// </summary>
+    public bool RequiresVerification { get; init; }
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Changes/PolicyFindingSeverity.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Changes/PolicyFindingSeverity.cs
@@ -25,6 +25,12 @@ public enum PolicyFindingSeverity
     /// <summary>Material concern. Default threshold treats High as blocking.</summary>
     High = 3,
 
-    /// <summary>Severe finding. Always blocking regardless of threshold configuration.</summary>
+    /// <summary>
+    /// Severe finding. Blocking regardless of threshold configuration — UNLESS the finding also sets
+    /// <see cref="PolicyFinding.RequiresVerification"/>, in which case a model assigned this severity
+    /// to an unconfirmed finding and <c>PolicyGate</c> deliberately does not trust it to block on its
+    /// own (see that field's remarks). A policy that has independently confirmed a Critical finding
+    /// sets <see cref="PolicyFinding.Blocking"/> instead, which always wins.
+    /// </summary>
     Critical = 4
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/ClaimVerification/IClaimConsequenceClassifier.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/ClaimVerification/IClaimConsequenceClassifier.cs
@@ -1,0 +1,14 @@
+using Domain.AI.ClaimVerification;
+
+namespace Application.AI.Common.Interfaces.ClaimVerification;
+
+/// <summary>
+/// Decides whether a claim is worth the cost of verification, from code-owned structural signals
+/// only — never from the claim's own text. See <see cref="ClaimConsequenceSignals"/>'s remarks for
+/// why the model that asserted the claim must never be the one labeling its consequence.
+/// </summary>
+public interface IClaimConsequenceClassifier
+{
+    /// <summary>Classifies <paramref name="signals"/> as <see cref="ClaimConsequence.Low"/> or <see cref="ClaimConsequence.High"/>.</summary>
+    ClaimConsequence Classify(ClaimConsequenceSignals signals);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/ClaimVerification/IClaimVerifier.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/ClaimVerification/IClaimVerifier.cs
@@ -1,0 +1,28 @@
+using Domain.AI.ClaimVerification;
+
+namespace Application.AI.Common.Interfaces.ClaimVerification;
+
+/// <summary>
+/// Compares one <see cref="Claim"/> against evidence already fetched from the location it cites,
+/// and returns a <see cref="ClaimVerdict"/>. A conforming implementation judges the claim against
+/// the evidence text as given — it does not know or care which <c>ILocatedArtifactReader</c> scheme
+/// produced it.
+/// </summary>
+/// <remarks>
+/// Implementations are dispatched one claim at a time by <c>ClaimVerificationRunner</c>, which owns
+/// consequence classification, reader resolution/dispatch, the per-verifier timeout, and converting
+/// any exception this method throws into <see cref="ClaimVerdict.VerifierError"/> — an
+/// implementation does not need to catch its own failures for that reason, only for cases where it
+/// can produce a more specific <see cref="ClaimVerificationOutcome.Unverifiable"/> reason than a
+/// generic error would. An implementation that returns a soft-fail result from its own model call
+/// (rather than throwing) must still map that to <see cref="ClaimVerdict.VerifierError"/> itself —
+/// the runner's catch only sees exceptions.
+/// </remarks>
+public interface IClaimVerifier
+{
+    /// <summary>
+    /// Checks <paramref name="claim"/> against <paramref name="evidenceContent"/> — the text already
+    /// read from <see cref="Claim.Location"/>, untrusted — and returns the resulting verdict.
+    /// </summary>
+    Task<ClaimVerdict> VerifyAsync(Claim claim, string evidenceContent, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/ClaimVerification/ILocatedArtifactReader.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/ClaimVerification/ILocatedArtifactReader.cs
@@ -1,0 +1,35 @@
+namespace Application.AI.Common.Interfaces.ClaimVerification;
+
+/// <summary>
+/// Resolves one <see cref="Domain.AI.ClaimVerification.Claim.Location"/> scheme to its evidence
+/// content — the ground truth a claim is checked against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Registered keyed by scheme (the substring of a location before its first <c>':'</c> — e.g.
+/// <c>"file"</c>, <c>"config"</c>) via <c>AddKeyedSingleton&lt;ILocatedArtifactReader&gt;("file", ...)</c>.
+/// <c>ClaimVerificationRunner</c> resolves the reader for a claim's scheme before ever calling
+/// <see cref="TryReadAsync"/>; no reader registered for a scheme is a dispatch-level "unregistered
+/// scheme" outcome the runner handles itself, not something an implementation needs to signal.
+/// </para>
+/// <para>
+/// The critical semantic once a reader IS resolved: a <see langword="null"/> return means this
+/// reader — already established as authoritative for the location's scheme — positively could not
+/// resolve <em>this specific</em> location (file not found, config field not found). That is not
+/// the same as "the claim is false," but it IS a real, reportable finding (the runner maps it to
+/// <c>ClaimVerdict.LocationNotFound</c>, never to fail-safe silence) — the one place a naive reader
+/// gets the fail-safe rule backwards. Only ever return content, or <see langword="null"/>; never
+/// throw for "not found" — an implementation should let a genuine infrastructure failure (I/O error,
+/// permission failure unrelated to sandboxing) propagate as an exception instead, which the runner
+/// converts to <c>ClaimVerdict.VerifierError</c>.
+/// </para>
+/// </remarks>
+public interface ILocatedArtifactReader
+{
+    /// <summary>
+    /// Reads the evidence content at <paramref name="location"/>, or returns <see langword="null"/>
+    /// if this reader cannot resolve that specific location — see this type's remarks for what that
+    /// means to the caller.
+    /// </summary>
+    Task<string?> TryReadAsync(string location, CancellationToken cancellationToken);
+}

--- a/src/Content/Application/Application.AI.Common/Services/ClaimVerification/ClaimVerificationRunner.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ClaimVerification/ClaimVerificationRunner.cs
@@ -75,8 +75,12 @@ public sealed class ClaimVerificationRunner
     }
 
     /// <summary>
-    /// Verifies every claim in <paramref name="claims"/> concurrently, bounded by
-    /// <see cref="ClaimVerificationConfig.MaxParallelVerifiers"/>. A low-consequence claim (per
+    /// Verifies every claim in <paramref name="claims"/> (up to
+    /// <see cref="ClaimVerificationConfig.MaxClaims"/>) concurrently, bounded by
+    /// <see cref="ClaimVerificationConfig.MaxParallelVerifiers"/>. A claim beyond the cap produces no
+    /// verdict at all — it is not dispatched, and does not appear in the returned list, so a caller
+    /// that needs 1:1 correspondence with its input must treat a shorter result as "the trailing
+    /// claims were never checked," not as an error. A low-consequence claim (per
     /// <see cref="IClaimConsequenceClassifier"/>) is reported <see cref="ClaimVerificationOutcome.NotConsequential"/>
     /// without invoking any reader or verifier. Never throws for a per-claim failure — every
     /// exception a reader or verifier can raise, including a per-verifier timeout, is converted to
@@ -87,33 +91,45 @@ public sealed class ClaimVerificationRunner
     {
         ArgumentNullException.ThrowIfNull(claims);
 
-        var (maxParallelVerifiers, perVerifierTimeout) = ResolveEffectiveConfig();
+        var (maxClaims, maxParallelVerifiers, perVerifierTimeout) = ResolveEffectiveConfig();
+
+        var bounded = claims.Count > maxClaims ? claims.Take(maxClaims).ToList() : claims;
+        if (bounded.Count < claims.Count)
+        {
+            _logger.LogWarning(
+                "Claim batch of {Total} exceeds MaxClaims {Max} — {Dropped} claim(s) were NOT verified.",
+                claims.Count, maxClaims, claims.Count - bounded.Count);
+        }
 
         using var gate = new SemaphoreSlim(maxParallelVerifiers);
-        var tasks = claims.Select(c => VerifyOneAsync(c, gate, perVerifierTimeout, cancellationToken));
+        var tasks = bounded.Select(c => VerifyOneAsync(c, gate, perVerifierTimeout, cancellationToken));
         return await Task.WhenAll(tasks).ConfigureAwait(false);
     }
 
-    private (int MaxParallelVerifiers, TimeSpan PerVerifierTimeout) ResolveEffectiveConfig()
+    private (int MaxClaims, int MaxParallelVerifiers, TimeSpan PerVerifierTimeout) ResolveEffectiveConfig()
     {
         var config = _config.CurrentValue.AI.ClaimVerification;
 
+        var maxClaims = config.MaxClaims > 0 ? config.MaxClaims : Defaults.MaxClaims;
         var maxParallelVerifiers = config.MaxParallelVerifiers > 0 ? config.MaxParallelVerifiers : Defaults.MaxParallelVerifiers;
         var perVerifierTimeout = config.PerVerifierTimeout > TimeSpan.Zero
             ? config.PerVerifierTimeout
             : Defaults.PerVerifierTimeout;
 
-        if (maxParallelVerifiers != config.MaxParallelVerifiers || perVerifierTimeout != config.PerVerifierTimeout)
+        if (maxClaims != config.MaxClaims
+            || maxParallelVerifiers != config.MaxParallelVerifiers
+            || perVerifierTimeout != config.PerVerifierTimeout)
         {
             _logger.LogWarning(
-                "ClaimVerificationConfig has an invalid MaxParallelVerifiers ({MaxParallelVerifiers}) or " +
-                "PerVerifierTimeout ({PerVerifierTimeout}) — a hot-reloaded value bypassing startup " +
-                "validation. Falling back to {ClampedMaxParallelVerifiers}/{ClampedPerVerifierTimeout}.",
-                config.MaxParallelVerifiers, config.PerVerifierTimeout,
-                maxParallelVerifiers, perVerifierTimeout);
+                "ClaimVerificationConfig has an invalid MaxClaims ({MaxClaims}), MaxParallelVerifiers " +
+                "({MaxParallelVerifiers}), or PerVerifierTimeout ({PerVerifierTimeout}) — a hot-reloaded " +
+                "value bypassing startup validation. Falling back to " +
+                "{ClampedMaxClaims}/{ClampedMaxParallelVerifiers}/{ClampedPerVerifierTimeout}.",
+                config.MaxClaims, config.MaxParallelVerifiers, config.PerVerifierTimeout,
+                maxClaims, maxParallelVerifiers, perVerifierTimeout);
         }
 
-        return (maxParallelVerifiers, perVerifierTimeout);
+        return (maxClaims, maxParallelVerifiers, perVerifierTimeout);
     }
 
     private async Task<ClaimVerdict> VerifyOneAsync(

--- a/src/Content/Application/Application.AI.Common/Services/ClaimVerification/ClaimVerificationRunner.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ClaimVerification/ClaimVerificationRunner.cs
@@ -1,0 +1,185 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Domain.AI.ClaimVerification;
+using Domain.Common.Config;
+using Domain.Common.Config.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Application.AI.Common.Services.ClaimVerification;
+
+/// <summary>
+/// Dispatches one <see cref="IClaimVerifier"/> call per high-consequence claim, resolving each
+/// claim's evidence via the <see cref="ILocatedArtifactReader"/> keyed to its location scheme.
+/// Bounded by <see cref="ClaimVerificationConfig.MaxParallelVerifiers"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Modeled on <c>ObligationVerificationRunner</c>'s flat fan-out (a <see cref="SemaphoreSlim"/>
+/// gate, <c>Select</c>, <c>WhenAll</c>, per-item try/catch inside the fan-out lambda so nothing
+/// reaches <c>WhenAll</c> unconverted) — the two runners solve the same shaped problem
+/// (independent, unbounded-cost verifications with no dependencies on each other) and share the
+/// same reasoning for rejecting a DAG scheduler. They are deliberately NOT the same type: an
+/// obligation's evidence is a slice of an already-fetched shared artifact; a claim's evidence must
+/// be independently resolved per claim, via whichever reader its own <see cref="Claim.Location"/>
+/// scheme selects — see <c>IClaimVerifier</c>'s remarks.
+/// </para>
+/// <para>
+/// Consequence classification happens here, not in <see cref="IClaimVerifier"/> or a reader — it is
+/// this runner's own gate on whether a reader or verifier is ever invoked at all, exactly as
+/// <c>ObligationValidator</c> is <c>ObligationVerificationRunner</c>'s own gate on whether a
+/// verifier is invoked.
+/// </para>
+/// <para>
+/// Registered unconditionally in every host (unlike <c>ObligationVerificationRunner</c>, which is
+/// gated behind the eval-only <c>AddObligationVerification()</c>): this type has no direct
+/// dependency on a judge model, only on the interfaces it is handed, and its first caller
+/// (<c>TrainSkillCommandHandler</c>) runs in every host, not just an eval host. A host that has not
+/// opted into real verification simply gets <c>NotConfiguredClaimVerifier</c>'s fail-safe
+/// <see cref="ClaimVerificationOutcome.Unverifiable"/> for every claim.
+/// </para>
+/// </remarks>
+public sealed class ClaimVerificationRunner
+{
+    private readonly IClaimConsequenceClassifier _classifier;
+    private readonly IClaimVerifier _verifier;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ClaimVerificationRunner> _logger;
+
+    // Derived from ClaimVerificationConfig's own property-initializer defaults rather than
+    // re-literaled here, for the same reason ObligationVerificationRunner.Defaults is — a
+    // hand-typed second copy would silently drift the next time someone changes the config type
+    // without remembering this fallback.
+    private static readonly ClaimVerificationConfig Defaults = new();
+
+    /// <summary>Initializes a new instance of the <see cref="ClaimVerificationRunner"/> class.</summary>
+    public ClaimVerificationRunner(
+        IClaimConsequenceClassifier classifier,
+        IClaimVerifier verifier,
+        IServiceProvider serviceProvider,
+        IOptionsMonitor<AppConfig> config,
+        ILogger<ClaimVerificationRunner> logger)
+    {
+        ArgumentNullException.ThrowIfNull(classifier);
+        ArgumentNullException.ThrowIfNull(verifier);
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _classifier = classifier;
+        _verifier = verifier;
+        _serviceProvider = serviceProvider;
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Verifies every claim in <paramref name="claims"/> concurrently, bounded by
+    /// <see cref="ClaimVerificationConfig.MaxParallelVerifiers"/>. A low-consequence claim (per
+    /// <see cref="IClaimConsequenceClassifier"/>) is reported <see cref="ClaimVerificationOutcome.NotConsequential"/>
+    /// without invoking any reader or verifier. Never throws for a per-claim failure — every
+    /// exception a reader or verifier can raise, including a per-verifier timeout, is converted to
+    /// <see cref="ClaimVerdict.VerifierError"/> inside the fan-out.
+    /// </summary>
+    public async Task<IReadOnlyList<ClaimVerdict>> RunAsync(
+        IReadOnlyList<Claim> claims, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(claims);
+
+        var (maxParallelVerifiers, perVerifierTimeout) = ResolveEffectiveConfig();
+
+        using var gate = new SemaphoreSlim(maxParallelVerifiers);
+        var tasks = claims.Select(c => VerifyOneAsync(c, gate, perVerifierTimeout, cancellationToken));
+        return await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    private (int MaxParallelVerifiers, TimeSpan PerVerifierTimeout) ResolveEffectiveConfig()
+    {
+        var config = _config.CurrentValue.AI.ClaimVerification;
+
+        var maxParallelVerifiers = config.MaxParallelVerifiers > 0 ? config.MaxParallelVerifiers : Defaults.MaxParallelVerifiers;
+        var perVerifierTimeout = config.PerVerifierTimeout > TimeSpan.Zero
+            ? config.PerVerifierTimeout
+            : Defaults.PerVerifierTimeout;
+
+        if (maxParallelVerifiers != config.MaxParallelVerifiers || perVerifierTimeout != config.PerVerifierTimeout)
+        {
+            _logger.LogWarning(
+                "ClaimVerificationConfig has an invalid MaxParallelVerifiers ({MaxParallelVerifiers}) or " +
+                "PerVerifierTimeout ({PerVerifierTimeout}) — a hot-reloaded value bypassing startup " +
+                "validation. Falling back to {ClampedMaxParallelVerifiers}/{ClampedPerVerifierTimeout}.",
+                config.MaxParallelVerifiers, config.PerVerifierTimeout,
+                maxParallelVerifiers, perVerifierTimeout);
+        }
+
+        return (maxParallelVerifiers, perVerifierTimeout);
+    }
+
+    private async Task<ClaimVerdict> VerifyOneAsync(
+        Claim claim, SemaphoreSlim gate, TimeSpan perVerifierTimeout, CancellationToken cancellationToken)
+    {
+        if (_classifier.Classify(claim.ConsequenceSignals) == ClaimConsequence.Low)
+        {
+            return ClaimVerdict.NotConsequential(claim);
+        }
+
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // Linked, not a bare WaitAsync race — see ObligationVerificationRunner.VerifyOneAsync's
+        // identical comment: passing timeoutCts.Token means a per-claim timeout actually cancels
+        // the in-flight reader/verifier call, not merely races it in the background.
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(perVerifierTimeout);
+        try
+        {
+            return await ResolveAndVerifyAsync(claim, timeoutCts.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !cancellationToken.IsCancellationRequested)
+        {
+            // Same filter reasoning as ObligationVerificationRunner.VerifyOneAsync: an
+            // OperationCanceledException reaching this catch can only be timeoutCts's own
+            // CancelAfter — the whole-run cancellation case is let through uncaught above.
+            var timedOut = ex is OperationCanceledException;
+            _logger.LogWarning(ex,
+                "Claim verification failed for the claim at '{Location}' — reporting VerifierError " +
+                "(fail-safe) rather than propagating.", claim.Location);
+            var reason = timedOut
+                ? $"Verification exceeded the {perVerifierTimeout} timeout."
+                : "Claim verification failed; see logs for details.";
+            return ClaimVerdict.VerifierError(claim, reason);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private async Task<ClaimVerdict> ResolveAndVerifyAsync(Claim claim, CancellationToken cancellationToken)
+    {
+        var scheme = ExtractScheme(claim.Location);
+        if (scheme is null)
+        {
+            return ClaimVerdict.Unverifiable(claim, $"Location '{claim.Location}' has no recognizable scheme.");
+        }
+
+        var reader = _serviceProvider.GetKeyedService<ILocatedArtifactReader>(scheme);
+        if (reader is null)
+        {
+            return ClaimVerdict.Unverifiable(claim, $"No reader is registered for location scheme '{scheme}'.");
+        }
+
+        var evidence = await reader.TryReadAsync(claim.Location, cancellationToken).ConfigureAwait(false);
+        if (evidence is null)
+        {
+            return ClaimVerdict.LocationNotFound(claim, $"Location '{claim.Location}' does not exist.");
+        }
+
+        return await _verifier.VerifyAsync(claim, evidence, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string? ExtractScheme(string location)
+    {
+        var separatorIndex = location.IndexOf(':');
+        return separatorIndex > 0 ? location[..separatorIndex] : null;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/ClaimVerification/NotConfiguredClaimVerifier.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ClaimVerification/NotConfiguredClaimVerifier.cs
@@ -1,0 +1,56 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Domain.AI.ClaimVerification;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.ClaimVerification;
+
+/// <summary>
+/// Default <see cref="IClaimVerifier"/> registered in every host: reports every claim as
+/// <see cref="ClaimVerificationOutcome.Unverifiable"/> rather than throwing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Deliberately NOT the fail-fast throw-on-use shape of this subsystem's siblings
+/// (<c>NotConfiguredRolloutRunner</c>, <c>NotConfiguredPatchProposer</c>): those gate a step
+/// skill-training cannot meaningfully proceed without, so silently doing nothing would be worse
+/// than a loud failure. Claim verification is additive quality assurance layered on an
+/// already-advisory, already-fail-soft caller (<c>TrainSkillCommandHandler.EmitHarnessChangeSuggestionsAsync</c>
+/// treats a faulty suggester the same way — logged, never fatal to the run) — so an unconfigured
+/// host should degrade to "we couldn't check this," which
+/// <see cref="ClaimVerificationOutcome.Unverifiable"/> already exists to express, not throw
+/// something the caller would only catch and downgrade to the identical outcome anyway.
+/// </para>
+/// <para>
+/// A host that wants real LLM-backed verification calls
+/// <c>Infrastructure.AI.Evaluation.DependencyInjectionClaimVerification.AddClaimVerification</c>,
+/// which registers the real implementation via a plain <c>AddSingleton</c> — last-registration-wins
+/// over this type's <c>TryAddSingleton</c> default, the same mechanism
+/// <c>NotConfiguredEvalRunner</c>'s own remarks document for <c>IEvalRunner</c>.
+/// </para>
+/// </remarks>
+public sealed class NotConfiguredClaimVerifier : IClaimVerifier
+{
+    private readonly ILogger<NotConfiguredClaimVerifier> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="NotConfiguredClaimVerifier"/> class.</summary>
+    public NotConfiguredClaimVerifier(ILogger<NotConfiguredClaimVerifier> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<ClaimVerdict> VerifyAsync(Claim claim, string evidenceContent, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        ArgumentNullException.ThrowIfNull(evidenceContent);
+
+        _logger.LogInformation(
+            "Claim verification is not configured in this host; reporting claim at '{Location}' as Unverifiable. " +
+            "Call AddClaimVerification() to wire the real LLM-backed verifier.",
+            claim.Location);
+
+        return Task.FromResult(ClaimVerdict.Unverifiable(
+            claim, "Claim verification is not configured in this host."));
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/ClaimVerification/RuleBasedClaimConsequenceClassifier.cs
+++ b/src/Content/Application/Application.AI.Common/Services/ClaimVerification/RuleBasedClaimConsequenceClassifier.cs
@@ -1,0 +1,23 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Domain.AI.ClaimVerification;
+
+namespace Application.AI.Common.Services.ClaimVerification;
+
+/// <summary>
+/// The default <see cref="IClaimConsequenceClassifier"/>: <see cref="ClaimConsequence.High"/> iff
+/// either structural signal is set, <see cref="ClaimConsequence.Low"/> otherwise. Deliberately this
+/// simple — see <see cref="ClaimConsequenceSignals"/>'s remarks for why the inputs, not the rule
+/// combining them, are where this component's integrity actually lives.
+/// </summary>
+public sealed class RuleBasedClaimConsequenceClassifier : IClaimConsequenceClassifier
+{
+    /// <inheritdoc />
+    public ClaimConsequence Classify(ClaimConsequenceSignals signals)
+    {
+        ArgumentNullException.ThrowIfNull(signals);
+
+        return signals.CausesWrite || signals.GatesADecision
+            ? ClaimConsequence.High
+            : ClaimConsequence.Low;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/SkillTraining/ConfigSurfaceConstraint.cs
+++ b/src/Content/Application/Application.AI.Common/Services/SkillTraining/ConfigSurfaceConstraint.cs
@@ -64,4 +64,30 @@ public sealed class ConfigSurfaceConstraint
         MaxAttemptsField => value >= MinMaxAttempts && value <= MaxMaxAttempts,
         _ => false
     };
+
+    // The dotted path, from AppConfig's own root, that MaxAttemptsField actually lives at
+    // (Domain.Common.Config.AI.Resilience.RetryConfig.MaxAttempts, nested AppConfig.AI.Resilience.Retry).
+    // Hand-typed here rather than derived from AllowedFields, matching that set's own comment: this
+    // constraint's job is a fixed, minimal, code-owned allowlist, not a general-purpose surface→path
+    // mapper. A second admitted field adds one more entry to this switch, not a new mechanism.
+    private static readonly IReadOnlyDictionary<string, string> ConfigPaths =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [MaxAttemptsField] = "AI.Resilience.Retry.MaxAttempts"
+        };
+
+    /// <summary>
+    /// Resolves the dotted path, from <c>AppConfig</c>'s own root, that a suggestion's
+    /// <paramref name="surface"/>/<paramref name="field"/> pair actually reads its live value from —
+    /// e.g. <c>"AI.Resilience.Retry.MaxAttempts"</c> for <see cref="HarnessSurface.ToolErrorRetryLimit"/>/<see cref="MaxAttemptsField"/>.
+    /// Used to build the <c>"config:"</c>-scheme <c>Claim.Location</c> a
+    /// <see cref="Domain.AI.SkillTraining.HarnessChangeSuggestion.CurrentValue"/> claim is checked
+    /// against (#319). Returns <see langword="null"/> for any surface/field this constraint does not
+    /// govern — callers must check <see cref="GovernsSurface"/>/<see cref="IsFieldAllowed"/> first,
+    /// exactly as <see cref="IsWithinBounds"/> already requires.
+    /// </summary>
+    /// <param name="surface">The suggestion's target surface.</param>
+    /// <param name="field">The suggestion's target field (must satisfy <see cref="IsFieldAllowed"/>).</param>
+    public string? ResolveConfigPath(HarnessSurface surface, string field) =>
+        GovernsSurface(surface) && ConfigPaths.TryGetValue(field, out var path) ? path : null;
 }

--- a/src/Content/Application/Application.Core/Validation/ClaimVerificationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ClaimVerificationConfigValidator.cs
@@ -4,8 +4,8 @@ using FluentValidation;
 namespace Application.Core.Validation;
 
 /// <summary>
-/// Validates <see cref="ClaimVerificationConfig"/>: the parallelism ceiling must be positive, and
-/// the per-verifier timeout must be a positive duration. Auto-discovered via
+/// Validates <see cref="ClaimVerificationConfig"/>: the claim and parallelism ceilings must be
+/// positive, and the per-verifier timeout must be a positive duration. Auto-discovered via
 /// <c>AddValidatorsFromAssembly</c>, consistent with the sibling config validators.
 /// </summary>
 public sealed class ClaimVerificationConfigValidator : AbstractValidator<ClaimVerificationConfig>
@@ -13,6 +13,9 @@ public sealed class ClaimVerificationConfigValidator : AbstractValidator<ClaimVe
     /// <summary>Initializes a new instance of the <see cref="ClaimVerificationConfigValidator"/> class.</summary>
     public ClaimVerificationConfigValidator()
     {
+        RuleFor(x => x.MaxClaims)
+            .GreaterThan(0).WithMessage("MaxClaims must be > 0.");
+
         RuleFor(x => x.MaxParallelVerifiers)
             .GreaterThan(0).WithMessage("MaxParallelVerifiers must be > 0.");
 

--- a/src/Content/Application/Application.Core/Validation/ClaimVerificationConfigValidator.cs
+++ b/src/Content/Application/Application.Core/Validation/ClaimVerificationConfigValidator.cs
@@ -1,0 +1,22 @@
+using Domain.Common.Config.AI;
+using FluentValidation;
+
+namespace Application.Core.Validation;
+
+/// <summary>
+/// Validates <see cref="ClaimVerificationConfig"/>: the parallelism ceiling must be positive, and
+/// the per-verifier timeout must be a positive duration. Auto-discovered via
+/// <c>AddValidatorsFromAssembly</c>, consistent with the sibling config validators.
+/// </summary>
+public sealed class ClaimVerificationConfigValidator : AbstractValidator<ClaimVerificationConfig>
+{
+    /// <summary>Initializes a new instance of the <see cref="ClaimVerificationConfigValidator"/> class.</summary>
+    public ClaimVerificationConfigValidator()
+    {
+        RuleFor(x => x.MaxParallelVerifiers)
+            .GreaterThan(0).WithMessage("MaxParallelVerifiers must be > 0.");
+
+        RuleFor(x => x.PerVerifierTimeout)
+            .GreaterThan(TimeSpan.Zero).WithMessage("PerVerifierTimeout must be a positive duration.");
+    }
+}

--- a/src/Content/Domain/Domain.AI/ClaimVerification/Claim.cs
+++ b/src/Content/Domain/Domain.AI/ClaimVerification/Claim.cs
@@ -1,0 +1,41 @@
+namespace Domain.AI.ClaimVerification;
+
+/// <summary>
+/// One falsifiable assertion an agent made about something outside its own context — "the handler
+/// at <c>Foo.cs:42</c> never disposes the connection," "the current value of
+/// <c>RetryConfig.MaxAttempts</c> is 3" — that can be checked against the thing it is about rather
+/// than trusted on the agent's own confidence.
+/// </summary>
+/// <remarks>
+/// Deliberately not a reuse of <see cref="Domain.AI.Verification.Obligation"/>: an obligation names
+/// two locations already known to sit inside the SAME already-fetched artifact text, while a claim's
+/// evidence has to be independently resolved (and may not exist at all) via <see cref="Location"/> —
+/// see <c>Application.AI.Common.Interfaces.ClaimVerification.ILocatedArtifactReader</c>.
+/// </remarks>
+public sealed record Claim
+{
+    /// <summary>The claim's own text — what is being asserted.</summary>
+    public required string Text { get; init; }
+
+    /// <summary>
+    /// Where to check the claim: a scheme-prefixed string (e.g. <c>"file:src/Foo.cs:42"</c>,
+    /// <c>"config:AI.Resilience.Retry.MaxAttempts"</c>). The substring before the first
+    /// <c>':'</c> selects which registered <c>ILocatedArtifactReader</c> resolves it.
+    /// </summary>
+    public required string Location { get; init; }
+
+    /// <summary>
+    /// How much the claim should be trusted, in <c>[0, 1]</c>. Starts at the asserting agent's own
+    /// confidence (default <c>1.0</c> when unstated) and is only ever revised downward by
+    /// verification — see <see cref="ClaimVerdict"/>'s factories. A failed claim is revised, never
+    /// deleted, so its history stays visible to whatever consumed it.
+    /// </summary>
+    public double Confidence { get; init; } = 1.0;
+
+    /// <summary>
+    /// Code-owned facts about what acting on this claim would do — never inferred from
+    /// <see cref="Text"/>, which the asserting model controls. Drives whether verification is
+    /// worth its cost; see <see cref="ClaimConsequence"/>.
+    /// </summary>
+    public required ClaimConsequenceSignals ConsequenceSignals { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/ClaimVerification/ClaimConsequence.cs
+++ b/src/Content/Domain/Domain.AI/ClaimVerification/ClaimConsequence.cs
@@ -1,0 +1,15 @@
+namespace Domain.AI.ClaimVerification;
+
+/// <summary>
+/// How much acting on an unverified <see cref="Claim"/> could cost if the claim turns out to be
+/// wrong. Assigned by code from <see cref="ClaimConsequenceSignals"/>, never by the model that
+/// asserted the claim — see that type's remarks for why.
+/// </summary>
+public enum ClaimConsequence
+{
+    /// <summary>Nothing durable depends on this claim being true. Not worth verification's cost.</summary>
+    Low,
+
+    /// <summary>A write or a gated decision depends on this claim being true. Worth verifying.</summary>
+    High
+}

--- a/src/Content/Domain/Domain.AI/ClaimVerification/ClaimConsequenceSignals.cs
+++ b/src/Content/Domain/Domain.AI/ClaimVerification/ClaimConsequenceSignals.cs
@@ -1,0 +1,29 @@
+namespace Domain.AI.ClaimVerification;
+
+/// <summary>
+/// Structural facts about what acting on a <see cref="Claim"/> would do, supplied by the code that
+/// constructs the claim — never inferred from the claim's own text.
+/// </summary>
+/// <remarks>
+/// If a model could label its own claims' consequence, it could opt itself out of verification by
+/// declaring everything low-consequence — the same incentive problem
+/// <c>Application.AI.Common.Evaluation.Judges.ViolatedClauseVerifier</c>'s remarks already name for
+/// a judge grading its own verdict. These two flags are answerable by the calling code with
+/// certainty (it knows whether its own call site writes anything, and whether its own gate blocks
+/// on this claim), which is exactly why they are the only inputs
+/// <c>IClaimConsequenceClassifier</c> accepts.
+/// </remarks>
+public sealed record ClaimConsequenceSignals
+{
+    /// <summary>
+    /// Whether acting on this claim (if true) would cause a write — to a file, to live
+    /// configuration, to any state outside the current call.
+    /// </summary>
+    public required bool CausesWrite { get; init; }
+
+    /// <summary>
+    /// Whether this claim's truth is what a decision — a blocking gate, or a human accepting an
+    /// audited proposal — actually turns on.
+    /// </summary>
+    public required bool GatesADecision { get; init; }
+}

--- a/src/Content/Domain/Domain.AI/ClaimVerification/ClaimLocationScheme.cs
+++ b/src/Content/Domain/Domain.AI/ClaimVerification/ClaimLocationScheme.cs
@@ -1,0 +1,25 @@
+namespace Domain.AI.ClaimVerification;
+
+/// <summary>
+/// The scheme names <see cref="Claim.Location"/> is built from and dispatched on — the single
+/// source of truth every claim-constructing caller and every keyed
+/// <c>ILocatedArtifactReader</c> registration shares, so the two can never drift apart the way two
+/// independently-retyped string literals could.
+/// </summary>
+/// <remarks>
+/// Mirrors this repo's own established idiom for a DI-key string a producer and a consumer must
+/// agree on byte-for-byte — <c>FileSystemTool.ToolName</c> and <c>WellKnownGateKeys.Policy</c> are
+/// both a type-owned constant referenced by symbol at every registration and construction site,
+/// never a bare literal retyped per call site. Lives in <c>Domain.AI</c> (not on either
+/// <c>ILocatedArtifactReader</c> implementation, which are Infrastructure-layer) specifically so an
+/// Application-layer claim-constructing caller — which cannot reference Infrastructure — can still
+/// build a correct <see cref="Claim.Location"/> without retyping the scheme name.
+/// </remarks>
+public static class ClaimLocationScheme
+{
+    /// <summary>The <c>"file"</c> scheme — a workspace-relative path, optionally with a trailing <c>:line</c>.</summary>
+    public const string File = "file";
+
+    /// <summary>The <c>"config"</c> scheme — a dotted path into the live <c>AppConfig</c> snapshot.</summary>
+    public const string Config = "config";
+}

--- a/src/Content/Domain/Domain.AI/ClaimVerification/ClaimVerdict.cs
+++ b/src/Content/Domain/Domain.AI/ClaimVerification/ClaimVerdict.cs
@@ -1,0 +1,56 @@
+namespace Domain.AI.ClaimVerification;
+
+/// <summary>
+/// The result of checking one <see cref="ClaimVerification.Claim"/> against its cited location.
+/// </summary>
+/// <param name="Claim">The claim this verdict is about, as originally asserted.</param>
+/// <param name="Outcome">Why <see cref="RevisedClaim"/> has the confidence it has.</param>
+/// <param name="Explanation">
+/// Free-text detail — <see langword="null"/> for <see cref="ClaimVerificationOutcome.Held"/> and
+/// <see cref="ClaimVerificationOutcome.NotConsequential"/>, which need none.
+/// </param>
+/// <param name="RevisedClaim">
+/// The claim to actually surface. Fail-safe by construction: use the static factories below rather
+/// than constructing this directly — they are the only place that decides whether
+/// <see cref="ClaimVerification.Claim.Confidence"/> is floored, so a caller cannot accidentally
+/// pair a real finding with an unrevised claim or a fail-safe outcome with a floored one.
+/// </param>
+public sealed record ClaimVerdict(
+    Claim Claim, ClaimVerificationOutcome Outcome, string? Explanation, Claim RevisedClaim)
+{
+    /// <summary>
+    /// A failed claim is revised, not deleted — surfaced at this confidence rather than removed
+    /// from whatever list it came from, so its history stays visible to any consumer.
+    /// </summary>
+    private const double FlooredConfidence = 0.1;
+
+    /// <summary>The claim was checked and holds. Confidence unchanged.</summary>
+    public static ClaimVerdict Held(Claim claim) =>
+        new(claim, ClaimVerificationOutcome.Held, Explanation: null, RevisedClaim: claim);
+
+    /// <summary>The claim was checked and does NOT hold — a real finding. Confidence floored.</summary>
+    public static ClaimVerdict Broken(Claim claim, string explanation) =>
+        new(claim, ClaimVerificationOutcome.Broken, explanation, claim with { Confidence = FlooredConfidence });
+
+    /// <summary>
+    /// A reader recognized the claim's location scheme but the location itself does not exist — a
+    /// real finding, never fail-safe silence. Confidence floored, same as <see cref="Broken"/>.
+    /// </summary>
+    public static ClaimVerdict LocationNotFound(Claim claim, string reason) =>
+        new(claim, ClaimVerificationOutcome.LocationNotFound, reason, claim with { Confidence = FlooredConfidence });
+
+    /// <summary>
+    /// No reader was authoritative for the claim's location scheme, or the evidence found was
+    /// insufficient to judge the claim. Fail-safe: confidence unchanged.
+    /// </summary>
+    public static ClaimVerdict Unverifiable(Claim claim, string reason) =>
+        new(claim, ClaimVerificationOutcome.Unverifiable, reason, RevisedClaim: claim);
+
+    /// <summary>The verifier itself failed before producing a real verdict. Fail-safe: unchanged.</summary>
+    public static ClaimVerdict VerifierError(Claim claim, string reason) =>
+        new(claim, ClaimVerificationOutcome.VerifierError, reason, RevisedClaim: claim);
+
+    /// <summary>Skipped as low-consequence — no reader or verifier was invoked. Confidence unchanged.</summary>
+    public static ClaimVerdict NotConsequential(Claim claim) =>
+        new(claim, ClaimVerificationOutcome.NotConsequential, Explanation: null, RevisedClaim: claim);
+}

--- a/src/Content/Domain/Domain.AI/ClaimVerification/ClaimVerificationOutcome.cs
+++ b/src/Content/Domain/Domain.AI/ClaimVerification/ClaimVerificationOutcome.cs
@@ -1,0 +1,41 @@
+namespace Domain.AI.ClaimVerification;
+
+/// <summary>
+/// Why a <see cref="ClaimVerdict"/> has its <see cref="ClaimVerdict.RevisedClaim"/>. Kept distinct
+/// from a plain pass/fail so telemetry and audit output never collapse "checked and true," "checked
+/// and false," "cited a location that doesn't exist," "could not be checked," and "skipped as
+/// low-stakes" into the same observable state — the same reasoning
+/// <see cref="Domain.AI.Verification.VerificationOutcome"/> documents for obligations, extended
+/// here with the one outcome that must NOT be fail-safe-silent: see
+/// <see cref="ClaimVerdict.LocationNotFound"/>.
+/// </summary>
+public enum ClaimVerificationOutcome
+{
+    /// <summary>The claim was checked against its cited location and holds.</summary>
+    Held,
+
+    /// <summary>The claim was checked against its cited location and does NOT hold.</summary>
+    Broken,
+
+    /// <summary>
+    /// A reader recognized the claim's location scheme but the specific location does not exist.
+    /// Unlike <see cref="Unverifiable"/>, this IS a real finding — the claim named something that
+    /// isn't there, which is itself informative and is never reported as fail-safe silence.
+    /// </summary>
+    LocationNotFound,
+
+    /// <summary>
+    /// No reader was authoritative for the claim's location scheme, or the evidence found there was
+    /// insufficient to judge the claim. Fail-safe: the claim is left unchanged.
+    /// </summary>
+    Unverifiable,
+
+    /// <summary>The verifier itself failed before producing a real verdict. Fail-safe: unchanged.</summary>
+    VerifierError,
+
+    /// <summary>
+    /// Skipped by <c>IClaimConsequenceClassifier</c> — nothing durable turns on this claim, so no
+    /// reader or verifier was ever invoked.
+    /// </summary>
+    NotConsequential
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/AIConfig.cs
@@ -248,6 +248,13 @@ public class AIConfig
     /// </summary>
     public ObligationConfig Obligations { get; set; } = new();
 
+    /// <summary>
+    /// Artifact-grounded claim verification configuration (#319): checking a high-consequence claim
+    /// against the artifact it cites. Off by default — see
+    /// <see cref="ClaimVerificationConfig.Enabled"/>.
+    /// </summary>
+    public ClaimVerificationConfig ClaimVerification { get; set; } = new();
+
     /// <summary>Agent Governance Toolkit configuration.</summary>
     public GovernanceConfig Governance { get; init; } = new();
 

--- a/src/Content/Domain/Domain.Common/Config/AI/ClaimVerificationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/ClaimVerificationConfig.cs
@@ -1,0 +1,29 @@
+namespace Domain.Common.Config.AI;
+
+/// <summary>
+/// Configuration for artifact-grounded claim verification (#319): checking a high-consequence claim
+/// against the artifact it cites before it is trusted. Bound from
+/// <c>AppConfig:AI:ClaimVerification</c>.
+/// </summary>
+public class ClaimVerificationConfig
+{
+    /// <summary>
+    /// Whether the LLM-backed verifier actually runs. Off by default: verification calls a judge
+    /// model, and a host that never uses this should not pay for that call. Read-side readers
+    /// (<c>ILocatedArtifactReader</c>) and the consequence classifier are registered unconditionally
+    /// regardless of this flag; only the judge call itself is gated.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>Maximum number of verifiers dispatched concurrently for one batch of claims.</summary>
+    /// <value>Default: 4.</value>
+    public int MaxParallelVerifiers { get; set; } = 4;
+
+    /// <summary>
+    /// Per-verifier timeout. A verifier that exceeds this is treated as
+    /// <c>ClaimVerificationOutcome.VerifierError</c> (fail-safe: the claim is left unchanged), not
+    /// as a hang that blocks the whole batch.
+    /// </summary>
+    /// <value>Default: 30 seconds.</value>
+    public TimeSpan PerVerifierTimeout { get; set; } = TimeSpan.FromSeconds(30);
+}

--- a/src/Content/Domain/Domain.Common/Config/AI/ClaimVerificationConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/ClaimVerificationConfig.cs
@@ -15,6 +15,17 @@ public class ClaimVerificationConfig
     /// </summary>
     public bool Enabled { get; set; }
 
+    /// <summary>
+    /// Maximum number of claims in one batch that will actually be dispatched to verifiers. Guards
+    /// against an untrusted or misbehaving <c>IHarnessChangeSuggester</c> (or any future claim
+    /// producer — the interface's own contract only promises "possibly empty", never "bounded")
+    /// fanning out an unbounded number of judge-model calls in a single batch. Mirrors
+    /// <c>ObligationConfig.MaxObligations</c>'s identical rationale for its own untrusted-extraction
+    /// input.
+    /// </summary>
+    /// <value>Default: 14.</value>
+    public int MaxClaims { get; set; } = 14;
+
     /// <summary>Maximum number of verifiers dispatched concurrently for one batch of claims.</summary>
     /// <value>Default: 4.</value>
     public int MaxParallelVerifiers { get; set; } = 4;

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/DependencyInjection.ClaimVerification.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/DependencyInjection.ClaimVerification.cs
@@ -1,0 +1,50 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Infrastructure.AI.Verification;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.AI.Evaluation;
+
+/// <summary>
+/// <see cref="IClaimVerifier"/> real-implementation DI registration, factored out for the same
+/// reason as <see cref="DependencyInjectionVerification.AddObligationVerification(IServiceCollection)"/>:
+/// a consumer that needs claim verification without the rest of the eval framework can call it
+/// alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Lives here rather than in <c>Infrastructure.AI</c> — where <see cref="LlmClaimVerifier"/> and
+/// the two <c>ILocatedArtifactReader</c> implementations are — because
+/// <see cref="LlmClaimVerifier"/> depends on
+/// <see cref="Application.AI.Common.Evaluation.Interfaces.IJudgeChatClientProvider"/>, which only
+/// <see cref="DependencyInjectionJudges.AddLlmJudge(IServiceCollection)"/> registers, and
+/// <c>Infrastructure.AI</c> does not (and must not) reference <c>Infrastructure.AI.Evaluation</c> —
+/// the dependency runs the other way. <c>DependencyInjection.AddEvaluationDependencies</c> calls
+/// this automatically for the common case.
+/// </para>
+/// <para>
+/// Registers <see cref="IClaimVerifier"/> via a plain <c>AddSingleton</c>, not <c>TryAddSingleton</c>
+/// — it must WIN over the <c>NotConfiguredClaimVerifier</c> fail-safe default every host registers
+/// via <c>ClaimVerificationDependencyInjection.AddClaimVerificationDependencies</c>, by
+/// last-registration-wins, so a host must call this method AFTER the core registration (the normal
+/// composition order — <c>AddApplicationAIDependencies</c> before <c>AddEvaluationDependencies</c>).
+/// </para>
+/// </remarks>
+public static class DependencyInjectionClaimVerification
+{
+    /// <summary>
+    /// Registers the real <see cref="LlmClaimVerifier"/> as <see cref="IClaimVerifier"/> (overriding
+    /// the fail-safe default) and its shared judge-model client provider (via
+    /// <see cref="DependencyInjectionJudges.AddLlmJudge(IServiceCollection)"/>).
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    public static IServiceCollection AddClaimVerification(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddLlmJudge();
+        services.AddSingleton<IClaimVerifier, LlmClaimVerifier>();
+
+        return services;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI.Evaluation/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.Evaluation/DependencyInjection.cs
@@ -93,6 +93,12 @@ public static class DependencyInjection
         services.AddObligationVerification();
         services.AddEvalMetric<ObligationsHoldMetric>("obligations_hold");
 
+        // Artifact-grounded claim verification (#319) — factored into AddClaimVerification
+        // (DependencyInjection.ClaimVerification.cs), same reasoning as AddObligationVerification
+        // above. Overrides the fail-safe NotConfiguredClaimVerifier default every host registers via
+        // AddApplicationAIDependencies → AddClaimVerificationDependencies.
+        services.AddClaimVerification();
+
         // NOTE: RAG metrics resolve their prompts via IPromptRegistry; the registry is
         // wired by the composition root through AddPromptRegistry(...) so the eval
         // framework stays decoupled from the prompts root path.

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
@@ -107,7 +107,14 @@ public sealed class PolicyGate : IChangeProposalGate
             return GateResult.Pass($"{policies.Count} policy(ies) evaluated, no findings");
         }
 
-        var blocking = allFindings.Where(f => f.Severity >= threshold).ToList();
+        // A finding with RequiresVerification set carries a model-assigned severity that has not
+        // been independently confirmed against the artifact it is about — it is excluded from the
+        // severity/threshold comparison entirely (neither blocking nor "passing below threshold";
+        // simply not counted), unless the SAME finding also sets Blocking, meaning a verifier already
+        // confirmed it. Every existing policy leaves both flags at their false default, so this is
+        // byte-identical to the prior `f.Severity >= threshold` check for every finding in the repo
+        // today. See PolicyFinding.RequiresVerification's remarks.
+        var blocking = allFindings.Where(f => f.Blocking || (f.Severity >= threshold && !f.RequiresVerification)).ToList();
         if (blocking.Count > 0)
         {
             var summary = string.Join("; ", blocking.Take(5).Select(f =>

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
@@ -120,12 +120,24 @@ public sealed class PolicyGate : IChangeProposalGate
             var summary = string.Join("; ", blocking.Take(5).Select(f =>
                 $"[{f.Severity} {f.PolicyKey}] {f.Message}"));
             var more = blocking.Count > 5 ? $" (+{blocking.Count - 5} more)" : string.Empty;
+            // Not "at or above {threshold}" — a Blocking=true finding can be blocking regardless of
+            // its own severity (see PolicyFinding.Blocking's remarks), so that phrase would be false
+            // for it. Each finding's actual severity is already visible in the summary above.
             return GateResult.Fail(
-                $"{blocking.Count} blocking finding(s) at or above {threshold}: {summary}{more}");
+                $"{blocking.Count} blocking finding(s): {summary}{more}");
         }
 
+        // Every non-blocking finding is either genuinely below threshold, or excluded because its
+        // severity has not been independently verified (RequiresVerification, unconfirmed) — the
+        // two are not the same claim, and collapsing them into "below threshold" would misdescribe
+        // an unconfirmed Critical finding as one the gate judged too minor to matter.
+        var excludedPendingVerification = allFindings.Count(f => f.RequiresVerification && !f.Blocking);
+        var belowThreshold = allFindings.Count - excludedPendingVerification;
+        var excludedSuffix = excludedPendingVerification > 0
+            ? $", {excludedPendingVerification} excluded pending verification"
+            : string.Empty;
         return GateResult.Pass(
-            $"{policies.Count} policy(ies) evaluated, {allFindings.Count} finding(s) below {threshold} threshold");
+            $"{policies.Count} policy(ies) evaluated, {belowThreshold} finding(s) below {threshold} threshold{excludedSuffix}");
     }
 
     private static PolicyFindingSeverity ParseThreshold(string raw)

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/Gates/PolicyGate.cs
@@ -127,11 +127,16 @@ public sealed class PolicyGate : IChangeProposalGate
                 $"{blocking.Count} blocking finding(s): {summary}{more}");
         }
 
-        // Every non-blocking finding is either genuinely below threshold, or excluded because its
-        // severity has not been independently verified (RequiresVerification, unconfirmed) — the
-        // two are not the same claim, and collapsing them into "below threshold" would misdescribe
-        // an unconfirmed Critical finding as one the gate judged too minor to matter.
-        var excludedPendingVerification = allFindings.Count(f => f.RequiresVerification && !f.Blocking);
+        // Every non-blocking finding is either genuinely below threshold, or excluded because it
+        // WOULD have blocked (severity >= threshold) but its severity has not been independently
+        // verified — the two are not the same claim, and collapsing them into "below threshold"
+        // would misdescribe an unconfirmed Critical finding as one the gate judged too minor to
+        // matter. Not `!f.Blocking`: control only reaches this line when blocking.Count == 0, which
+        // already guarantees no finding here has Blocking == true, so that conjunct would be dead
+        // weight. A RequiresVerification finding whose severity is itself below threshold was never
+        // going to block either way — it belongs in "below threshold", not "excluded", since
+        // confirming it would not have changed anything.
+        var excludedPendingVerification = allFindings.Count(f => f.RequiresVerification && f.Severity >= threshold);
         var belowThreshold = allFindings.Count - excludedPendingVerification;
         var excludedSuffix = excludedPendingVerification > 0
             ? $", {excludedPendingVerification} excluded pending verification"

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -72,6 +72,20 @@ public static partial class DependencyInjection
         services.AddKeyedSingleton<ITool>(FileSystemTool.ToolName, (sp, _) =>
             new FileSystemTool(sp.GetRequiredService<IFileSystemService>()));
 
+        // ILocatedArtifactReader implementations (#319 claim verification) — keyed by location
+        // scheme, unconditional (neither depends on a judge model, unlike ClaimVerificationRunner's
+        // eval-gated IClaimVerifier). Registered here, not in Infrastructure.AI.Evaluation, because
+        // gating a plain file read or config lookup behind AddClaimVerification() would be scope
+        // creep — see ClaimVerificationDependencyInjection's remarks.
+        services.AddKeyedSingleton<Application.AI.Common.Interfaces.ClaimVerification.ILocatedArtifactReader>(
+            "file", (sp, _) => new Verification.Readers.FileSystemLocatedArtifactReader(
+                sp.GetRequiredService<IFileSystemService>(),
+                sp.GetRequiredService<ILogger<Verification.Readers.FileSystemLocatedArtifactReader>>()));
+        services.AddKeyedSingleton<Application.AI.Common.Interfaces.ClaimVerification.ILocatedArtifactReader>(
+            "config", (sp, _) => new Verification.Readers.ConfigSnapshotLocatedArtifactReader(
+                sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+                sp.GetRequiredService<ILogger<Verification.Readers.ConfigSnapshotLocatedArtifactReader>>()));
+
         // Restricted search tool — sandboxed read-only shell commands for the proposer.
         // Always registered; surfaced to the proposer only when EnableShellTool is true.
         services.AddKeyedSingleton<ITool>(RestrictedSearchTool.ToolName, (sp, _) =>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -78,11 +78,11 @@ public static partial class DependencyInjection
         // gating a plain file read or config lookup behind AddClaimVerification() would be scope
         // creep — see ClaimVerificationDependencyInjection's remarks.
         services.AddKeyedSingleton<Application.AI.Common.Interfaces.ClaimVerification.ILocatedArtifactReader>(
-            "file", (sp, _) => new Verification.Readers.FileSystemLocatedArtifactReader(
+            Domain.AI.ClaimVerification.ClaimLocationScheme.File, (sp, _) => new Verification.Readers.FileSystemLocatedArtifactReader(
                 sp.GetRequiredService<IFileSystemService>(),
                 sp.GetRequiredService<ILogger<Verification.Readers.FileSystemLocatedArtifactReader>>()));
         services.AddKeyedSingleton<Application.AI.Common.Interfaces.ClaimVerification.ILocatedArtifactReader>(
-            "config", (sp, _) => new Verification.Readers.ConfigSnapshotLocatedArtifactReader(
+            Domain.AI.ClaimVerification.ClaimLocationScheme.Config, (sp, _) => new Verification.Readers.ConfigSnapshotLocatedArtifactReader(
                 sp.GetRequiredService<IOptionsMonitor<AppConfig>>(),
                 sp.GetRequiredService<ILogger<Verification.Readers.ConfigSnapshotLocatedArtifactReader>>()));
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/ClaimVerificationResponse.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/ClaimVerificationResponse.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace Infrastructure.AI.Verification;
+
+/// <summary>
+/// Wire shape for <see cref="LlmClaimVerifier"/>'s structured-output call. <see cref="Status"/> is a
+/// free-text field validated in code (<see cref="LlmClaimVerifier"/>) rather than a C# enum — an
+/// unrecognized value must fail safe as <see cref="Domain.AI.ClaimVerification.ClaimVerificationOutcome.VerifierError"/>,
+/// which a failed enum deserialization would instead surface as an unhandled parse exception rather
+/// than a verdict. Mirrors <c>ObligationVerificationResponse</c>'s shape and rationale exactly.
+/// </summary>
+internal sealed record ClaimVerificationResponse
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("explanation")]
+    public required string Explanation { get; init; }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/LlmClaimVerifier.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/LlmClaimVerifier.cs
@@ -189,12 +189,22 @@ public sealed class LlmClaimVerifier : IClaimVerifier
             explanation = "Verifier did not provide an explanation.";
         }
 
-        return response.Status.Trim().ToLowerInvariant() switch
+        // Same gap applies to Status: `required` guarantees the constructor call, not the
+        // deserializer, so a model returning {"status":null,...} would NRE on .Trim() below without
+        // this guard. Treated as an unrecognized status (fail-safe VerifierError) rather than a
+        // distinct case — a missing status carries no more information than a nonsense one.
+        var status = response.Status;
+        if (string.IsNullOrWhiteSpace(status))
+        {
+            return LogAndFailUnrecognizedStatus(claim, status ?? "(null)");
+        }
+
+        return status.Trim().ToLowerInvariant() switch
         {
             HeldStatus => ClaimVerdict.Held(claim),
             BrokenStatus => ClaimVerdict.Broken(claim, explanation),
             UnverifiableStatus => ClaimVerdict.Unverifiable(claim, explanation),
-            _ => LogAndFailUnrecognizedStatus(claim, response.Status),
+            _ => LogAndFailUnrecognizedStatus(claim, status),
         };
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/LlmClaimVerifier.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/LlmClaimVerifier.cs
@@ -6,8 +6,10 @@ using Application.AI.Common.Prompts.Interfaces;
 using Application.AI.Common.StructuredOutput;
 using Domain.AI.ClaimVerification;
 using Domain.AI.Prompts;
+using Domain.Common.Config;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.AI.Verification;
 
@@ -54,6 +56,7 @@ public sealed class LlmClaimVerifier : IClaimVerifier
     private readonly IPromptRegistry _promptRegistry;
     private readonly IPromptRenderer _promptRenderer;
     private readonly IPromptUsageRecorder _usageRecorder;
+    private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<LlmClaimVerifier> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="LlmClaimVerifier"/> class.</summary>
@@ -63,6 +66,7 @@ public sealed class LlmClaimVerifier : IClaimVerifier
         IPromptRegistry promptRegistry,
         IPromptRenderer promptRenderer,
         IPromptUsageRecorder usageRecorder,
+        IOptionsMonitor<AppConfig> config,
         ILogger<LlmClaimVerifier> logger)
     {
         ArgumentNullException.ThrowIfNull(chatClientProvider);
@@ -70,6 +74,7 @@ public sealed class LlmClaimVerifier : IClaimVerifier
         ArgumentNullException.ThrowIfNull(promptRegistry);
         ArgumentNullException.ThrowIfNull(promptRenderer);
         ArgumentNullException.ThrowIfNull(usageRecorder);
+        ArgumentNullException.ThrowIfNull(config);
         ArgumentNullException.ThrowIfNull(logger);
 
         _chatClientProvider = chatClientProvider;
@@ -77,6 +82,7 @@ public sealed class LlmClaimVerifier : IClaimVerifier
         _promptRegistry = promptRegistry;
         _promptRenderer = promptRenderer;
         _usageRecorder = usageRecorder;
+        _config = config;
         _logger = logger;
     }
 
@@ -85,6 +91,12 @@ public sealed class LlmClaimVerifier : IClaimVerifier
     {
         ArgumentNullException.ThrowIfNull(claim);
         ArgumentNullException.ThrowIfNull(evidenceContent);
+
+        if (!_config.CurrentValue.AI.ClaimVerification.Enabled)
+        {
+            return ClaimVerdict.Unverifiable(
+                claim, "Claim verification is disabled (AppConfig:AI:ClaimVerification:Enabled=false).");
+        }
 
         var descriptorResult = await PromptDescriptorResolver.ResolveAsync(
             _promptRegistry, PromptName, _logger, cancellationToken).ConfigureAwait(false);

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/LlmClaimVerifier.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/LlmClaimVerifier.cs
@@ -1,0 +1,196 @@
+using Application.AI.Common.Evaluation;
+using Application.AI.Common.Evaluation.Interfaces;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Application.AI.Common.Prompts.Interfaces;
+using Application.AI.Common.StructuredOutput;
+using Domain.AI.ClaimVerification;
+using Domain.AI.Prompts;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Verification;
+
+/// <summary>
+/// Model-backed <see cref="IClaimVerifier"/>: given one claim and the evidence text already read
+/// from the location it cites, asks the fixed judge model
+/// (<see cref="IJudgeChatClientProvider"/>) whether the evidence supports it — see
+/// <c>prompts/claim-verifier/v1.md</c> for the exact instruction.
+/// </summary>
+/// <remarks>
+/// Mirrors <c>LlmObligationVerifier</c>'s architecture (structured output, the shared injection
+/// envelope, prompt-descriptor resolution) closely — the two verifiers solve the same shaped problem
+/// (ask a judge to compare a located claim against text and return a structured held/broken/
+/// unverifiable verdict) — but are separate types because <see cref="ClaimVerdict"/> and
+/// <see cref="Claim"/> are not <c>VerificationVerdict</c>/<c>Obligation</c>: a claim's confidence is
+/// revised rather than collapsed to a bool, and a claim's evidence is independently fetched per
+/// claim rather than sliced from one shared pre-fetched artifact. Never throws for an expected
+/// model-call failure — a soft-fail <see cref="StructuredOutputResult{T}"/> or an unrecognized
+/// <c>status</c> value is mapped to <see cref="ClaimVerdict.VerifierError"/> here, inside this
+/// method, rather than left to escape as an exception; <c>ClaimVerificationRunner</c>'s own catch
+/// only sees exceptions (a genuine infrastructure failure, or the per-verifier timeout).
+/// </remarks>
+public sealed class LlmClaimVerifier : IClaimVerifier
+{
+    // Must match the prompts/{name}/ folder exactly — FilePromptRegistry resolves by this literal
+    // string with no fallback, so a typo here fails silently into VerifierError on every host,
+    // undetectable by unit tests that mock IPromptRegistry.
+    private const string PromptName = "claim-verifier";
+    private const string EnvelopeTagName = "evidence_data";
+    private const string MetricKey = "claim_verification";
+
+    private const string HeldStatus = "held";
+    private const string BrokenStatus = "broken";
+    private const string UnverifiableStatus = "unverifiable";
+
+    // Built once — the schema attached to the request and the schema the reply is validated
+    // against are the same object, so they can never independently drift.
+    private static readonly StructuredOutputContract Contract =
+        StructuredOutputSchema.Build<ClaimVerificationResponse>(
+            "claim_verification", "Whether one claim holds against its cited evidence");
+
+    private readonly IJudgeChatClientProvider _chatClientProvider;
+    private readonly IStructuredOutputInvoker _structuredOutput;
+    private readonly IPromptRegistry _promptRegistry;
+    private readonly IPromptRenderer _promptRenderer;
+    private readonly IPromptUsageRecorder _usageRecorder;
+    private readonly ILogger<LlmClaimVerifier> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="LlmClaimVerifier"/> class.</summary>
+    public LlmClaimVerifier(
+        IJudgeChatClientProvider chatClientProvider,
+        IStructuredOutputInvoker structuredOutput,
+        IPromptRegistry promptRegistry,
+        IPromptRenderer promptRenderer,
+        IPromptUsageRecorder usageRecorder,
+        ILogger<LlmClaimVerifier> logger)
+    {
+        ArgumentNullException.ThrowIfNull(chatClientProvider);
+        ArgumentNullException.ThrowIfNull(structuredOutput);
+        ArgumentNullException.ThrowIfNull(promptRegistry);
+        ArgumentNullException.ThrowIfNull(promptRenderer);
+        ArgumentNullException.ThrowIfNull(usageRecorder);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _chatClientProvider = chatClientProvider;
+        _structuredOutput = structuredOutput;
+        _promptRegistry = promptRegistry;
+        _promptRenderer = promptRenderer;
+        _usageRecorder = usageRecorder;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<ClaimVerdict> VerifyAsync(Claim claim, string evidenceContent, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        ArgumentNullException.ThrowIfNull(evidenceContent);
+
+        var descriptorResult = await PromptDescriptorResolver.ResolveAsync(
+            _promptRegistry, PromptName, _logger, cancellationToken).ConfigureAwait(false);
+        if (!descriptorResult.IsSuccess || descriptorResult.Value is null)
+        {
+            return ClaimVerdict.VerifierError(claim, string.Join("; ", descriptorResult.Errors));
+        }
+
+        // The claim's own text is itself the asserting agent's untrusted output, so it gets the same
+        // envelope treatment as the evidence content — one untrusted body, one nonce, rather than
+        // treating the claim text as trusted just because it originated from a prior model call.
+        var untrustedBody =
+            $"Claim to verify:\n{claim.Text}\n\n" +
+            $"Evidence read from the claim's cited location:\n{evidenceContent}";
+
+        var nonce = PromptInjectionEnvelope.NewNonce();
+        if (PromptInjectionEnvelope.HasCollision(nonce, untrustedBody))
+        {
+            _logger.LogWarning(
+                "Nonce collision against claim/evidence content for the claim at '{Location}'; refusing to verify to avoid injection ambiguity.",
+                claim.Location);
+            return ClaimVerdict.VerifierError(
+                claim, "Nonce collision against claim/evidence content; refusing to verify to avoid injection ambiguity.");
+        }
+
+        return await InvokeVerificationModelAsync(descriptorResult.Value, claim, untrustedBody, nonce, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private async Task<ClaimVerdict> InvokeVerificationModelAsync(
+        PromptDescriptor descriptor, Claim claim, string untrustedBody, string nonce, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // No data dependency between building the request and resolving the chat client — run
+            // concurrently, mirroring LlmObligationVerifier's identical reasoning.
+            var buildTask = EnvelopedRequestBuilder.BuildAsync(
+                _promptRenderer, _usageRecorder, descriptor, untrustedBody, EnvelopeTagName, nonce,
+                MetricKey, "verify", cancellationToken);
+            var clientTask = _chatClientProvider.GetJudgeAsync(cancellationToken);
+            await Task.WhenAll(buildTask, clientTask).ConfigureAwait(false);
+            var (systemPrompt, envelopedUser) = await buildTask.ConfigureAwait(false);
+            var chatClient = await clientTask.ConfigureAwait(false);
+
+            var messages = new List<ChatMessage>
+            {
+                new(ChatRole.System, systemPrompt),
+                new(ChatRole.User, envelopedUser)
+            };
+
+            var result = await _structuredOutput.InvokeAsync<ClaimVerificationResponse>(
+                chatClient, Contract, messages, chatOptions: null, cancellationToken).ConfigureAwait(false);
+
+            if (!result.IsSuccess || result.Value is null)
+            {
+                _logger.LogWarning(
+                    "Claim verification failed for the claim at '{Location}': {Outcome} — {Reason}",
+                    claim.Location, result.Outcome, result.ErrorMessage);
+                // result.ErrorMessage can itself wrap a raw provider exception message — logged
+                // above in full, never echoed into the returned reason.
+                return ClaimVerdict.VerifierError(claim, $"Claim verification failed ({result.Outcome}); see logs for details.");
+            }
+
+            return MapToVerdict(claim, result.Value);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Claim verification failed for the claim at '{Location}'", claim.Location);
+            return ClaimVerdict.VerifierError(claim, "Claim verification failed; see logs for details.");
+        }
+    }
+
+    private ClaimVerdict MapToVerdict(Claim claim, ClaimVerificationResponse response)
+    {
+        // Same RespectNullableAnnotations gap ObligationVerificationResponse's own remarks document:
+        // `required` on Explanation is a constructor-time guarantee only, not a deserialize-time one,
+        // so a model returning {"status":"broken","explanation":null} deserializes with Explanation
+        // == null despite the keyword. Guarded here for the same reason: a blank explanation on a
+        // real finding is worse than a placeholder.
+        var explanation = response.Explanation;
+        if (string.IsNullOrWhiteSpace(explanation))
+        {
+            _logger.LogWarning(
+                "Claim verifier omitted 'explanation' for the claim at '{Location}' despite it being schema-required; substituting a placeholder.",
+                claim.Location);
+            explanation = "Verifier did not provide an explanation.";
+        }
+
+        return response.Status.Trim().ToLowerInvariant() switch
+        {
+            HeldStatus => ClaimVerdict.Held(claim),
+            BrokenStatus => ClaimVerdict.Broken(claim, explanation),
+            UnverifiableStatus => ClaimVerdict.Unverifiable(claim, explanation),
+            _ => LogAndFailUnrecognizedStatus(claim, response.Status),
+        };
+    }
+
+    private ClaimVerdict LogAndFailUnrecognizedStatus(Claim claim, string status)
+    {
+        _logger.LogWarning(
+            "Claim verifier returned an unrecognized status '{Status}' for the claim at '{Location}'; treating as VerifierError.",
+            status, claim.Location);
+        return ClaimVerdict.VerifierError(claim, $"Verifier returned an unrecognized status: '{status}'.");
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/ConfigSnapshotLocatedArtifactReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/ConfigSnapshotLocatedArtifactReader.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.ClaimVerification;
 using Application.Common.Helpers;
+using Domain.AI.ClaimVerification;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,7 +34,7 @@ namespace Infrastructure.AI.Verification.Readers;
 /// </remarks>
 public sealed class ConfigSnapshotLocatedArtifactReader : ILocatedArtifactReader
 {
-    private const string SchemePrefix = "config:";
+    private const string SchemePrefix = $"{ClaimLocationScheme.Config}:";
 
     private static readonly IReadOnlySet<string> AllowedPaths =
         new HashSet<string>(StringComparer.Ordinal) { "AI.Resilience.Retry.MaxAttempts" };

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/ConfigSnapshotLocatedArtifactReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/ConfigSnapshotLocatedArtifactReader.cs
@@ -1,5 +1,5 @@
-using System.Reflection;
 using Application.AI.Common.Interfaces.ClaimVerification;
+using Application.Common.Helpers;
 using Domain.Common.Config;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,14 +13,30 @@ namespace Infrastructure.AI.Verification.Readers;
 /// the live value as evidence text.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The first consumer of this scheme is <c>HarnessChangeSuggestion.CurrentValue</c> — a model's
 /// claim about what a config field currently holds, checked against what it actually holds via
 /// <see cref="Application.AI.Common.Services.SkillTraining.ConfigSurfaceConstraint.ResolveConfigPath"/>.
+/// </para>
+/// <para>
+/// <see cref="AppConfig"/> carries live secrets (provider API keys, connection strings, HMAC keys,
+/// bearer tokens) alongside ordinary settings, all as public instance properties — reflection with
+/// no filter would make every one of them readable via a crafted <c>Claim.Location</c>. This is a
+/// model-supplied field, so <see cref="AllowedPaths"/> is a fixed, minimal, code-owned allowlist
+/// deliberately separate from (not derived from) <c>ConfigSurfaceConstraint</c>'s own — that
+/// constraint governs which fields a suggestion may propose <em>changing</em>, a different question
+/// than which fields are safe to expose as claim-verification evidence, and coupling the two would
+/// let a future widening of one accidentally widen the other. Only paths named here resolve; every
+/// other path — including a perfectly well-formed one — is refused the same way a nonexistent one
+/// would be, so this reader's refusal never distinguishes "not allowed" from "not found."
+/// </para>
 /// </remarks>
 public sealed class ConfigSnapshotLocatedArtifactReader : ILocatedArtifactReader
 {
     private const string SchemePrefix = "config:";
-    private const BindingFlags PropertyLookup = BindingFlags.Public | BindingFlags.Instance;
+
+    private static readonly IReadOnlySet<string> AllowedPaths =
+        new HashSet<string>(StringComparer.Ordinal) { "AI.Resilience.Retry.MaxAttempts" };
 
     private readonly IOptionsMonitor<AppConfig> _config;
     private readonly ILogger<ConfigSnapshotLocatedArtifactReader> _logger;
@@ -51,31 +67,22 @@ public sealed class ConfigSnapshotLocatedArtifactReader : ILocatedArtifactReader
             return Task.FromResult<string?>(null);
         }
 
-        var value = ResolveByPath(_config.CurrentValue, path.Split('.'), path);
-        return Task.FromResult(value is null ? null : $"{path} = {value}");
-    }
-
-    private object? ResolveByPath(object? current, IReadOnlyList<string> segments, string fullPath)
-    {
-        foreach (var segment in segments)
+        if (!AllowedPaths.Contains(path))
         {
-            if (current is null)
-            {
-                return null;
-            }
-
-            var property = current.GetType().GetProperty(segment, PropertyLookup);
-            if (property is null)
-            {
-                _logger.LogWarning(
-                    "Config location '{FullPath}' does not resolve — '{Segment}' is not a property of '{Type}'.",
-                    fullPath, segment, current.GetType().Name);
-                return null;
-            }
-
-            current = property.GetValue(current);
+            _logger.LogWarning(
+                "Config location '{Path}' is not on the claim-verification allowlist; refusing to read it.", path);
+            return Task.FromResult<string?>(null);
         }
 
-        return current;
+        var value = ReflectionHelper.GetPropertyValue(_config.CurrentValue, path);
+        if (value is null)
+        {
+            _logger.LogWarning(
+                "Allowlisted config location '{Path}' did not resolve against the live AppConfig snapshot — the allowlist entry may have drifted from the config schema.",
+                path);
+            return Task.FromResult<string?>(null);
+        }
+
+        return Task.FromResult<string?>($"{path} = {value}");
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/ConfigSnapshotLocatedArtifactReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/ConfigSnapshotLocatedArtifactReader.cs
@@ -1,0 +1,81 @@
+using System.Reflection;
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Domain.Common.Config;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.AI.Verification.Readers;
+
+/// <summary>
+/// The <c>"config"</c>-scheme <see cref="ILocatedArtifactReader"/>: resolves a
+/// <c>"config:AI.Resilience.Retry.MaxAttempts"</c>-shaped location by walking that dotted path
+/// against the live <see cref="AppConfig"/> snapshot via public-property reflection, and returns
+/// the live value as evidence text.
+/// </summary>
+/// <remarks>
+/// The first consumer of this scheme is <c>HarnessChangeSuggestion.CurrentValue</c> — a model's
+/// claim about what a config field currently holds, checked against what it actually holds via
+/// <see cref="Application.AI.Common.Services.SkillTraining.ConfigSurfaceConstraint.ResolveConfigPath"/>.
+/// </remarks>
+public sealed class ConfigSnapshotLocatedArtifactReader : ILocatedArtifactReader
+{
+    private const string SchemePrefix = "config:";
+    private const BindingFlags PropertyLookup = BindingFlags.Public | BindingFlags.Instance;
+
+    private readonly IOptionsMonitor<AppConfig> _config;
+    private readonly ILogger<ConfigSnapshotLocatedArtifactReader> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="ConfigSnapshotLocatedArtifactReader"/> class.</summary>
+    public ConfigSnapshotLocatedArtifactReader(IOptionsMonitor<AppConfig> config, ILogger<ConfigSnapshotLocatedArtifactReader> logger)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        _config = config;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<string?> TryReadAsync(string location, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+
+        if (!location.StartsWith(SchemePrefix, StringComparison.Ordinal))
+        {
+            return Task.FromResult<string?>(null);
+        }
+
+        var path = location[SchemePrefix.Length..];
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            _logger.LogWarning("Malformed config location '{Location}' — no path after the 'config:' prefix.", location);
+            return Task.FromResult<string?>(null);
+        }
+
+        var value = ResolveByPath(_config.CurrentValue, path.Split('.'), path);
+        return Task.FromResult(value is null ? null : $"{path} = {value}");
+    }
+
+    private object? ResolveByPath(object? current, IReadOnlyList<string> segments, string fullPath)
+    {
+        foreach (var segment in segments)
+        {
+            if (current is null)
+            {
+                return null;
+            }
+
+            var property = current.GetType().GetProperty(segment, PropertyLookup);
+            if (property is null)
+            {
+                _logger.LogWarning(
+                    "Config location '{FullPath}' does not resolve — '{Segment}' is not a property of '{Type}'.",
+                    fullPath, segment, current.GetType().Name);
+                return null;
+            }
+
+            current = property.GetValue(current);
+        }
+
+        return current;
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/FileSystemLocatedArtifactReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/FileSystemLocatedArtifactReader.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.ClaimVerification;
 using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.ClaimVerification;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Verification.Readers;
@@ -18,7 +19,7 @@ namespace Infrastructure.AI.Verification.Readers;
 /// </remarks>
 public sealed class FileSystemLocatedArtifactReader : ILocatedArtifactReader
 {
-    private const string SchemePrefix = "file:";
+    private const string SchemePrefix = $"{ClaimLocationScheme.File}:";
 
     private readonly IFileSystemService _fileSystem;
     private readonly ILogger<FileSystemLocatedArtifactReader> _logger;
@@ -83,6 +84,16 @@ public sealed class FileSystemLocatedArtifactReader : ILocatedArtifactReader
         if (lastColon > 0 && int.TryParse(remainder[(lastColon + 1)..], out var line))
         {
             return (remainder[..lastColon], line);
+        }
+
+        // A trailing ':' with nothing after it (e.g. "file:Foo.cs:") is not a valid line-number
+        // suffix, but it is also clearly not part of the path — a plausible model formatting slip
+        // (line number omitted), not an intentional colon-bearing filename. Left unstripped, the
+        // colon becomes part of the path handed to the file system and the read fails with a false
+        // "location not found" for a file that genuinely exists.
+        if (lastColon == remainder.Length - 1)
+        {
+            return (remainder[..lastColon], null);
         }
 
         return (remainder, null);

--- a/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/FileSystemLocatedArtifactReader.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Verification/Readers/FileSystemLocatedArtifactReader.cs
@@ -1,0 +1,90 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Application.AI.Common.Interfaces.Tools;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Verification.Readers;
+
+/// <summary>
+/// The <c>"file"</c>-scheme <see cref="ILocatedArtifactReader"/>: resolves a
+/// <c>"file:relative/path.cs"</c> or <c>"file:relative/path.cs:42"</c> location by reading the path
+/// through the same sandbox every other file read in this repo goes through.
+/// </summary>
+/// <remarks>
+/// Deliberately depends on <see cref="IFileSystemService"/> — the same sandboxed, size-limited,
+/// symlink-canonicalizing guard <c>FileSystemTool</c> wraps for model-initiated reads — rather than
+/// calling <c>File.ReadAllTextAsync</c> directly. A claim's <c>Location</c> is model-supplied text;
+/// treating it as a trusted path would reopen exactly the traversal surface
+/// <c>SandboxedPathGuard</c> exists to close.
+/// </remarks>
+public sealed class FileSystemLocatedArtifactReader : ILocatedArtifactReader
+{
+    private const string SchemePrefix = "file:";
+
+    private readonly IFileSystemService _fileSystem;
+    private readonly ILogger<FileSystemLocatedArtifactReader> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="FileSystemLocatedArtifactReader"/> class.</summary>
+    public FileSystemLocatedArtifactReader(IFileSystemService fileSystem, ILogger<FileSystemLocatedArtifactReader> logger)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        ArgumentNullException.ThrowIfNull(logger);
+        _fileSystem = fileSystem;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> TryReadAsync(string location, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+
+        var (path, line) = ExtractPathAndLine(location);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            _logger.LogWarning("Malformed file location '{Location}' — no path after the 'file:' prefix.", location);
+            return null;
+        }
+
+        string content;
+        try
+        {
+            content = await _fileSystem.ReadFileAsync(path, cancellationToken).ConfigureAwait(false);
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or ArgumentException)
+        {
+            // A claim citing a path outside the sandbox — traversal, a protected directory, a bad
+            // pattern — is refused, not read. Reported identically to "not found" so a claim's
+            // confidence never carries a distinction between "doesn't exist" and "exists but
+            // forbidden," which would leak sandbox layout through verification output.
+            _logger.LogWarning(ex, "Refused to read '{Path}' cited by a claim — the sandbox rejected the path.", path);
+            return null;
+        }
+
+        return line is null ? content : $"(the claim cites line {line})\n{content}";
+    }
+
+    private static (string? Path, int? Line) ExtractPathAndLine(string location)
+    {
+        if (!location.StartsWith(SchemePrefix, StringComparison.Ordinal))
+        {
+            return (null, null);
+        }
+
+        var remainder = location[SchemePrefix.Length..];
+        if (string.IsNullOrWhiteSpace(remainder))
+        {
+            return (null, null);
+        }
+
+        var lastColon = remainder.LastIndexOf(':');
+        if (lastColon > 0 && int.TryParse(remainder[(lastColon + 1)..], out var line))
+        {
+            return (remainder[..lastColon], line);
+        }
+
+        return (remainder, null);
+    }
+}

--- a/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Content/Presentation/Presentation.Common/Extensions/IServiceCollectionExtensions.cs
@@ -246,6 +246,13 @@ public static class IServiceCollectionExtensions
             .ValidateFluentValidation<ObligationConfig, ObligationConfigValidator>()
             .ValidateOnStart();
 
+        services.AddOptions<Domain.Common.Config.AI.ClaimVerificationConfig>()
+            .Bind(configuration.GetSection("AppConfig:AI:ClaimVerification"))
+            .ValidateFluentValidation<
+                Domain.Common.Config.AI.ClaimVerificationConfig,
+                ClaimVerificationConfigValidator>()
+            .ValidateOnStart();
+
         // PerResultCharLimit is now the ceiling every tool result is cut to before the model sees it
         // (#532), not just the spill-to-disk threshold it used to be. At zero or below that cut takes
         // everything, so every tool would return an empty string to the model with nothing logged.

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -5,7 +5,6 @@ using Application.AI.Common.Services.SkillTraining;
 using Domain.AI.SkillTraining;
 using Domain.Common.Config;
 using MediatR;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -100,20 +99,19 @@ public sealed class SkillTrainingExample
         var proposer = new DeterministicProposer();
         ILogger<TrainSkillCommandHandler> logger = NullLogger<TrainSkillCommandHandler>.Instance;
 
-        // Bare service provider — this demo wires everything else by hand, but
         // ClaimVerificationRunner needs an IServiceProvider for its keyed-reader lookup and an
-        // IOptionsMonitor<AppConfig> for its parallelism/timeout config; a one-line container is
-        // simpler and less error-prone than hand-rolling either. NoHarnessChangeSuggester never
-        // actually produces a suggestion, so this runner is never invoked at runtime in this demo —
-        // it exists here only so the handler's dependency graph is genuinely satisfiable.
-        var services = new ServiceCollection();
-        services.Configure<AppConfig>(_ => { });
-        var provider = services.BuildServiceProvider();
+        // IOptionsMonitor<AppConfig> for its parallelism/timeout config. This demo wires everything
+        // else by hand with no DI container at all, so a throwaway ServiceCollection just for these
+        // two would be an undisposed IDisposable with nothing else to justify pulling in a whole
+        // container — these two trivial, non-disposable stand-ins match the file's own style instead.
+        // NoHarnessChangeSuggester never actually produces a suggestion, so this runner is never
+        // invoked at runtime in this demo — it exists here only so the handler's dependency graph is
+        // genuinely satisfiable.
         var claimVerificationRunner = new ClaimVerificationRunner(
             new RuleBasedClaimConsequenceClassifier(),
             new NotConfiguredClaimVerifier(NullLogger<NotConfiguredClaimVerifier>.Instance),
-            provider,
-            provider.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+            new NoReaderServiceProvider(),
+            new StaticOptionsMonitor<AppConfig>(new AppConfig()),
             NullLogger<ClaimVerificationRunner>.Instance);
 
         return new TrainSkillCommandHandler(
@@ -182,5 +180,22 @@ public sealed class SkillTrainingExample
         public Task Publish(object notification, CancellationToken ct = default) => Task.CompletedTask;
         public Task Publish<TNotification>(TNotification notification, CancellationToken ct = default) where TNotification : INotification
             => Task.CompletedTask;
+    }
+
+    // ClaimVerificationRunner's IServiceProvider dependency exists for keyed ILocatedArtifactReader
+    // lookup; this demo never registers a reader (NoHarnessChangeSuggester never produces a
+    // suggestion, so no claim is ever built), so every lookup correctly finding nothing is exactly
+    // the right behavior — no container needed to express that.
+    private sealed class NoReaderServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
     }
 }

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -1,10 +1,14 @@
 using Application.AI.Common.CQRS.SkillTraining.TrainSkill;
 using Application.AI.Common.Interfaces.SkillTraining;
+using Application.AI.Common.Services.ClaimVerification;
 using Application.AI.Common.Services.SkillTraining;
 using Domain.AI.SkillTraining;
+using Domain.Common.Config;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Presentation.ConsoleUI.Common.Helpers;
 using Spectre.Console;
 
@@ -89,15 +93,32 @@ public sealed class SkillTrainingExample
         var gate = new GateEvaluator();
         var fence = new HarnessPatchValidator(new EditableSurfaceRegistry());
         var suggester = new NoHarnessChangeSuggester();
-        var suggestionValidator = new HarnessChangeSuggestionValidator(new ConfigSurfaceConstraint());
+        var configSurfaceConstraint = new ConfigSurfaceConstraint();
+        var suggestionValidator = new HarnessChangeSuggestionValidator(configSurfaceConstraint);
         var store = new InMemorySkillTrainingCheckpointStore();
         var runner = new DeterministicRolloutRunner();
         var proposer = new DeterministicProposer();
         ILogger<TrainSkillCommandHandler> logger = NullLogger<TrainSkillCommandHandler>.Instance;
 
+        // Bare service provider — this demo wires everything else by hand, but
+        // ClaimVerificationRunner needs an IServiceProvider for its keyed-reader lookup and an
+        // IOptionsMonitor<AppConfig> for its parallelism/timeout config; a one-line container is
+        // simpler and less error-prone than hand-rolling either. NoHarnessChangeSuggester never
+        // actually produces a suggestion, so this runner is never invoked at runtime in this demo —
+        // it exists here only so the handler's dependency graph is genuinely satisfiable.
+        var services = new ServiceCollection();
+        services.Configure<AppConfig>(_ => { });
+        var provider = services.BuildServiceProvider();
+        var claimVerificationRunner = new ClaimVerificationRunner(
+            new RuleBasedClaimConsequenceClassifier(),
+            new NotConfiguredClaimVerifier(NullLogger<NotConfiguredClaimVerifier>.Instance),
+            provider,
+            provider.GetRequiredService<IOptionsMonitor<AppConfig>>(),
+            NullLogger<ClaimVerificationRunner>.Instance);
+
         return new TrainSkillCommandHandler(
             runner, proposer, aggregator, selector, applier, gate, fence,
-            suggester, suggestionValidator, store,
+            suggester, suggestionValidator, configSurfaceConstraint, claimVerificationRunner, store,
             new NoOpMediator(), TimeProvider.System, logger);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/CQRS/SkillTraining/TrainSkillCommandHandlerTests.cs
@@ -1,11 +1,18 @@
 using Application.AI.Common.CQRS.SkillTraining.TrainSkill;
+using Application.AI.Common.Interfaces.ClaimVerification;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.SkillTraining;
+using Application.AI.Common.Services.ClaimVerification;
 using Application.AI.Common.Services.SkillTraining;
+using Domain.AI.ClaimVerification;
 using Domain.AI.SkillTraining;
+using Domain.Common.Config;
 using FluentAssertions;
 using MediatR;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Tests.AI.Fakes;
 using Xunit;
 
 namespace Application.AI.Common.Tests.CQRS.SkillTraining;
@@ -17,7 +24,20 @@ public class TrainSkillCommandHandlerTests
     private static readonly TopKEditSelector Selector = new();
     private static readonly GateEvaluator Gate = new();
     private static readonly HarnessPatchValidator Fence = new(new EditableSurfaceRegistry());
-    private static readonly HarnessChangeSuggestionValidator SuggestionValidator = new(new ConfigSurfaceConstraint());
+    private static readonly ConfigSurfaceConstraint SurfaceConstraint = new();
+    private static readonly HarnessChangeSuggestionValidator SuggestionValidator = new(SurfaceConstraint);
+
+    // NotConfiguredClaimVerifier — the same fail-safe default every host registers by default —
+    // reports every claim Unverifiable, so it never mutates a suggestion under test. Tests
+    // exercising real claim-verification behavior live in ClaimVerificationRunnerTests and
+    // TrainSkillCommandHandler-specific annotation tests below, which inject a scripted verifier
+    // directly rather than going through this shared field.
+    private static readonly ClaimVerificationRunner ClaimVerification = new(
+        new RuleBasedClaimConsequenceClassifier(),
+        new NotConfiguredClaimVerifier(NullLogger<NotConfiguredClaimVerifier>.Instance),
+        new ServiceCollection().BuildServiceProvider(),
+        new StaticOptionsMonitor<AppConfig>(new AppConfig()),
+        NullLogger<ClaimVerificationRunner>.Instance);
 
     private static TrainSkillCommandHandler NewSut(
         IRolloutRunner runner,
@@ -25,13 +45,41 @@ public class TrainSkillCommandHandlerTests
         InMemorySkillTrainingCheckpointStore store,
         IGovernanceAuditService? audit = null,
         HarnessPatchValidator? fence = null,
-        IHarnessChangeSuggester? suggester = null)
+        IHarnessChangeSuggester? suggester = null,
+        ClaimVerificationRunner? claimVerification = null)
     {
         return new TrainSkillCommandHandler(
             runner, proposer, Aggregator, Selector, Applier, Gate, fence ?? Fence,
-            suggester ?? new NoHarnessChangeSuggester(), SuggestionValidator,
+            suggester ?? new NoHarnessChangeSuggester(), SuggestionValidator, SurfaceConstraint,
+            claimVerification ?? ClaimVerification,
             store, new NoOpMediator(), TimeProvider.System,
             NullLogger<TrainSkillCommandHandler>.Instance, audit);
+    }
+
+    // A single "config"-scheme reader/verifier pair, scripted per test — mirrors ClaimVerification's
+    // own construction shape above but with a caller-supplied IClaimVerifier so these tests can
+    // control what the claim about CurrentValue is judged against.
+    private static ClaimVerificationRunner BuildClaimVerification(IClaimVerifier verifier)
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ILocatedArtifactReader>(
+            "config", new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("MaxAttempts = 2")));
+        var provider = services.BuildServiceProvider();
+
+        return new ClaimVerificationRunner(
+            new RuleBasedClaimConsequenceClassifier(),
+            verifier,
+            provider,
+            new StaticOptionsMonitor<AppConfig>(new AppConfig()),
+            NullLogger<ClaimVerificationRunner>.Instance);
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
     }
 
     /// <summary>A fence whose registry has been widened to unlock the given prose surfaces (Phase 2).</summary>
@@ -698,6 +746,61 @@ public class TrainSkillCommandHandlerTests
         result.IsSuccess.Should().BeTrue(because: "the suggestion path must never fail a completed run");
         result.Value!.HarnessChangeSuggestions.Should().BeEmpty();
         result.Value.Steps.Should().ContainSingle(because: "the optimization loop ran to completion regardless");
+    }
+
+    // THE CONTROL PAIR (#319 first consumer): byte-identical accepted suggestion, differing only in
+    // what the claim verifier reports about the suggestion's claimed CurrentValue — proving a
+    // confirmed claim leaves Rationale untouched and a contradicted claim annotates it, so the two
+    // cannot silently drift apart.
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_CurrentValueClaimHeld_RationaleUnannotated()
+    {
+        var claimVerification = BuildClaimVerification(
+            new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c))));
+        var suggester = new StubSuggester(_ => [RetrySuggestion("3")]);
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            suggester: suggester, claimVerification: claimVerification);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        result.Value!.HarnessChangeSuggestions.Should().ContainSingle()
+            .Which.Rationale.Should().Be("many transient tool failures");
+    }
+
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_CurrentValueClaimBroken_RationaleAnnotatedNotDropped()
+    {
+        var claimVerification = BuildClaimVerification(
+            new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Broken(c, "actual value is 5"))));
+        var suggester = new StubSuggester(_ => [RetrySuggestion("3")]);
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            suggester: suggester, claimVerification: claimVerification);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        var surfaced = result.Value!.HarnessChangeSuggestions.Should().ContainSingle().Subject;
+        surfaced.Rationale.Should().Contain("UNVERIFIED CURRENT VALUE");
+        surfaced.Rationale.Should().Contain("actual value is 5");
+        surfaced.Rationale.Should().Contain("many transient tool failures",
+            because: "the original rationale is preserved, not replaced");
+    }
+
+    [Fact]
+    public async Task Handle_SuggestionsEnabled_ClaimVerifierThrows_SurfacesSuggestionUnannotated()
+    {
+        // Advisory-by-design, same tolerance as a faulty suggester: a throwing verifier must never
+        // fail an already-completed run or drop an otherwise-valid suggestion.
+        var claimVerification = BuildClaimVerification(
+            new RecordingClaimVerifier((_, _, _) => throw new InvalidOperationException("verifier boom")));
+        var suggester = new StubSuggester(_ => [RetrySuggestion("3")]);
+        var sut = NewSut(AcceptingRunner(), AppendProposer(), new InMemorySkillTrainingCheckpointStore(),
+            suggester: suggester, claimVerification: claimVerification);
+
+        var result = await sut.Handle(NewCommand(SuggestConfig(emit: true)), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.HarnessChangeSuggestions.Should().ContainSingle()
+            .Which.Rationale.Should().Be("many transient tool failures");
     }
 
     // ── Stubs ────────────────────────────────────────────────────────────────────

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/ClaimVerificationRunnerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/ClaimVerificationRunnerTests.cs
@@ -1,0 +1,262 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Application.AI.Common.Services.ClaimVerification;
+using Domain.AI.ClaimVerification;
+using Domain.Common.Config;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Tests.AI.Fakes;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.ClaimVerification;
+
+/// <summary>
+/// Proves <see cref="ClaimVerificationRunner"/>'s dispatch contract: consequence-gated skipping,
+/// scheme-keyed reader resolution, the fail-safe/real-finding split between "no reader" and
+/// "reader found but location doesn't exist," and that a per-claim failure (thrown exception or
+/// timeout) never escapes to <c>Task.WhenAll</c>.
+/// </summary>
+public sealed class ClaimVerificationRunnerTests
+{
+    private static readonly ClaimConsequenceSignals LowConsequence = new() { CausesWrite = false, GatesADecision = false };
+    private static readonly ClaimConsequenceSignals HighConsequence = new() { CausesWrite = false, GatesADecision = true };
+
+    private static Claim MakeClaim(string location, ClaimConsequenceSignals? signals = null, string text = "the claim") =>
+        new() { Text = text, Location = location, ConsequenceSignals = signals ?? HighConsequence };
+
+    // Zero reader/verifier invocations for a low-consequence claim — deleting the classifier check
+    // in ClaimVerificationRunner.VerifyOneAsync makes this fail (CallCount would become 1).
+    [Fact]
+    public async Task RunAsync_LowConsequenceClaim_SkipsWithoutInvokingReaderOrVerifier()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, ("file", reader));
+        var claim = MakeClaim("file:src/Foo.cs", LowConsequence);
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts.Should().ContainSingle();
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.NotConsequential);
+        verdicts[0].RevisedClaim.Confidence.Should().Be(claim.Confidence);
+        reader.CallCount.Should().Be(0);
+        verifier.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_UnregisteredScheme_ReturnsUnverifiableAndClaimUnchanged()
+    {
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier); // no reader registered for any scheme
+        var claim = MakeClaim("nosuchscheme:whatever");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts.Should().ContainSingle();
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.Unverifiable);
+        verdicts[0].RevisedClaim.Should().Be(claim);
+        verifier.CallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunAsync_MalformedLocationNoScheme_ReturnsUnverifiable()
+    {
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier);
+        var claim = MakeClaim("no-colon-at-all");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.Unverifiable);
+        verifier.CallCount.Should().Be(0);
+    }
+
+    // An authoritative reader returning null is a REAL finding — not fail-safe silence — and the
+    // verifier is never called (nothing left to judge once the location itself doesn't exist).
+    [Fact]
+    public async Task RunAsync_ReaderReturnsNull_ReturnsLocationNotFoundWithFlooredConfidenceAndSkipsVerifier()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>(null));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, ("file", reader));
+        var claim = MakeClaim("file:does/not/exist.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.LocationNotFound);
+        verdicts[0].RevisedClaim.Confidence.Should().Be(0.1);
+        reader.CallCount.Should().Be(1);
+        verifier.CallCount.Should().Be(0);
+    }
+
+    // THE CONTROL PAIR: byte-identical claim/location shape through the same reader, differing only
+    // in what the verifier reports — proving Held leaves confidence untouched and Broken floors it,
+    // in the same test class so the two cannot drift apart.
+    [Fact]
+    public async Task RunAsync_VerifierReportsHeld_ConfidenceUnchanged()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence text"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, ("file", reader));
+        var claim = MakeClaim("file:src/Foo.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.Held);
+        verdicts[0].RevisedClaim.Confidence.Should().Be(claim.Confidence);
+    }
+
+    [Fact]
+    public async Task RunAsync_VerifierReportsBroken_ConfidenceFloored()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence text"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Broken(c, "contradicted")));
+        var sut = CreateSut(verifier, ("file", reader));
+        var claim = MakeClaim("file:src/Foo.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.Broken);
+        verdicts[0].RevisedClaim.Confidence.Should().Be(0.1);
+        verdicts[0].Explanation.Should().Be("contradicted");
+    }
+
+    [Fact]
+    public async Task RunAsync_ReaderThrows_ReportsVerifierErrorNotThrow()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => throw new InvalidOperationException("boom"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, ("file", reader));
+        var claim = MakeClaim("file:src/Foo.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+        verdicts[0].RevisedClaim.Should().Be(claim);
+    }
+
+    [Fact]
+    public async Task RunAsync_OneVerifierThrows_OtherClaimsUnaffected()
+    {
+        var poisoned = MakeClaim("file:poisoned.cs", text: "poisoned claim");
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence"));
+        var verifier = new RecordingClaimVerifier((c, _, _) =>
+            c.Location == poisoned.Location
+                ? throw new InvalidOperationException("boom")
+                : Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, ("file", reader));
+        var claims = new[] { poisoned, MakeClaim("file:ok1.cs"), MakeClaim("file:ok2.cs") };
+
+        var verdicts = await sut.RunAsync(claims, CancellationToken.None);
+
+        verdicts.Should().HaveCount(3);
+        var poisonedVerdict = verdicts.Single(v => v.Claim.Location == poisoned.Location);
+        poisonedVerdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+        verdicts.Where(v => v.Claim.Location != poisoned.Location)
+            .Should().OnlyContain(v => v.Outcome == ClaimVerificationOutcome.Held);
+    }
+
+    [Fact]
+    public async Task RunAsync_VerifierExceedsPerVerifierTimeout_ReportsVerifierErrorNotAHang()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence"));
+        var verifier = new RecordingClaimVerifier(async (c, _, ct) =>
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            return ClaimVerdict.Held(c);
+        });
+        var sut = CreateSut(verifier, [("file", reader)], perVerifierTimeout: TimeSpan.FromMilliseconds(50));
+        var claim = MakeClaim("file:src/Foo.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None);
+
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+    }
+
+    [Fact]
+    public async Task RunAsync_MaxParallelVerifiersIsZero_DoesNotHangAndVerifiesNormally()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, [("file", reader)], maxParallelVerifiers: 0);
+        var claim = MakeClaim("file:src/Foo.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        verdicts.Should().ContainSingle();
+        verdicts[0].Outcome.Should().Be(ClaimVerificationOutcome.Held);
+    }
+
+    [Fact]
+    public async Task RunAsync_MaxParallelVerifiersIsNegative_DoesNotThrowFromSemaphoreConstruction()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, [("file", reader)], maxParallelVerifiers: -1);
+        var claim = MakeClaim("file:src/Foo.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        verdicts.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RunAsync_PerVerifierTimeoutIsNonPositive_DoesNotThrowFromCancelAfter()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, [("file", reader)], perVerifierTimeout: TimeSpan.Zero);
+        var claim = MakeClaim("file:src/Foo.cs");
+
+        var verdicts = await sut.RunAsync([claim], CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        verdicts.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void RunAsync_DefaultAppConfig_UsesDocumentedMaxParallelVerifiers()
+    {
+        var config = new AppConfig();
+
+        config.AI.ClaimVerification.MaxParallelVerifiers.Should().Be(4);
+    }
+
+    private static ClaimVerificationRunner CreateSut(
+        IClaimVerifier verifier,
+        params (string Scheme, ILocatedArtifactReader Reader)[] readers) =>
+        CreateSut(verifier, readers, maxParallelVerifiers: 4, perVerifierTimeout: TimeSpan.FromSeconds(30));
+
+    private static ClaimVerificationRunner CreateSut(
+        IClaimVerifier verifier,
+        IReadOnlyCollection<(string Scheme, ILocatedArtifactReader Reader)> readers,
+        int maxParallelVerifiers = 4,
+        TimeSpan? perVerifierTimeout = null)
+    {
+        var services = new ServiceCollection();
+        foreach (var (scheme, reader) in readers)
+        {
+            services.AddKeyedSingleton(scheme, reader);
+        }
+        var provider = services.BuildServiceProvider();
+
+        var config = new AppConfig();
+        config.AI.ClaimVerification.MaxParallelVerifiers = maxParallelVerifiers;
+        config.AI.ClaimVerification.PerVerifierTimeout = perVerifierTimeout ?? TimeSpan.FromSeconds(30);
+
+        return new ClaimVerificationRunner(
+            new RuleBasedClaimConsequenceClassifier(),
+            verifier,
+            provider,
+            new StaticOptionsMonitor<AppConfig>(config),
+            NullLogger<ClaimVerificationRunner>.Instance);
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/ClaimVerificationRunnerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/ClaimVerificationRunnerTests.cs
@@ -219,7 +219,22 @@ public sealed class ClaimVerificationRunnerTests
     {
         var config = new AppConfig();
 
+        config.AI.ClaimVerification.MaxClaims.Should().Be(14);
         config.AI.ClaimVerification.MaxParallelVerifiers.Should().Be(4);
+    }
+
+    [Fact]
+    public async Task RunAsync_MoreClaimsThanMaxClaims_OnlyVerifiesUpToTheCapAndDropsTheRestSilently()
+    {
+        var reader = new RecordingLocatedArtifactReader((_, _) => Task.FromResult<string?>("evidence"));
+        var verifier = new RecordingClaimVerifier((c, _, _) => Task.FromResult(ClaimVerdict.Held(c)));
+        var sut = CreateSut(verifier, [("file", reader)], maxClaims: 3);
+        var claims = Enumerable.Range(0, 5).Select(i => MakeClaim($"file:claim-{i}.cs")).ToList();
+
+        var verdicts = await sut.RunAsync(claims, CancellationToken.None);
+
+        verdicts.Should().HaveCount(3);
+        verifier.CallCount.Should().Be(3);
     }
 
     private static ClaimVerificationRunner CreateSut(
@@ -231,7 +246,8 @@ public sealed class ClaimVerificationRunnerTests
         IClaimVerifier verifier,
         IReadOnlyCollection<(string Scheme, ILocatedArtifactReader Reader)> readers,
         int maxParallelVerifiers = 4,
-        TimeSpan? perVerifierTimeout = null)
+        TimeSpan? perVerifierTimeout = null,
+        int maxClaims = 14)
     {
         var services = new ServiceCollection();
         foreach (var (scheme, reader) in readers)
@@ -241,6 +257,7 @@ public sealed class ClaimVerificationRunnerTests
         var provider = services.BuildServiceProvider();
 
         var config = new AppConfig();
+        config.AI.ClaimVerification.MaxClaims = maxClaims;
         config.AI.ClaimVerification.MaxParallelVerifiers = maxParallelVerifiers;
         config.AI.ClaimVerification.PerVerifierTimeout = perVerifierTimeout ?? TimeSpan.FromSeconds(30);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/NotConfiguredClaimVerifierTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/NotConfiguredClaimVerifierTests.cs
@@ -1,0 +1,28 @@
+using Application.AI.Common.Services.ClaimVerification;
+using Domain.AI.ClaimVerification;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.ClaimVerification;
+
+public sealed class NotConfiguredClaimVerifierTests
+{
+    private readonly NotConfiguredClaimVerifier _sut = new(NullLogger<NotConfiguredClaimVerifier>.Instance);
+
+    [Fact]
+    public async Task VerifyAsync_AnyClaim_ReturnsUnverifiableNotThrow()
+    {
+        var claim = new Claim
+        {
+            Text = "some claim",
+            Location = "file:Foo.cs",
+            ConsequenceSignals = new ClaimConsequenceSignals { CausesWrite = false, GatesADecision = true }
+        };
+
+        var verdict = await _sut.VerifyAsync(claim, "evidence", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Unverifiable);
+        verdict.RevisedClaim.Should().Be(claim);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/RuleBasedClaimConsequenceClassifierTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/ClaimVerification/RuleBasedClaimConsequenceClassifierTests.cs
@@ -1,0 +1,35 @@
+using Application.AI.Common.Services.ClaimVerification;
+using Domain.AI.ClaimVerification;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.ClaimVerification;
+
+public sealed class RuleBasedClaimConsequenceClassifierTests
+{
+    private readonly RuleBasedClaimConsequenceClassifier _sut = new();
+
+    [Fact]
+    public void Classify_NeitherSignalSet_ReturnsLow()
+        => _sut.Classify(new ClaimConsequenceSignals { CausesWrite = false, GatesADecision = false })
+            .Should().Be(ClaimConsequence.Low);
+
+    [Fact]
+    public void Classify_CausesWriteOnly_ReturnsHigh()
+        => _sut.Classify(new ClaimConsequenceSignals { CausesWrite = true, GatesADecision = false })
+            .Should().Be(ClaimConsequence.High);
+
+    [Fact]
+    public void Classify_GatesADecisionOnly_ReturnsHigh()
+        => _sut.Classify(new ClaimConsequenceSignals { CausesWrite = false, GatesADecision = true })
+            .Should().Be(ClaimConsequence.High);
+
+    [Fact]
+    public void Classify_BothSignalsSet_ReturnsHigh()
+        => _sut.Classify(new ClaimConsequenceSignals { CausesWrite = true, GatesADecision = true })
+            .Should().Be(ClaimConsequence.High);
+
+    [Fact]
+    public void Classify_Null_Throws()
+        => FluentActions.Invoking(() => _sut.Classify(null!)).Should().Throw<ArgumentNullException>();
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/ConfigSurfaceConstraintTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/ConfigSurfaceConstraintTests.cs
@@ -81,4 +81,26 @@ public class ConfigSurfaceConstraintTests
     public void ResolveConfigPath_GovernedSurfaceUnknownField_ReturnsNull()
         => _sut.ResolveConfigPath(HarnessSurface.ToolErrorRetryLimit, "BaseDelaySeconds")
             .Should().BeNull();
+
+    // Reflection, not a hand-typed field list: ConfigSurfaceConstraint hand-maintains AllowedFields
+    // (which field a suggestion may target) and ConfigPaths (where that field's live value lives)
+    // as two independent structures — nothing in the compiler ties them together. A field added to
+    // one and forgotten in the other means ResolveConfigPath silently returns null for a governed,
+    // allowed field, and AnnotateWithClaimVerificationAsync treats that as "nothing to verify
+    // against" — a silent, permanent skip with no error or warning. This fails the moment the two
+    // sets diverge, regardless of which field name is added.
+    [Fact]
+    public void EveryAllowedField_HasAResolvableConfigPath()
+    {
+        var allowedFieldsField = typeof(ConfigSurfaceConstraint).GetField(
+            "AllowedFields", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var allowedFields = (IReadOnlySet<string>)allowedFieldsField!.GetValue(null)!;
+
+        allowedFields.Should().NotBeEmpty();
+        foreach (var field in allowedFields)
+        {
+            _sut.ResolveConfigPath(_sut.GovernedSurface, field).Should().NotBeNull(
+                because: $"'{field}' is in AllowedFields but has no matching ConfigPaths entry");
+        }
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/ConfigSurfaceConstraintTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/SkillTraining/ConfigSurfaceConstraintTests.cs
@@ -65,4 +65,20 @@ public class ConfigSurfaceConstraintTests
         ConfigSurfaceConstraint.MinMaxAttempts.Should().BeLessThan(ConfigSurfaceConstraint.MaxMaxAttempts);
         ConfigSurfaceConstraint.MinMaxAttempts.Should().BeGreaterThanOrEqualTo(1);
     }
+
+    // #319 first consumer: the dotted path a "config:" claim's Location is built from.
+    [Fact]
+    public void ResolveConfigPath_GovernedSurfaceAndField_ReturnsTheLiveConfigPath()
+        => _sut.ResolveConfigPath(HarnessSurface.ToolErrorRetryLimit, ConfigSurfaceConstraint.MaxAttemptsField)
+            .Should().Be("AI.Resilience.Retry.MaxAttempts");
+
+    [Fact]
+    public void ResolveConfigPath_UngovernedSurface_ReturnsNull()
+        => _sut.ResolveConfigPath(HarnessSurface.SkillDocument, ConfigSurfaceConstraint.MaxAttemptsField)
+            .Should().BeNull();
+
+    [Fact]
+    public void ResolveConfigPath_GovernedSurfaceUnknownField_ReturnsNull()
+        => _sut.ResolveConfigPath(HarnessSurface.ToolErrorRetryLimit, "BaseDelaySeconds")
+            .Should().BeNull();
 }

--- a/src/Content/Tests/Domain.AI.Tests/ClaimVerification/ClaimVerdictTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/ClaimVerification/ClaimVerdictTests.cs
@@ -1,0 +1,94 @@
+using Domain.AI.ClaimVerification;
+using FluentAssertions;
+using Xunit;
+
+namespace Domain.AI.Tests.ClaimVerification;
+
+/// <summary>
+/// Proves <see cref="ClaimVerdict"/>'s fail-safe shape: confidence is floored only for a genuine
+/// finding (<see cref="ClaimVerificationOutcome.Broken"/>, <see cref="ClaimVerificationOutcome.LocationNotFound"/>)
+/// and left untouched for every fail-safe outcome — "a failed claim is revised, not deleted," and a
+/// claim that was never really checked is not revised at all.
+/// </summary>
+public sealed class ClaimVerdictTests
+{
+    private static readonly ClaimConsequenceSignals Signals = new() { CausesWrite = false, GatesADecision = true };
+
+    private static readonly Claim SampleClaim = new()
+    {
+        Text = "the claim",
+        Location = "file:Foo.cs",
+        Confidence = 0.9,
+        ConsequenceSignals = Signals
+    };
+
+    [Fact]
+    public void Held_LeavesConfidenceUnchanged()
+    {
+        var verdict = ClaimVerdict.Held(SampleClaim);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Held);
+        verdict.Explanation.Should().BeNull();
+        verdict.RevisedClaim.Confidence.Should().Be(0.9);
+    }
+
+    [Fact]
+    public void Broken_FloorsConfidenceToOneTenth()
+    {
+        var verdict = ClaimVerdict.Broken(SampleClaim, "contradicted");
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Broken);
+        verdict.Explanation.Should().Be("contradicted");
+        verdict.RevisedClaim.Confidence.Should().Be(0.1);
+    }
+
+    // The one outcome that must NOT be fail-safe-silent — a nonexistent location is a real finding,
+    // not "we couldn't check," so it gets the same floor as Broken.
+    [Fact]
+    public void LocationNotFound_FloorsConfidenceToOneTenth()
+    {
+        var verdict = ClaimVerdict.LocationNotFound(SampleClaim, "does not exist");
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.LocationNotFound);
+        verdict.RevisedClaim.Confidence.Should().Be(0.1);
+    }
+
+    [Fact]
+    public void Unverifiable_LeavesConfidenceUnchanged()
+    {
+        var verdict = ClaimVerdict.Unverifiable(SampleClaim, "no reader for scheme");
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Unverifiable);
+        verdict.RevisedClaim.Confidence.Should().Be(0.9);
+    }
+
+    [Fact]
+    public void VerifierError_LeavesConfidenceUnchanged()
+    {
+        var verdict = ClaimVerdict.VerifierError(SampleClaim, "timed out");
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+        verdict.RevisedClaim.Confidence.Should().Be(0.9);
+    }
+
+    [Fact]
+    public void NotConsequential_LeavesConfidenceUnchanged()
+    {
+        var verdict = ClaimVerdict.NotConsequential(SampleClaim);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.NotConsequential);
+        verdict.Explanation.Should().BeNull();
+        verdict.RevisedClaim.Confidence.Should().Be(0.9);
+    }
+
+    // The revise-don't-delete rule, made concrete: a failed claim is a NEW record with the same
+    // identity (Text/Location), never absent from whatever list it came from.
+    [Fact]
+    public void Broken_RevisedClaim_KeepsTextAndLocationIdentity()
+    {
+        var verdict = ClaimVerdict.Broken(SampleClaim, "contradicted");
+
+        verdict.RevisedClaim.Text.Should().Be(SampleClaim.Text);
+        verdict.RevisedClaim.Location.Should().Be(SampleClaim.Location);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/PolicyGateTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/PolicyGateTests.cs
@@ -25,11 +25,15 @@ public sealed class PolicyGateTests
             => throw new InvalidOperationException("policy exploded");
     }
 
-    private static PolicyFinding Finding(string policyKey, PolicyFindingSeverity sev, string msg = "issue") => new()
+    private static PolicyFinding Finding(
+        string policyKey, PolicyFindingSeverity sev, string msg = "issue",
+        bool blocking = false, bool requiresVerification = false) => new()
     {
         PolicyKey = policyKey,
         Severity = sev,
-        Message = msg
+        Message = msg,
+        Blocking = blocking,
+        RequiresVerification = requiresVerification
     };
 
     private static (PolicyGate Gate, string TempDir) Build(params IChangeProposalPolicy[] policies)
@@ -237,6 +241,88 @@ public sealed class PolicyGateTests
 
             result.Action.Should().Be(GateAction.Fail);
             result.Reason.Should().Contain("nit");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    // THE MOST IMPORTANT mutation in Package F (#319): a model-assigned Critical finding that has
+    // NOT been independently confirmed must not block on severity alone. Deleting the
+    // `&& !f.RequiresVerification` clause makes this fail (the gate would block again).
+    [Fact]
+    public async Task EvaluateAsync_CriticalFindingRequiresVerificationNotConfirmed_DoesNotBlock()
+    {
+        var (sut, dir) = Build(new ScriptedPolicy("claim-checker",
+            Finding("claim-checker", PolicyFindingSeverity.Critical, "unconfirmed", requiresVerification: true)));
+        try
+        {
+            var result = await sut.EvaluateAsync(TestProposals.NewProposal(), Ctx(), CancellationToken.None);
+
+            result.Action.Should().Be(GateAction.Pass);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    // The control for the mutation above: the SAME finding, but a verifier has since confirmed it
+    // and the policy re-emits it with Blocking set — it must block regardless of RequiresVerification.
+    [Fact]
+    public async Task EvaluateAsync_RequiresVerificationFindingConfirmedViaBlocking_StillBlocks()
+    {
+        var (sut, dir) = Build(new ScriptedPolicy("claim-checker",
+            Finding("claim-checker", PolicyFindingSeverity.Critical, "confirmed broken",
+                blocking: true, requiresVerification: true)));
+        try
+        {
+            var result = await sut.EvaluateAsync(TestProposals.NewProposal(), Ctx(), CancellationToken.None);
+
+            result.Action.Should().Be(GateAction.Fail);
+            result.Reason.Should().Contain("confirmed broken");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    // Blocking wins independent of severity — an Info-severity finding a policy has independently
+    // confirmed as a hard stop must still block, even though Info never crosses any threshold.
+    [Fact]
+    public async Task EvaluateAsync_BlockingFindingBelowSeverityThreshold_StillBlocks()
+    {
+        var (sut, dir) = Build(new ScriptedPolicy("claim-checker",
+            Finding("claim-checker", PolicyFindingSeverity.Info, "hard stop", blocking: true)));
+        try
+        {
+            var result = await sut.EvaluateAsync(TestProposals.NewProposal(), Ctx(), CancellationToken.None);
+
+            result.Action.Should().Be(GateAction.Fail);
+            result.Reason.Should().Contain("hard stop");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
+    // Regression pin (#319): every finding above this line in the file leaves Blocking and
+    // RequiresVerification at their false default, and every one of those tests still asserts the
+    // exact pre-#319 behavior — proving `f.Blocking || (f.Severity >= threshold && !f.RequiresVerification)`
+    // is byte-identical to the old `f.Severity >= threshold` whenever both new flags are unset.
+    [Fact]
+    public async Task EvaluateAsync_BothNewFlagsDefaultFalse_BehavesExactlyLikeSeverityThresholdAlone()
+    {
+        var (sut, dir) = Build(new ScriptedPolicy("checkov", Finding("checkov", PolicyFindingSeverity.High, "unflagged")));
+        try
+        {
+            var result = await sut.EvaluateAsync(TestProposals.NewProposal(), Ctx(), CancellationToken.None);
+
+            result.Action.Should().Be(GateAction.Fail);
+            result.Reason.Should().Contain("unflagged");
         }
         finally
         {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/PolicyGateTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/PolicyGateTests.cs
@@ -261,6 +261,11 @@ public sealed class PolicyGateTests
             var result = await sut.EvaluateAsync(TestProposals.NewProposal(), Ctx(), CancellationToken.None);
 
             result.Action.Should().Be(GateAction.Pass);
+            // Not "below threshold" — Critical IS at/above every real threshold. The Reason must say
+            // it was excluded pending verification, not misdescribe it as too minor to matter.
+            result.Reason.Should().Contain("excluded pending verification");
+            result.Reason.Should().NotContain("1 finding(s) below",
+                because: "an unconfirmed Critical finding was excluded, not judged below threshold");
         }
         finally
         {
@@ -302,6 +307,9 @@ public sealed class PolicyGateTests
 
             result.Action.Should().Be(GateAction.Fail);
             result.Reason.Should().Contain("hard stop");
+            // Must not claim the finding was "at or above" threshold — it wasn't; Blocking is what
+            // forced the fail, and the message must not misdescribe why.
+            result.Reason.Should().NotContain("at or above");
         }
         finally
         {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/PolicyGateTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/Gates/PolicyGateTests.cs
@@ -273,6 +273,29 @@ public sealed class PolicyGateTests
         }
     }
 
+    // The control for the test above: a RequiresVerification finding whose severity was NEVER
+    // going to block (Info, well under the default High threshold) belongs in "below threshold" —
+    // confirming it would not have changed the outcome, so calling it "excluded pending
+    // verification" would overstate its significance.
+    [Fact]
+    public async Task EvaluateAsync_LowSeverityRequiresVerificationFinding_CountedAsBelowThresholdNotExcluded()
+    {
+        var (sut, dir) = Build(new ScriptedPolicy("claim-checker",
+            Finding("claim-checker", PolicyFindingSeverity.Info, "unconfirmed but minor", requiresVerification: true)));
+        try
+        {
+            var result = await sut.EvaluateAsync(TestProposals.NewProposal(), Ctx(), CancellationToken.None);
+
+            result.Action.Should().Be(GateAction.Pass);
+            result.Reason.Should().Contain("1 finding(s) below");
+            result.Reason.Should().NotContain("excluded pending verification");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); } catch { }
+        }
+    }
+
     // The control for the mutation above: the SAME finding, but a verifier has since confirmed it
     // and the policy re-emits it with Blocking set — it must block regardless of RequiresVerification.
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/LlmClaimVerifierTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/LlmClaimVerifierTests.cs
@@ -156,6 +156,19 @@ public sealed class LlmClaimVerifierTests
         verdict.Explanation.Should().NotBeNullOrWhiteSpace();
     }
 
+    // Same RespectNullableAnnotations gap, on Status this time: a model returning
+    // {"status":null,...} deserializes successfully despite `required`. Must fail safe to
+    // VerifierError, not throw an NRE out of .Trim().
+    [Fact]
+    public async Task VerifyAsync_NullStatus_ReturnsVerifierErrorNotThrow()
+    {
+        SetupChatClientResponse("""{ "status": null, "explanation": "whatever" }""");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+    }
+
     [Fact]
     public async Task VerifyAsync_StatusIsCaseInsensitive()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/LlmClaimVerifierTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/LlmClaimVerifierTests.cs
@@ -5,10 +5,12 @@ using Application.AI.Common.Prompts.Models;
 using Application.AI.Common.StructuredOutput;
 using Domain.AI.ClaimVerification;
 using Domain.AI.Prompts;
+using Domain.Common.Config;
 using FluentAssertions;
 using Infrastructure.AI.Verification;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Tests.Common;
 using Xunit;
@@ -40,6 +42,12 @@ public sealed class LlmClaimVerifierTests
     private readonly Mock<IPromptRegistry> _promptRegistry = new();
     private readonly Mock<IPromptRenderer> _promptRenderer = new();
     private readonly Mock<IPromptUsageRecorder> _usageRecorder = new();
+
+    // Enabled=true by default in this fixture: every test in this file exercises the model-call
+    // path, so the feature must be on. The Enabled=false gate is its own dedicated test below,
+    // built with a separate SUT instance rather than mutating this shared config.
+    private readonly IOptionsMonitor<AppConfig> _config = new StaticOptionsMonitor<AppConfig>(
+        new AppConfig { AI = { ClaimVerification = { Enabled = true } } });
 
     private readonly LlmClaimVerifier _sut;
 
@@ -84,6 +92,7 @@ public sealed class LlmClaimVerifierTests
             _promptRegistry.Object,
             _promptRenderer.Object,
             _usageRecorder.Object,
+            _config,
             NullLogger<LlmClaimVerifier>.Instance);
     }
 
@@ -257,11 +266,44 @@ public sealed class LlmClaimVerifierTests
             realRegistry,
             realRenderer,
             _usageRecorder.Object,
+            _config,
             NullLogger<LlmClaimVerifier>.Instance);
         SetupChatClientResponse("""{ "status": "held", "explanation": "confirmed" }""");
 
         var verdict = await sutWithRealRegistry.VerifyAsync(SampleClaim, "content", CancellationToken.None);
 
         verdict.Outcome.Should().Be(ClaimVerificationOutcome.Held, because: verdict.Explanation);
+    }
+
+    // AppConfig:AI:ClaimVerification:Enabled gates the judge call itself — a disabled host must
+    // never send claim/evidence content to a model, and must fail safe (Unverifiable) rather than
+    // throw. Deleting this check restores the dead-control defect: setting Enabled=false would no
+    // longer stop a live judge call.
+    [Fact]
+    public async Task VerifyAsync_ClaimVerificationDisabled_ReturnsUnverifiableWithoutCallingTheModel()
+    {
+        var disabledSut = new LlmClaimVerifier(
+            _chatClientProvider.Object,
+            new StructuredOutputInvoker(NullLogger<StructuredOutputInvoker>.Instance),
+            _promptRegistry.Object,
+            _promptRenderer.Object,
+            _usageRecorder.Object,
+            new StaticOptionsMonitor<AppConfig>(new AppConfig { AI = { ClaimVerification = { Enabled = false } } }),
+            NullLogger<LlmClaimVerifier>.Instance);
+
+        var verdict = await disabledSut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Unverifiable);
+        _chatClient.Verify(
+            c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/LlmClaimVerifierTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/LlmClaimVerifierTests.cs
@@ -1,0 +1,267 @@
+using Application.AI.Common.Evaluation.Interfaces;
+using Application.AI.Common.Interfaces.AI;
+using Application.AI.Common.Prompts.Interfaces;
+using Application.AI.Common.Prompts.Models;
+using Application.AI.Common.StructuredOutput;
+using Domain.AI.ClaimVerification;
+using Domain.AI.Prompts;
+using FluentAssertions;
+using Infrastructure.AI.Verification;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Tests.Common;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Verification;
+
+/// <summary>
+/// Proves <see cref="LlmClaimVerifier"/>'s own wiring: the status→<see cref="ClaimVerificationOutcome"/>
+/// mapping (including the fail-safe path for an unrecognized status), that a soft-fail
+/// <see cref="StructuredOutputResult{T}"/> maps to <see cref="ClaimVerdict.VerifierError"/> rather
+/// than propagating, and that the claim plus evidence content actually reach the model wrapped in
+/// <see cref="Application.AI.Common.Evaluation.PromptInjectionEnvelope"/>'s tags. Uses a real
+/// <see cref="StructuredOutputInvoker"/> (not mocked), matching <c>LlmObligationVerifierTests</c>'s
+/// precedent for testing a structured-output consumer.
+/// </summary>
+public sealed class LlmClaimVerifierTests
+{
+    private const string PromptName = "claim-verifier";
+
+    private static readonly Claim SampleClaim = new()
+    {
+        Text = "The current value of RetryConfig.MaxAttempts is 2.",
+        Location = "config:AI.Resilience.Retry.MaxAttempts",
+        ConsequenceSignals = new ClaimConsequenceSignals { CausesWrite = false, GatesADecision = true }
+    };
+
+    private readonly Mock<IJudgeChatClientProvider> _chatClientProvider = new();
+    private readonly Mock<IChatClient> _chatClient = new();
+    private readonly Mock<IPromptRegistry> _promptRegistry = new();
+    private readonly Mock<IPromptRenderer> _promptRenderer = new();
+    private readonly Mock<IPromptUsageRecorder> _usageRecorder = new();
+
+    private readonly LlmClaimVerifier _sut;
+
+    public LlmClaimVerifierTests()
+    {
+        _chatClientProvider
+            .Setup(p => p.GetJudgeAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_chatClient.Object);
+
+        var descriptor = new PromptDescriptor
+        {
+            Name = PromptName,
+            Version = new PromptVersion(1, 0),
+            ContentHash = "deadbeef",
+            Body = "claim verifier system prompt body",
+        };
+        _promptRegistry
+            .Setup(r => r.GetLatestAsync(PromptName, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(descriptor);
+        _promptRenderer
+            .Setup(r => r.RenderAsync(
+                It.IsAny<PromptDescriptor>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PromptDescriptor d, IReadOnlyDictionary<string, object?> _, CancellationToken __)
+                => new RenderedPrompt { Source = d, Body = "rendered-claim-verifier-system-prompt" });
+        _usageRecorder
+            .Setup(r => r.RecordAsync(It.IsAny<PromptDescriptor>(), It.IsAny<PromptUsageContext>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PromptDescriptor d, PromptUsageContext c, CancellationToken _) => new PromptUsageRecord
+            {
+                Descriptor = d,
+                CaseId = c.CaseId,
+                MetricKey = c.MetricKey,
+                RecordedAtUtc = DateTimeOffset.UtcNow,
+            });
+
+        var structuredOutput = new StructuredOutputInvoker(NullLogger<StructuredOutputInvoker>.Instance);
+
+        _sut = new LlmClaimVerifier(
+            _chatClientProvider.Object,
+            structuredOutput,
+            _promptRegistry.Object,
+            _promptRenderer.Object,
+            _usageRecorder.Object,
+            NullLogger<LlmClaimVerifier>.Instance);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_HeldStatus_ReturnsHeldVerdict()
+    {
+        SetupChatClientResponse("""{ "status": "held", "explanation": "confirmed" }""");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "MaxAttempts = 2", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Held);
+        verdict.RevisedClaim.Confidence.Should().Be(SampleClaim.Confidence);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_BrokenStatus_ReturnsBrokenVerdictWithFlooredConfidence()
+    {
+        SetupChatClientResponse("""{ "status": "broken", "explanation": "MaxAttempts is actually 3" }""");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "MaxAttempts = 3", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Broken);
+        verdict.RevisedClaim.Confidence.Should().Be(0.1);
+        verdict.Explanation.Should().Be("MaxAttempts is actually 3");
+    }
+
+    [Fact]
+    public async Task VerifyAsync_UnverifiableStatus_ReturnsUnverifiableVerdictUnchanged()
+    {
+        SetupChatClientResponse("""{ "status": "unverifiable", "explanation": "evidence does not address the claim" }""");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "unrelated evidence", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Unverifiable);
+        verdict.RevisedClaim.Confidence.Should().Be(SampleClaim.Confidence);
+    }
+
+    // Fail-safe: a status the contract doesn't define must not be silently treated as "held" and
+    // must not throw — it becomes VerifierError, the same as an infrastructure failure.
+    [Fact]
+    public async Task VerifyAsync_UnrecognizedStatus_ReturnsVerifierError()
+    {
+        SetupChatClientResponse("""{ "status": "maybe", "explanation": "not sure" }""");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+        verdict.RevisedClaim.Confidence.Should().Be(SampleClaim.Confidence);
+    }
+
+    // Same RespectNullableAnnotations gap LlmObligationVerifierTests documents: `required` on
+    // ClaimVerificationResponse.Explanation is a constructor-time guarantee only.
+    [Fact]
+    public async Task VerifyAsync_BrokenStatusWithNullExplanation_SubstitutesPlaceholderNotNull()
+    {
+        SetupChatClientResponse("""{ "status": "broken", "explanation": null }""");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Broken);
+        verdict.Explanation.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task VerifyAsync_StatusIsCaseInsensitive()
+    {
+        SetupChatClientResponse("""{ "status": "HELD", "explanation": "confirmed" }""");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Held);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_MalformedResponse_ReturnsVerifierErrorNotThrow()
+    {
+        SetupChatClientResponse("this is not json");
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_PromptRegistryThrowsKeyNotFound_ReturnsVerifierError()
+    {
+        _promptRegistry
+            .Setup(r => r.GetLatestAsync(PromptName, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new KeyNotFoundException("no such prompt"));
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_PromptRendererThrows_ReturnsVerifierErrorNotThrow()
+    {
+        _promptRenderer
+            .Setup(r => r.RenderAsync(
+                It.IsAny<PromptDescriptor>(),
+                It.IsAny<IReadOnlyDictionary<string, object?>>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("render blew up"));
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_UsageRecorderThrows_ReturnsVerifierErrorNotThrow()
+    {
+        _usageRecorder
+            .Setup(r => r.RecordAsync(It.IsAny<PromptDescriptor>(), It.IsAny<PromptUsageContext>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("recording blew up"));
+
+        var verdict = await _sut.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.VerifierError);
+    }
+
+    [Fact]
+    public async Task VerifyAsync_SendsClaimAndEvidenceEnvelopedInTheUserMessage()
+    {
+        IEnumerable<ChatMessage>? capturedMessages = null;
+        _chatClient
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions?>(), It.IsAny<CancellationToken>()))
+            .Callback<IEnumerable<ChatMessage>, ChatOptions?, CancellationToken>((msgs, _, _) => capturedMessages = msgs)
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, """{ "status": "held", "explanation": "ok" }""")));
+
+        var claim = new Claim
+        {
+            Text = "<b>the claim</b>",
+            Location = "file:src/Foo.cs",
+            ConsequenceSignals = new ClaimConsequenceSignals { CausesWrite = false, GatesADecision = true }
+        };
+        await _sut.VerifyAsync(claim, "<script>alert(1)</script> the evidence body", CancellationToken.None);
+
+        var messages = capturedMessages!.ToList();
+        var userText = messages.Single(m => m.Role == ChatRole.User).Text!;
+
+        userText.Should().Contain("<evidence_data_").And.Contain("</evidence_data_");
+        userText.Should().Contain("&lt;script&gt;");
+        userText.Should().Contain("&lt;b&gt;the claim&lt;/b&gt;");
+        userText.Should().NotContain("<script>alert(1)</script>");
+
+        var systemText = messages.Single(m => m.Role == ChatRole.System).Text!;
+        systemText.Should().Contain("verify");
+    }
+
+    private void SetupChatClientResponse(string json)
+    {
+        _chatClient
+            .Setup(c => c.GetResponseAsync(It.IsAny<IEnumerable<ChatMessage>>(), It.IsAny<ChatOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ChatResponse(new ChatMessage(ChatRole.Assistant, json)));
+    }
+
+    // Every other test in this file mocks IPromptRegistry, which cannot catch the sut's own
+    // PromptName constant drifting from the real prompts/{name}/ folder. This test wires the SUT
+    // against a real FilePromptRegistry pointed at the actual checked-in prompts/ directory.
+    [Fact]
+    public async Task VerifyAsync_PromptNameResolvesAgainstTheRealPromptsDirectory()
+    {
+        var realRegistry = new Infrastructure.AI.Prompts.FilePromptRegistry(
+            RepoRoot.Combine("prompts"), NullLogger<Infrastructure.AI.Prompts.FilePromptRegistry>.Instance);
+        var realRenderer = new Infrastructure.AI.Prompts.ScribanPromptRenderer(NullLogger<Infrastructure.AI.Prompts.ScribanPromptRenderer>.Instance);
+        var sutWithRealRegistry = new LlmClaimVerifier(
+            _chatClientProvider.Object,
+            new StructuredOutputInvoker(NullLogger<StructuredOutputInvoker>.Instance),
+            realRegistry,
+            realRenderer,
+            _usageRecorder.Object,
+            NullLogger<LlmClaimVerifier>.Instance);
+        SetupChatClientResponse("""{ "status": "held", "explanation": "confirmed" }""");
+
+        var verdict = await sutWithRealRegistry.VerifyAsync(SampleClaim, "content", CancellationToken.None);
+
+        verdict.Outcome.Should().Be(ClaimVerificationOutcome.Held, because: verdict.Explanation);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/ConfigSnapshotLocatedArtifactReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/ConfigSnapshotLocatedArtifactReaderTests.cs
@@ -32,6 +32,18 @@ public sealed class ConfigSnapshotLocatedArtifactReaderTests
         content.Should().Be("AI.Resilience.Retry.MaxAttempts = 5");
     }
 
+    // The security-critical case: a path that resolves perfectly well but was never put on the
+    // allowlist — e.g. a live secret — must be refused exactly like a nonexistent one.
+    [Fact]
+    public async Task TryReadAsync_WellFormedButNotAllowlistedPath_ReturnsNullWithoutLeakingTheValue()
+    {
+        _config.AI.AgentFramework.ApiKey = "sk-super-secret-value";
+
+        var content = await _sut.TryReadAsync("config:AI.AgentFramework.ApiKey", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
     [Fact]
     public async Task TryReadAsync_UnknownSegment_ReturnsNull()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/ConfigSnapshotLocatedArtifactReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/ConfigSnapshotLocatedArtifactReaderTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using Application.AI.Common.Services.SkillTraining;
 using Domain.Common.Config;
 using FluentAssertions;
 using Infrastructure.AI.Verification.Readers;
@@ -74,6 +76,33 @@ public sealed class ConfigSnapshotLocatedArtifactReaderTests
         var content = await _sut.TryReadAsync("config:", CancellationToken.None);
 
         content.Should().BeNull();
+    }
+
+    // Cross-checks two INDEPENDENTLY hand-maintained allowlists: ConfigSurfaceConstraint's
+    // suggestion-target fields (what CurrentValue claims may name) and this reader's own
+    // claim-verification-evidence allowlist (what it will actually resolve). Neither is derived
+    // from the other by design — see this reader's own remarks — so nothing but a test stops them
+    // from drifting apart. If they do, a real, governed suggestion's claim silently comes back
+    // LocationNotFound (a floored-confidence "finding") for no reason but allowlist drift.
+    [Fact]
+    public async Task TryReadAsync_EveryConfigSurfaceConstraintResolvablePath_IsAlsoOnThisReadersAllowlist()
+    {
+        var constraint = new ConfigSurfaceConstraint();
+        var allowedFieldsField = typeof(ConfigSurfaceConstraint).GetField(
+            "AllowedFields", BindingFlags.NonPublic | BindingFlags.Static);
+        var allowedFields = (IReadOnlySet<string>)allowedFieldsField!.GetValue(null)!;
+        allowedFields.Should().NotBeEmpty();
+
+        foreach (var field in allowedFields)
+        {
+            var path = constraint.ResolveConfigPath(constraint.GovernedSurface, field);
+            path.Should().NotBeNull(because: $"'{field}' is allowed by ConfigSurfaceConstraint but has no ConfigPaths entry");
+
+            var content = await _sut.TryReadAsync($"config:{path}", CancellationToken.None);
+
+            content.Should().NotBeNull(
+                because: $"'{path}' is resolvable via ConfigSurfaceConstraint but missing from {nameof(ConfigSnapshotLocatedArtifactReader)}'s own allowlist");
+        }
     }
 
     private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/ConfigSnapshotLocatedArtifactReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/ConfigSnapshotLocatedArtifactReaderTests.cs
@@ -1,0 +1,74 @@
+using Domain.Common.Config;
+using FluentAssertions;
+using Infrastructure.AI.Verification.Readers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Verification.Readers;
+
+/// <summary>
+/// Proves <see cref="ConfigSnapshotLocatedArtifactReader"/>'s dotted-path reflection walk against a
+/// live <see cref="AppConfig"/> snapshot.
+/// </summary>
+public sealed class ConfigSnapshotLocatedArtifactReaderTests
+{
+    private readonly AppConfig _config = new();
+    private readonly ConfigSnapshotLocatedArtifactReader _sut;
+
+    public ConfigSnapshotLocatedArtifactReaderTests()
+    {
+        _sut = new ConfigSnapshotLocatedArtifactReader(
+            new StaticOptionsMonitor<AppConfig>(_config), NullLogger<ConfigSnapshotLocatedArtifactReader>.Instance);
+    }
+
+    [Fact]
+    public async Task TryReadAsync_ValidDottedPath_ReturnsLiveValue()
+    {
+        _config.AI.Resilience.Retry.MaxAttempts = 5;
+
+        var content = await _sut.TryReadAsync("config:AI.Resilience.Retry.MaxAttempts", CancellationToken.None);
+
+        content.Should().Be("AI.Resilience.Retry.MaxAttempts = 5");
+    }
+
+    [Fact]
+    public async Task TryReadAsync_UnknownSegment_ReturnsNull()
+    {
+        var content = await _sut.TryReadAsync("config:AI.Resilience.Retry.NoSuchField", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryReadAsync_UnknownTopLevelSegment_ReturnsNull()
+    {
+        var content = await _sut.TryReadAsync("config:NoSuchSection.Field", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryReadAsync_NotConfigScheme_ReturnsNull()
+    {
+        var content = await _sut.TryReadAsync("file:src/Foo.cs", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryReadAsync_EmptyPathAfterScheme_ReturnsNull()
+    {
+        var content = await _sut.TryReadAsync("config:", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    private sealed class StaticOptionsMonitor<T> : IOptionsMonitor<T>
+    {
+        public StaticOptionsMonitor(T value) { CurrentValue = value; }
+        public T CurrentValue { get; }
+        public T Get(string? name) => CurrentValue;
+        public IDisposable? OnChange(Action<T, string?> listener) => null;
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/FileSystemLocatedArtifactReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/FileSystemLocatedArtifactReaderTests.cs
@@ -1,0 +1,108 @@
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Infrastructure.AI.Verification.Readers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Verification.Readers;
+
+/// <summary>
+/// Proves <see cref="FileSystemLocatedArtifactReader"/> against a real, sandboxed
+/// <see cref="FileSystemService"/> (not mocked) — so the path-traversal refusal test exercises the
+/// actual <c>SandboxedPathGuard</c> a claim's location string would hit, not a stand-in for it.
+/// </summary>
+public sealed class FileSystemLocatedArtifactReaderTests : IDisposable
+{
+    private readonly string _root;
+    private readonly FileSystemLocatedArtifactReader _sut;
+
+    public FileSystemLocatedArtifactReaderTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), $"file-reader-tests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+
+        var fileSystem = new FileSystemService(NullLogger<FileSystemService>.Instance, [_root]);
+        _sut = new FileSystemLocatedArtifactReader(fileSystem, NullLogger<FileSystemLocatedArtifactReader>.Instance);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public async Task TryReadAsync_ExistingFile_ReturnsContent()
+    {
+        File.WriteAllText(Path.Combine(_root, "Foo.cs"), "class Foo { }");
+
+        var content = await _sut.TryReadAsync("file:Foo.cs", CancellationToken.None);
+
+        content.Should().Contain("class Foo { }");
+    }
+
+    [Fact]
+    public async Task TryReadAsync_FileDoesNotExist_ReturnsNull()
+    {
+        var content = await _sut.TryReadAsync("file:DoesNotExist.cs", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryReadAsync_LineNumberSuffix_StripsSuffixAndPrependsHint()
+    {
+        File.WriteAllText(Path.Combine(_root, "Foo.cs"), "class Foo { }");
+
+        var content = await _sut.TryReadAsync("file:Foo.cs:42", CancellationToken.None);
+
+        content.Should().Contain("line 42");
+        content.Should().Contain("class Foo { }");
+    }
+
+    [Fact]
+    public async Task TryReadAsync_NotFileScheme_ReturnsNull()
+    {
+        var content = await _sut.TryReadAsync("config:AI.SomeField", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TryReadAsync_EmptyPathAfterScheme_ReturnsNull()
+    {
+        var content = await _sut.TryReadAsync("file:", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+
+    // THE security-critical mutation: a claim citing a path outside the sandbox is refused, not
+    // read — this is SandboxedPathGuard's own traversal check firing through the reader, proven
+    // against the real guard rather than a mock that could silently no-op it. A real secret file
+    // sits exactly where "../outside.txt" resolves to, so a null result here proves refusal, not a
+    // coincidental "not found."
+    [Fact]
+    public async Task TryReadAsync_PathTraversal_IsRefusedNotRead()
+    {
+        var secretPath = Path.Combine(Path.GetTempPath(), $"file-reader-secret-{Guid.NewGuid():N}.txt");
+        File.WriteAllText(secretPath, "SECRET CONTENT");
+        try
+        {
+            var content = await _sut.TryReadAsync($"file:../{Path.GetFileName(secretPath)}", CancellationToken.None);
+
+            content.Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(secretPath);
+        }
+    }
+
+    [Fact]
+    public async Task TryReadAsync_DeepPathTraversal_IsRefusedNotRead()
+    {
+        var content = await _sut.TryReadAsync("file:../../../../etc/passwd", CancellationToken.None);
+
+        content.Should().BeNull();
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/FileSystemLocatedArtifactReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Verification/Readers/FileSystemLocatedArtifactReaderTests.cs
@@ -49,6 +49,19 @@ public sealed class FileSystemLocatedArtifactReaderTests : IDisposable
         content.Should().BeNull();
     }
 
+    // A model omitting the line number after a trailing ':' ("file:Foo.cs:" instead of
+    // "file:Foo.cs") must not corrupt the path — the file genuinely exists and must be read, not
+    // reported as LocationNotFound because of an unstripped trailing colon.
+    [Fact]
+    public async Task TryReadAsync_TrailingColonWithNoLineNumber_StripsColonAndReadsTheFile()
+    {
+        File.WriteAllText(Path.Combine(_root, "Foo.cs"), "class Foo { }");
+
+        var content = await _sut.TryReadAsync("file:Foo.cs:", CancellationToken.None);
+
+        content.Should().Contain("class Foo { }");
+    }
+
     [Fact]
     public async Task TryReadAsync_LineNumberSuffix_StripsSuffixAndPrependsHint()
     {

--- a/src/Content/Tests/Tests.AI.Fakes/RecordingClaimVerifier.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/RecordingClaimVerifier.cs
@@ -1,0 +1,30 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+using Domain.AI.ClaimVerification;
+
+namespace Tests.AI.Fakes;
+
+/// <summary>
+/// Scriptable <see cref="IClaimVerifier"/> fake: delegates <see cref="VerifyAsync"/> to a
+/// caller-supplied handler and counts invocations.
+/// </summary>
+public sealed class RecordingClaimVerifier : IClaimVerifier
+{
+    private readonly Func<Claim, string, CancellationToken, Task<ClaimVerdict>> _handler;
+    private int _callCount;
+
+    /// <summary>Initializes a new instance of the <see cref="RecordingClaimVerifier"/> class.</summary>
+    public RecordingClaimVerifier(Func<Claim, string, CancellationToken, Task<ClaimVerdict>> handler)
+    {
+        _handler = handler;
+    }
+
+    /// <summary>Number of times <see cref="VerifyAsync"/> has been called.</summary>
+    public int CallCount => _callCount;
+
+    /// <inheritdoc />
+    public Task<ClaimVerdict> VerifyAsync(Claim claim, string evidenceContent, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _callCount);
+        return _handler(claim, evidenceContent, cancellationToken);
+    }
+}

--- a/src/Content/Tests/Tests.AI.Fakes/RecordingLocatedArtifactReader.cs
+++ b/src/Content/Tests/Tests.AI.Fakes/RecordingLocatedArtifactReader.cs
@@ -1,0 +1,29 @@
+using Application.AI.Common.Interfaces.ClaimVerification;
+
+namespace Tests.AI.Fakes;
+
+/// <summary>
+/// Scriptable <see cref="ILocatedArtifactReader"/> fake: delegates <see cref="TryReadAsync"/> to a
+/// caller-supplied handler and counts invocations.
+/// </summary>
+public sealed class RecordingLocatedArtifactReader : ILocatedArtifactReader
+{
+    private readonly Func<string, CancellationToken, Task<string?>> _handler;
+    private int _callCount;
+
+    /// <summary>Initializes a new instance of the <see cref="RecordingLocatedArtifactReader"/> class.</summary>
+    public RecordingLocatedArtifactReader(Func<string, CancellationToken, Task<string?>> handler)
+    {
+        _handler = handler;
+    }
+
+    /// <summary>Number of times <see cref="TryReadAsync"/> has been called.</summary>
+    public int CallCount => _callCount;
+
+    /// <inheritdoc />
+    public Task<string?> TryReadAsync(string location, CancellationToken cancellationToken)
+    {
+        Interlocked.Increment(ref _callCount);
+        return _handler(location, cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary

Sixth package of the verification cluster: check a model's claim about a specific location (a file line, a live config value) against the actual thing there, rather than trusting the asserting model's own confidence.

**New subsystem.** `Claim`/`ClaimVerdict`/`ClaimVerificationOutcome` — deliberately not a reuse of Package E's `Obligation`/`VerificationVerdict`: a claim's evidence is independently resolved per claim via a scheme-keyed reader (`"file:"`, `"config:"`), not sliced from one shared pre-fetched artifact, and a location that doesn't exist is a real finding (confidence floored, never fail-safe silence) — the one place a naive reader gets the fail-safe rule backwards. `ClaimVerificationRunner` classifies each claim's consequence from code-owned structural signals (never model-assigned, so a model can't opt itself out of verification by mislabeling its own claim's stakes) before dispatching a reader and an LLM-backed verifier.

**First consumer.** The skill-training loop's `HarnessChangeSuggestion.CurrentValue` claim is now checked against live config before being surfaced to a human; a contradicted claim is annotated, never dropped.

**Governance change.** `PolicyFinding` gains `Blocking`/`RequiresVerification` (both default `false`, so every existing policy's behavior is unchanged by construction): a finding whose severity a model assigned but nothing has independently confirmed can no longer block a governance gate on severity alone.

## Review

Three full review rounds (mandatory `security-reviewer` plus two `/code-review` passes, four `run-gates.sh` cycles). Real findings fixed, in order found:

- **HIGH (security):** the config-value reader had no allowlist and could reflect out live secrets (API keys, connection strings) via a crafted claim location. Not exploitable via today's single hardcoded caller, but a landmine for the next one — added a fixed, minimal, code-owned allowlist.
- **MEDIUM (security + code-review, independently):** the "off by default" flag for the judge-model call was never actually read anywhere — the exact "wiring a dead control" defect class this repo tracks. Now genuinely gates the call.
- A trailing-colon path-parsing bug that reported an existing file as not-found.
- A dead conditional and a message-accuracy bug in the governance gate's audit text.
- No cap on a claim batch (unlike the sibling obligation-analysis package's cap) — added `MaxClaims`, mirroring the established pattern.
- Four independently-retyped scheme-name string literals — consolidated into one shared constant.
- A null-guard gap on the verifier's response DTO, symmetric with an existing guard on the same type.

Deliberately deferred, with reasoning recorded in the commit history: a shared fan-out helper across this and the sibling obligation-verification runner (would touch already-shipped code), a structured field for the verification outcome on the suggestion type (no consumer needs it yet), and splitting the skill-training handler into partial files (under the repo's hard line-count ceiling).

## Test plan

- [x] Full solution build + test suite green, every review round
- [x] `run-gates.sh`: all 8 gates passed on the final commit (build, test, owasp, docs-links, grader, correctness, security, docs-drift)
- [x] Mutation-tested: the config-reader allowlist (a well-formed but disallowed path is refused, not read), the `Enabled` gate (disabled → no model call), the trailing-colon fix, the `PolicyGate` blocking/exclusion logic (four scenarios incl. a byte-identical-to-before regression pin), the `MaxClaims` cap (batch truncated, handler zip stays aligned against a shorter verdict list)
- [x] Security-reviewed twice (initial pass + a fresh pass on the final commit) — no HIGH findings on the final commit
- [x] Cross-check guard proving the two independently-maintained config allowlists (suggestion-target fields, claim-verification-evidence fields) can't silently drift apart

Closes #319.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj