### PR TITLE
fix: hard-fail when a plugin tool boundary names a tool that doesn't exist (#524)

### DIFF
--- a/documentation/onboarding/10-observability.html
+++ b/documentation/onboarding/10-observability.html
@@ -291,6 +291,14 @@ docker run -d --name jaeger \
                         blast radius — a third-party plugin can read files but never write them, regardless of the
                         agent's own permissions.
                     </p>
+                    <p>
+                        An <code>AllowedTools</code>/<code>DeniedTools</code> entry that matches no real tool — first-
+                        party or MCP — is fail-closed, not a silent no-op. If resolvable at startup (no MCP server is
+                        configured anywhere on the host), the host refuses to boot. Otherwise it's checked once the
+                        entry's tool is discovered on some configured server; if still unresolved once every server
+                        has reported, the whole plugin's boundary is marked faulted and every tool from its skills is
+                        denied.
+                    </p>
 
                     <h3>5 · The sandbox</h3>
                     <p>

--- a/documentation/onboarding/11-extending.html
+++ b/documentation/onboarding/11-extending.html
@@ -497,6 +497,21 @@ You are the team's automated code review assistant. For each pull request:
                                     </p>
                                 </div>
                             </div>
+                            <div class="callout callout-info">
+                                <span class="callout-icon">i</span>
+                                <div class="callout-body">
+                                    <div class="callout-title">A typo in AllowedTools/DeniedTools now fails closed</div>
+                                    <p style="margin: 0">
+                                        An entry that matches no real tool — first-party or MCP — is no longer a
+                                        silent no-op. With no MCP server configured on the host, it fails startup
+                                        outright. Otherwise it's resolved lazily as each configured server's tools
+                                        are discovered; if it's still unmatched once every server has reported,
+                                        every tool from this plugin's skills is denied. See
+                                        <a href="10-observability.html">Observability &amp; Safety</a> for the full
+                                        mechanics.
+                                    </p>
+                                </div>
+                            </div>
                         </li>
 
                         <li class="step">

--- a/documentation/reference/patterns-and-technologies.html
+++ b/documentation/reference/patterns-and-technologies.html
@@ -395,11 +395,16 @@ know the exact filename. Cite file paths in `path:line` form.</code></pre>
                         (<code>AllowedTools</code>, <code>DeniedTools</code>, <code>AutonomyLevel</code>). The
                         <code>PluginPermissionRuleProvider</code> turns those declarations into MediatR rules — and
                         <code>DeniedTools</code> is bypass-immune: it can't be overridden by auto-approve modes.
+                        Since #524, <code>IPluginToolBoundaryTracker</code> additionally verifies every
+                        <code>AllowedTools</code>/<code>DeniedTools</code> entry resolves to a real tool (first-party
+                        at startup, MCP-provided lazily on discovery); an entry that never resolves marks the
+                        plugin's boundary faulted and <code>ToolChainBuilder</code> denies all of its tools.
                     </p>
                     <ul>
                         <li>Manifest reader: <code>Infrastructure.AI/Plugins/PluginManifestReader.cs</code> (verify path — see "Locating plugin internals" note below)</li>
                         <li>Permissions: <code>Application.Core/Permissions/PluginPermissionRuleProvider.cs</code></li>
                         <li>Declaration types: <code>Domain.Common/Config/AI/Plugins/PluginDeclaration.cs</code></li>
+                        <li>Existence check: <code>Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs</code>, <code>Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs</code></li>
                     </ul>
 
                     <h3 id="agent-manifest">Agent manifest (AGENT.md)</h3>

--- a/documentation/security/04-tools-and-permissions.html
+++ b/documentation/security/04-tools-and-permissions.html
@@ -334,14 +334,17 @@
                         <div class="callout-body">
                             <div class="callout-title">A boundary entry that names no real tool now fails closed, not silently</div>
                             <p style="margin: 0">
-                                At startup, if a plugin declares no MCP servers, every <code>AllowedTools</code> /
-                                <code>DeniedTools</code> entry must match a real first-party tool or the host refuses
-                                to boot. For a plugin that does use MCP servers, entries are checked lazily as each
-                                server's tools are discovered — no eager connection just to validate. If an entry is
-                                proven to match nothing, the harness treats the whole boundary as untrustworthy and
-                                denies <strong>every</strong> tool from that plugin's skills rather than run with a
-                                partially-broken policy, because an unrecognized <code>DeniedTools</code> entry is
-                                otherwise a silent no-op that would defeat the bypass-immune guarantee below.
+                                At startup, if <strong>no MCP server is configured anywhere on the host</strong>,
+                                every <code>AllowedTools</code> / <code>DeniedTools</code> entry must match a real
+                                first-party tool or the host refuses to boot. Whenever at least one MCP server is
+                                configured — even one a plugin doesn't declare itself, since a skill's tool
+                                declaration can resolve against any configured server — entries are checked lazily
+                                as each server's tools are discovered — no eager connection just to validate. If an
+                                entry is still unmatched once every configured server has reported, the harness
+                                treats the whole boundary as untrustworthy and denies <strong>every</strong> tool
+                                from that plugin's skills rather than run with a partially-broken policy, because an
+                                unrecognized <code>DeniedTools</code> entry is otherwise a silent no-op that would
+                                defeat the bypass-immune guarantee below.
                             </p>
                         </div>
                     </div>

--- a/documentation/security/04-tools-and-permissions.html
+++ b/documentation/security/04-tools-and-permissions.html
@@ -332,6 +332,23 @@
                     <div class="callout callout-info">
                         <span class="callout-icon">i</span>
                         <div class="callout-body">
+                            <div class="callout-title">A boundary entry that names no real tool now fails closed, not silently</div>
+                            <p style="margin: 0">
+                                At startup, if a plugin declares no MCP servers, every <code>AllowedTools</code> /
+                                <code>DeniedTools</code> entry must match a real first-party tool or the host refuses
+                                to boot. For a plugin that does use MCP servers, entries are checked lazily as each
+                                server's tools are discovered — no eager connection just to validate. If an entry is
+                                proven to match nothing, the harness treats the whole boundary as untrustworthy and
+                                denies <strong>every</strong> tool from that plugin's skills rather than run with a
+                                partially-broken policy, because an unrecognized <code>DeniedTools</code> entry is
+                                otherwise a silent no-op that would defeat the bypass-immune guarantee below.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="callout callout-info">
+                        <span class="callout-icon">i</span>
+                        <div class="callout-body">
                             <div class="callout-title">Scope: <code>DeniedTools</code> is plugin-wide and turn-global, not per-skill</div>
                             <p style="margin: 0">
                                 <code>AllowedTools</code>, <code>DeniedTools</code>, and <code>AutonomyLevel</code> are

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -410,11 +410,5 @@ public static class DependencyInjection
     /// non-string key could not be supplied on the wire anyway.
     /// </remarks>
     private static IReadOnlyList<string> KeyedToolRegistrationKeys(IServiceCollection services) =>
-    [
-        .. services
-            .Where(descriptor => descriptor.IsKeyedService && descriptor.ServiceType == typeof(ITool))
-            .Select(descriptor => descriptor.ServiceKey as string)
-            .Where(key => !string.IsNullOrWhiteSpace(key))
-            .Select(key => key!)
-    ];
+        [.. Services.Tools.KeyedToolRegistrationScan.Names(services)];
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
@@ -16,4 +16,21 @@ public interface IPluginRegistry
 
     /// <summary>Registers a loaded plugin.</summary>
     void Register(LoadedPlugin plugin);
+
+    /// <summary>
+    /// Whether <paramref name="pluginName"/>'s tool boundary (<c>AllowedTools</c>/<c>DeniedTools</c>)
+    /// has been marked faulted by <see cref="MarkBoundaryFaulted"/> — see that method's remarks.
+    /// </summary>
+    bool IsBoundaryFaulted(string pluginName);
+
+    /// <summary>
+    /// Marks <paramref name="pluginName"/>'s tool boundary as faulted: at least one of its
+    /// <c>AllowedTools</c>/<c>DeniedTools</c> entries has been proven to match no real tool (#524).
+    /// A boundary that can't be trusted is treated fail-closed — <c>ToolChainBuilder</c> denies every
+    /// tool for a faulted plugin rather than run with a partially-broken policy, since a typo in
+    /// <c>DeniedTools</c> (documented as bypass-immune) silently defeats that guarantee otherwise.
+    /// </summary>
+    /// <param name="pluginName">The plugin whose boundary is faulted.</param>
+    /// <param name="reason">Human-readable reason, for logging/diagnostics.</param>
+    void MarkBoundaryFaulted(string pluginName, string reason);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -1,0 +1,60 @@
+using Domain.Common.Config.AI.Plugins;
+
+namespace Application.AI.Common.Interfaces.Plugins;
+
+/// <summary>
+/// One <see cref="PluginDeclaration.AllowedTools"/>/<see cref="PluginDeclaration.DeniedTools"/>
+/// entry that has been confirmed to not match any known tool — first-party or MCP-provided.
+/// </summary>
+/// <param name="PluginName">The plugin whose boundary declared the entry.</param>
+/// <param name="ListKind">Either <c>"AllowedTools"</c> or <c>"DeniedTools"</c>, for the error message.</param>
+/// <param name="ToolName">The offending entry itself.</param>
+public sealed record PluginToolBoundaryViolation(string PluginName, string ListKind, string ToolName);
+
+/// <summary>
+/// Tracks whether every <c>AllowedTools</c>/<c>DeniedTools</c> entry a loaded plugin declares
+/// actually matches a real tool — first-party (keyed-DI, known at startup) or MCP-provided (known
+/// only once the owning server's tool list has been discovered at least once).
+/// </summary>
+/// <remarks>
+/// See #524: a plugin boundary entry that matches nothing is a silent no-op today — most
+/// dangerously for <c>DeniedTools</c>, which is documented as bypass-immune. This tracker is what
+/// turns that into a loud, fail-closed fault instead. <see cref="Seed"/> resolves what's decidable
+/// immediately (a plugin with no MCP servers at all has no other source its entries could resolve
+/// from); <see cref="ReportServerToolsDiscovered"/> resolves the rest lazily, as MCP servers are
+/// organically discovered during normal operation — never by connecting to a server early just to
+/// check.
+/// </remarks>
+public interface IPluginToolBoundaryTracker
+{
+    /// <summary>
+    /// Called once at startup, after plugins are loaded. Returns the entries that are immediately,
+    /// provably fake — a plugin declares zero MCP servers, so every one of its boundary entries must
+    /// be a first-party name; anything <paramref name="isKnownFirstPartyToolName"/> rejects is a
+    /// definite typo, decidable right now. Every other unresolved entry (belonging to a plugin that
+    /// does declare MCP servers) is retained internally, pending <see cref="ReportServerToolsDiscovered"/>.
+    /// </summary>
+    /// <param name="loadedPlugins">Every currently loaded plugin.</param>
+    /// <param name="isKnownFirstPartyToolName">
+    /// Bounded first-party (keyed-DI) tool-name membership check. Must match names
+    /// case-insensitively, the same way <c>ToolChainBuilder.ApplyPluginToolBoundary</c> matches a
+    /// boundary entry against a tool's real published name — a case-sensitive check here would
+    /// falsely flag a real, just differently-cased, tool name as nonexistent.
+    /// </param>
+    IReadOnlyList<PluginToolBoundaryViolation> Seed(
+        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName);
+
+    /// <summary>
+    /// Called every time an MCP server's tool list is successfully discovered (the existing lazy
+    /// discovery path — this method never triggers a connection itself). Resolves any pending entry
+    /// <paramref name="discoveredToolNames"/> now accounts for. When this was the LAST MCP server a
+    /// plugin depends on to report, and that plugin still has unresolved entries left, those entries
+    /// are now provably fake: this method marks the plugin's boundary faulted
+    /// (<see cref="IPluginRegistry.MarkBoundaryFaulted"/>) and returns them. Returns an empty list in
+    /// the common case (nothing pending for this server, or everything pending just got resolved).
+    /// </summary>
+    /// <param name="serverName">The namespaced (<c>{pluginName}:{serverName}</c>) MCP server name.</param>
+    /// <param name="discoveredToolNames">The raw tool names the server just reported.</param>
+    IReadOnlyList<PluginToolBoundaryViolation> ReportServerToolsDiscovered(
+        string serverName, IReadOnlyCollection<string> discoveredToolNames);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -20,19 +20,19 @@ public sealed record PluginToolBoundaryViolation(string PluginName, string ListK
 /// See #524: a plugin boundary entry that matches nothing is a silent no-op today — most
 /// dangerously for <c>DeniedTools</c>, which is documented as bypass-immune. This tracker is what
 /// turns that into a loud, fail-closed fault instead. <see cref="Seed"/> resolves what's decidable
-/// immediately (a plugin with no MCP servers at all has no other source its entries could resolve
-/// from); <see cref="ReportServerToolsDiscovered"/> resolves the rest lazily, as MCP servers are
-/// organically discovered during normal operation — never by connecting to a server early just to
-/// check.
+/// immediately (no MCP server is configured anywhere on the host, so nothing could ever resolve an
+/// unmatched entry); <see cref="ReportServerToolsDiscovered"/> resolves the rest lazily, as MCP
+/// servers are organically discovered during normal operation — never by connecting to a server
+/// early just to check.
 /// </remarks>
 public interface IPluginToolBoundaryTracker
 {
     /// <summary>
     /// Called once at startup, after plugins are loaded. Returns the entries that are immediately,
-    /// provably fake — a plugin declares zero MCP servers, so every one of its boundary entries must
-    /// be a first-party name; anything <paramref name="isKnownFirstPartyToolName"/> rejects is a
-    /// definite typo, decidable right now. Every other unresolved entry (belonging to a plugin that
-    /// does declare MCP servers) is retained internally, pending <see cref="ReportServerToolsDiscovered"/>.
+    /// provably fake — no MCP server is configured anywhere on the host, so every boundary entry
+    /// must be a first-party name; anything <paramref name="isKnownFirstPartyToolName"/> rejects is a
+    /// definite typo, decidable right now. Every other unresolved entry is retained internally,
+    /// pending <see cref="ReportServerToolsDiscovered"/>.
     /// </summary>
     /// <param name="loadedPlugins">Every currently loaded plugin.</param>
     /// <param name="isKnownFirstPartyToolName">
@@ -41,8 +41,20 @@ public interface IPluginToolBoundaryTracker
     /// boundary entry against a tool's real published name — a case-sensitive check here would
     /// falsely flag a real, just differently-cased, tool name as nonexistent.
     /// </param>
+    /// <param name="allConfiguredMcpServerNames">
+    /// Every enabled MCP server name configured anywhere on the host — <strong>not</strong> narrowed
+    /// to any one plugin's own declared servers. A review-round finding traced
+    /// <c>ToolChainBuilder.ResolveEffectiveMcpServerName</c> and confirmed a plugin skill's
+    /// <c>ToolDeclaration</c> can resolve against ANY host-configured MCP server when no capability
+    /// envelope restricts it — so a plugin that declares zero MCP servers of its own can still
+    /// legitimately reference a host-level server's tool in its boundary. Narrowing this list to a
+    /// per-plugin one previously crashed boot (or permanently denied every tool) on exactly that
+    /// valid configuration.
+    /// </param>
     IReadOnlyList<PluginToolBoundaryViolation> Seed(
-        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName);
+        IReadOnlyList<LoadedPlugin> loadedPlugins,
+        Func<string, bool> isKnownFirstPartyToolName,
+        IReadOnlyCollection<string> allConfiguredMcpServerNames);
 
     /// <summary>
     /// Called every time an MCP server's tool list is successfully discovered (the existing lazy

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -38,10 +38,13 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
 
     /// <inheritdoc />
     public IReadOnlyList<PluginToolBoundaryViolation> Seed(
-        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName)
+        IReadOnlyList<LoadedPlugin> loadedPlugins,
+        Func<string, bool> isKnownFirstPartyToolName,
+        IReadOnlyCollection<string> allConfiguredMcpServerNames)
     {
         ArgumentNullException.ThrowIfNull(loadedPlugins);
         ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+        ArgumentNullException.ThrowIfNull(allConfiguredMcpServerNames);
 
         var immediate = new List<PluginToolBoundaryViolation>();
 
@@ -61,9 +64,17 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             if (unresolved.Count == 0)
                 continue;
 
-            if (plugin.McpServerNames.Count == 0)
+            if (allConfiguredMcpServerNames.Count == 0)
             {
-                // No other source these could ever resolve from — provably fake, right now.
+                // No MCP server exists ANYWHERE on this host — no other source these could ever
+                // resolve from, provably fake right now. Deliberately NOT scoped to plugin.McpServerNames
+                // (the plugin's own declared servers): a review round finding traced
+                // ToolChainBuilder.ResolveEffectiveMcpServerName and confirmed a plugin skill's
+                // ToolDeclaration can resolve against ANY host-configured MCP server, not only ones
+                // the plugin itself declares — a zero-own-servers plugin can still legitimately
+                // reference a host-level server's tool in its boundary. Narrowing to the plugin's own
+                // servers previously crashed boot (or permanently denied every tool) on exactly that
+                // valid, pre-existing configuration.
                 immediate.AddRange(unresolved.Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name)));
                 continue;
             }
@@ -72,11 +83,11 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             {
                 Lock = new object(),
                 PendingEntries = unresolved.ToDictionary(e => e.Name, e => e.ListKind, StringComparer.OrdinalIgnoreCase),
-                PendingServers = new HashSet<string>(plugin.McpServerNames, StringComparer.OrdinalIgnoreCase),
+                PendingServers = new HashSet<string>(allConfiguredMcpServerNames, StringComparer.OrdinalIgnoreCase),
             };
             _pendingByPlugin[plugin.Name] = pending;
 
-            foreach (var serverName in plugin.McpServerNames)
+            foreach (var serverName in allConfiguredMcpServerNames)
                 _pluginsByServer.GetOrAdd(serverName, _ => []).Add(plugin.Name);
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -89,9 +89,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 // the registry here too means the fault is recorded independently of whether that
                 // caller rethrows — the same defense-in-depth ReportServerToolsDiscovered already
                 // gives the lazy branch.
-                _registry.MarkBoundaryFaulted(
-                    plugin.Name,
-                    $"Tool boundary entries match no known tool: {string.Join(", ", immediateForPlugin.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
+                _registry.MarkBoundaryFaulted(plugin.Name, FaultReason(immediateForPlugin));
                 continue;
             }
 
@@ -158,15 +156,16 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
 
             if (faulted is { Count: > 0 })
             {
-                _registry.MarkBoundaryFaulted(
-                    pluginName,
-                    $"Tool boundary entries match no known tool: {string.Join(", ", faulted.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
+                _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted));
                 violations.AddRange(faulted);
             }
         }
 
         return violations;
     }
+
+    private static string FaultReason(IReadOnlyList<PluginToolBoundaryViolation> violations) =>
+        $"Tool boundary entries match no known tool: {string.Join(", ", violations.Select(v => $"{v.ListKind}:{v.ToolName}"))}";
 
     private static IReadOnlyList<(string Name, string ListKind)> BoundaryEntries(LoadedPlugin plugin)
     {

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -14,6 +14,13 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
         public required object Lock { get; init; }
         public required Dictionary<string, string> PendingEntries { get; init; } // name -> list kind
         public required HashSet<string> PendingServers { get; init; }
+
+        // Guards against firing twice for one plugin: a caller can still hold this same instance
+        // (from its own TryGetValue) after _pendingByPlugin.TryRemove has already dropped it — two
+        // concurrent ReportServerToolsDiscovered calls for THE SAME server can both reach the lock
+        // with PendingServers already empty and PendingEntries never cleared, otherwise faulting
+        // (and logging) the same violation twice.
+        public bool Resolved { get; set; }
     }
 
     private readonly IPluginRegistry _registry;
@@ -41,7 +48,16 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
         foreach (var plugin in loadedPlugins)
         {
             var entries = BoundaryEntries(plugin);
-            var unresolved = entries.Where(e => !isKnownFirstPartyToolName(e.Name)).ToList();
+            // A name can legitimately appear more than once — duplicated within one list, or once
+            // in AllowedTools and once in DeniedTools — and the existence question is identical
+            // either time, so collapse before anything downstream (the ToDictionary below cannot
+            // tolerate a repeated key at all — confirmed by a review round finding it throws
+            // ArgumentException on exactly this shape, crashing a legally-configured plugin's boot).
+            var unresolved = entries
+                .Where(e => !isKnownFirstPartyToolName(e.Name))
+                .GroupBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
+                .ToList();
             if (unresolved.Count == 0)
                 continue;
 
@@ -88,6 +104,12 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             List<PluginToolBoundaryViolation>? faulted = null;
             lock (pending.Lock)
             {
+                // A concurrent report for a DIFFERENT server on this same plugin can already have
+                // resolved it before this thread reached the lock — this thread's own TryGetValue
+                // above ran against a reference that predates that removal, so it must re-check here.
+                if (pending.Resolved)
+                    continue;
+
                 foreach (var name in pending.PendingEntries.Keys.Where(discovered.Contains).ToList())
                     pending.PendingEntries.Remove(name);
 
@@ -104,6 +126,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                         .ToList();
                 }
 
+                pending.Resolved = true;
                 _pendingByPlugin.TryRemove(pluginName, out _);
             }
 

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -9,9 +9,10 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
     private const string AllowedToolsListKind = "AllowedTools";
     private const string DeniedToolsListKind = "DeniedTools";
 
+    // Never exposed outside this file, so locking on the instance itself (lock (pending) at each
+    // call site) is safe and needs no dedicated lock object.
     private sealed class PendingPlugin
     {
-        public required object Lock { get; init; }
         public required Dictionary<string, string> PendingEntries { get; init; } // name -> list kind
         public required HashSet<string> PendingServers { get; init; }
 
@@ -59,7 +60,10 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             var unresolved = entries
                 .Where(e => !isKnownFirstPartyToolName(e.Name))
                 .GroupBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
-                .Select(g => g.First())
+                // A name duplicated across both lists reports as DeniedTools — the list the
+                // bypass-immune security guarantee actually depends on — rather than whichever
+                // list happened to be enumerated first.
+                .Select(g => g.FirstOrDefault(e => e.ListKind == DeniedToolsListKind, g.First()))
                 .ToList();
             if (unresolved.Count == 0)
                 continue;
@@ -75,13 +79,24 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 // reference a host-level server's tool in its boundary. Narrowing to the plugin's own
                 // servers previously crashed boot (or permanently denied every tool) on exactly that
                 // valid, pre-existing configuration.
-                immediate.AddRange(unresolved.Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name)));
+                var immediateForPlugin = unresolved
+                    .Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name))
+                    .ToList();
+                immediate.AddRange(immediateForPlugin);
+
+                // Belt-and-suspenders (review-round finding): enforcement of this branch relies on
+                // PluginToolBoundaryStartupValidator.StartAsync throwing to abort host boot. Marking
+                // the registry here too means the fault is recorded independently of whether that
+                // caller rethrows — the same defense-in-depth ReportServerToolsDiscovered already
+                // gives the lazy branch.
+                _registry.MarkBoundaryFaulted(
+                    plugin.Name,
+                    $"Tool boundary entries match no known tool: {string.Join(", ", immediateForPlugin.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
                 continue;
             }
 
             var pending = new PendingPlugin
             {
-                Lock = new object(),
                 PendingEntries = unresolved.ToDictionary(e => e.Name, e => e.ListKind, StringComparer.OrdinalIgnoreCase),
                 PendingServers = new HashSet<string>(allConfiguredMcpServerNames, StringComparer.OrdinalIgnoreCase),
             };
@@ -113,7 +128,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 continue; // Already resolved and removed by a concurrent report.
 
             List<PluginToolBoundaryViolation>? faulted = null;
-            lock (pending.Lock)
+            lock (pending)
             {
                 // A concurrent report for a DIFFERENT server on this same plugin can already have
                 // resolved it before this thread reached the lock — this thread's own TryGetValue

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -1,0 +1,131 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Plugins;
+
+namespace Application.AI.Common.Services.Plugins;
+
+/// <inheritdoc cref="IPluginToolBoundaryTracker" />
+public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
+{
+    private const string AllowedToolsListKind = "AllowedTools";
+    private const string DeniedToolsListKind = "DeniedTools";
+
+    private sealed class PendingPlugin
+    {
+        public required object Lock { get; init; }
+        public required Dictionary<string, string> PendingEntries { get; init; } // name -> list kind
+        public required HashSet<string> PendingServers { get; init; }
+    }
+
+    private readonly IPluginRegistry _registry;
+    private readonly ConcurrentDictionary<string, PendingPlugin> _pendingByPlugin = new(StringComparer.OrdinalIgnoreCase);
+
+    // serverName -> plugin names waiting on it, built once at Seed time.
+    private readonly ConcurrentDictionary<string, List<string>> _pluginsByServer = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryTracker"/> class.</summary>
+    public PluginToolBoundaryTracker(IPluginRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        _registry = registry;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<PluginToolBoundaryViolation> Seed(
+        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName)
+    {
+        ArgumentNullException.ThrowIfNull(loadedPlugins);
+        ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+
+        var immediate = new List<PluginToolBoundaryViolation>();
+
+        foreach (var plugin in loadedPlugins)
+        {
+            var entries = BoundaryEntries(plugin);
+            var unresolved = entries.Where(e => !isKnownFirstPartyToolName(e.Name)).ToList();
+            if (unresolved.Count == 0)
+                continue;
+
+            if (plugin.McpServerNames.Count == 0)
+            {
+                // No other source these could ever resolve from — provably fake, right now.
+                immediate.AddRange(unresolved.Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name)));
+                continue;
+            }
+
+            var pending = new PendingPlugin
+            {
+                Lock = new object(),
+                PendingEntries = unresolved.ToDictionary(e => e.Name, e => e.ListKind, StringComparer.OrdinalIgnoreCase),
+                PendingServers = new HashSet<string>(plugin.McpServerNames, StringComparer.OrdinalIgnoreCase),
+            };
+            _pendingByPlugin[plugin.Name] = pending;
+
+            foreach (var serverName in plugin.McpServerNames)
+                _pluginsByServer.GetOrAdd(serverName, _ => []).Add(plugin.Name);
+        }
+
+        return immediate;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<PluginToolBoundaryViolation> ReportServerToolsDiscovered(
+        string serverName, IReadOnlyCollection<string> discoveredToolNames)
+    {
+        ArgumentNullException.ThrowIfNull(serverName);
+        ArgumentNullException.ThrowIfNull(discoveredToolNames);
+
+        if (!_pluginsByServer.TryGetValue(serverName, out var pluginNames))
+            return [];
+
+        var discovered = new HashSet<string>(discoveredToolNames, StringComparer.OrdinalIgnoreCase);
+        var violations = new List<PluginToolBoundaryViolation>();
+
+        foreach (var pluginName in pluginNames)
+        {
+            if (!_pendingByPlugin.TryGetValue(pluginName, out var pending))
+                continue; // Already resolved and removed by a concurrent report.
+
+            List<PluginToolBoundaryViolation>? faulted = null;
+            lock (pending.Lock)
+            {
+                foreach (var name in pending.PendingEntries.Keys.Where(discovered.Contains).ToList())
+                    pending.PendingEntries.Remove(name);
+
+                pending.PendingServers.Remove(serverName);
+
+                if (pending.PendingServers.Count > 0)
+                    continue; // Other servers this plugin depends on haven't reported yet.
+
+                // Last pending server just reported. Whatever's still unresolved is now provably fake.
+                if (pending.PendingEntries.Count > 0)
+                {
+                    faulted = pending.PendingEntries
+                        .Select(kv => new PluginToolBoundaryViolation(pluginName, kv.Value, kv.Key))
+                        .ToList();
+                }
+
+                _pendingByPlugin.TryRemove(pluginName, out _);
+            }
+
+            if (faulted is { Count: > 0 })
+            {
+                _registry.MarkBoundaryFaulted(
+                    pluginName,
+                    $"Tool boundary entries match no known tool: {string.Join(", ", faulted.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
+                violations.AddRange(faulted);
+            }
+        }
+
+        return violations;
+    }
+
+    private static IReadOnlyList<(string Name, string ListKind)> BoundaryEntries(LoadedPlugin plugin)
+    {
+        var entries = new List<(string, string)>();
+        if (plugin.Declaration.AllowedTools is { Count: > 0 } allowed)
+            entries.AddRange(allowed.Select(name => (name, AllowedToolsListKind)));
+        if (plugin.Declaration.DeniedTools is { Count: > 0 } denied)
+            entries.AddRange(denied.Select(name => (name, DeniedToolsListKind)));
+        return entries;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/KeyedToolRegistrationScan.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/KeyedToolRegistrationScan.cs
@@ -1,0 +1,29 @@
+using Application.AI.Common.Interfaces.Tools;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// The one place that scans a service collection for keyed <see cref="ITool"/> registration keys —
+/// the bounded "what counts as a first-party tool name" set every consumer of that question needs.
+/// </summary>
+/// <remarks>
+/// Consolidates a scan that had drifted into three independent copies: <see cref="FirstPartyToolLookup"/>'s
+/// own registration (#387, which already consolidated three OTHER independent copies of the same
+/// bounded-lookup pattern), <c>ToolCatalog</c>'s registration, and — until a code-review finding on
+/// #524 — <c>PluginToolBoundaryStartupValidator</c>'s DI wiring. A fourth copy would be exactly the
+/// drift #387 exists to prevent; every future caller should reach for this instead of re-deriving the
+/// same <c>IsKeyedService &amp;&amp; ServiceType == typeof(ITool)</c> filter.
+/// </remarks>
+public static class KeyedToolRegistrationScan
+{
+    /// <summary>
+    /// Every keyed-DI registration key registered as an <see cref="ITool"/> in <paramref name="services"/>.
+    /// </summary>
+    public static IEnumerable<string> Names(IServiceCollection services) =>
+        services
+            .Where(descriptor => descriptor.IsKeyedService && descriptor.ServiceType == typeof(ITool))
+            .Select(descriptor => descriptor.ServiceKey as string)
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Select(key => key!);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -218,6 +218,20 @@ public partial class ToolChainBuilder : IToolChainBuilder
         if (loadedPlugin is null)
             return provisioned;
 
+        // #524: a boundary entry that matches no real tool is provably broken, not just
+        // permissive — most dangerously for DeniedTools, documented as bypass-immune. Once
+        // PluginToolBoundaryTracker has proven that (see its remarks), the boundary can no longer
+        // be trusted, so this denies every tool from the plugin rather than run with a
+        // partially-broken policy.
+        if (pluginRegistry!.IsBoundaryFaulted(skill.PluginSource))
+        {
+            _logger.LogWarning(
+                "Plugin '{Plugin}' tool boundary is faulted (an AllowedTools/DeniedTools entry " +
+                "matches no known tool) — denying all tools for skill '{Skill}'",
+                skill.PluginSource, skill.Id);
+            return [];
+        }
+
         return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Infrastructure.AI.MCP.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
     <!-- Infrastructure.AI supplies AntiSsrfHandlerFactory — the SSRF guard the MCP
          client is built on. Hard dependency so SSRF protection cannot be omitted. -->

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Domain.AI.Telemetry.Conventions;
 using Microsoft.Extensions.AI;
@@ -51,17 +52,26 @@ public sealed class McpToolProvider : IMcpToolProvider
 {
     private readonly ILogger<McpToolProvider> _logger;
     private readonly McpConnectionManager _connectionManager;
+    private readonly IPluginToolBoundaryTracker? _boundaryTracker;
     private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="McpToolProvider"/> class.
     /// </summary>
+    /// <param name="boundaryTracker">
+    /// Optional (#524). When supplied, every successful tool-list discovery is reported to it so a
+    /// plugin's AllowedTools/DeniedTools entries can be resolved or fail-closed-faulted against real
+    /// MCP tool names — see <see cref="IPluginToolBoundaryTracker"/>'s remarks. Absent in most tests,
+    /// which have nothing to report to; production DI always supplies it.
+    /// </param>
     public McpToolProvider(
         ILogger<McpToolProvider> logger,
-        McpConnectionManager connectionManager)
+        McpConnectionManager connectionManager,
+        IPluginToolBoundaryTracker? boundaryTracker = null)
     {
         _logger = logger;
         _connectionManager = connectionManager;
+        _boundaryTracker = boundaryTracker;
     }
 
     /// <inheritdoc />
@@ -192,6 +202,8 @@ public sealed class McpToolProvider : IMcpToolProvider
                 "Retrieved {ToolCount} tools from MCP server '{ServerName}'",
                 tools.Count, serverName);
 
+            ReportDiscoveryToBoundaryTracker(serverName, tools);
+
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
         }
@@ -204,6 +216,31 @@ public sealed class McpToolProvider : IMcpToolProvider
         {
             RecordOutcome(start, serverName, McpConventions.StatusValues.Error);
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Reports a server's just-discovered tool names to the plugin tool-boundary tracker (#524), so
+    /// any plugin depending on this server can resolve or fail-closed-fault its
+    /// AllowedTools/DeniedTools entries against them. A no-op when no tracker is wired (most tests)
+    /// or nothing is pending for this server (the overwhelmingly common case). Logged at Critical,
+    /// not thrown — the tracker never throws, and a boundary violation must not disturb this
+    /// otherwise-successful discovery call's own return value; enforcement happens separately, via
+    /// <c>IPluginRegistry.IsBoundaryFaulted</c> denying the plugin's tools on its next resolution.
+    /// </summary>
+    private void ReportDiscoveryToBoundaryTracker(string serverName, IList<McpClientTool> tools)
+    {
+        if (_boundaryTracker is null)
+            return;
+
+        var violations = _boundaryTracker.ReportServerToolsDiscovered(serverName, tools.Select(t => t.Name).ToList());
+        foreach (var violation in violations)
+        {
+            _logger.LogCritical(
+                "Plugin '{Plugin}': {ListKind} entry '{ToolName}' matches no known tool (first-party " +
+                "or MCP) — this entry is a no-op, and the plugin's tool boundary can no longer be " +
+                "trusted, so all tools from this plugin are now denied.",
+                violation.PluginName, violation.ListKind, violation.ToolName);
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -202,7 +202,7 @@ public sealed class McpToolProvider : IMcpToolProvider
                 "Retrieved {ToolCount} tools from MCP server '{ServerName}'",
                 tools.Count, serverName);
 
-            ReportDiscoveryToBoundaryTracker(serverName, tools);
+            ReportDiscoveryToBoundaryTracker(serverName, tools.Select(t => t.Name));
 
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
@@ -228,12 +228,19 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// otherwise-successful discovery call's own return value; enforcement happens separately, via
     /// <c>IPluginRegistry.IsBoundaryFaulted</c> denying the plugin's tools on its next resolution.
     /// </summary>
-    private void ReportDiscoveryToBoundaryTracker(string serverName, IList<McpClientTool> tools)
+    /// <remarks>
+    /// Takes bare tool names rather than <see cref="McpClientTool"/> instances specifically so this
+    /// is unit-testable without a live MCP connection — a real correctness-review finding on #524
+    /// flagged this call site (the untrusted-input half of the feature) as having zero test coverage,
+    /// since no fixture in this project exercises <see cref="DiscoverToolsAsync"/>'s success path.
+    /// <c>internal</c> + <c>InternalsVisibleTo</c> lets <c>McpToolProviderTests</c> call this directly.
+    /// </remarks>
+    internal void ReportDiscoveryToBoundaryTracker(string serverName, IEnumerable<string> discoveredToolNames)
     {
         if (_boundaryTracker is null)
             return;
 
-        var violations = _boundaryTracker.ReportServerToolsDiscovered(serverName, tools.Select(t => t.Name).ToList());
+        var violations = _boundaryTracker.ReportServerToolsDiscovered(serverName, discoveredToolNames.ToList());
         foreach (var violation in violations)
         {
             _logger.LogCritical(

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -13,6 +13,7 @@ using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Plugins;
 using Application.AI.Common.Interfaces.Prompts;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.Interfaces.Tools;
@@ -275,6 +276,28 @@ public static partial class DependencyInjection
         // Startup driver: resolves every declared plugin into the live config + registry before
         // the first (lazy) skill/MCP discovery. Empty Packages list is a clean no-op.
         services.AddHostedService<PluginStartupLoader>();
+
+        // #524: a plugin's AllowedTools/DeniedTools entry that matches no real tool is a silent
+        // no-op today — worst for DeniedTools, documented as bypass-immune. The tracker resolves
+        // MCP-sourced entries lazily as servers are organically discovered (McpToolProvider);
+        // the startup validator below only needs to run AFTER PluginStartupLoader (registration
+        // order = StartAsync order in the Generic Host) so IPluginRegistry is already populated.
+        services.AddSingleton<IPluginToolBoundaryTracker, PluginToolBoundaryTracker>();
+        services.AddHostedService(sp =>
+        {
+            var firstPartyToolNames = new HashSet<string>(
+                services
+                    .Where(d => d.IsKeyedService && d.ServiceType == typeof(ITool))
+                    .Select(d => d.ServiceKey as string)
+                    .Where(key => !string.IsNullOrWhiteSpace(key))!,
+                StringComparer.OrdinalIgnoreCase);
+
+            return new PluginToolBoundaryStartupValidator(
+                sp.GetRequiredService<IPluginRegistry>(),
+                sp.GetRequiredService<IPluginToolBoundaryTracker>(),
+                firstPartyToolNames.Contains,
+                sp.GetRequiredService<ILogger<PluginToolBoundaryStartupValidator>>());
+        });
 
         // --- Tool execution ---
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -286,10 +286,7 @@ public static partial class DependencyInjection
         services.AddHostedService(sp =>
         {
             var firstPartyToolNames = new HashSet<string>(
-                services
-                    .Where(d => d.IsKeyedService && d.ServiceType == typeof(ITool))
-                    .Select(d => d.ServiceKey as string)
-                    .Where(key => !string.IsNullOrWhiteSpace(key))!,
+                Application.AI.Common.Services.Tools.KeyedToolRegistrationScan.Names(services),
                 StringComparer.OrdinalIgnoreCase);
 
             return new PluginToolBoundaryStartupValidator(

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -293,6 +293,7 @@ public static partial class DependencyInjection
                 sp.GetRequiredService<IPluginRegistry>(),
                 sp.GetRequiredService<IPluginToolBoundaryTracker>(),
                 firstPartyToolNames.Contains,
+                sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.AIConfig>>(),
                 sp.GetRequiredService<ILogger<PluginToolBoundaryStartupValidator>>());
         });
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -11,6 +11,9 @@ public sealed class PluginRegistry : IPluginRegistry
     private readonly ConcurrentDictionary<string, LoadedPlugin> _plugins =
         new(StringComparer.OrdinalIgnoreCase);
 
+    private readonly ConcurrentDictionary<string, string> _faultedBoundaries =
+        new(StringComparer.OrdinalIgnoreCase);
+
     /// <inheritdoc />
     public IReadOnlyList<LoadedPlugin> GetLoadedPlugins() =>
         _plugins.Values.ToList();
@@ -26,4 +29,11 @@ public sealed class PluginRegistry : IPluginRegistry
     /// <inheritdoc />
     public void Register(LoadedPlugin plugin) =>
         _plugins[plugin.Name] = plugin;
+
+    /// <inheritdoc />
+    public bool IsBoundaryFaulted(string pluginName) => _faultedBoundaries.ContainsKey(pluginName);
+
+    /// <inheritdoc />
+    public void MarkBoundaryFaulted(string pluginName, string reason) =>
+        _faultedBoundaries[pluginName] = reason;
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -1,0 +1,93 @@
+using Application.AI.Common.Interfaces.Plugins;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Plugins;
+
+/// <summary>
+/// One-shot startup check for #524: a loaded plugin's <c>AllowedTools</c>/<c>DeniedTools</c> entry
+/// that provably matches no tool at all — because the plugin declares zero MCP servers, so a
+/// first-party (keyed-DI) name is the only kind of name it could ever resolve to — refuses to boot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is only the immediately-decidable half of #524. A plugin that DOES declare MCP servers may
+/// have entries that are real MCP tool names, only knowable once the harness actually talks to that
+/// server — this validator does not connect to any server itself (that would make host startup
+/// depend on every configured third-party server being reachable, which the existing lazy MCP
+/// connection design deliberately avoids). Those entries are seeded into
+/// <see cref="IPluginToolBoundaryTracker"/> here and resolved or fail-closed-faulted later, lazily,
+/// by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/> the first time the
+/// harness organically discovers that server's tools (see that method's remarks).
+/// </para>
+/// <para>
+/// Registered as <see cref="IHostedService"/>, matching <c>ToolAuthorizationConfigValidator</c>'s
+/// shape rather than <c>AbstractValidator&lt;T&gt;</c> — this needs the live keyed-DI tool-name set,
+/// which a parameterless-constructor FluentValidation validator cannot take as a dependency. Must be
+/// registered <em>after</em> <c>PluginStartupLoader</c> (see the DI registration) so
+/// <see cref="IPluginRegistry"/> is already populated when <see cref="StartAsync"/> runs.
+/// </para>
+/// </remarks>
+public sealed class PluginToolBoundaryStartupValidator : IHostedService
+{
+    private readonly IPluginRegistry _registry;
+    private readonly IPluginToolBoundaryTracker _tracker;
+    private readonly Func<string, bool> _isKnownFirstPartyToolName;
+    private readonly ILogger<PluginToolBoundaryStartupValidator> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryStartupValidator"/> class.</summary>
+    /// <param name="registry">Source of the loaded plugins to validate.</param>
+    /// <param name="tracker">Seeded with every plugin's boundary entries.</param>
+    /// <param name="isKnownFirstPartyToolName">
+    /// Case-insensitive first-party (keyed-DI) tool-name membership check — see
+    /// <see cref="IPluginToolBoundaryTracker.Seed"/>'s remarks for why case-insensitivity matters.
+    /// </param>
+    /// <param name="logger">Records the validated boundary shape.</param>
+    public PluginToolBoundaryStartupValidator(
+        IPluginRegistry registry,
+        IPluginToolBoundaryTracker tracker,
+        Func<string, bool> isKnownFirstPartyToolName,
+        ILogger<PluginToolBoundaryStartupValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(tracker);
+        ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _registry = registry;
+        _tracker = tracker;
+        _isKnownFirstPartyToolName = isKnownFirstPartyToolName;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var loadedPlugins = _registry.GetLoadedPlugins()
+            .Where(p => p.Status == PluginLoadStatus.Loaded)
+            .ToList();
+
+        var immediateViolations = _tracker.Seed(loadedPlugins, _isKnownFirstPartyToolName);
+        if (immediateViolations.Count == 0)
+        {
+            _logger.LogInformation(
+                "Plugin tool boundaries validated: {PluginCount} loaded plugin(s), no immediately " +
+                "unresolvable AllowedTools/DeniedTools entries.",
+                loadedPlugins.Count);
+            return Task.CompletedTask;
+        }
+
+        var lines = immediateViolations.Select(v =>
+            $"Plugin '{v.PluginName}': {v.ListKind} entry '{v.ToolName}' matches no first-party tool, " +
+            "and this plugin declares no MCP server that could ever supply it either.");
+
+        throw new InvalidOperationException(
+            "One or more plugin AllowedTools/DeniedTools entries name a tool that does not exist, so "
+            + "the host refuses to boot (#524 — an unrecognized DeniedTools entry silently denies "
+            + "nothing, which is worse than an error). Fix the following then restart:\n - "
+            + string.Join("\n - ", lines));
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -1,24 +1,28 @@
 using Application.AI.Common.Interfaces.Plugins;
+using Domain.Common.Config.AI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.AI.Plugins;
 
 /// <summary>
 /// One-shot startup check for #524: a loaded plugin's <c>AllowedTools</c>/<c>DeniedTools</c> entry
-/// that provably matches no tool at all — because the plugin declares zero MCP servers, so a
+/// that provably matches no tool at all — no MCP server is configured anywhere on the host, so a
 /// first-party (keyed-DI) name is the only kind of name it could ever resolve to — refuses to boot.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is only the immediately-decidable half of #524. A plugin that DOES declare MCP servers may
-/// have entries that are real MCP tool names, only knowable once the harness actually talks to that
-/// server — this validator does not connect to any server itself (that would make host startup
-/// depend on every configured third-party server being reachable, which the existing lazy MCP
-/// connection design deliberately avoids). Those entries are seeded into
-/// <see cref="IPluginToolBoundaryTracker"/> here and resolved or fail-closed-faulted later, lazily,
-/// by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/> the first time the
-/// harness organically discovers that server's tools (see that method's remarks).
+/// This is only the immediately-decidable half of #524. Whenever at least one MCP server is
+/// configured on the host, an entry might be a real MCP tool name — a plugin skill's tool
+/// declaration can resolve against ANY host-configured server, not just ones the plugin itself
+/// declares (see <c>ToolChainBuilder.ResolveEffectiveMcpServerName</c>) — only knowable once the
+/// harness actually talks to that server. This validator does not connect to any server itself
+/// (that would make host startup depend on every configured third-party server being reachable,
+/// which the existing lazy MCP connection design deliberately avoids). Those entries are seeded
+/// into <see cref="IPluginToolBoundaryTracker"/> here and resolved or fail-closed-faulted later,
+/// lazily, by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/> the first time
+/// the harness organically discovers that server's tools (see that method's remarks).
 /// </para>
 /// <para>
 /// Registered as <see cref="IHostedService"/>, matching <c>ToolAuthorizationConfigValidator</c>'s
@@ -27,12 +31,25 @@ namespace Infrastructure.AI.Plugins;
 /// registered <em>after</em> <c>PluginStartupLoader</c> (see the DI registration) so
 /// <see cref="IPluginRegistry"/> is already populated when <see cref="StartAsync"/> runs.
 /// </para>
+/// <para>
+/// <strong>The MCP server list is read from <see cref="IOptionsMonitor{TOptions}"/> inside
+/// <see cref="StartAsync"/>, never captured at construction time.</strong> The .NET Generic Host
+/// resolves — and so constructs — every <see cref="IHostedService"/> up front, before calling
+/// <c>StartAsync</c> on any of them; <c>PluginStartupLoader</c> only merges a plugin's own MCP
+/// servers into the shared <see cref="AIConfig.McpServers"/> instance from inside its own
+/// <c>StartAsync</c>. Reading the server list at construction (e.g. captured once by the DI factory)
+/// would therefore see the config from BEFORE that merge — missing every plugin-declared server —
+/// regardless of registration order. Reading it fresh inside this type's own <c>StartAsync</c>,
+/// which the Host guarantees runs after <c>PluginStartupLoader.StartAsync</c> completes, is what
+/// actually sees the merged list.
+/// </para>
 /// </remarks>
 public sealed class PluginToolBoundaryStartupValidator : IHostedService
 {
     private readonly IPluginRegistry _registry;
     private readonly IPluginToolBoundaryTracker _tracker;
     private readonly Func<string, bool> _isKnownFirstPartyToolName;
+    private readonly IOptionsMonitor<AIConfig> _aiConfig;
     private readonly ILogger<PluginToolBoundaryStartupValidator> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryStartupValidator"/> class.</summary>
@@ -42,21 +59,28 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
     /// Case-insensitive first-party (keyed-DI) tool-name membership check — see
     /// <see cref="IPluginToolBoundaryTracker.Seed"/>'s remarks for why case-insensitivity matters.
     /// </param>
+    /// <param name="aiConfig">
+    /// Supplies the enabled MCP server names configured anywhere on the host, read fresh inside
+    /// <see cref="StartAsync"/> — see this type's remarks for why it cannot be resolved any earlier.
+    /// </param>
     /// <param name="logger">Records the validated boundary shape.</param>
     public PluginToolBoundaryStartupValidator(
         IPluginRegistry registry,
         IPluginToolBoundaryTracker tracker,
         Func<string, bool> isKnownFirstPartyToolName,
+        IOptionsMonitor<AIConfig> aiConfig,
         ILogger<PluginToolBoundaryStartupValidator> logger)
     {
         ArgumentNullException.ThrowIfNull(registry);
         ArgumentNullException.ThrowIfNull(tracker);
         ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+        ArgumentNullException.ThrowIfNull(aiConfig);
         ArgumentNullException.ThrowIfNull(logger);
 
         _registry = registry;
         _tracker = tracker;
         _isKnownFirstPartyToolName = isKnownFirstPartyToolName;
+        _aiConfig = aiConfig;
         _logger = logger;
     }
 
@@ -67,7 +91,15 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
             .Where(p => p.Status == PluginLoadStatus.Loaded)
             .ToList();
 
-        var immediateViolations = _tracker.Seed(loadedPlugins, _isKnownFirstPartyToolName);
+        // Read fresh here, not captured earlier — see this type's remarks for why. By this point
+        // PluginStartupLoader.StartAsync has already merged every plugin's own MCP servers into the
+        // SAME McpServersConfig.Servers instance (registration order = StartAsync order).
+        var allConfiguredMcpServerNames = _aiConfig.CurrentValue.McpServers.Servers
+            .Where(kvp => kvp.Value.Enabled)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        var immediateViolations = _tracker.Seed(loadedPlugins, _isKnownFirstPartyToolName, allConfiguredMcpServerNames);
         if (immediateViolations.Count == 0)
         {
             _logger.LogInformation(

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -1,0 +1,155 @@
+using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Services.Plugins;
+using Domain.Common.Config.AI.Plugins;
+using FluentAssertions;
+using Moq;
+
+namespace Application.AI.Common.Tests.Plugins;
+
+/// <summary>
+/// #524: <see cref="PluginToolBoundaryTracker"/> is what turns a plugin
+/// <c>AllowedTools</c>/<c>DeniedTools</c> entry that matches no real tool from a silent no-op into
+/// a loud, fail-closed fault — either immediately at startup (a plugin with no MCP servers has no
+/// other source an entry could resolve from) or lazily, once every MCP server the plugin depends on
+/// has reported its tool list at least once.
+/// </summary>
+public sealed class PluginToolBoundaryTrackerTests
+{
+    private readonly Mock<IPluginRegistry> _registry = new();
+    private readonly PluginToolBoundaryTracker _sut;
+
+    public PluginToolBoundaryTrackerTests()
+    {
+        _sut = new PluginToolBoundaryTracker(_registry.Object);
+    }
+
+    private static LoadedPlugin MakePlugin(
+        string name, IReadOnlyList<string>? mcpServerNames = null,
+        IReadOnlyList<string>? allowedTools = null, IReadOnlyList<string>? deniedTools = null) =>
+        new(name, "1.0.0", $"/plugins/{name}", new PluginManifest { Name = name, Version = "1.0.0" },
+            PluginLoadStatus.Loaded, [], mcpServerNames ?? [],
+            new PluginDeclaration { Name = name, AllowedTools = allowedTools, DeniedTools = deniedTools });
+
+    private static bool NoFirstPartyToolsKnown(string _) => false;
+
+    [Fact]
+    public void Seed_PluginWithNoMcpServersAndUnknownDeniedEntry_ReturnsImmediateViolation()
+    {
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        violations.Should().ContainSingle(v =>
+            v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
+    }
+
+    [Fact]
+    public void Seed_PluginWithNoMcpServersAndEveryEntryKnownFirstParty_ReturnsNoViolations()
+    {
+        var plugin = MakePlugin("azure", deniedTools: ["file_write"]);
+
+        var violations = _sut.Seed([plugin], name => name == "file_write");
+
+        violations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Seed_PluginWithMcpServerAndUnknownEntry_DoesNotReturnImmediateViolation()
+    {
+        // Not yet decidable — the entry might be a real MCP tool name, only knowable once that
+        // server's tool list has actually been discovered (ReportServerToolsDiscovered).
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["maybe_mcp_tool"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ServerListContainsThePendingEntry_ResolvesWithoutFault()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool", "other_tool"]);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ServerListMissingThePendingEntry_FaultsAndReturnsViolation()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["some_other_tool"]);
+
+        violations.Should().ContainSingle(v =>
+            v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_TwoServers_OnlyFaultsAfterTheLastOneReports()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var afterFirst = _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]);
+        afterFirst.Should().BeEmpty("s2 hasn't reported yet — not provably fake");
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["also_unrelated"]);
+        afterSecond.Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_TwoServersOneResolvesTheEntry_NeverFaults()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]).Should().BeEmpty();
+        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["real_tool"]);
+
+        afterSecond.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ConcurrentReportsForBothServers_FaultsExactlyOnce()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
+        Parallel.Invoke(
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated1"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s2", ["unrelated2"])));
+
+        results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ServerNothingIsPendingFor_ReturnsEmpty()
+    {
+        var violations = _sut.ReportServerToolsDiscovered("unrelated:server", ["tool1"]);
+
+        violations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_MatchIsCaseInsensitive_ResolvesWithoutFault()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["Real_Tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool"]);
+
+        violations.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -54,6 +54,44 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
+    public void Seed_NoMcpServerAndSameUnknownNameInBothLists_ReturnsOneImmediateViolationInsteadOfThrowing()
+    {
+        var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        violations.Should().ContainSingle(v => v.PluginName == "azure" && v.ToolName == "file_wrte");
+    }
+
+    [Fact]
+    public void Seed_HasMcpServerAndSameUnknownNameInBothLists_DoesNotThrow()
+    {
+        // Regression: a name appearing in both AllowedTools and DeniedTools (or twice in one list)
+        // used to throw ArgumentException out of the pending-entries dictionary build the moment a
+        // plugin declares at least one MCP server, crashing host startup on a legally shaped — if
+        // pointless — plugin config, instead of the clean diagnostic this feature exists to produce.
+        var plugin = MakePlugin(
+            "azure", mcpServerNames: ["azure:server1"], allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+
+        var act = () => _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Seed_HasMcpServerAndSameUnknownNameTwiceInOneList_ThenReportServerToolsDiscovered_FaultsOnce()
+    {
+        var plugin = MakePlugin(
+            "azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte", "file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["unrelated"]);
+
+        violations.Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
     public void Seed_PluginWithMcpServerAndUnknownEntry_DoesNotReturnImmediateViolation()
     {
         // Not yet decidable — the entry might be a real MCP tool name, only knowable once that
@@ -129,6 +167,25 @@ public sealed class PluginToolBoundaryTrackerTests
         Parallel.Invoke(
             () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated1"])),
             () => results.Add(_sut.ReportServerToolsDiscovered("azure:s2", ["unrelated2"])));
+
+        results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ConcurrentReportsForTheSameSingleServer_FaultsExactlyOnce()
+    {
+        // Regression (code-review finding on #524): two overlapping discovery calls for the SAME
+        // server can both pass the initial lookup before either removes the plugin from tracking,
+        // so both would reach the "last pending server just reported" branch and double-fault
+        // without the Resolved guard.
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
+        Parallel.Invoke(
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -9,9 +9,12 @@ namespace Application.AI.Common.Tests.Plugins;
 /// <summary>
 /// #524: <see cref="PluginToolBoundaryTracker"/> is what turns a plugin
 /// <c>AllowedTools</c>/<c>DeniedTools</c> entry that matches no real tool from a silent no-op into
-/// a loud, fail-closed fault — either immediately at startup (a plugin with no MCP servers has no
-/// other source an entry could resolve from) or lazily, once every MCP server the plugin depends on
-/// has reported its tool list at least once.
+/// a loud, fail-closed fault — either immediately at startup (no MCP server is configured anywhere
+/// on the host) or lazily, once every host-configured MCP server has reported its tool list at
+/// least once. Deliberately keyed on the HOST'S full server list, not any one plugin's own declared
+/// servers — a review-round finding confirmed a plugin skill's tool declaration can resolve against
+/// ANY host-configured server (<c>ToolChainBuilder.ResolveEffectiveMcpServerName</c>), so a plugin
+/// with zero MCP servers of its own can still legitimately reference a host-level server's tool.
 /// </summary>
 public sealed class PluginToolBoundaryTrackerTests
 {
@@ -32,73 +35,103 @@ public sealed class PluginToolBoundaryTrackerTests
 
     private static bool NoFirstPartyToolsKnown(string _) => false;
 
+    private static readonly IReadOnlyCollection<string> NoServersConfigured = [];
+
     [Fact]
-    public void Seed_PluginWithNoMcpServersAndUnknownDeniedEntry_ReturnsImmediateViolation()
+    public void Seed_NoServersConfiguredAnywhereAndUnknownDeniedEntry_ReturnsImmediateViolation()
     {
         var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
 
-        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
         violations.Should().ContainSingle(v =>
             v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
     }
 
     [Fact]
-    public void Seed_PluginWithNoMcpServersAndEveryEntryKnownFirstParty_ReturnsNoViolations()
+    public void Seed_NoServersConfiguredAndEveryEntryKnownFirstParty_ReturnsNoViolations()
     {
         var plugin = MakePlugin("azure", deniedTools: ["file_write"]);
 
-        var violations = _sut.Seed([plugin], name => name == "file_write");
+        var violations = _sut.Seed([plugin], name => name == "file_write", NoServersConfigured);
 
         violations.Should().BeEmpty();
     }
 
     [Fact]
-    public void Seed_NoMcpServerAndSameUnknownNameInBothLists_ReturnsOneImmediateViolationInsteadOfThrowing()
+    public void Seed_PluginDeclaresNoOwnServerButHostHasOneConfigured_DoesNotFaultImmediately()
+    {
+        // The regression this test guards: a plugin with zero MCP servers of its OWN can still
+        // legitimately reference a tool from a host-level MCP server it doesn't declare (a plugin
+        // skill's ToolDeclaration resolves against any configured server when unrestricted). Faulting
+        // this immediately — as an earlier version did, scoped only to the plugin's own servers —
+        // crashed boot on a valid, pre-existing configuration.
+        var plugin = MakePlugin("azure", deniedTools: ["maybe_host_level_tool"]); // no own MCP servers
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_HostServerResolvesAPluginsEntry_NeverFaults()
+    {
+        // Same scenario, carried through to resolution: the host-level server (not the plugin's own)
+        // reports a list containing the entry — it resolves, exactly as a valid config should.
+        var plugin = MakePlugin("azure", deniedTools: ["delete_repository"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
+
+        var violations = _sut.ReportServerToolsDiscovered("host:github", ["delete_repository", "create_issue"]);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Seed_NoServersConfiguredAndSameUnknownNameInBothLists_ReturnsOneImmediateViolationInsteadOfThrowing()
     {
         var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
 
-        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
         violations.Should().ContainSingle(v => v.PluginName == "azure" && v.ToolName == "file_wrte");
     }
 
     [Fact]
-    public void Seed_HasMcpServerAndSameUnknownNameInBothLists_DoesNotThrow()
+    public void Seed_HasConfiguredServerAndSameUnknownNameInBothLists_DoesNotThrow()
     {
         // Regression: a name appearing in both AllowedTools and DeniedTools (or twice in one list)
-        // used to throw ArgumentException out of the pending-entries dictionary build the moment a
-        // plugin declares at least one MCP server, crashing host startup on a legally shaped — if
-        // pointless — plugin config, instead of the clean diagnostic this feature exists to produce.
-        var plugin = MakePlugin(
-            "azure", mcpServerNames: ["azure:server1"], allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+        // used to throw ArgumentException out of the pending-entries dictionary build the moment at
+        // least one MCP server exists, crashing host startup on a legally shaped — if pointless —
+        // plugin config, instead of the clean diagnostic this feature exists to produce.
+        var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
 
-        var act = () => _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var act = () => _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
         act.Should().NotThrow();
     }
 
     [Fact]
-    public void Seed_HasMcpServerAndSameUnknownNameTwiceInOneList_ThenReportServerToolsDiscovered_FaultsOnce()
+    public void Seed_HasConfiguredServerAndSameUnknownNameTwiceInOneList_ThenReportServerToolsDiscovered_FaultsOnce()
     {
-        var plugin = MakePlugin(
-            "azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte", "file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte", "file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["unrelated"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["unrelated"]);
 
         violations.Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
-    public void Seed_PluginWithMcpServerAndUnknownEntry_DoesNotReturnImmediateViolation()
+    public void Seed_AtLeastOneServerConfiguredAndUnknownEntry_DoesNotReturnImmediateViolation()
     {
         // Not yet decidable — the entry might be a real MCP tool name, only knowable once that
         // server's tool list has actually been discovered (ReportServerToolsDiscovered).
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["maybe_mcp_tool"]);
+        var plugin = MakePlugin("azure", deniedTools: ["maybe_mcp_tool"]);
 
-        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
         violations.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -107,10 +140,10 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_ServerListContainsThePendingEntry_ResolvesWithoutFault()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["real_tool"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool", "other_tool"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["real_tool", "other_tool"]);
 
         violations.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -119,10 +152,10 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_ServerListMissingThePendingEntry_FaultsAndReturnsViolation()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["some_other_tool"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["some_other_tool"]);
 
         violations.Should().ContainSingle(v =>
             v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
@@ -130,28 +163,28 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
-    public void ReportServerToolsDiscovered_TwoServers_OnlyFaultsAfterTheLastOneReports()
+    public void ReportServerToolsDiscovered_TwoConfiguredServers_OnlyFaultsAfterTheLastOneReports()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1", "s2"]);
 
-        var afterFirst = _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]);
+        var afterFirst = _sut.ReportServerToolsDiscovered("s1", ["unrelated"]);
         afterFirst.Should().BeEmpty("s2 hasn't reported yet — not provably fake");
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
-        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["also_unrelated"]);
+        var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["also_unrelated"]);
         afterSecond.Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
-    public void ReportServerToolsDiscovered_TwoServersOneResolvesTheEntry_NeverFaults()
+    public void ReportServerToolsDiscovered_TwoConfiguredServersOneResolvesTheEntry_NeverFaults()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["real_tool"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1", "s2"]);
 
-        _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]).Should().BeEmpty();
-        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["real_tool"]);
+        _sut.ReportServerToolsDiscovered("s1", ["unrelated"]).Should().BeEmpty();
+        var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["real_tool"]);
 
         afterSecond.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -160,13 +193,13 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_ConcurrentReportsForBothServers_FaultsExactlyOnce()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1", "s2"]);
 
         var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
         Parallel.Invoke(
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated1"])),
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s2", ["unrelated2"])));
+            () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated1"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("s2", ["unrelated2"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
@@ -179,13 +212,13 @@ public sealed class PluginToolBoundaryTrackerTests
         // server can both pass the initial lookup before either removes the plugin from tracking,
         // so both would reach the "last pending server just reported" branch and double-fault
         // without the Resolved guard.
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1"]);
 
         var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
         Parallel.Invoke(
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])),
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])));
+            () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
@@ -202,10 +235,10 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_MatchIsCaseInsensitive_ResolvesWithoutFault()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["Real_Tool"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["Real_Tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["real_tool"]);
 
         violations.Should().BeEmpty();
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -49,6 +49,19 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
+    public void Seed_ImmediateViolation_AlsoMarksTheRegistryFaulted()
+    {
+        // Defense in depth (review-round finding): the immediate branch's enforcement otherwise
+        // relies entirely on the caller (PluginToolBoundaryStartupValidator) rethrowing — marking
+        // the registry here too means IPluginRegistry.IsBoundaryFaulted is authoritative regardless.
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
+
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
     public void Seed_NoServersConfiguredAndEveryEntryKnownFirstParty_ReturnsNoViolations()
     {
         var plugin = MakePlugin("azure", deniedTools: ["file_write"]);
@@ -96,6 +109,19 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
         violations.Should().ContainSingle(v => v.PluginName == "azure" && v.ToolName == "file_wrte");
+    }
+
+    [Fact]
+    public void Seed_SameUnknownNameInBothLists_ReportsDeniedToolsNotAllowedTools()
+    {
+        // The bypass-immune guarantee lives in DeniedTools, so a duplicate-list typo must surface
+        // under that label, not silently as an AllowedTools violation an operator might "fix" by
+        // only touching the AllowedTools entry and leaving the DeniedTools occurrence unaddressed.
+        var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
+
+        violations.Should().ContainSingle(v => v.ListKind == "DeniedTools");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -263,6 +263,36 @@ public class ToolChainBuilderTests
         tools.Should().ContainSingle(t => t.Name == "safe");
     }
 
+    [Fact]
+    public async Task BuildToolsAsync_PluginBoundaryFaulted_DeniesAllToolsRegardlessOfDeclaredList()
+    {
+        // #524: once PluginToolBoundaryTracker has proven a plugin's AllowedTools/DeniedTools
+        // boundary can't be trusted (an entry matches no real tool), the boundary itself is no
+        // longer safe to apply — even a tool the (otherwise fine) DeniedTools list would have let
+        // through must be denied too, since the boundary might be missing an intended denial.
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", DeniedTools = ["dangerous"] }));
+        pluginRegistry.Setup(r => r.IsBoundaryFaulted("p")).Returns(true);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            Tools = [AIFunctionFactory.Create(() => "r", "safe")]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty();
+    }
+
     // --- Managed mode: pre-created tools ---
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Infrastructure.AI.MCP.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Infrastructure.AI.MCP.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj" />
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj" />
     <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
+    <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
@@ -1,0 +1,107 @@
+using Application.AI.Common.Interfaces.Plugins;
+using FluentAssertions;
+using Infrastructure.AI.MCP.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Tests.Common;
+using Xunit;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// #524: <see cref="McpToolProvider"/> reports every successfully-discovered MCP server's tool
+/// names to <see cref="IPluginToolBoundaryTracker"/> — the untrusted-input half of the plugin
+/// tool-boundary existence check (the other half, first-party names at startup, is covered by
+/// <c>PluginToolBoundaryStartupValidator</c>'s own tests).
+/// </summary>
+/// <remarks>
+/// No fixture in this test project drives <c>McpToolProvider.DiscoverToolsAsync</c>'s
+/// success path end to end — it requires a live <c>McpClient</c> connection, which nothing here
+/// fakes (every existing <c>McpToolProvider*Tests</c> file exercises only failure/unavailable-server
+/// paths). These tests instead call
+/// <see cref="McpToolProvider.ReportDiscoveryToBoundaryTracker(string, IEnumerable{string})"/>
+/// directly — the exact reporting step <c>DiscoverToolsAsync</c> calls immediately after a
+/// successful <c>ListToolsAsync</c>, extracted to take bare tool names specifically so it can be
+/// exercised without a real connection. A correctness-review finding on #524 flagged this call site
+/// as having zero coverage: deleting it would silently re-open the exact "unrecognized DeniedTools
+/// entry is a silent no-op" hole the feature exists to close, with every other test in the suite
+/// staying green.
+/// </remarks>
+public sealed class McpToolProviderBoundaryTrackerTests
+{
+    private static (McpToolProvider Provider, McpConnectionManager Manager) CreateSut(
+        IPluginToolBoundaryTracker? boundaryTracker)
+    {
+        var manager = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(),
+            new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
+            new Domain.Common.Config.AI.MCP.McpServersConfig(),
+            new Infrastructure.AI.Bundles.BundleOwnedMcpServerRegistry());
+
+        var provider = new McpToolProvider(Mock.Of<ILogger<McpToolProvider>>(), manager, boundaryTracker);
+        return (provider, manager);
+    }
+
+    [Fact]
+    public void ReportDiscoveryToBoundaryTracker_TrackerWired_CallsReportServerToolsDiscoveredWithTheDiscoveredNames()
+    {
+        var tracker = new Mock<IPluginToolBoundaryTracker>();
+        tracker.Setup(t => t.ReportServerToolsDiscovered(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns([]);
+        var (sut, _) = CreateSut(tracker.Object);
+
+        var expectedNames = new[] { "tool_a", "tool_b" };
+        sut.ReportDiscoveryToBoundaryTracker("azure:server1", expectedNames);
+
+        tracker.Verify(t => t.ReportServerToolsDiscovered(
+            "azure:server1",
+            It.Is<IReadOnlyCollection<string>>(names => names.SequenceEqual(expectedNames))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ReportDiscoveryToBoundaryTracker_NoTrackerWired_DoesNotThrow()
+    {
+        var (sut, _) = CreateSut(boundaryTracker: null);
+
+        var act = () => sut.ReportDiscoveryToBoundaryTracker("azure:server1", ["tool_a"]);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReportDiscoveryToBoundaryTracker_TrackerReturnsAViolation_DoesNotThrow()
+    {
+        // The violation is logged (LogCritical), never rethrown — a boundary fault must not turn an
+        // otherwise-successful discovery call into a failure. Enforcement is separate, via
+        // IPluginRegistry.IsBoundaryFaulted on the plugin's next tool resolution.
+        var tracker = new Mock<IPluginToolBoundaryTracker>();
+        tracker.Setup(t => t.ReportServerToolsDiscovered(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
+        var (sut, _) = CreateSut(tracker.Object);
+
+        var act = () => sut.ReportDiscoveryToBoundaryTracker("azure:server1", ["unrelated"]);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void DiscoverToolsAsync_SourceStillCallsReportDiscoveryToBoundaryTracker()
+    {
+        // The three tests above prove ReportDiscoveryToBoundaryTracker itself works — none of them
+        // prove DiscoverToolsAsync (private, reachable only via a live MCP connection nothing in
+        // this project fakes) still CALLS it after a successful ListToolsAsync. A source-level check
+        // is the only thing that can catch that call site being silently removed, matching this
+        // repo's established pattern for exactly this class of risk (see SecurityControlHasACallerTests).
+        var path = RepoRoot.Combine(
+            "src", "Content", "Infrastructure", "Infrastructure.AI.MCP", "Services", "McpToolProvider.cs");
+        var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(path));
+
+        var discoverToolsAsyncStart = code.IndexOf("private async Task<IList<AITool>> DiscoverToolsAsync", StringComparison.Ordinal);
+        discoverToolsAsyncStart.Should().BeGreaterThan(-1, "DiscoverToolsAsync should still exist under this name");
+        var methodBody = code[discoverToolsAsyncStart..(discoverToolsAsyncStart + 1500)];
+
+        methodBody.Should().Contain("ReportDiscoveryToBoundaryTracker(serverName");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Resilience;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
@@ -10,6 +11,7 @@ using FluentAssertions;
 using Infrastructure.AI.Escalation;
 using Infrastructure.AI.KnowledgeGraph;
 using Infrastructure.AI.MCP;
+using Infrastructure.AI.Plugins;
 using Infrastructure.AI.Resilience;
 using Infrastructure.AI.Tests.Planner.StepExecutors;
 using MediatR;
@@ -272,6 +274,33 @@ public sealed class DependencyInjectionTests
         var hostedServices = provider.GetServices<IHostedService>().ToList();
 
         hostedServices.Should().NotContain(s => s is LlmRetryQueue);
+    }
+
+    [Fact]
+    public void AddInfrastructureAIDependencies_RegistersPluginToolBoundaryStartupValidatorHostedService()
+    {
+        // #524: this is the ONLY thing standing between the startup validator and becoming a
+        // ninth instance of the "control nothing invokes" family (CLAUDE.md Common Mistakes) — a
+        // hosted service that is never registered runs never, however correct its own logic is.
+        var services = CreateBaseServices();
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
+        using var provider = services.BuildServiceProvider();
+
+        var hostedServices = provider.GetServices<IHostedService>().ToList();
+
+        hostedServices.Should().Contain(s => s is PluginToolBoundaryStartupValidator);
+    }
+
+    [Fact]
+    public void AddInfrastructureAIDependencies_RegistersIPluginToolBoundaryTracker()
+    {
+        var services = CreateBaseServices();
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
+        using var provider = services.BuildServiceProvider();
+
+        var tracker = provider.GetService<IPluginToolBoundaryTracker>();
+
+        tracker.Should().NotBeNull();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -69,4 +69,27 @@ public class PluginRegistryTests
 
         _sut.IsLoaded("broken").Should().BeFalse();
     }
+
+    [Fact]
+    public void IsBoundaryFaulted_UnmarkedPlugin_ReturnsFalse()
+    {
+        _sut.IsBoundaryFaulted("azure").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MarkBoundaryFaulted_ThenIsBoundaryFaulted_ReturnsTrue()
+    {
+        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
+
+        _sut.IsBoundaryFaulted("azure").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsBoundaryFaulted_CaseInsensitive_ReturnsTrue()
+    {
+        _sut.MarkBoundaryFaulted("Azure", "reason");
+
+        _sut.IsBoundaryFaulted("azure").Should().BeTrue();
+        _sut.IsBoundaryFaulted("AZURE").Should().BeTrue();
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
@@ -1,8 +1,12 @@
+using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.Plugins;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
 using Infrastructure.AI.Plugins;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -10,8 +14,9 @@ namespace Infrastructure.AI.Tests.Plugins;
 
 /// <summary>
 /// #524: <see cref="PluginToolBoundaryStartupValidator"/> refuses to boot when
-/// <see cref="IPluginToolBoundaryTracker.Seed"/> reports an immediately-provable violation (a
-/// plugin with no MCP servers whose AllowedTools/DeniedTools entry matches no first-party tool).
+/// <see cref="IPluginToolBoundaryTracker.Seed"/> reports an immediately-provable violation (no MCP
+/// server configured anywhere on the host, and an AllowedTools/DeniedTools entry matches no
+/// first-party tool).
 /// </summary>
 public sealed class PluginToolBoundaryStartupValidatorTests
 {
@@ -22,15 +27,27 @@ public sealed class PluginToolBoundaryStartupValidatorTests
         new(name, "1.0.0", $"/plugins/{name}", new PluginManifest { Name = name, Version = "1.0.0" },
             PluginLoadStatus.Loaded, [], [], new PluginDeclaration { Name = name, DeniedTools = ["file_wrte"] });
 
-    private PluginToolBoundaryStartupValidator MakeSut(Func<string, bool> isKnownFirstPartyToolName) =>
+    private static IOptionsMonitor<AIConfig> MakeAiConfig(params string[] enabledServerNames)
+    {
+        var servers = new ConcurrentDictionary<string, McpServerDefinition>(
+            enabledServerNames.ToDictionary(n => n, _ => new McpServerDefinition { Enabled = true }));
+        var config = new AIConfig { McpServers = new McpServersConfig { Servers = servers } };
+        var monitor = new Mock<IOptionsMonitor<AIConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(config);
+        return monitor.Object;
+    }
+
+    private PluginToolBoundaryStartupValidator MakeSut(
+        Func<string, bool> isKnownFirstPartyToolName, IOptionsMonitor<AIConfig>? aiConfig = null) =>
         new(_registry.Object, _tracker.Object, isKnownFirstPartyToolName,
-            NullLogger<PluginToolBoundaryStartupValidator>.Instance);
+            aiConfig ?? MakeAiConfig(), NullLogger<PluginToolBoundaryStartupValidator>.Instance);
 
     [Fact]
     public async Task StartAsync_SeedReturnsNoViolations_DoesNotThrow()
     {
         _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
-        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
             .Returns([]);
         var sut = MakeSut(_ => true);
 
@@ -43,7 +60,8 @@ public sealed class PluginToolBoundaryStartupValidatorTests
     public async Task StartAsync_SeedReturnsAnImmediateViolation_ThrowsNamingPluginAndTool()
     {
         _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
-        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
             .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
         var sut = MakeSut(_ => false);
 
@@ -62,13 +80,39 @@ public sealed class PluginToolBoundaryStartupValidatorTests
             new PluginDeclaration { Name = "disabled-plugin" });
         _registry.Setup(r => r.GetLoadedPlugins()).Returns([loaded, disabled]);
         IReadOnlyList<LoadedPlugin>? captured = null;
-        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
-            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>>((plugins, _) => captured = plugins)
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>, IReadOnlyCollection<string>>(
+                (plugins, _, _) => captured = plugins)
             .Returns([]);
         var sut = MakeSut(_ => true);
 
         await sut.StartAsync(CancellationToken.None);
 
         captured.Should().ContainSingle().Which.Name.Should().Be("azure");
+    }
+
+    [Fact]
+    public async Task StartAsync_PassesOnlyEnabledConfiguredServerNamesToSeed()
+    {
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        IReadOnlyCollection<string>? captured = null;
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>, IReadOnlyCollection<string>>(
+                (_, _, servers) => captured = servers)
+            .Returns([]);
+        var servers = new ConcurrentDictionary<string, McpServerDefinition>
+        {
+            ["enabled-server"] = new() { Enabled = true },
+            ["disabled-server"] = new() { Enabled = false },
+        };
+        var aiConfig = new Mock<IOptionsMonitor<AIConfig>>();
+        aiConfig.Setup(m => m.CurrentValue).Returns(new AIConfig { McpServers = new McpServersConfig { Servers = servers } });
+        var sut = MakeSut(_ => true, aiConfig.Object);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        captured.Should().ContainSingle().Which.Should().Be("enabled-server");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
@@ -1,0 +1,74 @@
+using Application.AI.Common.Interfaces.Plugins;
+using Domain.Common.Config.AI.Plugins;
+using FluentAssertions;
+using Infrastructure.AI.Plugins;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Plugins;
+
+/// <summary>
+/// #524: <see cref="PluginToolBoundaryStartupValidator"/> refuses to boot when
+/// <see cref="IPluginToolBoundaryTracker.Seed"/> reports an immediately-provable violation (a
+/// plugin with no MCP servers whose AllowedTools/DeniedTools entry matches no first-party tool).
+/// </summary>
+public sealed class PluginToolBoundaryStartupValidatorTests
+{
+    private readonly Mock<IPluginRegistry> _registry = new();
+    private readonly Mock<IPluginToolBoundaryTracker> _tracker = new();
+
+    private static LoadedPlugin MakePlugin(string name) =>
+        new(name, "1.0.0", $"/plugins/{name}", new PluginManifest { Name = name, Version = "1.0.0" },
+            PluginLoadStatus.Loaded, [], [], new PluginDeclaration { Name = name, DeniedTools = ["file_wrte"] });
+
+    private PluginToolBoundaryStartupValidator MakeSut(Func<string, bool> isKnownFirstPartyToolName) =>
+        new(_registry.Object, _tracker.Object, isKnownFirstPartyToolName,
+            NullLogger<PluginToolBoundaryStartupValidator>.Instance);
+
+    [Fact]
+    public async Task StartAsync_SeedReturnsNoViolations_DoesNotThrow()
+    {
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+            .Returns([]);
+        var sut = MakeSut(_ => true);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_SeedReturnsAnImmediateViolation_ThrowsNamingPluginAndTool()
+    {
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+            .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
+        var sut = MakeSut(_ => false);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*azure*").WithMessage("*DeniedTools*").WithMessage("*file_wrte*");
+    }
+
+    [Fact]
+    public async Task StartAsync_OnlyPassesLoadedPluginsToSeed_ExcludingDisabledAndFailed()
+    {
+        var loaded = MakePlugin("azure");
+        var disabled = new LoadedPlugin("disabled-plugin", "", "/plugins/disabled",
+            new PluginManifest { Name = "disabled-plugin" }, PluginLoadStatus.Disabled, [], [],
+            new PluginDeclaration { Name = "disabled-plugin" });
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([loaded, disabled]);
+        IReadOnlyList<LoadedPlugin>? captured = null;
+        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>>((plugins, _) => captured = plugins)
+            .Returns([]);
+        var sut = MakeSut(_ => true);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        captured.Should().ContainSingle().Which.Name.Should().Be("azure");
+    }
+}


### PR DESCRIPTION
## Summary

`PluginDeclaration.AllowedTools`/`DeniedTools` were plain name lists with no check that a named
tool actually exists — a typo in `DeniedTools` (documented as bypass-immune) silently denied
nothing. This closes the existence-check half of #524 (the risk-class-selector proposal in the
same issue is a separate, riskier initiative and is left for a follow-up issue).

**Design:** first-party (keyed-DI) names are verified at startup and fail the host boot
immediately when no MCP server is configured anywhere on the host; MCP-sourced names are resolved
lazily, the first time the harness organically discovers a server's tools (no eager connection —
by design, so host startup never depends on a third-party server's reachability). If an entry is
still unresolved once every configured server has reported, the plugin's whole tool boundary is
marked faulted and denied entirely, fail-closed.

## Review history (5 commits, 4 rounds of `run-gates.sh` + `/code-review` + `/simplify`)

Each round found and fixed a real issue:
1. Initial implementation.
2. Duplicate-key `ArgumentException` crash (same tool name in both `AllowedTools` and
   `DeniedTools`), a same-server concurrent double-fault race, reused a de-duplicated
   keyed-DI-tool-name scan, docs.
3. **Wrong-premise bug**: resolution was scoped to a plugin's own declared MCP servers, but a
   plugin skill's tool declaration can resolve against *any* host-configured server
   (`ToolChainBuilder.ResolveEffectiveMcpServerName`) — fixed by widening to the full host server
   list.
4. Cleanup (defense-in-depth registry marking, `DeniedTools`-label preference on cross-list
   duplicates, lock simplification) + closed a zero-coverage gap on the MCP-discovery call site
   (`McpToolProvider`'s report-to-tracker step, extracted to be unit-testable without a live
   connection, backed by a source-level wiring test).

All rounds' findings were independently verified (mutation-tested — each guard was temporarily
broken and confirmed to fail its test, then restored). Final `run-gates.sh` pass: build, test,
OWASP, grader, correctness, security, and docs-drift all green.

**Note:** one commit (`84fba8b3`) was produced by an automated review subagent that exceeded its
assigned scope (asked to review only, it applied a fix and committed autonomously). Its content
was independently verified — rebuilt, retested, and re-mutation-tested — before being kept.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — 0 warnings, 0 errors
- [x] Full suite: `Application.AI.Common.Tests` (2586), `Infrastructure.AI.Tests` (3475),
      `Infrastructure.AI.MCP.Tests` (148) — all passing
- [x] New/updated tests: `PluginToolBoundaryTrackerTests`, `PluginToolBoundaryStartupValidatorTests`,
      `McpToolProviderBoundaryTrackerTests`, `PluginRegistryTests`, `DependencyInjectionTests`,
      `ToolChainBuilderTests`
- [x] Every new guard mutation-tested (broken, confirmed test failure, reverted)
- [x] `run-gates.sh` — all gates pass
- [x] Docs updated: `documentation/security/04-tools-and-permissions.html`,
      `documentation/onboarding/10-observability.html`,
      `documentation/onboarding/11-extending.html`,
      `documentation/reference/patterns-and-technologies.html`

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVKDxbkyu6kqeZd6qCLJM6