### PR TITLE
fix: name the reason a failure message was substituted (#472)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalExecutionReporter.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalExecutionReporter.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Escalation;
 
 namespace Application.AI.Common.Interfaces.Escalation;
@@ -37,9 +38,13 @@ public interface IApprovalExecutionReporter
     ValueTask ReportSucceededAsync(ApprovedCall call, string reportedBy, CancellationToken ct);
 
     /// <summary>Reports that an approved action ran and failed.</summary>
-    /// <param name="failureReason">A human-readable reason, shown to the approver.</param>
+    /// <param name="failureReason">
+    /// The text to show the approver, plus why it is a substitute when it is one (#472) — a sanitizer
+    /// that removed everything and a tool that genuinely emitted the resulting placeholder string used
+    /// to be indistinguishable at this parameter's old <c>string</c> type.
+    /// </param>
     /// <param name="reportedBy">See <see cref="ReportSucceededAsync"/>.</param>
-    ValueTask ReportFailedAsync(ApprovedCall call, string failureReason, string reportedBy, CancellationToken ct);
+    ValueTask ReportFailedAsync(ApprovedCall call, PreparedFailureText failureReason, string reportedBy, CancellationToken ct);
 
     /// <summary>Reports that an approved action never ran.</summary>
     /// <param name="reportedBy">See <see cref="ReportSucceededAsync"/>.</param>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalFailureMemory.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Escalation/IApprovalFailureMemory.cs
@@ -1,3 +1,5 @@
+using Domain.AI.Escalation;
+
 namespace Application.AI.Common.Interfaces.Escalation;
 
 /// <summary>
@@ -29,7 +31,10 @@ public interface IApprovalFailureMemory
     ApprovalFailureRecall? TryRecall(in ApprovalFailureKey key);
 
     /// <summary>Records a failed approved attempt against this key.</summary>
-    void RecordFailure(in ApprovalFailureKey key, string failureReason, Guid escalationId);
+    /// <param name="failureReasonSubstitution">See <see cref="ApprovalFailureRecall.Substitution"/>.</param>
+    void RecordFailure(
+        in ApprovalFailureKey key, string failureReason, FailureTextSubstitution failureReasonSubstitution,
+        Guid escalationId);
 
     /// <summary>
     /// Clears any recorded failure for this key — and, as a side effect, any recorded revision
@@ -97,7 +102,12 @@ public readonly record struct ApprovalFailureKey(string ConversationId, string A
 }
 
 /// <summary>A recalled prior failure: how many times it has failed, why, and which escalation last approved it.</summary>
-public readonly record struct ApprovalFailureRecall(int PriorAttemptCount, string FailureReason, Guid EscalationId);
+/// <param name="Substitution">
+/// Why <see cref="FailureReason"/> is a substitute rather than the tool's own message (#472) — see
+/// <see cref="Domain.AI.Escalation.FailureTextSubstitution"/>.
+/// </param>
+public readonly record struct ApprovalFailureRecall(
+    int PriorAttemptCount, string FailureReason, FailureTextSubstitution Substitution, Guid EscalationId);
 
 /// <summary>
 /// A recalled prior revision: which round the next attempt continues, what the reviewer asked for

--- a/src/Content/Application/Application.AI.Common/Services/Escalation/DefaultApprovalExecutionReporter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Escalation/DefaultApprovalExecutionReporter.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Escalation;
 using Microsoft.Extensions.Logging;
 
@@ -49,11 +50,14 @@ public sealed class DefaultApprovalExecutionReporter : IApprovalExecutionReporte
             ct);
 
     /// <inheritdoc />
-    public ValueTask ReportFailedAsync(ApprovedCall call, string failureReason, string reportedBy, CancellationToken ct) =>
+    public ValueTask ReportFailedAsync(
+        ApprovedCall call, PreparedFailureText failureReason, string reportedBy, CancellationToken ct) =>
         ReportAsync(
             call,
-            () => EscalationExecutionRecord.Failed(call.EscalationId, failureReason, _timeProvider.GetUtcNow(), reportedBy),
-            onRecorded: () => _failureMemory.RecordFailure(call.Key, failureReason, call.EscalationId),
+            () => EscalationExecutionRecord.Failed(
+                call.EscalationId, failureReason.Text, failureReason.Substitution, _timeProvider.GetUtcNow(), reportedBy),
+            onRecorded: () => _failureMemory.RecordFailure(
+                call.Key, failureReason.Text, failureReason.Substitution, call.EscalationId),
             ct);
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Services/Escalation/InProcessApprovalFailureMemory.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Escalation/InProcessApprovalFailureMemory.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.Escalation;
+using Domain.AI.Escalation;
 using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Escalation;
@@ -43,7 +44,7 @@ public sealed class InProcessApprovalFailureMemory : IApprovalFailureMemory
             return null;
 
         entry.LastAccessTicks = _timeProvider.GetUtcNow().UtcTicks;
-        var (attemptCount, failureReason, escalationId) = entry.Snapshot();
+        var (attemptCount, failureReason, substitution, escalationId) = entry.Snapshot();
 
         // Zero means this entry's failure half was never touched — it exists only because
         // RecordRevision created it. Without this guard, any key that ever recorded a revision
@@ -52,11 +53,15 @@ public sealed class InProcessApprovalFailureMemory : IApprovalFailureMemory
         // shape EscalationRequestInvariants rejects outright ("attempt 1 carries a prior failure
         // reason, which never happened"), fail-closing the next approval attempt after every
         // successful revise. Mirrors TryRecallRevision's RevisionRound==0 guard below.
-        return attemptCount == 0 ? null : new ApprovalFailureRecall(attemptCount, failureReason, escalationId);
+        return attemptCount == 0
+            ? null
+            : new ApprovalFailureRecall(attemptCount, failureReason, substitution, escalationId);
     }
 
     /// <inheritdoc />
-    public void RecordFailure(in ApprovalFailureKey key, string failureReason, Guid escalationId)
+    public void RecordFailure(
+        in ApprovalFailureKey key, string failureReason, FailureTextSubstitution failureReasonSubstitution,
+        Guid escalationId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(failureReason);
 
@@ -64,7 +69,7 @@ public sealed class InProcessApprovalFailureMemory : IApprovalFailureMemory
         // Stamp the access time at creation so a brand-new entry is never rank-0 (oldest) for a
         // concurrent eviction running before this thread updates the timestamp.
         var entry = _entries.GetOrAdd(key, _ => new Entry { LastAccessTicks = now });
-        entry.RecordFailure(failureReason, escalationId);
+        entry.RecordFailure(failureReason, failureReasonSubstitution, escalationId);
         entry.LastAccessTicks = now;
         // Deliberately not folded into the entry's own lock: LastAccessTicks is a pure ranking
         // signal, and two concurrent writers each stamping "now" in whichever order is a benign
@@ -158,6 +163,7 @@ public sealed class InProcessApprovalFailureMemory : IApprovalFailureMemory
         private long _lastAccessTicks;
         private int _attemptCount;
         private string _failureReason = string.Empty;
+        private FailureTextSubstitution _failureReasonSubstitution;
         private Guid _escalationId;
 
         /// <summary>
@@ -172,18 +178,19 @@ public sealed class InProcessApprovalFailureMemory : IApprovalFailureMemory
         }
 
         /// <summary>A coherent snapshot of the attempt count, failure reason, and escalation id together.</summary>
-        public (int AttemptCount, string FailureReason, Guid EscalationId) Snapshot()
+        public (int AttemptCount, string FailureReason, FailureTextSubstitution Substitution, Guid EscalationId) Snapshot()
         {
             lock (_gate)
-                return (_attemptCount, _failureReason, _escalationId);
+                return (_attemptCount, _failureReason, _failureReasonSubstitution, _escalationId);
         }
 
-        public void RecordFailure(string failureReason, Guid escalationId)
+        public void RecordFailure(string failureReason, FailureTextSubstitution failureReasonSubstitution, Guid escalationId)
         {
             lock (_gate)
             {
                 _attemptCount++;
                 _failureReason = failureReason;
+                _failureReasonSubstitution = failureReasonSubstitution;
                 _escalationId = escalationId;
             }
         }

--- a/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/EscalationToolApprovalRouter.cs
@@ -247,6 +247,9 @@ public sealed class EscalationToolApprovalRouter : IToolApprovalRouter
                     escalation.RetryAttribution.MaxPriorFailureLength,
                     EscalationRequestInvariants.MaxPriorFailureReasonLength)
                 : null,
+            // #472: carried alongside the clamped text, not clamped itself — an enum has no length
+            // to bound.
+            PriorFailureReasonSubstitution = recall is { } r3 ? r3.Substitution : null,
             // Revision wins when both are live: ClearRevision fires the instant any escalation for
             // this key is approved, so a failure can only ever be recorded (which requires an
             // approval to have happened first) *before* a still-live revision recall, never after.

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -989,7 +989,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
     /// otherwise bypass entirely (the exception would propagate before <see cref="ReportExecutionAsync"/>
     /// ever reaches its own body). Fails closed: never returns the raw, untreated text on this path.
     /// </summary>
-    private string SafePrepareFailureText(string reason, string? toolName)
+    private PreparedFailureText SafePrepareFailureText(string reason, string? toolName)
     {
         try
         {
@@ -1000,7 +1000,12 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
             _logger.LogError(ex,
                 "Failed to sanitize/redact failure text for {ToolName}; withholding raw text from the report",
                 toolName);
-            return "[tool failure text withheld: sanitization or redaction failed]";
+            // #472: named FailureTextSubstitution.TreatmentFailed rather than an orphan literal — the
+            // third of three substitution reasons ReportedFailureText.PrepareForReporting's own two
+            // (Oversized, SanitizedToEmpty) previously left this one uncovered by the same discriminator.
+            return new PreparedFailureText(
+                "[tool failure text withheld: sanitization or redaction failed]",
+                FailureTextSubstitution.TreatmentFailed);
         }
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ReportedFailureText.cs
@@ -1,9 +1,27 @@
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Governance;
+using Domain.AI.Escalation;
 using Domain.AI.Telemetry.Redaction;
 
 namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// <see cref="ReportedFailureText.PrepareForReporting"/>'s result: the text to report, plus why it is a
+/// substitute when it is one. See <see cref="Domain.AI.Escalation.FailureTextSubstitution"/> for why the
+/// discriminator itself lives in Domain rather than here.
+/// </summary>
+/// <param name="Text">
+/// Always safe to persist to the audit trail, replay to a human approver, or hand back to the model on
+/// a retry. Never null-or-whitespace: <c>EscalationExecutionRecord.Failed</c> and
+/// <c>InProcessApprovalFailureMemory.RecordFailure</c> both reject that, so every substitution below is
+/// itself a non-blank placeholder string — <see cref="Substitution"/> is what lets a caller tell a
+/// placeholder apart from the tool's own text without relying on that string's exact wording.
+/// </param>
+/// <param name="Substitution">
+/// <see cref="FailureTextSubstitution.None"/> when <paramref name="Text"/> is the tool's own message.
+/// </param>
+public readonly record struct PreparedFailureText(string Text, FailureTextSubstitution Substitution);
 
 /// <summary>
 /// Prepares a tool's raw failure text for every consumer downstream of admission reporting — the audit
@@ -62,8 +80,11 @@ internal static class ReportedFailureText
     /// <param name="redactionFilter">Scrubs known secret patterns (emails, SSNs, AWS keys, JWTs, etc.).</param>
     /// <param name="toolName">The tool that produced <paramref name="text"/>, passed to the sanitizer as context.</param>
     /// <returns>
-    /// The text to report: either the tool's own sanitized/redacted/capped message, or one of the fixed
-    /// withheld placeholders below.
+    /// The text to report — either the tool's own sanitized/redacted/capped message
+    /// (<see cref="FailureTextSubstitution.None"/>), or a fixed withheld placeholder identified by its
+    /// <see cref="PreparedFailureText.Substitution"/> (#472: previously an in-band sentinel string with
+    /// no type-level way to tell it apart from genuine tool text — see this repo's own recorded history
+    /// of that shape, e.g. <c>IacSandboxRunner</c>'s <c>ExitCode</c>/<c>Attestation</c> discriminators).
     /// </returns>
     /// <remarks>
     /// <para>
@@ -77,13 +98,17 @@ internal static class ReportedFailureText
     /// does not close that gap on its own.
     /// </para>
     /// <para>
-    /// <strong>Cap last.</strong> Capping first can slice a real secret in half at the length boundary,
-    /// and the truncated fragment that survives is never run back through the redaction filter, so it
-    /// would reach the audit trail as-is. Redacting the full, uncapped text first and bounding the
-    /// (already-safe) result afterward is the only ordering that can't leak a fragment.
+    /// <strong>Cap last, and every path routes through it.</strong> Capping first can slice a real secret
+    /// in half at the length boundary, and the truncated fragment that survives is never run back through
+    /// the redaction filter, so it would reach the audit trail as-is. Redacting the full, uncapped text
+    /// first and bounding the (already-safe) result afterward is the only ordering that can't leak a
+    /// fragment. Both placeholders below are far under <see cref="MaxLength"/> so routing them through
+    /// <see cref="Cap"/> changes nothing observable today — but every terminal value returning from a
+    /// single point is what makes "does this bypass the cap" a question with one obviously-correct
+    /// answer, rather than something the next placeholder added here has to re-derive.
     /// </para>
     /// </remarks>
-    public static string PrepareForReporting(
+    public static PreparedFailureText PrepareForReporting(
         string text, ICompositeResponseSanitizer sanitizer, IContentRedactionFilter redactionFilter, string? toolName)
     {
         // Bounds the cost of every pattern in the sanitizer/redaction chain before any of them run,
@@ -91,23 +116,26 @@ internal static class ReportedFailureText
         // does nothing to bound how much text the dozens of regex passes upstream of it must scan.
         if (text.Length > MaxScanLength)
         {
-            return OversizedInputPlaceholder;
+            return new PreparedFailureText(Cap(OversizedInputPlaceholder), FailureTextSubstitution.Oversized);
         }
 
         // Sanitize-then-redact ordering lives once in SanitizeThenRedact (#470); the withheld-placeholder
         // decision plugs into its onSanitizedEmpty hook, so this method no longer hand-rolls the same
         // sanitize → check → redact sequence every other call site already converged on.
+        var sanitizedToEmpty = false;
         var reported = SanitizeThenRedact.Apply(
             text, sanitizer, redactionFilter, RedactionCategories.All, toolName,
-            onSanitizedEmpty: _ => EmptyAfterSanitizationPlaceholder);
+            onSanitizedEmpty: _ =>
+            {
+                sanitizedToEmpty = true;
+                return EmptyAfterSanitizationPlaceholder;
+            });
 
-        return Cap(reported);
+        return new PreparedFailureText(
+            Cap(reported),
+            sanitizedToEmpty ? FailureTextSubstitution.SanitizedToEmpty : FailureTextSubstitution.None);
     }
 
-    /// <summary>
-    /// Truncates <paramref name="text"/> to a bounded length, if it exceeds one, via the one
-    /// cut-and-mark primitive every trust-boundary truncation site shares (#467/#470).
-    /// </summary>
-    public static string Cap(string text) =>
+    private static string Cap(string text) =>
         BoundedText.Cap(text, MaxLength, "…[truncated]").Text;
 }

--- a/src/Content/Application/Application.Core/CQRS/Escalation/EscalationExecutionSummary.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/EscalationExecutionSummary.cs
@@ -16,6 +16,9 @@ public sealed record EscalationExecutionSummary
     /// <summary>Why the action failed. Non-null if and only if <see cref="Status"/> is <see cref="EscalationExecutionStatus.Failed"/>.</summary>
     public string? FailureReason { get; init; }
 
+    /// <summary>Why <see cref="FailureReason"/> is a substitute rather than the tool's own message (#472).</summary>
+    public FailureTextSubstitution? FailureReasonSubstitution { get; init; }
+
     /// <summary>Why the action never ran. Non-null if and only if <see cref="Status"/> is <see cref="EscalationExecutionStatus.NeverExecuted"/>.</summary>
     public EscalationNotExecutedReason? NotExecutedReason { get; init; }
 
@@ -34,6 +37,7 @@ public sealed record EscalationExecutionSummary
         {
             Status = record.Status,
             FailureReason = record.FailureReason,
+            FailureReasonSubstitution = record.FailureReasonSubstitution,
             NotExecutedReason = record.NotExecutedReason,
             ReportedAt = record.ReportedAt,
             ReportedBy = record.ReportedBy

--- a/src/Content/Application/Application.Core/CQRS/Escalation/EscalationSummary.cs
+++ b/src/Content/Application/Application.Core/CQRS/Escalation/EscalationSummary.cs
@@ -68,6 +68,9 @@ public sealed record EscalationSummary
     /// </summary>
     public string? PriorFailureReason { get; init; }
 
+    /// <summary>Why <see cref="PriorFailureReason"/> is a substitute rather than the tool's own message (#472).</summary>
+    public FailureTextSubstitution? PriorFailureReasonSubstitution { get; init; }
+
     /// <summary>
     /// The escalation that approved the prior attempt this one retries, or the prior revision
     /// round this one follows, letting an approver open the earlier record for full context.
@@ -110,6 +113,7 @@ public sealed record EscalationSummary
             TimeoutAction = request.TimeoutAction,
             AttemptNumber = request.AttemptNumber,
             PriorFailureReason = request.PriorFailureReason,
+            PriorFailureReasonSubstitution = request.PriorFailureReasonSubstitution,
             PredecessorEscalationId = request.PredecessorEscalationId,
             RevisionRound = request.RevisionRound,
             PriorRevisionInstructions = request.PriorRevisionInstructions

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationExecutionRecord.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationExecutionRecord.cs
@@ -23,6 +23,7 @@ public sealed record EscalationExecutionRecord
         Guid escalationId,
         EscalationExecutionStatus status,
         string? failureReason,
+        FailureTextSubstitution? failureReasonSubstitution,
         EscalationNotExecutedReason? notExecutedReason,
         DateTimeOffset reportedAt,
         string reportedBy)
@@ -30,6 +31,7 @@ public sealed record EscalationExecutionRecord
         EscalationId = escalationId;
         Status = status;
         FailureReason = failureReason;
+        FailureReasonSubstitution = failureReasonSubstitution;
         NotExecutedReason = notExecutedReason;
         ReportedAt = reportedAt;
         ReportedBy = reportedBy;
@@ -46,6 +48,17 @@ public sealed record EscalationExecutionRecord
     /// <see cref="EscalationExecutionStatus.Failed"/>.
     /// </summary>
     public string? FailureReason { get; }
+
+    /// <summary>
+    /// Why <see cref="FailureReason"/> is a substitute rather than the tool's own message (#472) —
+    /// <see cref="Escalation.FailureTextSubstitution.None"/> or null when it is the tool's own
+    /// message. A nullable sibling field, not a change to <see cref="FailureReason"/>'s own type:
+    /// this record is JSON-serialized to an append-only, hash-chained audit store, and a persisted
+    /// line written before this field existed must still deserialize — the JSON constructor's
+    /// missing-property default (null) reads exactly as "unknown, treat as the tool's own message,"
+    /// which is the only backward-compatible interpretation an old line can support.
+    /// </summary>
+    public FailureTextSubstitution? FailureReasonSubstitution { get; }
 
     /// <summary>
     /// Why the action never ran. Non-null if and only if <see cref="Status"/> is
@@ -70,7 +83,7 @@ public sealed record EscalationExecutionRecord
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reportedBy);
         return new EscalationExecutionRecord(
-            escalationId, EscalationExecutionStatus.Succeeded, null, null, reportedAt, reportedBy);
+            escalationId, EscalationExecutionStatus.Succeeded, null, null, null, reportedAt, reportedBy);
     }
 
     /// <summary>The action ran and failed.</summary>
@@ -78,13 +91,19 @@ public sealed record EscalationExecutionRecord
     /// Why it failed. Must contain something an approver can read — blank is rejected as well as
     /// null, for the same reason as <see cref="FailureReason"/>'s own doc.
     /// </param>
+    /// <param name="failureReasonSubstitution">See <see cref="FailureReasonSubstitution"/>.</param>
     public static EscalationExecutionRecord Failed(
-        Guid escalationId, string failureReason, DateTimeOffset reportedAt, string reportedBy)
+        Guid escalationId,
+        string failureReason,
+        FailureTextSubstitution failureReasonSubstitution,
+        DateTimeOffset reportedAt,
+        string reportedBy)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(failureReason);
         ArgumentException.ThrowIfNullOrWhiteSpace(reportedBy);
         return new EscalationExecutionRecord(
-            escalationId, EscalationExecutionStatus.Failed, failureReason, null, reportedAt, reportedBy);
+            escalationId, EscalationExecutionStatus.Failed, failureReason, failureReasonSubstitution, null,
+            reportedAt, reportedBy);
     }
 
     /// <summary>The action never ran.</summary>
@@ -96,6 +115,6 @@ public sealed record EscalationExecutionRecord
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reportedBy);
         return new EscalationExecutionRecord(
-            escalationId, EscalationExecutionStatus.NeverExecuted, null, reason, reportedAt, reportedBy);
+            escalationId, EscalationExecutionStatus.NeverExecuted, null, null, reason, reportedAt, reportedBy);
     }
 }

--- a/src/Content/Domain/Domain.AI/Escalation/EscalationRequest.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/EscalationRequest.cs
@@ -71,6 +71,13 @@ public sealed record EscalationRequest
     public string? PriorFailureReason { get; init; }
 
     /// <summary>
+    /// Why <see cref="PriorFailureReason"/> is a substitute rather than the tool's own message
+    /// (#472) — null on a first attempt, same as its sibling. See
+    /// <see cref="FailureTextSubstitution"/>.
+    /// </summary>
+    public FailureTextSubstitution? PriorFailureReasonSubstitution { get; init; }
+
+    /// <summary>
     /// The escalation id of the failed prior attempt or the prior revision round this one
     /// follows, when <see cref="AttemptNumber"/> is greater than 1 or <see cref="RevisionRound"/>
     /// is greater than 1. Null on a first attempt. Shared correlation link between the two

--- a/src/Content/Domain/Domain.AI/Escalation/FailureTextSubstitution.cs
+++ b/src/Content/Domain/Domain.AI/Escalation/FailureTextSubstitution.cs
@@ -1,0 +1,24 @@
+namespace Domain.AI.Escalation;
+
+/// <summary>
+/// Why a reported failure's text is a substitute rather than the tool's own message — carried
+/// alongside the text itself (#472) so a downstream consumer (the audit trail, the approver card
+/// replaying "why it failed last time") can render a distinct badge instead of trying to tell a
+/// substitution apart from a tool that genuinely emitted matching text. Domain-level rather than
+/// living next to the sanitizer that produces it, because <see cref="EscalationExecutionRecord"/>
+/// needs to carry it and Domain must not depend on Application.
+/// </summary>
+public enum FailureTextSubstitution
+{
+    /// <summary>The tool's own text, sanitized/redacted/capped — not a substitution.</summary>
+    None = 0,
+
+    /// <summary>The input exceeded the scan-cost bound before sanitize/redact ever ran.</summary>
+    Oversized,
+
+    /// <summary>Sanitization removed all content from the tool's failure message.</summary>
+    SanitizedToEmpty,
+
+    /// <summary>Sanitizing or redacting the text threw; the raw text is withheld rather than leaked unsafely.</summary>
+    TreatmentFailed,
+}

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEscalationEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEscalationEvents.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Domain.AI.Escalation;
 
 namespace Presentation.AgentHub.AgUi;
 
@@ -51,6 +52,14 @@ public sealed record EscalationRequestedEvent : AgUiEvent
     /// <summary>Why the previous attempt at this action failed. Null on a first attempt.</summary>
     [JsonPropertyName("priorFailureReason")]
     public string? PriorFailureReason { get; init; }
+
+    /// <summary>
+    /// Why <see cref="PriorFailureReason"/> is a substitute rather than the tool's own message
+    /// (#472) — null on a first attempt, same as its sibling. Additive, like every other field
+    /// added to this event after its first shape.
+    /// </summary>
+    [JsonPropertyName("priorFailureReasonSubstitution")]
+    public FailureTextSubstitution? PriorFailureReasonSubstitution { get; init; }
 
     /// <summary>
     /// Which round of reviewer revision this is, 1-based. Greater than 1 means a prior escalation
@@ -169,6 +178,13 @@ public sealed record EscalationExecutedEvent : AgUiEvent
     /// <summary>Why the action failed. Present only when <see cref="Status"/> is "Failed".</summary>
     [JsonPropertyName("failureReason")]
     public string? FailureReason { get; init; }
+
+    /// <summary>
+    /// Why <see cref="FailureReason"/> is a substitute rather than the tool's own message (#472).
+    /// Additive, like every other field added to this event after its first shape.
+    /// </summary>
+    [JsonPropertyName("failureReasonSubstitution")]
+    public FailureTextSubstitution? FailureReasonSubstitution { get; init; }
 
     /// <summary>Why the action never ran. Present only when <see cref="Status"/> is "NeverExecuted".</summary>
     [JsonPropertyName("notExecutedReason")]

--- a/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiEscalationNotifier.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/Notifications/AgUiEscalationNotifier.cs
@@ -55,6 +55,7 @@ public sealed class AgUiEscalationNotifier : IEscalationNotificationChannel
                 : null,
             AttemptNumber = request.AttemptNumber,
             PriorFailureReason = request.PriorFailureReason,
+            PriorFailureReasonSubstitution = request.PriorFailureReasonSubstitution,
             RevisionRound = request.RevisionRound,
             PriorRevisionInstructions = request.PriorRevisionInstructions,
         };
@@ -162,6 +163,7 @@ public sealed class AgUiEscalationNotifier : IEscalationNotificationChannel
             EscalationId = record.EscalationId.ToString(),
             Status = record.Status.ToString(),
             FailureReason = record.FailureReason,
+            FailureReasonSubstitution = record.FailureReasonSubstitution,
             NotExecutedReason = record.NotExecutedReason?.ToString(),
             ReportedAt = record.ReportedAt,
             ReportedBy = record.ReportedBy,

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/EscalationToolApprovalRouterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/EscalationToolApprovalRouterTests.cs
@@ -514,13 +514,19 @@ public sealed class EscalationToolApprovalRouterTests
         var predecessorId = Guid.NewGuid();
         _failureMemory
             .Setup(m => m.TryRecall(ExpectedKey))
-            .Returns(new ApprovalFailureRecall(PriorAttemptCount: 1, FailureReason: "permission denied", predecessorId));
+            .Returns(new ApprovalFailureRecall(
+                PriorAttemptCount: 1, FailureReason: "permission denied",
+                Substitution: FailureTextSubstitution.SanitizedToEmpty, EscalationId: predecessorId));
 
         await Route(Config());
 
         Assert.NotNull(captured());
         Assert.Equal(2, captured()!.AttemptNumber);
         Assert.Equal("permission denied", captured()!.PriorFailureReason);
+        // #472: a non-None substitution proves the wiring actually carries the value through, not
+        // just that the parameter exists — None would pass even if EscalationToolApprovalRouter
+        // silently dropped it.
+        Assert.Equal(FailureTextSubstitution.SanitizedToEmpty, captured()!.PriorFailureReasonSubstitution);
         Assert.Equal(predecessorId, captured()!.PredecessorEscalationId);
     }
 
@@ -535,7 +541,7 @@ public sealed class EscalationToolApprovalRouterTests
         var predecessorId = Guid.NewGuid();
         _failureMemory
             .Setup(m => m.TryRecall(ExpectedKey))
-            .Returns(new ApprovalFailureRecall(1, "boom", predecessorId));
+            .Returns(new ApprovalFailureRecall(1, "boom", FailureTextSubstitution.None, predecessorId));
         CaptureRequest(out var captured);
 
         await Route(Config());
@@ -565,7 +571,7 @@ public sealed class EscalationToolApprovalRouterTests
         CaptureRequest(out var captured);
         _failureMemory
             .Setup(m => m.TryRecall(ExpectedKey))
-            .Returns(new ApprovalFailureRecall(1, new string('x', 1000), Guid.NewGuid()));
+            .Returns(new ApprovalFailureRecall(1, new string('x', 1000), FailureTextSubstitution.None, Guid.NewGuid()));
 
         var config = Config();
         var narrowCap = new GovernanceConfig
@@ -594,7 +600,7 @@ public sealed class EscalationToolApprovalRouterTests
         CaptureRequest(out var captured);
         _failureMemory
             .Setup(m => m.TryRecall(ExpectedKey))
-            .Returns(new ApprovalFailureRecall(1, "short reason", Guid.NewGuid()));
+            .Returns(new ApprovalFailureRecall(1, "short reason", FailureTextSubstitution.None, Guid.NewGuid()));
 
         await Route(Config());
 
@@ -822,7 +828,7 @@ public sealed class EscalationToolApprovalRouterTests
         var revisionEscalationId = Guid.NewGuid();
         _failureMemory
             .Setup(m => m.TryRecall(ExpectedKey))
-            .Returns(new ApprovalFailureRecall(1, "timed out", failureEscalationId));
+            .Returns(new ApprovalFailureRecall(1, "timed out", FailureTextSubstitution.None, failureEscalationId));
         _failureMemory
             .Setup(m => m.TryRecallRevision(ExpectedKey))
             .Returns(new ApprovalRevisionRecall(2, "narrow the scope", revisionEscalationId));

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCallAdmissionPipelineTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Telemetry;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Changes;
 using Domain.AI.Context;
 using Domain.AI.Escalation;
@@ -1031,7 +1032,7 @@ public sealed class ToolCallAdmissionPipelineTests
             admission, new ToolExecutionReport(EscalationExecutionStatus.Succeeded, null, null), "test-site", CancellationToken.None);
 
         reporter.Verify(r => r.ReportSucceededAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        reporter.Verify(r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        reporter.Verify(r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<PreparedFailureText>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         reporter.Verify(r => r.ReportNotExecutedAsync(It.IsAny<ApprovedCall>(), It.IsAny<EscalationNotExecutedReason>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -1058,7 +1059,12 @@ public sealed class ToolCallAdmissionPipelineTests
         await WithReporter(reporter).ReportExecutionAsync(
             admission, new ToolExecutionReport(EscalationExecutionStatus.Failed, "permission denied", null), "test-site", CancellationToken.None);
 
-        reporter.Verify(r => r.ReportFailedAsync(call, "permission denied", It.IsAny<string>(), CancellationToken.None), Times.Once);
+        reporter.Verify(
+            r => r.ReportFailedAsync(
+                call,
+                It.Is<PreparedFailureText>(p => p.Text == "permission denied" && p.Substitution == FailureTextSubstitution.None),
+                It.IsAny<string>(), CancellationToken.None),
+            Times.Once);
     }
 
     [Fact]
@@ -1092,9 +1098,10 @@ public sealed class ToolCallAdmissionPipelineTests
         reporter.Verify(
             r => r.ReportFailedAsync(
                 call,
-                It.Is<string>(s =>
-                    s.Contains("[SANITIZED]") && !s.Contains("IGNORE PREVIOUS INSTRUCTIONS")
-                    && s.Contains("[REDACTED:Email]") && !s.Contains("admin@example.com")),
+                It.Is<PreparedFailureText>(p =>
+                    p.Text.Contains("[SANITIZED]") && !p.Text.Contains("IGNORE PREVIOUS INSTRUCTIONS")
+                    && p.Text.Contains("[REDACTED:Email]") && !p.Text.Contains("admin@example.com")
+                    && p.Substitution == FailureTextSubstitution.None),
                 "test-site", CancellationToken.None),
             Times.Once);
     }
@@ -1121,10 +1128,14 @@ public sealed class ToolCallAdmissionPipelineTests
             new ToolExecutionReport(EscalationExecutionStatus.Failed, "entirely hostile content", null, ToolName: Tool),
             "test-site", CancellationToken.None);
 
+        // #472: asserted on Substitution directly, not just non-blank text — the whole point of the
+        // typed discriminator is that a caller no longer has to infer "this was a substitution" from
+        // the text's shape.
         reporter.Verify(
             r => r.ReportFailedAsync(
                 call,
-                It.Is<string>(s => !string.IsNullOrWhiteSpace(s)),
+                It.Is<PreparedFailureText>(p =>
+                    !string.IsNullOrWhiteSpace(p.Text) && p.Substitution == FailureTextSubstitution.SanitizedToEmpty),
                 "test-site", CancellationToken.None),
             Times.Once);
     }
@@ -1153,7 +1164,9 @@ public sealed class ToolCallAdmissionPipelineTests
         reporter.Verify(
             r => r.ReportFailedAsync(
                 call,
-                It.Is<string>(s => s.Contains("exceeded") && s.Contains("characters")),
+                It.Is<PreparedFailureText>(p =>
+                    p.Text.Contains("exceeded") && p.Text.Contains("characters")
+                    && p.Substitution == FailureTextSubstitution.Oversized),
                 "test-site", CancellationToken.None),
             Times.Once);
     }
@@ -1186,7 +1199,9 @@ public sealed class ToolCallAdmissionPipelineTests
         reporter.Verify(
             r => r.ReportFailedAsync(
                 call,
-                It.Is<string>(s => s.Contains("withheld") && !s.Contains("boom")),
+                It.Is<PreparedFailureText>(p =>
+                    p.Text.Contains("withheld") && !p.Text.Contains("boom")
+                    && p.Substitution == FailureTextSubstitution.TreatmentFailed),
                 "test-site", CancellationToken.None),
             Times.Once);
     }
@@ -1203,7 +1218,7 @@ public sealed class ToolCallAdmissionPipelineTests
         await WithReporter(reporter).ReportExecutionAsync(
             admission, new ToolExecutionReport(EscalationExecutionStatus.Failed, null, null), "test-site", CancellationToken.None);
 
-        reporter.Verify(r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        reporter.Verify(r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<PreparedFailureText>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/DefaultApprovalExecutionReporterTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/DefaultApprovalExecutionReporterTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Services.Escalation;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Escalation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
@@ -65,10 +66,10 @@ public sealed class DefaultApprovalExecutionReporterTests
     public async Task ReportFailedAsync_RecordsFailureAgainstMemory_NotClear()
     {
         var call = Call();
-        await Create().ReportFailedAsync(call, "permission denied", "tool-invocation", CancellationToken.None);
+        await Create().ReportFailedAsync(call, new PreparedFailureText("permission denied", FailureTextSubstitution.None), "tool-invocation", CancellationToken.None);
 
         _failureMemory.Verify(
-            m => m.RecordFailure(call.Key, "permission denied", call.EscalationId), Times.Once);
+            m => m.RecordFailure(call.Key, "permission denied", FailureTextSubstitution.None, call.EscalationId), Times.Once);
         _failureMemory.Verify(m => m.Clear(It.IsAny<ApprovalFailureKey>()), Times.Never);
     }
 
@@ -81,7 +82,7 @@ public sealed class DefaultApprovalExecutionReporterTests
             .Returns(Task.CompletedTask);
 
         var call = Call();
-        await Create().ReportFailedAsync(call, "permission denied", "tool-invocation", CancellationToken.None);
+        await Create().ReportFailedAsync(call, new PreparedFailureText("permission denied", FailureTextSubstitution.None), "tool-invocation", CancellationToken.None);
 
         Assert.NotNull(recorded);
         Assert.Equal(EscalationExecutionStatus.Failed, recorded!.Status);
@@ -99,7 +100,7 @@ public sealed class DefaultApprovalExecutionReporterTests
 
         _failureMemory.Verify(m => m.Clear(It.IsAny<ApprovalFailureKey>()), Times.Never);
         _failureMemory.Verify(
-            m => m.RecordFailure(It.IsAny<ApprovalFailureKey>(), It.IsAny<string>(), It.IsAny<Guid>()), Times.Never);
+            m => m.RecordFailure(It.IsAny<ApprovalFailureKey>(), It.IsAny<string>(), It.IsAny<FailureTextSubstitution>(), It.IsAny<Guid>()), Times.Never);
     }
 
     [Fact]
@@ -163,11 +164,11 @@ public sealed class DefaultApprovalExecutionReporterTests
     public async Task ReportFailedAsync_MemoryThrows_DoesNotThrow()
     {
         _failureMemory
-            .Setup(m => m.RecordFailure(It.IsAny<ApprovalFailureKey>(), It.IsAny<string>(), It.IsAny<Guid>()))
+            .Setup(m => m.RecordFailure(It.IsAny<ApprovalFailureKey>(), It.IsAny<string>(), It.IsAny<FailureTextSubstitution>(), It.IsAny<Guid>()))
             .Throws(new InvalidOperationException("memory corrupted"));
 
         var exception = await Record.ExceptionAsync(
-            () => Create().ReportFailedAsync(Call(), "boom", "tool-invocation", CancellationToken.None).AsTask());
+            () => Create().ReportFailedAsync(Call(), new PreparedFailureText("boom", FailureTextSubstitution.None), "tool-invocation", CancellationToken.None).AsTask());
 
         Assert.Null(exception);
     }
@@ -183,7 +184,7 @@ public sealed class DefaultApprovalExecutionReporterTests
         cts.Cancel();
 
         var exception = await Record.ExceptionAsync(
-            () => Create().ReportFailedAsync(Call(), "boom", "tool-invocation", cts.Token).AsTask());
+            () => Create().ReportFailedAsync(Call(), new PreparedFailureText("boom", FailureTextSubstitution.None), "tool-invocation", cts.Token).AsTask());
 
         Assert.Null(exception);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/InProcessApprovalFailureMemoryTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Escalation/InProcessApprovalFailureMemoryTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Services.Escalation;
+using Domain.AI.Escalation;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -34,12 +35,14 @@ public sealed class InProcessApprovalFailureMemoryTests
         var key = Key();
         var escalationId = Guid.NewGuid();
 
-        memory.RecordFailure(key, "permission denied", escalationId);
+        memory.RecordFailure(key, "permission denied", FailureTextSubstitution.SanitizedToEmpty, escalationId);
         var recall = memory.TryRecall(key);
 
         Assert.NotNull(recall);
         Assert.Equal(1, recall!.Value.PriorAttemptCount);
         Assert.Equal("permission denied", recall.Value.FailureReason);
+        // #472: the substitution reason round-trips through recall, not just the text.
+        Assert.Equal(FailureTextSubstitution.SanitizedToEmpty, recall.Value.Substitution);
         Assert.Equal(escalationId, recall.Value.EscalationId);
     }
 
@@ -49,9 +52,9 @@ public sealed class InProcessApprovalFailureMemoryTests
         var memory = Create();
         var key = Key();
 
-        memory.RecordFailure(key, "first failure", Guid.NewGuid());
+        memory.RecordFailure(key, "first failure", FailureTextSubstitution.None, Guid.NewGuid());
         var secondEscalationId = Guid.NewGuid();
-        memory.RecordFailure(key, "second failure", secondEscalationId);
+        memory.RecordFailure(key, "second failure", FailureTextSubstitution.None, secondEscalationId);
 
         var recall = memory.TryRecall(key);
 
@@ -66,7 +69,7 @@ public sealed class InProcessApprovalFailureMemoryTests
     {
         var memory = Create();
 
-        Assert.ThrowsAny<ArgumentException>(() => memory.RecordFailure(Key(), "", Guid.NewGuid()));
+        Assert.ThrowsAny<ArgumentException>(() => memory.RecordFailure(Key(), "", FailureTextSubstitution.None, Guid.NewGuid()));
     }
 
     [Fact]
@@ -74,7 +77,7 @@ public sealed class InProcessApprovalFailureMemoryTests
     {
         var memory = Create();
         var key = Key();
-        memory.RecordFailure(key, "boom", Guid.NewGuid());
+        memory.RecordFailure(key, "boom", FailureTextSubstitution.None, Guid.NewGuid());
 
         memory.Clear(key);
 
@@ -97,7 +100,7 @@ public sealed class InProcessApprovalFailureMemoryTests
         // The key is (conversation, agent, tool) precisely so one conversation's retry history can
         // never label another's approval card.
         var memory = Create();
-        memory.RecordFailure(Key(conversationId: "conv-a"), "boom", Guid.NewGuid());
+        memory.RecordFailure(Key(conversationId: "conv-a"), "boom", FailureTextSubstitution.None, Guid.NewGuid());
 
         var recall = memory.TryRecall(Key(conversationId: "conv-b"));
 
@@ -110,7 +113,7 @@ public sealed class InProcessApprovalFailureMemoryTests
         // A supervisor and a delegated sub-agent calling the same tool in one conversation must not
         // cross-label each other's retry history.
         var memory = Create();
-        memory.RecordFailure(Key(agentId: "supervisor"), "boom", Guid.NewGuid());
+        memory.RecordFailure(Key(agentId: "supervisor"), "boom", FailureTextSubstitution.None, Guid.NewGuid());
 
         var recall = memory.TryRecall(Key(agentId: "sub-agent"));
 
@@ -123,7 +126,7 @@ public sealed class InProcessApprovalFailureMemoryTests
         var memory = Create();
 
         for (var i = 0; i <= InProcessApprovalFailureMemory.MaxTrackedActions; i++)
-            memory.RecordFailure(Key(conversationId: $"conv-{i}"), "boom", Guid.NewGuid());
+            memory.RecordFailure(Key(conversationId: $"conv-{i}"), "boom", FailureTextSubstitution.None, Guid.NewGuid());
 
         // The most recently recorded entry must survive — the cap is respected, not exceeded.
         var survivor = Key(conversationId: $"conv-{InProcessApprovalFailureMemory.MaxTrackedActions}");
@@ -139,10 +142,10 @@ public sealed class InProcessApprovalFailureMemoryTests
         // failure reason" shape as valid rather than treating it as corruption.
         var memory = Create();
         var evicted = Key(conversationId: "first");
-        memory.RecordFailure(evicted, "boom", Guid.NewGuid());
+        memory.RecordFailure(evicted, "boom", FailureTextSubstitution.None, Guid.NewGuid());
 
         for (var i = 0; i <= InProcessApprovalFailureMemory.MaxTrackedActions; i++)
-            memory.RecordFailure(Key(conversationId: $"conv-{i}"), "boom", Guid.NewGuid());
+            memory.RecordFailure(Key(conversationId: $"conv-{i}"), "boom", FailureTextSubstitution.None, Guid.NewGuid());
 
         Assert.Null(memory.TryRecall(evicted));
     }
@@ -213,7 +216,7 @@ public sealed class InProcessApprovalFailureMemoryTests
         var key = Key();
         memory.RecordRevision(key, 2, "use the read-only endpoint instead", Guid.NewGuid());
 
-        memory.RecordFailure(key, "timed out", Guid.NewGuid());
+        memory.RecordFailure(key, "timed out", FailureTextSubstitution.None, Guid.NewGuid());
 
         var revision = memory.TryRecallRevision(key);
         Assert.NotNull(revision);
@@ -246,7 +249,7 @@ public sealed class InProcessApprovalFailureMemoryTests
         // the failure fields RecordFailure owns.
         var memory = Create();
         var key = Key();
-        memory.RecordFailure(key, "permission denied", Guid.NewGuid());
+        memory.RecordFailure(key, "permission denied", FailureTextSubstitution.None, Guid.NewGuid());
 
         memory.RecordRevision(key, 2, "narrow the scope", Guid.NewGuid());
 
@@ -261,7 +264,7 @@ public sealed class InProcessApprovalFailureMemoryTests
     {
         var memory = Create();
         var key = Key();
-        memory.RecordFailure(key, "permission denied", Guid.NewGuid());
+        memory.RecordFailure(key, "permission denied", FailureTextSubstitution.None, Guid.NewGuid());
         memory.RecordRevision(key, 2, "narrow the scope", Guid.NewGuid());
 
         memory.ClearRevision(key);

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -10,6 +10,7 @@ using Application.AI.Common.Services.Tools;
 using Application.AI.Common.Tests.Governance;
 using Domain.AI.Bundles;
 using Domain.AI.Changes;
+using Domain.AI.Escalation;
 using Domain.AI.Governance;
 using Domain.AI.Models;
 using Domain.Common.Config.AI;
@@ -750,7 +751,11 @@ public sealed class DirectToolInvokerTests
         await Invoke(Request("alpha"), Tool("alpha", result: ToolResult.Fail("permission denied")));
 
         _executionReporter.Verify(
-            r => r.ReportFailedAsync(call, "permission denied", "direct-invocation", CancellationToken.None), Times.Once);
+            r => r.ReportFailedAsync(
+                call,
+                It.Is<PreparedFailureText>(p => p.Text == "permission denied" && p.Substitution == FailureTextSubstitution.None),
+                "direct-invocation", CancellationToken.None),
+            Times.Once);
     }
 
     [Fact]
@@ -772,8 +777,9 @@ public sealed class DirectToolInvokerTests
         _executionReporter.Verify(
             r => r.ReportFailedAsync(
                 call,
-                It.Is<string>(reason =>
-                    !reason.Contains("admin@example.com") && reason.Contains("[REDACTED:Email]")),
+                It.Is<PreparedFailureText>(p =>
+                    !p.Text.Contains("admin@example.com") && p.Text.Contains("[REDACTED:Email]")
+                    && p.Substitution == FailureTextSubstitution.None),
                 "direct-invocation", CancellationToken.None),
             Times.Once);
     }
@@ -791,7 +797,7 @@ public sealed class DirectToolInvokerTests
         // The fault is reported (approval loop closed) but still surfaces as the invoker's own
         // faulted outcome — reporting must never swallow or replace the caller-facing result.
         _executionReporter.Verify(r => r.ReportFailedAsync(
-            call, It.IsAny<string>(), "direct-invocation", CancellationToken.None), Times.Once);
+            call, It.IsAny<PreparedFailureText>(), "direct-invocation", CancellationToken.None), Times.Once);
         outcome.Status.Should().Be(DirectToolInvocationStatus.Faulted);
     }
 

--- a/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/GetEscalationQueryHandlerTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/CQRS/Escalation/GetEscalationQueryHandlerTests.cs
@@ -124,7 +124,7 @@ public sealed class GetEscalationQueryHandlerTests
         _auditStore
             .Setup(s => s.GetLatestExecutionAsync(id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(EscalationExecutionRecord.Failed(
-                id, "downstream API returned 500", DateTimeOffset.UtcNow, "agent-turn"));
+                id, "downstream API returned 500", FailureTextSubstitution.None, DateTimeOffset.UtcNow, "agent-turn"));
 
         var result = await _handler.Handle(new GetEscalationQuery
         {

--- a/src/Content/Tests/Domain.AI.Tests/Escalation/EscalationExecutionRecordTests.cs
+++ b/src/Content/Tests/Domain.AI.Tests/Escalation/EscalationExecutionRecordTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Domain.AI.Escalation;
 using Xunit;
 
@@ -30,11 +32,25 @@ public sealed class EscalationExecutionRecordTests
     [Fact]
     public void Failed_SetsExpectedShape()
     {
-        var record = EscalationExecutionRecord.Failed(EscalationId, "permission denied", ReportedAt, ReportedBy);
+        var record = EscalationExecutionRecord.Failed(
+            EscalationId, "permission denied", FailureTextSubstitution.None, ReportedAt, ReportedBy);
 
         Assert.Equal(EscalationExecutionStatus.Failed, record.Status);
         Assert.Equal("permission denied", record.FailureReason);
+        Assert.Equal(FailureTextSubstitution.None, record.FailureReasonSubstitution);
         Assert.Null(record.NotExecutedReason);
+    }
+
+    [Fact]
+    public void Failed_SubstitutedText_CarriesTheSubstitutionReason()
+    {
+        // #472: the whole point of the new parameter — a caller can tell a placeholder apart from
+        // the tool's own text without relying on the string's exact wording.
+        var record = EscalationExecutionRecord.Failed(
+            EscalationId, "[tool failure text withheld: sanitization removed all content]",
+            FailureTextSubstitution.SanitizedToEmpty, ReportedAt, ReportedBy);
+
+        Assert.Equal(FailureTextSubstitution.SanitizedToEmpty, record.FailureReasonSubstitution);
     }
 
     [Theory]
@@ -47,14 +63,16 @@ public sealed class EscalationExecutionRecordTests
         // read is indistinguishable from success, so this shape must never exist rather than be
         // guarded against at every reader.
         Assert.ThrowsAny<ArgumentException>(
-            () => EscalationExecutionRecord.Failed(EscalationId, failureReason!, ReportedAt, ReportedBy));
+            () => EscalationExecutionRecord.Failed(
+                EscalationId, failureReason!, FailureTextSubstitution.None, ReportedAt, ReportedBy));
     }
 
     [Fact]
     public void Failed_NonBlankFailureReason_MutationControl_DoesNotThrow()
     {
         var exception = Record.Exception(
-            () => EscalationExecutionRecord.Failed(EscalationId, "boom", ReportedAt, ReportedBy));
+            () => EscalationExecutionRecord.Failed(
+                EscalationId, "boom", FailureTextSubstitution.None, ReportedAt, ReportedBy));
 
         Assert.Null(exception);
     }
@@ -89,5 +107,50 @@ public sealed class EscalationExecutionRecordTests
     {
         Assert.ThrowsAny<ArgumentException>(() => EscalationExecutionRecord.NeverExecuted(
             EscalationId, EscalationNotExecutedReason.RunCancelled, ReportedAt, reportedBy!));
+    }
+
+    // #472: the same snake_case + JsonStringEnumConverter shape JsonlEscalationAuditStore actually
+    // uses to write and read this record — see its SerializeOptions/DeserializeOptions.
+    private static readonly JsonSerializerOptions AuditJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    [Fact]
+    public void JsonRoundTrip_NewShape_PreservesFailureReasonSubstitution()
+    {
+        var record = EscalationExecutionRecord.Failed(
+            EscalationId, "permission denied", FailureTextSubstitution.SanitizedToEmpty, ReportedAt, ReportedBy);
+
+        var json = JsonSerializer.Serialize(record, AuditJsonOptions);
+        var rehydrated = JsonSerializer.Deserialize<EscalationExecutionRecord>(json, AuditJsonOptions);
+
+        Assert.NotNull(rehydrated);
+        Assert.Equal(FailureTextSubstitution.SanitizedToEmpty, rehydrated!.FailureReasonSubstitution);
+    }
+
+    [Fact]
+    public void JsonRoundTrip_PreExistingAuditLine_MissingFailureReasonSubstitution_StillDeserializes()
+    {
+        // #472: EscalationExecutionRecord is JSON-serialized to an append-only, hash-chained audit
+        // store — a line written before this field existed must still load. This is the actual
+        // payload shape a pre-#472 line has: no failure_reason_substitution key at all, not a null
+        // one (System.Text.Json's "missing property" and "property present but null" paths are
+        // different code paths, and only the former is what an old file on disk actually contains).
+        const string preExistingLine =
+            """
+            {"escalation_id":"11111111-1111-1111-1111-111111111111","status":"Failed",
+            "failure_reason":"downstream API returned 500","not_executed_reason":null,
+            "reported_at":"2026-01-01T00:00:00+00:00","reported_by":"agent-turn"}
+            """;
+
+        var record = JsonSerializer.Deserialize<EscalationExecutionRecord>(preExistingLine, AuditJsonOptions);
+
+        Assert.NotNull(record);
+        Assert.Equal("downstream API returned 500", record!.FailureReason);
+        // The only backward-compatible reading of "absent" — see FailureReasonSubstitution's own doc.
+        Assert.Null(record.FailureReasonSubstitution);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Attestation;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
@@ -628,7 +629,7 @@ public sealed class ToolUseStepExecutorTests
             new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         _executionReporter.Verify(
-            r => r.ReportFailedAsync(Call, It.IsAny<string>(), "plan-executor", CancellationToken.None), Times.Once);
+            r => r.ReportFailedAsync(Call, It.IsAny<PreparedFailureText>(), "plan-executor", CancellationToken.None), Times.Once);
     }
 
     [Fact]
@@ -643,7 +644,7 @@ public sealed class ToolUseStepExecutorTests
 
         Assert.Equal(StepExecutionStatus.Failed, result.Status);
         _executionReporter.Verify(
-            r => r.ReportFailedAsync(Call, It.IsAny<string>(), "plan-executor", CancellationToken.None), Times.Once);
+            r => r.ReportFailedAsync(Call, It.IsAny<PreparedFailureText>(), "plan-executor", CancellationToken.None), Times.Once);
     }
 
     [Fact]
@@ -664,7 +665,7 @@ public sealed class ToolUseStepExecutorTests
             r => r.ReportNotExecutedAsync(Call, EscalationNotExecutedReason.RunCancelled, "plan-executor", CancellationToken.None),
             Times.Once);
         _executionReporter.Verify(
-            r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            r => r.ReportFailedAsync(It.IsAny<ApprovedCall>(), It.IsAny<PreparedFailureText>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 }


### PR DESCRIPTION
## Summary
- `ReportedFailureText.PrepareForReporting` returned a plain string, so a sanitizer-withheld placeholder and a tool's genuine failure text traveled through the identical channel with no way to tell them apart — the "shared field, two meanings" defect shape this repo's CLAUDE.md already tracks twice for `IacSandboxRunner`. The placeholder is what a human approver reads on the next approval card as "why it failed last time"; nothing downstream could distinguish it from quoted tool output.
- Adds `Domain.AI.Escalation.FailureTextSubstitution` (`None`/`Oversized`/`SanitizedToEmpty`/`TreatmentFailed`) and `PreparedFailureText(Text, Substitution)`, threaded through `IApprovalExecutionReporter.ReportFailedAsync`, `EscalationExecutionRecord`, `IApprovalFailureMemory`, `EscalationRequest`, and the AG-UI wire events — as **additive nullable siblings**, never a type change on the existing string fields, since `EscalationExecutionRecord` is JSON-serialized to an append-only, hash-chained audit store where an old line must still deserialize.
- Folds in the third substitution reason (sanitize/redact threw) that previously lived as an unnamed literal in a different class, and fixes the `Cap`-ordering asymmetry the ticket named — both placeholders now route through the same terminal `Cap` call.
- The discriminator enum lives in `Domain.AI.Escalation` rather than next to the sanitizer that produces it, because `EscalationExecutionRecord` (Domain) needs to carry it and Domain must not depend on Application.

## Backward compatibility
Verified directly, not just asserted: a hand-crafted pre-#472 JSON line with no `failure_reason_substitution` key deserializes cleanly with the field reading `null` — the only correct interpretation of "unknown, written before this existed."

## Review history on this branch
- `run-gates.sh` (build, full test suite, OWASP, grader, correctness-review, security-review, docs-drift) passed clean on two separate runs against this exact diff — grader/correctness/security all green both times.
- The only gate failure across three attempts was `test`, and it was a different pre-existing `Infrastructure.AI.Tests.Sandbox.*` flake each time (Windows process/pipe timing under parallel load — matches this repo's documented main-branch flakiness, #537). None touch this diff.
- Mutation-tested: forcing the `Oversized` discriminator to `None` fails a test; forcing `EscalationToolApprovalRouter` to always report `null` substitution fails a test — both confirm the new discriminators are load-bearing, not decorative.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` on every directly-touched class (8 test files) — all pass
- [x] Full solution `dotnet test` via `run-gates.sh` (Docker up, real integration tests) — pass except the known unrelated flake
- [x] `detect_changes` (GitNexus) — scope matches expectation (21 files, 1 affected execution flow), no surprise blast radius
- [x] JSON round-trip test proving pre-existing audit lines still deserialize
- [x] Mutation tests on both new discriminators — confirmed load-bearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3QEuyXft9fqBhZrbkPWQj