### PR TITLE
fix: make TryApplyTextOutputPolicyAsync's outcome structural (#490)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -141,17 +141,29 @@ public interface IToolCallAdmissionPipeline
     /// <see cref="ApplyOutputPolicyAsync"/>'s identical parameter for why.
     /// </param>
     /// <returns>
-    /// See <see cref="TextOutputPolicyResult"/>. <see cref="TextOutputPolicyResult.Success"/> is
-    /// <see langword="false"/> when a redaction was required but did not produce text, in which case
-    /// the caller must <strong>withhold</strong> the result rather than emit the original.
-    /// <see cref="TextOutputPolicyResult.Result"/> is <paramref name="content"/>, run unconditionally
-    /// through the general-purpose sanitizer — the same guarantee <see cref="ApplyOutputPolicyAsync"/>
-    /// carries (#469) — and additionally through
+    /// See <see cref="TextOutputPolicyResult"/>. <see cref="TextOutputPolicyResult.Outcome"/> is
+    /// <see cref="TextOutputPolicyOutcome.Withheld"/> when a redaction was required but did not
+    /// produce text, in which case the caller must <strong>withhold</strong> the result rather than
+    /// emit the original — <see cref="TextOutputPolicyResult.Text"/> is <see cref="string.Empty"/> in
+    /// that case, never the original content. <see cref="TextOutputPolicyOutcome.NothingToAdmit"/>
+    /// means <paramref name="content"/> was null: there was nothing to sanitize or redact, so
+    /// <see cref="TextOutputPolicyResult.Text"/> is <see cref="string.Empty"/> rather than the original
+    /// null — a caller that needs to preserve "no content at all" as distinct from "empty content"
+    /// must branch on <see cref="TextOutputPolicyOutcome.NothingToAdmit"/> itself, not on
+    /// <see cref="TextOutputPolicyResult.Text"/>. Otherwise <see cref="TextOutputPolicyOutcome.Admitted"/>
+    /// with <paramref name="content"/> run unconditionally through the general-purpose sanitizer — the
+    /// same guarantee <see cref="ApplyOutputPolicyAsync"/> carries (#469) — and additionally through
     /// <see cref="IToolClassificationGate.RedactResult(string, string?)"/>'s known-secret-pattern scrub
     /// when a redaction was required (#479 closed the gap where this method sanitized only on that
-    /// second path, unlike its sibling). Null content passes through as null: there is nothing to
-    /// sanitize or redact. Null when <see cref="TextOutputPolicyResult.Success"/> is
-    /// <see langword="false"/>.
+    /// second path, unlike its sibling).
+    /// <para>
+    /// <see cref="TextOutputPolicyResult.Text"/> is deliberately non-nullable (#490): the two prior
+    /// meanings a null carried — "nothing to admit" and "withheld" — collapsed at every consumer into
+    /// the same <c>?? string.Empty</c> fallback, which made a withheld result and an absent one
+    /// indistinguishable by the time either reached an audit trail or a plan step's output. Read
+    /// <see cref="TextOutputPolicyOutcome"/> to tell them apart; do not infer it from whether
+    /// <see cref="TextOutputPolicyResult.Text"/> happens to be empty.
+    /// </para>
     /// </returns>
     /// <remarks>
     /// Separate from <see cref="ApplyOutputPolicyAsync"/> because the two callers want different things
@@ -240,16 +252,62 @@ public interface IToolCallAdmissionPipeline
 }
 
 /// <summary>
+/// Why <see cref="TextOutputPolicyResult.Text"/> is what it is — see
+/// <see cref="IToolCallAdmissionPipeline.TryApplyTextOutputPolicyAsync"/>'s own remarks for the full
+/// account of what produces each value. Introduced by #490: before this existed, all three of these
+/// outcomes shared one nullable <c>string?</c> field, and every consumer collapsed "nothing to admit"
+/// and "withheld" into the same <c>?? string.Empty</c> fallback — indistinguishable by the time either
+/// reached an audit trail or a plan step's output.
+/// </summary>
+public enum TextOutputPolicyOutcome
+{
+    /// <summary>
+    /// The input was treated and is safe to use as-is — the ordinary case. Named first (and so the
+    /// enum's default value) deliberately: a test double that leaves this field unset produces a
+    /// result that is trivially wrong to consume unguarded, rather than one that looks like a
+    /// legitimate withhold. See the second member for the alternative this rejects.
+    /// </summary>
+    Admitted = 0,
+
+    /// <summary>
+    /// A redaction was required but did not produce text — the gate broke its non-null-in/non-null-out
+    /// contract, or the sanitize/redact chain itself threw. The caller must withhold the result rather
+    /// than emit the original; <see cref="TextOutputPolicyResult.Text"/> is <see cref="string.Empty"/>,
+    /// never the original content.
+    /// </summary>
+    Withheld,
+
+    /// <summary>
+    /// The input was null: there was nothing to sanitize or redact. Distinct from
+    /// <see cref="Withheld"/> so a caller that needs to preserve "no content at all" can branch on this
+    /// value instead of inferring it from an empty <see cref="TextOutputPolicyResult.Text"/>.
+    /// </summary>
+    NothingToAdmit,
+}
+
+/// <summary>
 /// The outcome of <see cref="IToolCallAdmissionPipeline.TryApplyTextOutputPolicyAsync"/> — see that
 /// method's own remarks for what each member means.
 /// </summary>
-/// <param name="Success">
-/// <see langword="false"/> when a redaction was required but did not produce text; the caller must
-/// withhold the result rather than emit the original.
+/// <param name="Outcome">Which of the three outcomes produced <paramref name="Text"/>.</param>
+/// <param name="Text">
+/// The treated text. Non-nullable by design (#490): <see cref="string.Empty"/> on both
+/// <see cref="TextOutputPolicyOutcome.Withheld"/> and <see cref="TextOutputPolicyOutcome.NothingToAdmit"/>,
+/// so a caller can never silently coalesce a withheld result into an empty one — the two are already
+/// the same value on this field; <paramref name="Outcome"/> is what still distinguishes them.
 /// </param>
-/// <param name="Result">The treated text, or <see langword="null"/> when <paramref name="Success"/> is <see langword="false"/>.</param>
 /// <param name="WasTruncated">Whether the pipeline itself cut the text to fit its ceiling.</param>
-public readonly record struct TextOutputPolicyResult(bool Success, string? Result, bool WasTruncated);
+public readonly record struct TextOutputPolicyResult(
+    TextOutputPolicyOutcome Outcome, string Text, bool WasTruncated)
+{
+    /// <summary>
+    /// True when the caller must withhold the result rather than emit <see cref="Text"/> as the
+    /// original — kept as a convenience for the two call sites that only ever needed the boolean
+    /// <c>Success</c> check this record used to expose directly, so a mechanical signature change is
+    /// enough for them.
+    /// </summary>
+    public bool Success => Outcome != TextOutputPolicyOutcome.Withheld;
+}
 
 /// <summary>
 /// One tool call, as the admission chain sees it.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -262,20 +262,28 @@ public interface IToolCallAdmissionPipeline
 public enum TextOutputPolicyOutcome
 {
     /// <summary>
-    /// The input was treated and is safe to use as-is — the ordinary case. Named first (and so the
-    /// enum's default value) deliberately: a test double that leaves this field unset produces a
-    /// result that is trivially wrong to consume unguarded, rather than one that looks like a
-    /// legitimate withhold. See the second member for the alternative this rejects.
-    /// </summary>
-    Admitted = 0,
-
-    /// <summary>
     /// A redaction was required but did not produce text — the gate broke its non-null-in/non-null-out
     /// contract, or the sanitize/redact chain itself threw. The caller must withhold the result rather
     /// than emit the original; <see cref="TextOutputPolicyResult.Text"/> is <see cref="string.Empty"/>,
     /// never the original content.
     /// </summary>
-    Withheld,
+    /// <remarks>
+    /// Named first (and so the enum's default value, and what <c>default(TextOutputPolicyResult)</c>
+    /// reports) deliberately: this is the fail-closed value, matching the boolean <c>Success</c> field
+    /// this type replaced, which also defaulted to <see langword="false"/>. An earlier draft put
+    /// <see cref="Admitted"/> first on the theory that an unset field would be "trivially wrong to
+    /// consume unguarded" — code review caught that this was backwards. All three real consumers check
+    /// <see cref="TextOutputPolicyResult.Success"/> before reading anything else, so an unset field is
+    /// never "obviously wrong," it is silently treated as a legitimate admit — the opposite failure
+    /// direction from a security control's default. Reordering closes that: a value nobody set now
+    /// reads as a refusal, the same as it always did before this type existed.
+    /// </remarks>
+    Withheld = 0,
+
+    /// <summary>
+    /// The input was treated and is safe to use as-is — the ordinary case.
+    /// </summary>
+    Admitted,
 
     /// <summary>
     /// The input was null: there was nothing to sanitize or redact. Distinct from
@@ -302,7 +310,7 @@ public readonly record struct TextOutputPolicyResult(
 {
     /// <summary>
     /// True when the caller must withhold the result rather than emit <see cref="Text"/> as the
-    /// original — kept as a convenience for the two call sites that only ever needed the boolean
+    /// original — kept as a convenience for the three call sites that only ever needed the boolean
     /// <c>Success</c> check this record used to expose directly, so a mechanical signature change is
     /// enough for them.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -613,8 +613,12 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             if (!admission.RedactsOutput)
             {
                 // Non-redact branch: Sanitize's null-in/null-out guarantee (#490) means reaching here
-                // can only mean preCut was null — nothing to sanitize.
-                return new TextOutputPolicyResult(Success: true, Result: null, WasTruncated: false);
+                // can only mean preCut was null — nothing to sanitize. NothingToAdmit, not Withheld
+                // (#490 residual): the caller did not refuse anything here, there was simply nothing to
+                // treat — collapsing the two into the same Text: string.Empty was what let a withheld
+                // result and an absent one read as identical downstream.
+                return new TextOutputPolicyResult(
+                    TextOutputPolicyOutcome.NothingToAdmit, Text: string.Empty, WasTruncated: false);
             }
 
             // Fail closed, deliberately without asking whether preCut was itself null. A redact-required
@@ -629,7 +633,8 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
                 "Classification gate returned null when redacting output of {ToolName}; the result is "
                 + "withheld rather than returned unredacted.",
                 toolName);
-            return new TextOutputPolicyResult(Success: false, Result: null, WasTruncated: false);
+            return new TextOutputPolicyResult(
+                TextOutputPolicyOutcome.Withheld, Text: string.Empty, WasTruncated: false);
         }
 
         // #532: bound after sanitize/redact — see ApplyOutputPolicyAsync for why the order is fixed.
@@ -689,13 +694,13 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         if (rawFitsWithNoGenuinePromiseToMake)
         {
             SettleAggregateReservation(effectiveCeiling, bounded.Length);
-            return new TextOutputPolicyResult(Success: true, Result: bounded, WasTruncated: true);
+            return new TextOutputPolicyResult(TextOutputPolicyOutcome.Admitted, bounded, WasTruncated: true);
         }
 
         if (!wasTruncated)
         {
             SettleAggregateReservation(effectiveCeiling, bounded.Length);
-            return new TextOutputPolicyResult(Success: true, Result: bounded, WasTruncated: false);
+            return new TextOutputPolicyResult(TextOutputPolicyOutcome.Admitted, bounded, WasTruncated: false);
         }
 
         // #563: the ORIGINAL content — before the scan-cost pre-cut, before sanitize/redact — is what
@@ -736,11 +741,11 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         {
             var (plainBounded, _) = BoundedText.Cap(processed, effectiveCeiling, OutputTruncationMarker, alwaysEmbedMarker: true);
             SettleAggregateReservation(effectiveCeiling, plainBounded.Length);
-            return new TextOutputPolicyResult(Success: true, Result: plainBounded, WasTruncated: true);
+            return new TextOutputPolicyResult(TextOutputPolicyOutcome.Admitted, plainBounded, WasTruncated: true);
         }
 
         SettleAggregateReservation(effectiveCeiling, withId.Length);
-        return new TextOutputPolicyResult(Success: true, Result: withId, WasTruncated: true);
+        return new TextOutputPolicyResult(TextOutputPolicyOutcome.Admitted, withId, WasTruncated: true);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.Response.cs
@@ -66,7 +66,6 @@ public sealed partial class DirectToolInvoker
             var errorPolicy = await admissionPipeline
                 .TryApplyTextOutputPolicyAsync(admission, toolName, failureText, cancellationToken)
                 .ConfigureAwait(false);
-            var admittedError = errorPolicy.Result;
             if (!errorPolicy.Success)
             {
                 // #491: this Denied is not a governance refusal in the usual sense — the tool DID run
@@ -87,7 +86,10 @@ public sealed partial class DirectToolInvoker
             }
 
             // No ErrorTruncated outcome field exists to report a drop on, matching prior behavior.
-            var (error, _) = Governance.BoundedText.Cap(admittedError ?? string.Empty, ceiling, TruncationMarker);
+            // #490: errorPolicy.Text is non-nullable now, so no ?? string.Empty fallback is needed —
+            // Admitted and NothingToAdmit both already carry an honest string.Empty on this field, and
+            // Withheld already returned above.
+            var (error, _) = Governance.BoundedText.Cap(errorPolicy.Text, ceiling, TruncationMarker);
             return new DirectToolInvocationOutcome
             {
                 Status = DirectToolInvocationStatus.ToolFailed,
@@ -102,7 +104,6 @@ public sealed partial class DirectToolInvoker
         var successPolicy = await admissionPipeline
             .TryApplyTextOutputPolicyAsync(admission, toolName, successText, cancellationToken)
             .ConfigureAwait(false);
-        var admitted = successPolicy.Result;
         var truncatedByPipeline = successPolicy.WasTruncated;
         if (!successPolicy.Success)
         {
@@ -122,7 +123,8 @@ public sealed partial class DirectToolInvoker
                 duration);
         }
 
-        var (output, truncatedByOwnCeiling) = Governance.BoundedText.Cap(admitted ?? string.Empty, ceiling, TruncationMarker);
+        // #490: successPolicy.Text is non-nullable — see the failure branch's identical comment above.
+        var (output, truncatedByOwnCeiling) = Governance.BoundedText.Cap(successPolicy.Text, ceiling, TruncationMarker);
 
         return new DirectToolInvocationOutcome
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -242,7 +242,6 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         var textPolicy = await _admissionPipeline
             .TryApplyTextOutputPolicyAsync(admission, config.ToolName, sandboxResult.Output, ct)
             .ConfigureAwait(false);
-        var content = textPolicy.Result;
         if (!textPolicy.Success)
         {
             await ReportExecutionAsync(
@@ -260,10 +259,16 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
 
         await ReportExecutionAsync(admission, EscalationExecutionStatus.Succeeded, failureReason: null, config.ToolName);
 
+        // #490: StepExecutionResult.Output is documented as "null if the step produced no output" —
+        // textPolicy.Text is now non-nullable (string.Empty on NothingToAdmit), so mapping it straight
+        // through would silently turn "no output" into an empty-string output, a behavior change to a
+        // persisted plan step this fix has no business making. NothingToAdmit maps back to null,
+        // preserving Output's existing contract; every other reachable outcome here is Admitted
+        // (Withheld already returned above).
         return new StepExecutionResult
         {
             Status = StepExecutionStatus.Completed,
-            Output = content,
+            Output = textPolicy.Outcome == TextOutputPolicyOutcome.NothingToAdmit ? null : textPolicy.Text,
             Duration = sw.Elapsed,
             Attestation = sandboxResult.Attestation
         };

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -817,6 +817,21 @@ public sealed class ToolCallAdmissionPipelineTests
     }
 
     [Fact]
+    public void TextOutputPolicyResult_DefaultValue_IsFailClosed()
+    {
+        // #490 code-review finding: TextOutputPolicyOutcome.Withheld must be the enum's zero value, so
+        // an unset field — a test double that doesn't stub this, or any future code path that
+        // constructs the record without deciding — reads as a refusal, the same fail-closed direction
+        // the bool Success field this type replaced always defaulted to. The first cut of this fix put
+        // Admitted first on the theory that an unset field would be "obviously wrong to consume
+        // unguarded" — false, because every real consumer checks Success before reading anything else,
+        // so an unset field was silently treated as a legitimate admit instead.
+        default(TextOutputPolicyResult).Success.Should().BeFalse(
+            "an unset TextOutputPolicyResult must fail closed, not silently read as an admitted result");
+        default(TextOutputPolicyResult).Outcome.Should().Be(TextOutputPolicyOutcome.Withheld);
+    }
+
+    [Fact]
     public async Task TryApplyTextOutputPolicy_PlainAllow_NullContent_PassesThroughWithoutSanitizing()
     {
         var sanitizer = new Mock<ICompositeResponseSanitizer>(MockBehavior.Strict);

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -317,7 +317,7 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.AllowWithOutputRedaction(), Tool, raw, CancellationToken.None);
 
         policy.Success.Should().BeTrue();
-        policy.Result!.Length.Should().BeLessThanOrEqualTo(50,
+        policy.Text.Length.Should().BeLessThanOrEqualTo(50,
             "the aggregate/per-message ceiling must never be exceeded, however the truncation was decided");
         policy.WasTruncated.Should().BeTrue(
             "correctness-review finding: the returned text genuinely IS shorter than what redaction " +
@@ -383,7 +383,7 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.Allow(), Tool, "harmless output", CancellationToken.None);
 
         policy.Success.Should().BeTrue();
-        policy.Result.Should().Be("harmless output");
+        policy.Text.Should().Be("harmless output");
     }
 
     [Fact]
@@ -401,7 +401,8 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.AllowWithOutputRedaction(), Tool, "top secret value", CancellationToken.None);
 
         policy.Success.Should().BeFalse();
-        policy.Result.Should().BeNull();
+        policy.Outcome.Should().Be(TextOutputPolicyOutcome.Withheld);
+        policy.Text.Should().BeEmpty();
     }
 
     [Fact]
@@ -441,7 +442,7 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.Allow(), Tool, "a secret value", CancellationToken.None);
 
         policy.Success.Should().BeTrue();
-        policy.Result.Should().Be("a [SCRUBBED] value");
+        policy.Text.Should().Be("a [SCRUBBED] value");
         gate.Verify(g => g.RedactResult(It.IsAny<string>(), It.IsAny<object?>()), Times.Never);
     }
 
@@ -456,7 +457,7 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", CancellationToken.None);
 
         policy.Success.Should().BeTrue();
-        policy.Result.Should().Be("[redacted]");
+        policy.Text.Should().Be("[redacted]");
     }
 
     [Fact]
@@ -478,7 +479,8 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.AllowWithOutputRedaction(), Tool, "raw text", CancellationToken.None);
 
         policy.Success.Should().BeFalse();
-        policy.Result.Should().BeNull();
+        policy.Outcome.Should().Be(TextOutputPolicyOutcome.Withheld);
+        policy.Text.Should().BeEmpty();
     }
 
     // ===== #532: tool output is bounded, not just sanitized =====
@@ -669,9 +671,9 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.Allow(), Tool, new string('x', 5000), CancellationToken.None);
 
         policy.Success.Should().BeTrue("bounding is not a policy denial — the result is admitted, just cut");
-        policy.Result!.Length.Should().BeLessThanOrEqualTo(200);
-        policy.Result.Should().Contain("tool_result_fetch");
-        policy.Result.Should().EndWith("]");
+        policy.Text.Length.Should().BeLessThanOrEqualTo(200);
+        policy.Text.Should().Contain("tool_result_fetch");
+        policy.Text.Should().EndWith("]");
     }
 
     [Fact]
@@ -694,7 +696,7 @@ public sealed class ToolCallAdmissionPipelineTests
         // The property under test: a caller that ONLY reads the text (as ToolUseStepExecutor does) must
         // still be able to tell this was cut, because the final BoundedText.Cap never fires here --
         // sanitizing shrank the pre-cut's survivor to "HEADER" + marker, already under the 10,000 ceiling.
-        policy.Result.Should().Contain(ToolCallAdmissionPipeline.OutputTruncationMarker,
+        policy.Text.Should().Contain(ToolCallAdmissionPipeline.OutputTruncationMarker,
             "a reader with no access to WasTruncated (ToolUseStepExecutor.HandleSuccessAsync discards it) "
             + "must not conclude the result is complete just because the final cut never fired");
     }
@@ -823,7 +825,12 @@ public sealed class ToolCallAdmissionPipelineTests
         var policy = await pipeline.TryApplyTextOutputPolicyAsync(ToolCallAdmission.Allow(), Tool, null, CancellationToken.None);
 
         policy.Success.Should().BeTrue("there is nothing to sanitize in an absent result");
-        policy.Result.Should().BeNull();
+        // #490: NothingToAdmit, not Withheld — this call refused nothing, there was simply nothing to
+        // treat. Asserted on the Outcome itself, not inferred from Text being empty: Withheld also
+        // reports an empty Text, and collapsing the two into the same observable value is exactly the
+        // defect #490 fixed.
+        policy.Outcome.Should().Be(TextOutputPolicyOutcome.NothingToAdmit);
+        policy.Text.Should().BeEmpty();
     }
 
     [Fact]
@@ -843,7 +850,12 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.AllowWithOutputRedaction(), Tool, null, CancellationToken.None);
 
         policy.Success.Should().BeFalse("a redact-required call must never report success just because there was nothing to redact yet");
-        policy.Result.Should().BeNull();
+        // #490: Withheld, not NothingToAdmit — see the sibling PlainAllow test's identical comment.
+        // This is the observable difference the fix exists to make possible: the same null-content
+        // input produces a DIFFERENT Outcome here than on the non-redact path above, even though both
+        // report an empty Text.
+        policy.Outcome.Should().Be(TextOutputPolicyOutcome.Withheld);
+        policy.Text.Should().BeEmpty();
     }
 
     [Fact]
@@ -1324,7 +1336,7 @@ public sealed class ToolCallAdmissionPipelineTests
 
         var first = await pipeline.TryApplyTextOutputPolicyAsync(
             ToolCallAdmission.Allow(), Tool, new string('x', 5_000), CancellationToken.None);
-        first.Result!.Length.Should().Be(1_000);
+        first.Text.Length.Should().Be(1_000);
 
         var second = await pipeline.TryApplyTextOutputPolicyAsync(
             ToolCallAdmission.Allow(), Tool, new string('y', 50), CancellationToken.None);
@@ -1465,10 +1477,10 @@ public sealed class ToolCallAdmissionPipelineTests
             ToolCallAdmission.Allow(), Tool, new string('y', 5_000), CancellationToken.None);
 
         second.Success.Should().BeTrue();
-        second.Result.Should().NotBeNullOrEmpty(
+        second.Text.Should().NotBeNullOrEmpty(
             "an empty result with the aggregate budget fully spent is indistinguishable from the tool "
             + "genuinely returning nothing — the model must always be told something was cut");
-        second.Result.Should().Contain("tool output truncated",
+        second.Text.Should().Contain("tool output truncated",
             "the id-carrying marker may not fit this tight a budget, but the plain truncation marker "
             + "must still survive — ToolUseStepExecutor reads truncation from the text itself, not "
             + "from WasTruncated, so a markerless result here is read as a complete, real result");

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -595,10 +595,12 @@ public sealed class DirectToolInvokerTests
     public async Task A_redaction_that_cannot_be_applied_withholds_the_result()
     {
         // Fail closed. The gate decided this asset must not be emitted as-is; if its redaction cannot
-        // be applied, falling back to the original defeats the entire control. RedactResult is typed
-        // object? -> object?, and the shipped gate returns structured values unchanged for some
-        // inputs, so a consumer-supplied gate answering with a JsonElement is a realistic way to land
-        // here — and "as string ?? output" would have quietly emitted the unredacted text.
+        // be applied, falling back to the original defeats the entire control. A successful ToolResult
+        // routes through TryApplyTextOutputPolicyAsync's string-typed RedactResult(string, string?)
+        // overload (#490), whose contract is non-null-in/non-null-out — RedactionResult = 42 here is
+        // FakeClassificationGate's way of simulating a consumer-supplied gate that breaks that contract
+        // on real input, which the pipeline reports as TextOutputPolicyOutcome.Withheld rather than
+        // falling back to "as string ?? output" and quietly emitting the unredacted text.
         _classificationGate = new FakeClassificationGate(ClassificationVerdict.RedactOutput())
         {
             RedactionResult = 42

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -431,6 +431,27 @@ public sealed class ToolUseStepExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_SucceedsWithNoSandboxOutput_ReportsNullOutputNotEmptyString()
+    {
+        // #490 code-review finding: no test exercised HandleSuccessAsync's success path with null
+        // sandbox output, so the NothingToAdmit ? null : textPolicy.Text ternary that preserves
+        // StepExecutionResult.Output's "null means no output" contract had no coverage on the one
+        // branch it exists for.
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult
+            {
+                Success = true, Output = null, ResourceUsage = new ResourceUsage()
+            });
+
+        var step = CreateStep(new ToolUseConfig { ToolName = "file_system" });
+
+        var result = await _sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        Assert.Null(result.Output);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ClassificationSeesTheEffectiveArguments_NotJustTheDeclaredOnes()
     {
         // The gate resolves which asset a call touches from its arguments, so it must see what the


### PR DESCRIPTION
## Summary
- `TextOutputPolicyResult` carried a nullable string that meant three different things depending on which of three producers set it — "nothing to admit," "withheld," and "the sanitize/redact chain threw" all collapsed to `Result: null`, and every consumer silently coalesced that into `?? string.Empty`. A withheld result and an absent one were indistinguishable by the time either reached an audit trail or a plan step's output.
- Replaces `(bool Success, string? Result)` with a `TextOutputPolicyOutcome` enum (`Withheld`/`Admitted`/`NothingToAdmit`, `Withheld` deliberately the zero/default value so an unset field fails closed) plus a non-nullable `Text` field — the repo's existing "a fact that travels with the value" idiom.
- `ToolUseStepExecutor` maps `NothingToAdmit` back to `null` to preserve `StepExecutionResult.Output`'s documented "null means no output" contract.
- Closes #489, #491, #493, #513 as stale — verified already shipped in PRs #545/#557, left open only because GitHub's closing-keyword parser honors just the first `#N` in a `closes #A, #B, #C` list.

## Review history on this branch
- `/code-review` (angle findings) caught that the first cut of the enum ordering was fail-*open* by default (`Admitted = 0`, opposite of the old boolean's fail-closed default) — fixed by reordering `Withheld` to zero, with a test pinning `default(TextOutputPolicyResult).Success == false`.
- Same review pass flagged a missing test for `ToolUseStepExecutor`'s success path with null sandbox output — added.
- `run-gates.sh` (build, full test suite, OWASP, grader, correctness-review, security-review, docs-drift) passed clean, with three full-suite reruns each catching a different pre-existing, unrelated flaky test in `Infrastructure.AI.Tests.Sandbox.*` (Windows process/pipe timing under parallel load — matches this repo's documented main-branch flakiness, #537). None touch this diff; each was independently confirmed to pass in isolation.
- Mutation-tested: flipping the `Withheld` return to `NothingToAdmit` fails 3 tests; flipping the enum's default ordering back fails the new guard test — both confirm the new discriminators are load-bearing.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` on directly-touched classes (`ToolCallAdmissionPipelineTests`, `DirectToolInvokerTests`, `ToolUseStepExecutorTests`) — all pass
- [x] Full solution `dotnet test` via `run-gates.sh` — pass (Docker up, real Testcontainers run)
- [x] `detect_changes` (GitNexus) — scope matches expectation, no surprise blast radius
- [x] Mutation tests on both new discriminators — confirmed load-bearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj