### PR TITLE
fix: restore per-tool filesystem-path and network-host capability scoping

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolCallAdmissionPipeline.cs
@@ -345,11 +345,20 @@ public readonly record struct TextOutputPolicyResult(
 /// wrapper did not stamp, which the governor reads identically to "no findings". See
 /// <c>ToolInvocationGovernor.RequiresApprovalForToolComposition</c>.
 /// </param>
+/// <param name="ResourceRequest">
+/// The paths/hosts this call actually requested (#418), extracted by the caller before admission —
+/// see <c>Domain.AI.Sandbox.ToolCallResourceRequest</c>'s remarks for why <see langword="null"/>
+/// (couldn't be determined) and an empty request (determined, and there is none) mean different
+/// things to <c>ICapabilityEnforcer.EnforceAsync</c>, the eventual consumer. Null for a caller that
+/// never extracts one, which the enforcer treats as "unknown" — refusing outright when the tool's
+/// profile has any path/host scoping configured, never as "nothing to check".
+/// </param>
 public sealed record ToolCallAdmissionRequest(
     string ToolName,
     IReadOnlyDictionary<string, object?>? Arguments = null,
     bool CountsTowardLoopDetection = false,
-    ToolCompositionTaint? CompositionTaint = null);
+    ToolCompositionTaint? CompositionTaint = null,
+    Domain.AI.Sandbox.ToolCallResourceRequest? ResourceRequest = null);
 
 /// <summary>
 /// The admission chain's verdict for one tool call.

--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IToolInvocationGovernor.cs
@@ -48,6 +48,12 @@ public interface IToolInvocationGovernor
     /// the tool result. When enforcement is disabled the governor records the would-be decision but
     /// always returns <see cref="ToolInvocationDecision.Allow()"/>.
     /// </returns>
+    /// <param name="resourceRequest">
+    /// The paths/hosts this call actually requested (#418), when the caller extracted one — see
+    /// <c>Domain.AI.Sandbox.ToolCallResourceRequest</c>'s remarks for why <see langword="null"/> and
+    /// an empty request are not interchangeable. Forwarded to
+    /// <c>ICapabilityEnforcer.EnforceAsync</c>, the only stage that reads it.
+    /// </param>
     /// <remarks>
     /// <paramref name="arguments"/> is optional so the callers that authorize by capability name
     /// rather than by a model-supplied argument set — the plan-step executors — are unaffected.
@@ -56,7 +62,8 @@ public interface IToolInvocationGovernor
         string toolName,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<string, object?>? arguments = null,
-        ToolCompositionTaint? composition = null);
+        ToolCompositionTaint? composition = null,
+        Domain.AI.Sandbox.ToolCallResourceRequest? resourceRequest = null);
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Sandbox/ICapabilityEnforcer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Sandbox/ICapabilityEnforcer.cs
@@ -21,25 +21,26 @@ public interface ICapabilityEnforcer
 
     /// <summary>
     /// Enforces that the granted capabilities satisfy the tool's requirements, honoring any
-    /// per-tool <c>DeniedCapabilities</c> override (#405).
+    /// per-tool <c>DeniedCapabilities</c> override (#405), and — when the tool's resolved
+    /// <see cref="ToolPermissionProfile"/> has any path/host scoping configured — that
+    /// <paramref name="requestedPaths"/>/<paramref name="requestedHosts"/> fall within it (#418).
     /// </summary>
     /// <param name="toolName">The keyed DI tool name.</param>
     /// <param name="grantedCapabilities">Capabilities currently available.</param>
+    /// <param name="requestedPaths">
+    /// The filesystem paths this call actually named, extracted before this method runs — see
+    /// <c>ToolCallResourceRequest</c>'s remarks for why <see langword="null"/> (resource usage could
+    /// not be determined) and an empty list (determined, and there genuinely is none) are refused and
+    /// allowed respectively, never treated the same. A profile with no path scoping configured ignores
+    /// this parameter entirely regardless of its value.
+    /// </param>
+    /// <param name="requestedHosts">As <paramref name="requestedPaths"/>, for network hosts.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Success if allowed; failure with the specific violation reason.</returns>
-    /// <remarks>
-    /// <strong>Breaking change (#405):</strong> this method previously took two additional optional
-    /// parameters, <c>requestedPaths</c>/<c>requestedHosts</c>, for the per-tool filesystem-path and
-    /// network-host allow/deny scoping <see cref="ToolPermissionProfile"/> used to carry. That scoping
-    /// was removed as dead configuration — no production caller ever passed those arguments, and no
-    /// sandbox launch preparer (Docker or Process) ever read the corresponding profile fields either,
-    /// so the mechanism was inert end to end, not just the parameters. A consumer built against the
-    /// pre-#405 signature needs to drop those arguments on upgrade; the capability model
-    /// (<see cref="ToolCapability"/>) is unaffected. Re-introducing per-tool path/host scoping is
-    /// tracked separately — see the GitHub issue this PR's description links.
-    /// </remarks>
     Task<Result> EnforceAsync(
         string toolName,
         ToolCapability grantedCapabilities,
+        IReadOnlyList<string>? requestedPaths = null,
+        IReadOnlyList<string>? requestedHosts = null,
         CancellationToken ct = default);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Sandbox/IPathCanonicalizer.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Sandbox/IPathCanonicalizer.cs
@@ -1,0 +1,26 @@
+namespace Application.AI.Common.Interfaces.Sandbox;
+
+/// <summary>
+/// Resolves an already-normalized filesystem path to its canonical, link-resolved absolute form, so
+/// a containment comparison (<see cref="ICapabilityEnforcer"/>'s path scoping) cannot be defeated by a
+/// symlink or junction that spells a different path to the same — or a different — location than it
+/// appears to name.
+/// </summary>
+/// <remarks>
+/// Implemented in Infrastructure, where filesystem I/O belongs, and consumed here as an interface so
+/// <c>CapabilityEnforcer</c> (Application layer) never references the filesystem directly. Optional at
+/// every call site that takes one: a host that doesn't register an implementation still gets the
+/// normalized-string comparison <c>CapabilityEnforcer</c> falls back to, just without symlink
+/// resolution — a real but bounded loss of guarantee, not a broken build.
+/// </remarks>
+public interface IPathCanonicalizer
+{
+    /// <summary>
+    /// Returns the canonical absolute form of <paramref name="normalizedPath"/> — the same identity a
+    /// file access at that path would actually resolve to, links included — or the input unchanged
+    /// when the entry cannot be inspected (missing, unreadable, or an unsupported path shape), which is
+    /// the safe answer: a path that doesn't exist yet holds nothing to alias.
+    /// </summary>
+    /// <param name="normalizedPath">An already path-normalized (absolute, separator-trimmed) input.</param>
+    string Canonicalize(string normalizedPath);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Tools/ITool.cs
@@ -175,6 +175,23 @@ public interface ITool
     SandboxIsolationLevel MinimumIsolation => SandboxIsolationLevel.None;
 
     /// <summary>
+    /// For each operation this tool supports, which of its named parameters (the keys the
+    /// <c>parameters</c> dictionary in <see cref="ExecuteAsync"/> carries) represent a filesystem
+    /// path or a network host — what <c>ToolPermissionProfile</c>'s path/host allow/deny scoping
+    /// (#418) is checked against. Extracted before the call is admitted, so declaring a parameter
+    /// here is what makes per-tool path/host confinement possible at all for this tool.
+    /// </summary>
+    /// <remarks>
+    /// Default is <see langword="null"/> — deliberately NOT fail-closed the way
+    /// <see cref="RequiredCapabilities"/> is: an undeclared tool simply cannot be path/host-scoped
+    /// (the same "unknown, not both" reasoning <see cref="Capabilities"/> uses), not "scoped to
+    /// nothing." A profile with path/host scoping configured for a tool that declares nothing here
+    /// is refused outright by <c>CapabilityEnforcer</c> — see <c>ToolCallResourceRequest</c>'s
+    /// remarks — so there is no silent gap between "declared nothing" and "scoping doesn't apply."
+    /// </remarks>
+    IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>? ResourceParametersByOperation => null;
+
+    /// <summary>
     /// Executes a tool operation with the given parameters.
     /// </summary>
     /// <param name="operation">The operation to perform (must be in <see cref="SupportedOperations"/>).</param>

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolCallAdmissionPipeline.cs
@@ -207,7 +207,7 @@ public sealed class ToolCallAdmissionPipeline : IToolCallAdmissionPipeline
         // null included: the governor distinguishes "no arguments were available" from "the call had
         // none", and narrows its argument-conditioned rules accordingly.
         var decision = await _governor
-            .AuthorizeAsync(toolName, cancellationToken, request.Arguments, request.CompositionTaint)
+            .AuthorizeAsync(toolName, cancellationToken, request.Arguments, request.CompositionTaint, request.ResourceRequest)
             .ConfigureAwait(false);
         if (!decision.IsAllowed)
             return Refuse(decision.DeniedMessage, toolName);

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -155,7 +155,8 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         string toolName,
         CancellationToken cancellationToken,
         IReadOnlyDictionary<string, object?>? arguments = null,
-        ToolCompositionTaint? composition = null)
+        ToolCompositionTaint? composition = null,
+        Domain.AI.Sandbox.ToolCallResourceRequest? resourceRequest = null)
     {
         // Opt-in: when enforcement is off the governor never engages — pure pass-through, no record,
         // no behaviour change for existing deployments. Read live rather than from the trace's sticky
@@ -205,7 +206,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         // Every gate that can decide on its own runs first; the human is asked last, once.
         // See AuthorizeInOrderAsync for why that ordering is the design and not an accident.
         return await AuthorizeInOrderAsync(
-                agentId, toolName, permission, profile, arguments, composition, cancellationToken)
+                agentId, toolName, permission, profile, arguments, composition, resourceRequest, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -241,6 +242,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     private async ValueTask<ToolInvocationDecision> AuthorizeInOrderAsync(
         string agentId, string toolName, PermissionDecision permission, ToolRiskProfile profile,
         IReadOnlyDictionary<string, object?>? arguments, ToolCompositionTaint? composition,
+        Domain.AI.Sandbox.ToolCallResourceRequest? resourceRequest,
         CancellationToken cancellationToken)
     {
         // One snapshot for the whole decision. Two stages read this config, and reading the monitor
@@ -306,7 +308,10 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
             _sandboxConfig.CurrentValue.DefaultGrantedCapabilities);
 
         var capResult = await _capabilityEnforcer
-            .EnforceAsync(toolName, grantedCapabilities, ct: cancellationToken)
+            .EnforceAsync(
+                toolName, grantedCapabilities,
+                resourceRequest?.RequestedPaths, resourceRequest?.RequestedHosts,
+                ct: cancellationToken)
             .ConfigureAwait(false);
 
         if (!capResult.IsSuccess)

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -1,0 +1,132 @@
+using Domain.AI.Sandbox;
+using Domain.Common;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Sandbox;
+
+/// <summary>
+/// Network-host scoping half of <see cref="CapabilityEnforcer"/> (#418) — see that file's remarks for
+/// why this is a separate partial rather than folded into the main file.
+/// </summary>
+public sealed partial class CapabilityEnforcer
+{
+    /// <summary>
+    /// Checks <paramref name="requestedHosts"/> against the profile's host scoping, when any is
+    /// configured. Returns <see langword="null"/> on a pass, or the refusal to return. Mirrors
+    /// <see cref="EnforcePathScoping"/>.
+    /// </summary>
+    private Result? EnforceHostScoping(string toolName, IReadOnlyList<string>? requestedHosts, ToolPermissionProfile profile)
+    {
+        var hasHostScoping = profile.AllowedHosts.Count > 0 || profile.DeniedHosts.Count > 0;
+        if (!hasHostScoping)
+            return null;
+
+        if (requestedHosts is null)
+        {
+            _logger.LogWarning(
+                "Tool {ToolName} has host scoping configured but no requested host could be determined for this call",
+                toolName);
+            return Result.Forbidden(
+                $"Tool '{toolName}' has host scoping configured but no requested host could be determined for this call.");
+        }
+
+        if (requestedHosts.Count == 0)
+            return null;
+
+        // Each configured pattern is normalized once per call here, not once per (requested host ×
+        // pattern) pair inside the loop below.
+        var deniedPatterns = profile.DeniedHosts.Select(NormalizeHostForMatch).ToList();
+        var allowedPatterns = profile.AllowedHosts.Select(NormalizeHostForMatch).ToList();
+
+        if (ValidateHosts(requestedHosts, deniedPatterns, allowedPatterns) is { } hostViolation)
+        {
+            _logger.LogWarning("Tool {ToolName} host denied: {Host}", toolName, hostViolation);
+            return Result.Forbidden($"Tool '{toolName}' host denied: {hostViolation}");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first requested host that violates the pre-normalized <paramref name="deniedPatterns"/>/
+    /// <paramref name="allowedPatterns"/>, or <see langword="null"/> if every host is permitted.
+    /// Deny-overrides-allow, mirroring <see cref="ValidatePaths"/> (#418, restored from pre-#405 history).
+    /// </summary>
+    private static string? ValidateHosts(
+        IReadOnlyList<string> requestedHosts, IReadOnlyList<string> deniedPatterns, IReadOnlyList<string> allowedPatterns)
+    {
+        foreach (var host in requestedHosts)
+        {
+            var normalizedHost = NormalizeHostForMatch(host);
+
+            if (deniedPatterns.Any(pattern => HostPatternMatches(normalizedHost, pattern)))
+                return host;
+
+            if (allowedPatterns.Count > 0 && !allowedPatterns.Any(pattern => HostPatternMatches(normalizedHost, pattern)))
+                return host;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Matches an already-<see cref="NormalizeHostForMatch"/>d host against an already-normalized
+    /// pattern, which may be an exact host name or a <c>*.suffix</c> wildcard.
+    /// </summary>
+    private static bool HostPatternMatches(string normalizedHost, string normalizedPattern)
+    {
+        if (normalizedPattern.StartsWith("*."))
+        {
+            var suffix = normalizedPattern[1..];
+            return normalizedHost.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+                   || normalizedHost.Equals(normalizedPattern[2..], StringComparison.OrdinalIgnoreCase);
+        }
+
+        return normalizedHost.Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Reduces a host value — whether a requested host or a configured deny/allow entry — to a bare,
+    /// comparable host name. A value that parses as an absolute URI is reduced via <see cref="Uri.Host"/>
+    /// itself, which correctly drops a scheme, userinfo (<c>user@</c>), port, and path/query in one
+    /// step — <em>not</em> an ad-hoc scan for <c>"://"</c>, which matches the first occurrence anywhere
+    /// in the string rather than only a leading scheme and so can be pointed at an unrelated embedded
+    /// URL later in the value. A value that isn't itself an absolute URI falls back to a trailing-port
+    /// strip and a root-terminating FQDN dot trim. Applying the identical reduction to both sides of a
+    /// <see cref="HostPatternMatches"/> comparison is what keeps an operator's plain <c>"evil.com"</c>
+    /// entry matching every equivalent spelling of that same host a caller might supply.
+    /// </summary>
+    private static string NormalizeHostForMatch(string value)
+    {
+        var trimmed = value.Trim();
+
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host))
+            return uri.Host.TrimEnd('.');
+
+        return StripPort(trimmed).TrimEnd('.');
+    }
+
+    /// <summary>
+    /// Strips a trailing <c>:port</c> from <paramref name="host"/>, recognizing the bracketed IPv6
+    /// form (<c>[::1]:443</c>) and leaving a <em>bare</em> IPv6 literal (<c>::1</c>) untouched — more
+    /// than one colon with no brackets is never a host:port pair, so treating the last colon as a
+    /// port separator there would truncate the address itself (<c>::1</c> otherwise becomes <c>:</c>
+    /// and can never match a configured deny/allow entry for it).
+    /// </summary>
+    private static string StripPort(string host)
+    {
+        if (host.StartsWith('['))
+        {
+            var closeBracket = host.IndexOf(']');
+            return closeBracket > 0 ? host[1..closeBracket] : host;
+        }
+
+        if (host.Count(c => c == ':') != 1)
+            return host;
+
+        var colonIndex = host.IndexOf(':');
+        return colonIndex > 0 && host[(colonIndex + 1)..].All(char.IsDigit)
+            ? host[..colonIndex]
+            : host;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -34,9 +34,11 @@ public sealed partial class CapabilityEnforcer
             return null;
 
         // Each configured pattern is normalized once per call here, not once per (requested host ×
-        // pattern) pair inside the loop below.
-        var deniedPatterns = profile.DeniedHosts.Select(NormalizeHostForMatch).ToList();
-        var allowedPatterns = profile.AllowedHosts.Select(NormalizeHostForMatch).ToList();
+        // pattern) pair inside the loop below. A null entry (a literal JSON `null` in DeniedHosts/
+        // AllowedHosts, binding into a null List<string> element despite the non-nullable element
+        // type) is skipped rather than passed to NormalizeHostForMatch, which would NRE on it.
+        var deniedPatterns = profile.DeniedHosts.Where(h => h is not null).Select(NormalizeHostForMatch).ToList();
+        var allowedPatterns = profile.AllowedHosts.Where(h => h is not null).Select(NormalizeHostForMatch).ToList();
 
         if (ValidateHosts(requestedHosts, deniedPatterns, allowedPatterns) is { } hostViolation)
         {

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.PathScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.PathScoping.cs
@@ -84,7 +84,15 @@ public sealed partial class CapabilityEnforcer
             // unparsable deny entry as "never matches" would silently turn a misconfigured deny rule
             // into a no-op instead of the refusal it was written to enforce, which is the fail-open
             // shape this whole mechanism exists to prevent.
-            if (deniedBoundaries.Any(denied => denied is null || IsPathWithin(normalized, denied)))
+            //
+            // Checked in BOTH directions, not just "is the requested path inside a denied boundary":
+            // a subtree-reading operation (FileSystemTool's "search"/"list", which walk everything
+            // beneath the named path) can name a path that is an ANCESTOR of a denied boundary rather
+            // than a descendant of one — the single-string declaration this class validates has no way
+            // to see the individual file paths such a walk actually returns, so a denied boundary
+            // nested inside the requested path is refused outright rather than silently read through.
+            if (deniedBoundaries.Any(denied =>
+                    denied is null || IsPathWithin(normalized, denied) || IsPathWithin(denied, normalized)))
                 return path;
 
             if (allowedBoundaries.Count > 0 && !allowedBoundaries.Any(allowed => IsPathWithin(normalized, allowed)))
@@ -146,7 +154,18 @@ public sealed partial class CapabilityEnforcer
     /// consults the list. Deny entries are handled directly in <see cref="ValidatePaths"/> instead,
     /// where the same fallback would be fail-open rather than fail-closed.
     /// </summary>
-    private string NormalizeBoundary(string configuredPath) => NormalizeAndCanonicalize(configuredPath) ?? configuredPath;
+    private string NormalizeBoundary(string configuredPath)
+    {
+        if (NormalizeAndCanonicalize(configuredPath) is { } normalized)
+            return normalized;
+
+        // The raw-string fallback above only safely excludes a malformed entry because a raw,
+        // non-normalized string won't match a normalized candidate — except when that raw string is
+        // itself empty or whitespace, which collides with IsPathWithin's own, legitimate "root, fully
+        // normalized" empty-boundary case and would silently match every candidate instead of none.
+        // A NUL never appears in a real normalized path, so it is never mistaken for one.
+        return string.IsNullOrWhiteSpace(configuredPath) ? "\0" : configuredPath;
+    }
 
     /// <summary>
     /// Resolves <paramref name="path"/> to its absolute form via <see cref="PathScope.Normalize"/> —
@@ -162,9 +181,12 @@ public sealed partial class CapabilityEnforcer
     /// identically: neither side has any base directory of its own to resolve a relative path against
     /// that the other side would agree with.
     /// </summary>
-    private string? NormalizeAndCanonicalize(string path)
+    private string? NormalizeAndCanonicalize(string? path)
     {
-        if (!Path.IsPathFullyQualified(path))
+        // A null entry can reach here from a configured list — a literal JSON `null` in
+        // DeniedPaths/AllowedPaths binds to a null List<string> element despite the non-nullable
+        // element type — and Path.IsPathFullyQualified throws on null rather than answering false.
+        if (path is null || !Path.IsPathFullyQualified(path))
             return null;
 
         try

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.PathScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.PathScoping.cs
@@ -1,0 +1,180 @@
+using Domain.AI.Sandbox;
+using Domain.Common;
+using Domain.Common.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Application.AI.Common.Services.Sandbox;
+
+/// <summary>
+/// Filesystem-path scoping half of <see cref="CapabilityEnforcer"/> (#418) — see that file's remarks
+/// for why this is a separate partial rather than folded into the main file.
+/// </summary>
+public sealed partial class CapabilityEnforcer
+{
+    /// <summary>
+    /// Checks <paramref name="requestedPaths"/> against the profile's path scoping, when any is
+    /// configured. Returns <see langword="null"/> on a pass, or the refusal to return.
+    /// </summary>
+    /// <remarks>
+    /// #418: a profile with path scoping configured but no requested value to check against must
+    /// refuse, not silently allow — this is deliberately NOT <c>is { Count: > 0 }</c>, which is the
+    /// fail-open shape #405 shipped (null and <c>[]</c> were treated identically, so scoping was
+    /// configured but never actually enforced against a call whose resource usage was simply never
+    /// determined). See <see cref="Domain.AI.Sandbox.ToolCallResourceRequest"/>'s remarks for why
+    /// null vs. empty matters.
+    /// </remarks>
+    private Result? EnforcePathScoping(string toolName, IReadOnlyList<string>? requestedPaths, ToolPermissionProfile profile)
+    {
+        var hasPathScoping = profile.AllowedPaths.Count > 0 || profile.DeniedPaths.Count > 0;
+        if (!hasPathScoping)
+            return null;
+
+        if (requestedPaths is null)
+        {
+            _logger.LogWarning(
+                "Tool {ToolName} has path scoping configured but no requested path could be determined for this call",
+                toolName);
+            return Result.Forbidden(
+                $"Tool '{toolName}' has path scoping configured but no requested path could be determined for this call.");
+        }
+
+        if (requestedPaths.Count == 0)
+            return null;
+
+        // Each configured boundary is normalized (and, when a canonicalizer is registered,
+        // link-resolved via a real filesystem stat) at most once per call here, not once per
+        // (requested path × boundary) pair inside the loop below — a profile with several entries
+        // and a multi-path request would otherwise repeat that filesystem I/O for every pair.
+        var deniedBoundaries = profile.DeniedPaths.Select(NormalizeAndCanonicalize).ToList();
+        var allowedBoundaries = profile.AllowedPaths.Select(NormalizeBoundary).ToList();
+
+        if (ValidatePaths(requestedPaths, deniedBoundaries, allowedBoundaries) is { } pathViolation)
+        {
+            _logger.LogWarning("Tool {ToolName} path denied: {Path}", toolName, pathViolation);
+            return Result.Forbidden($"Tool '{toolName}' path denied: {pathViolation}");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the first requested path that violates the pre-normalized <paramref name="deniedBoundaries"/>/
+    /// <paramref name="allowedBoundaries"/>, or <see langword="null"/> if every path is permitted.
+    /// Deny-overrides-allow: a deny match wins even when the same path also matches an allow entry
+    /// (#418, restored from pre-#405 history).
+    /// </summary>
+    private string? ValidatePaths(
+        IReadOnlyList<string> requestedPaths, IReadOnlyList<string?> deniedBoundaries, IReadOnlyList<string> allowedBoundaries)
+    {
+        foreach (var path in requestedPaths)
+        {
+            // A model-supplied path this class cannot safely resolve — one carrying a traversal
+            // pattern, a relative path, or one the runtime rejects outright — is treated as a
+            // violation rather than compared. CI caught the alternative: a naive normalizer silently
+            // dropped a leading ".." instead of resolving it, so "../secrets/creds.txt" matched no
+            // configured boundary at all. CapabilityEnforcer has no base directory of its own to
+            // resolve a relative path against (that is IFileSystemService's own, separately-configured
+            // concern), so refusing outright — mirroring SandboxedPathGuard.ResolveAndValidate's own
+            // first check — is the only answer that cannot be tricked into comparing the wrong path.
+            if (NormalizeRequestedPath(path) is not { } normalized)
+                return path;
+
+            // A configured deny entry the runtime could not normalize (null) is treated as matching
+            // every candidate, not excluded from the check — unlike an allow entry below, treating an
+            // unparsable deny entry as "never matches" would silently turn a misconfigured deny rule
+            // into a no-op instead of the refusal it was written to enforce, which is the fail-open
+            // shape this whole mechanism exists to prevent.
+            if (deniedBoundaries.Any(denied => denied is null || IsPathWithin(normalized, denied)))
+                return path;
+
+            if (allowedBoundaries.Count > 0 && !allowedBoundaries.Any(allowed => IsPathWithin(normalized, allowed)))
+                return path;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="candidate"/> is the same as, or a descendant of,
+    /// <paramref name="boundary"/>, comparing on path-segment boundaries rather than raw string
+    /// prefixes via <see cref="PathScope.IsSameOrUnderNormalized"/> — the same primitive
+    /// <c>SandboxedPathGuard</c> compares real file access against, so the two cannot disagree about
+    /// which file a path names. Both inputs are expected to be already normalized (and, when a
+    /// canonicalizer is available, link-resolved) via <see cref="NormalizeAndCanonicalize"/>.
+    /// </summary>
+    private static bool IsPathWithin(string candidate, string boundary) =>
+        // An empty boundary (root, fully trimmed) confines everything — preserved as an explicit
+        // case because PathScope.IsSameOrUnderNormalized's own separator-prefixed check does not
+        // reduce to "matches everything" identically on every platform.
+        boundary.Length == 0 || PathScope.IsSameOrUnderNormalized(candidate, boundary);
+
+    /// <summary>
+    /// Normalizes and canonicalizes a model-supplied path for a scoping comparison, refusing
+    /// (returning <see langword="null"/>) rather than guessing when the input carries a traversal
+    /// pattern, is not fully qualified, or the runtime cannot parse it at all.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <em>relative</em> path is refused outright, not resolved — CI caught the alternative:
+    /// resolving it against <see cref="PathScope.Normalize"/>'s implicit base (the process's current
+    /// directory) answers a different question than the one that matters, because the tool that
+    /// actually opens the file resolves the identical string against its own, separately-configured
+    /// sandbox base path (<c>SandboxedPathGuard.ResolveRelative</c>) — a base this class has no
+    /// visibility into and no business assuming. The two resolutions can name different files
+    /// entirely, so a relative path is unsafe to compare here at all, exactly like a traversal
+    /// pattern is.
+    /// </para>
+    /// <para>
+    /// The fully-qualified check lives inside <see cref="NormalizeAndCanonicalize"/> itself, applied
+    /// identically to a requested path and a configured boundary — CI caught the alternative: checking
+    /// it only here left a <em>relative</em> <c>DeniedPaths</c>/<c>AllowedPaths</c> config entry to
+    /// silently resolve against the process's CWD via <see cref="PathScope.Normalize"/>, the exact
+    /// fail-open shape this guard exists to prevent, just on the configured side instead of the
+    /// requested side.
+    /// </para>
+    /// </remarks>
+    private string? NormalizeRequestedPath(string path) =>
+        SecureInputValidatorHelper.ValidateFilePath(path) ? NormalizeAndCanonicalize(path) : null;
+
+    /// <summary>
+    /// Normalizes and canonicalizes an operator-configured <em>allow</em> boundary the same way as a
+    /// requested path (#418) — both sides must go through identical treatment, or a boundary reached
+    /// only through a symlink would compare unequal to an already-resolved candidate. Falls back to
+    /// the raw configured string on a normalization failure, which for an allow entry safely excludes
+    /// it (a raw, non-normalized string will not match a normalized candidate) rather than throwing —
+    /// a typo in one operator entry should degrade that one comparison, not take down every call that
+    /// consults the list. Deny entries are handled directly in <see cref="ValidatePaths"/> instead,
+    /// where the same fallback would be fail-open rather than fail-closed.
+    /// </summary>
+    private string NormalizeBoundary(string configuredPath) => NormalizeAndCanonicalize(configuredPath) ?? configuredPath;
+
+    /// <summary>
+    /// Resolves <paramref name="path"/> to its absolute form via <see cref="PathScope.Normalize"/> —
+    /// the same routine <c>SandboxedPathGuard</c> normalizes real file access through, so a genuine
+    /// <c>..</c> segment is actually resolved rather than silently discarded, and platform quirks
+    /// (e.g. a Windows trailing-dot path component) are handled identically on both sides of the
+    /// comparison — then link-resolves through <see cref="_pathCanonicalizer"/> when one is
+    /// registered. Returns <see langword="null"/> on any input that is not already fully qualified
+    /// (checked via <c>Path.IsPathFullyQualified</c>, not <c>Path.IsPathRooted</c> — the latter answers
+    /// <see langword="true"/> for a Windows drive-relative path like <c>"C:secrets\creds.txt"</c>,
+    /// which still resolves against the current directory on that drive, not an absolute location) or
+    /// that the runtime cannot parse at all. Applied to both a requested path and a configured boundary
+    /// identically: neither side has any base directory of its own to resolve a relative path against
+    /// that the other side would agree with.
+    /// </summary>
+    private string? NormalizeAndCanonicalize(string path)
+    {
+        if (!Path.IsPathFullyQualified(path))
+            return null;
+
+        try
+        {
+            var normalized = PathScope.Normalize(path);
+            return _pathCanonicalizer?.Canonicalize(normalized) ?? normalized;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
@@ -234,16 +234,16 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// pattern is.
     /// </para>
     /// <para>
-    /// Checked via <c>Path.IsPathFullyQualified</c>, not <c>Path.IsPathRooted</c> — the
-    /// latter answers <see langword="true"/> for a Windows drive-relative path like
-    /// <c>"C:secrets\creds.txt"</c>, which is exactly the CWD-dependent ambiguity this guard exists to
-    /// reject: it still resolves against the current directory on that drive, not an absolute location.
+    /// The fully-qualified check lives inside <see cref="NormalizeAndCanonicalize"/> itself, applied
+    /// identically to a requested path and a configured boundary — CI caught the alternative: checking
+    /// it only here left a <em>relative</em> <c>DeniedPaths</c>/<c>AllowedPaths</c> config entry to
+    /// silently resolve against the process's CWD via <see cref="PathScope.Normalize"/>, the exact
+    /// fail-open shape this guard exists to prevent, just on the configured side instead of the
+    /// requested side.
     /// </para>
     /// </remarks>
     private string? NormalizeRequestedPath(string path) =>
-        Path.IsPathFullyQualified(path) && SecureInputValidatorHelper.ValidateFilePath(path)
-            ? NormalizeAndCanonicalize(path)
-            : null;
+        SecureInputValidatorHelper.ValidateFilePath(path) ? NormalizeAndCanonicalize(path) : null;
 
     /// <summary>
     /// Normalizes and canonicalizes an operator-configured <em>allow</em> boundary the same way as a
@@ -263,10 +263,19 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// <c>..</c> segment is actually resolved rather than silently discarded, and platform quirks
     /// (e.g. a Windows trailing-dot path component) are handled identically on both sides of the
     /// comparison — then link-resolves through <see cref="_pathCanonicalizer"/> when one is
-    /// registered. Returns <see langword="null"/> on any input the runtime cannot parse.
+    /// registered. Returns <see langword="null"/> on any input that is not already fully qualified
+    /// (checked via <c>Path.IsPathFullyQualified</c>, not <c>Path.IsPathRooted</c> — the latter answers
+    /// <see langword="true"/> for a Windows drive-relative path like <c>"C:secrets\creds.txt"</c>,
+    /// which still resolves against the current directory on that drive, not an absolute location) or
+    /// that the runtime cannot parse at all. Applied to both a requested path and a configured boundary
+    /// identically: neither side has any base directory of its own to resolve a relative path against
+    /// that the other side would agree with.
     /// </summary>
     private string? NormalizeAndCanonicalize(string path)
     {
+        if (!Path.IsPathFullyQualified(path))
+            return null;
+
         try
         {
             var normalized = PathScope.Normalize(path);

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
+using Domain.Common.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Sandbox;
@@ -15,18 +16,27 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
 {
     private readonly ToolPermissionProfileResolver _resolver;
     private readonly ILogger<CapabilityEnforcer> _logger;
+    private readonly IPathCanonicalizer? _pathCanonicalizer;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CapabilityEnforcer"/> class.
     /// </summary>
     /// <param name="resolver">Resolves tool permission profiles from attributes and config.</param>
     /// <param name="logger">Logger for enforcement decision auditing.</param>
+    /// <param name="pathCanonicalizer">
+    /// Resolves symlinks/junctions before a path-scoping comparison (#418's CI hardening), so
+    /// <see cref="ValidatePaths"/> cannot be defeated by a link the sandbox itself would follow.
+    /// Optional: a host that doesn't register one still gets the normalized-string comparison, just
+    /// without link resolution — see <see cref="IPathCanonicalizer"/>'s own remarks.
+    /// </param>
     public CapabilityEnforcer(
         ToolPermissionProfileResolver resolver,
-        ILogger<CapabilityEnforcer> logger)
+        ILogger<CapabilityEnforcer> logger,
+        IPathCanonicalizer? pathCanonicalizer = null)
     {
         _resolver = resolver;
         _logger = logger;
+        _pathCanonicalizer = pathCanonicalizer;
     }
 
     /// <inheritdoc />
@@ -110,17 +120,26 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// or <see langword="null"/> if every path is permitted. Deny-overrides-allow: a deny match wins
     /// even when the same path also matches an allow entry (#418, restored from pre-#405 history).
     /// </summary>
-    private static string? ValidatePaths(IReadOnlyList<string> requestedPaths, ToolPermissionProfile profile)
+    private string? ValidatePaths(IReadOnlyList<string> requestedPaths, ToolPermissionProfile profile)
     {
         foreach (var path in requestedPaths)
         {
-            var normalized = NormalizePath(path);
+            // A model-supplied path this class cannot safely resolve — one carrying a traversal
+            // pattern, or one the runtime rejects outright — is treated as a violation rather than
+            // compared. CI caught the alternative: a naive normalizer silently dropped a leading
+            // ".." instead of resolving it, so "../secrets/creds.txt" matched no configured
+            // boundary at all. CapabilityEnforcer has no base directory of its own to resolve a
+            // relative traversal against (that is IFileSystemService's own, separately-configured
+            // concern), so refusing outright — mirroring SandboxedPathGuard.ResolveAndValidate's own
+            // first check — is the only answer that cannot be tricked into comparing the wrong path.
+            if (NormalizeRequestedPath(path) is not { } normalized)
+                return path;
 
-            if (profile.DeniedPaths.Any(denied => IsPathWithin(normalized, NormalizePath(denied))))
+            if (profile.DeniedPaths.Any(denied => IsPathWithin(normalized, NormalizeBoundary(denied))))
                 return path;
 
             if (profile.AllowedPaths.Count > 0 &&
-                !profile.AllowedPaths.Any(allowed => IsPathWithin(normalized, NormalizePath(allowed))))
+                !profile.AllowedPaths.Any(allowed => IsPathWithin(normalized, NormalizeBoundary(allowed))))
             {
                 return path;
             }
@@ -132,23 +151,54 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// <summary>
     /// Determines whether <paramref name="candidate"/> is the same as, or a descendant of,
     /// <paramref name="boundary"/>, comparing on path-segment boundaries rather than raw string
-    /// prefixes. This prevents sibling-directory bypass (e.g. boundary "C:/sandbox/work" must NOT
-    /// match "C:/sandbox/work-evil"). Both inputs are expected to be already normalized via
-    /// <see cref="NormalizePath"/> (slash-separated, no empty/relative segments, no trailing slash).
+    /// prefixes via <see cref="PathScope.IsSameOrUnderNormalized"/> — the same primitive
+    /// <c>SandboxedPathGuard</c> compares real file access against, so the two cannot disagree about
+    /// which file a path names. Both inputs are expected to be already normalized (and, when a
+    /// canonicalizer is available, link-resolved) via <see cref="NormalizeAndCanonicalize"/>.
     /// </summary>
-    private static bool IsPathWithin(string candidate, string boundary)
+    private static bool IsPathWithin(string candidate, string boundary) =>
+        // An empty boundary (root, fully trimmed) confines everything — preserved as an explicit
+        // case because PathScope.IsSameOrUnderNormalized's own separator-prefixed check does not
+        // reduce to "matches everything" identically on every platform.
+        boundary.Length == 0 || PathScope.IsSameOrUnderNormalized(candidate, boundary);
+
+    /// <summary>
+    /// Normalizes and canonicalizes a model-supplied path for a scoping comparison, refusing
+    /// (returning <see langword="null"/>) rather than guessing when the input carries a traversal
+    /// pattern or the runtime cannot parse it at all. See <see cref="ValidatePaths"/>'s remarks for
+    /// why a relative traversal cannot be safely resolved at this layer.
+    /// </summary>
+    private string? NormalizeRequestedPath(string path) =>
+        SecureInputValidatorHelper.ValidateFilePath(path) ? NormalizeAndCanonicalize(path) : null;
+
+    /// <summary>
+    /// Normalizes and canonicalizes an operator-configured boundary the same way as a requested path
+    /// (#418) — both sides must go through identical treatment, or a boundary reached only through a
+    /// symlink would compare unequal to an already-resolved candidate. Falls back to the raw
+    /// configured string on a normalization failure rather than refusing: a typo in one operator
+    /// entry should degrade that one comparison, not take down every call that consults the list.
+    /// </summary>
+    private string NormalizeBoundary(string configuredPath) => NormalizeAndCanonicalize(configuredPath) ?? configuredPath;
+
+    /// <summary>
+    /// Resolves <paramref name="path"/> to its absolute form via <see cref="PathScope.Normalize"/> —
+    /// the same routine <c>SandboxedPathGuard</c> normalizes real file access through, so a genuine
+    /// <c>..</c> segment is actually resolved rather than silently discarded, and platform quirks
+    /// (e.g. a Windows trailing-dot path component) are handled identically on both sides of the
+    /// comparison — then link-resolves through <see cref="_pathCanonicalizer"/> when one is
+    /// registered. Returns <see langword="null"/> on any input the runtime cannot parse.
+    /// </summary>
+    private string? NormalizeAndCanonicalize(string path)
     {
-        // An empty boundary (e.g. root after normalization) confines everything.
-        if (boundary.Length == 0)
-            return true;
-
-        if (candidate.Equals(boundary, StringComparison.OrdinalIgnoreCase))
-            return true;
-
-        // Descendant must start with "boundary/" so the next character is a true segment boundary.
-        return candidate.Length > boundary.Length
-            && candidate[boundary.Length] == '/'
-            && candidate.StartsWith(boundary, StringComparison.OrdinalIgnoreCase);
+        try
+        {
+            var normalized = PathScope.Normalize(path);
+            return _pathCanonicalizer?.Canonicalize(normalized) ?? normalized;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return null;
+        }
     }
 
     /// <summary>
@@ -174,49 +224,46 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     }
 
     /// <summary>
-    /// Matches <paramref name="host"/> (port stripped) against <paramref name="pattern"/>, which may
-    /// be an exact host name or a <c>*.suffix</c> wildcard.
+    /// Matches <paramref name="host"/> (port stripped, trailing FQDN dot trimmed) against
+    /// <paramref name="pattern"/>, which may be an exact host name or a <c>*.suffix</c> wildcard.
     /// </summary>
     private static bool HostMatches(string host, string pattern)
     {
-        var normalizedHost = StripPort(host);
+        var normalizedHost = StripPort(host).TrimEnd('.');
+        var normalizedPattern = pattern.TrimEnd('.');
 
-        if (pattern.StartsWith("*."))
+        if (normalizedPattern.StartsWith("*."))
         {
-            var suffix = pattern[1..];
+            var suffix = normalizedPattern[1..];
             return normalizedHost.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
-                   || normalizedHost.Equals(pattern[2..], StringComparison.OrdinalIgnoreCase);
+                   || normalizedHost.Equals(normalizedPattern[2..], StringComparison.OrdinalIgnoreCase);
         }
 
-        return normalizedHost.Equals(pattern, StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string StripPort(string host)
-    {
-        var colonIndex = host.LastIndexOf(':');
-        return colonIndex > 0 && host[(colonIndex + 1)..].All(char.IsDigit)
-            ? host[..colonIndex]
-            : host;
+        return normalizedHost.Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
-    /// Normalizes path separators to <c>/</c> and resolves <c>.</c>/<c>..</c> segments so
-    /// <see cref="IsPathWithin"/> compares like-for-like regardless of how the caller or the config
-    /// wrote a path.
+    /// Strips a trailing <c>:port</c> from <paramref name="host"/>, recognizing the bracketed IPv6
+    /// form (<c>[::1]:443</c>) and leaving a <em>bare</em> IPv6 literal (<c>::1</c>) untouched — more
+    /// than one colon with no brackets is never a host:port pair, so treating the last colon as a
+    /// port separator there would truncate the address itself (<c>::1</c> otherwise becomes <c>:</c>
+    /// and can never match a configured deny/allow entry for it).
     /// </summary>
-    private static string NormalizePath(string path)
+    private static string StripPort(string host)
     {
-        var segments = path.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
-        var result = new List<string>();
-        foreach (var segment in segments)
+        if (host.StartsWith('['))
         {
-            if (segment == ".") continue;
-            if (segment == ".." && result.Count > 0 && result[^1] != "..")
-                result.RemoveAt(result.Count - 1);
-            else if (segment != "..")
-                result.Add(segment);
+            var closeBracket = host.IndexOf(']');
+            return closeBracket > 0 ? host[1..closeBracket] : host;
         }
-        return string.Join('/', result);
+
+        if (host.Count(c => c == ':') != 1)
+            return host;
+
+        var colonIndex = host.IndexOf(':');
+        return colonIndex > 0 && host[(colonIndex + 1)..].All(char.IsDigit)
+            ? host[..colonIndex]
+            : host;
     }
 
     private static string FormatMissingCapabilities(ToolCapability missing)

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
@@ -1,7 +1,6 @@
 using Application.AI.Common.Interfaces.Sandbox;
 using Domain.AI.Sandbox;
 using Domain.Common;
-using Domain.Common.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Sandbox;
@@ -12,7 +11,16 @@ namespace Application.AI.Common.Services.Sandbox;
 /// <see cref="ToolPermissionProfile.DeniedCapabilities"/> override (#405), and validating any
 /// requested filesystem paths/network hosts against the profile's deny-overrides-allow scoping (#418).
 /// </summary>
-public sealed class CapabilityEnforcer : ICapabilityEnforcer
+/// <remarks>
+/// Split by concern into partial classes — <c>CapabilityEnforcer.PathScoping.cs</c> and
+/// <c>CapabilityEnforcer.HostScoping.cs</c> — the same pattern this codebase already uses for a large
+/// class with genuinely independent responsibilities (see <c>PlanExecutor.Scheduling.cs</c>/
+/// <c>PlanExecutor.Recovery.cs</c>, <c>ToolInvocationGovernor</c>). Path scoping and host scoping each
+/// own their own normalization rules and fail-open/fail-closed reasoning and share nothing with
+/// capability-flag checking beyond "same profile object, same deny-overrides-allow pattern" — this
+/// file keeps only the shared entry point and the capability check itself.
+/// </remarks>
+public sealed partial class CapabilityEnforcer : ICapabilityEnforcer
 {
     private readonly ToolPermissionProfileResolver _resolver;
     private readonly ILogger<CapabilityEnforcer> _logger;
@@ -24,10 +32,10 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// <param name="resolver">Resolves tool permission profiles from attributes and config.</param>
     /// <param name="logger">Logger for enforcement decision auditing.</param>
     /// <param name="pathCanonicalizer">
-    /// Resolves symlinks/junctions before a path-scoping comparison (#418's CI hardening), so
-    /// <see cref="ValidatePaths"/> cannot be defeated by a link the sandbox itself would follow.
-    /// Optional: a host that doesn't register one still gets the normalized-string comparison, just
-    /// without link resolution — see <see cref="IPathCanonicalizer"/>'s own remarks.
+    /// Resolves symlinks/junctions before a path-scoping comparison (#418's CI hardening), so the
+    /// path-scoping check cannot be defeated by a link the sandbox itself would follow. Optional: a
+    /// host that doesn't register one still gets the normalized-string comparison, just without link
+    /// resolution — see <see cref="IPathCanonicalizer"/>'s own remarks.
     /// </param>
     public CapabilityEnforcer(
         ToolPermissionProfileResolver resolver,
@@ -83,297 +91,6 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
         var missingNames = FormatMissingCapabilities(missing);
         _logger.LogWarning("Tool {ToolName} requires capabilities not granted: {Missing}", toolName, missingNames);
         return Result.Forbidden($"Tool '{toolName}' requires capabilities not granted: {missingNames}");
-    }
-
-    /// <summary>
-    /// Checks <paramref name="requestedPaths"/> against the profile's path scoping, when any is
-    /// configured. Returns <see langword="null"/> on a pass, or the refusal to return.
-    /// </summary>
-    /// <remarks>
-    /// #418: a profile with path scoping configured but no requested value to check against must
-    /// refuse, not silently allow — this is deliberately NOT <c>is { Count: > 0 }</c>, which is the
-    /// fail-open shape #405 shipped (null and <c>[]</c> were treated identically, so scoping was
-    /// configured but never actually enforced against a call whose resource usage was simply never
-    /// determined). See <see cref="Domain.AI.Sandbox.ToolCallResourceRequest"/>'s remarks for why
-    /// null vs. empty matters.
-    /// </remarks>
-    private Result? EnforcePathScoping(string toolName, IReadOnlyList<string>? requestedPaths, ToolPermissionProfile profile)
-    {
-        var hasPathScoping = profile.AllowedPaths.Count > 0 || profile.DeniedPaths.Count > 0;
-        if (!hasPathScoping)
-            return null;
-
-        if (requestedPaths is null)
-        {
-            _logger.LogWarning(
-                "Tool {ToolName} has path scoping configured but no requested path could be determined for this call",
-                toolName);
-            return Result.Forbidden(
-                $"Tool '{toolName}' has path scoping configured but no requested path could be determined for this call.");
-        }
-
-        if (requestedPaths.Count > 0 && ValidatePaths(requestedPaths, profile) is { } pathViolation)
-        {
-            _logger.LogWarning("Tool {ToolName} path denied: {Path}", toolName, pathViolation);
-            return Result.Forbidden($"Tool '{toolName}' path denied: {pathViolation}");
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Checks <paramref name="requestedHosts"/> against the profile's host scoping, when any is
-    /// configured. Returns <see langword="null"/> on a pass, or the refusal to return. Mirrors
-    /// <see cref="EnforcePathScoping"/>.
-    /// </summary>
-    private Result? EnforceHostScoping(string toolName, IReadOnlyList<string>? requestedHosts, ToolPermissionProfile profile)
-    {
-        var hasHostScoping = profile.AllowedHosts.Count > 0 || profile.DeniedHosts.Count > 0;
-        if (!hasHostScoping)
-            return null;
-
-        if (requestedHosts is null)
-        {
-            _logger.LogWarning(
-                "Tool {ToolName} has host scoping configured but no requested host could be determined for this call",
-                toolName);
-            return Result.Forbidden(
-                $"Tool '{toolName}' has host scoping configured but no requested host could be determined for this call.");
-        }
-
-        if (requestedHosts.Count > 0 && ValidateHosts(requestedHosts, profile) is { } hostViolation)
-        {
-            _logger.LogWarning("Tool {ToolName} host denied: {Host}", toolName, hostViolation);
-            return Result.Forbidden($"Tool '{toolName}' host denied: {hostViolation}");
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Returns the first requested path that violates <paramref name="profile"/>'s deny/allow lists,
-    /// or <see langword="null"/> if every path is permitted. Deny-overrides-allow: a deny match wins
-    /// even when the same path also matches an allow entry (#418, restored from pre-#405 history).
-    /// </summary>
-    private string? ValidatePaths(IReadOnlyList<string> requestedPaths, ToolPermissionProfile profile)
-    {
-        foreach (var path in requestedPaths)
-        {
-            // A model-supplied path this class cannot safely resolve — one carrying a traversal
-            // pattern, a relative path, or one the runtime rejects outright — is treated as a
-            // violation rather than compared. CI caught the alternative: a naive normalizer silently
-            // dropped a leading ".." instead of resolving it, so "../secrets/creds.txt" matched no
-            // configured boundary at all. CapabilityEnforcer has no base directory of its own to
-            // resolve a relative path against (that is IFileSystemService's own, separately-configured
-            // concern), so refusing outright — mirroring SandboxedPathGuard.ResolveAndValidate's own
-            // first check — is the only answer that cannot be tricked into comparing the wrong path.
-            if (NormalizeRequestedPath(path) is not { } normalized)
-                return path;
-
-            if (IsDeniedPath(normalized, profile))
-                return path;
-
-            if (profile.AllowedPaths.Count > 0 &&
-                !profile.AllowedPaths.Any(allowed => IsPathWithin(normalized, NormalizeBoundary(allowed))))
-            {
-                return path;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Whether <paramref name="normalized"/> falls within any of <paramref name="profile"/>'s denied
-    /// paths. A configured deny entry the runtime cannot normalize is treated as matching every
-    /// candidate, not excluded from the check — unlike an allow entry (see <see cref="NormalizeBoundary"/>),
-    /// treating an unparsable deny entry as "never matches" would silently turn a misconfigured deny
-    /// rule into a no-op instead of the refusal it was written to enforce, which is the fail-open shape
-    /// this whole mechanism exists to prevent.
-    /// </summary>
-    private bool IsDeniedPath(string normalized, ToolPermissionProfile profile)
-    {
-        foreach (var denied in profile.DeniedPaths)
-        {
-            var normalizedDenied = NormalizeAndCanonicalize(denied);
-            if (normalizedDenied is null || IsPathWithin(normalized, normalizedDenied))
-                return true;
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether <paramref name="candidate"/> is the same as, or a descendant of,
-    /// <paramref name="boundary"/>, comparing on path-segment boundaries rather than raw string
-    /// prefixes via <see cref="PathScope.IsSameOrUnderNormalized"/> — the same primitive
-    /// <c>SandboxedPathGuard</c> compares real file access against, so the two cannot disagree about
-    /// which file a path names. Both inputs are expected to be already normalized (and, when a
-    /// canonicalizer is available, link-resolved) via <see cref="NormalizeAndCanonicalize"/>.
-    /// </summary>
-    private static bool IsPathWithin(string candidate, string boundary) =>
-        // An empty boundary (root, fully trimmed) confines everything — preserved as an explicit
-        // case because PathScope.IsSameOrUnderNormalized's own separator-prefixed check does not
-        // reduce to "matches everything" identically on every platform.
-        boundary.Length == 0 || PathScope.IsSameOrUnderNormalized(candidate, boundary);
-
-    /// <summary>
-    /// Normalizes and canonicalizes a model-supplied path for a scoping comparison, refusing
-    /// (returning <see langword="null"/>) rather than guessing when the input carries a traversal
-    /// pattern, is not fully qualified, or the runtime cannot parse it at all.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// A <em>relative</em> path is refused outright, not resolved — CI caught the alternative:
-    /// resolving it against <see cref="PathScope.Normalize"/>'s implicit base (the process's current
-    /// directory) answers a different question than the one that matters, because the tool that
-    /// actually opens the file resolves the identical string against its own, separately-configured
-    /// sandbox base path (<c>SandboxedPathGuard.ResolveRelative</c>) — a base this class has no
-    /// visibility into and no business assuming. The two resolutions can name different files
-    /// entirely, so a relative path is unsafe to compare here at all, exactly like a traversal
-    /// pattern is.
-    /// </para>
-    /// <para>
-    /// The fully-qualified check lives inside <see cref="NormalizeAndCanonicalize"/> itself, applied
-    /// identically to a requested path and a configured boundary — CI caught the alternative: checking
-    /// it only here left a <em>relative</em> <c>DeniedPaths</c>/<c>AllowedPaths</c> config entry to
-    /// silently resolve against the process's CWD via <see cref="PathScope.Normalize"/>, the exact
-    /// fail-open shape this guard exists to prevent, just on the configured side instead of the
-    /// requested side.
-    /// </para>
-    /// </remarks>
-    private string? NormalizeRequestedPath(string path) =>
-        SecureInputValidatorHelper.ValidateFilePath(path) ? NormalizeAndCanonicalize(path) : null;
-
-    /// <summary>
-    /// Normalizes and canonicalizes an operator-configured <em>allow</em> boundary the same way as a
-    /// requested path (#418) — both sides must go through identical treatment, or a boundary reached
-    /// only through a symlink would compare unequal to an already-resolved candidate. Falls back to
-    /// the raw configured string on a normalization failure, which for an allow entry safely excludes
-    /// it (a raw, non-normalized string will not match a normalized candidate) rather than throwing —
-    /// a typo in one operator entry should degrade that one comparison, not take down every call that
-    /// consults the list. Deny entries use the stricter <see cref="IsDeniedPath"/> instead, where the
-    /// same fallback would be fail-open rather than fail-closed.
-    /// </summary>
-    private string NormalizeBoundary(string configuredPath) => NormalizeAndCanonicalize(configuredPath) ?? configuredPath;
-
-    /// <summary>
-    /// Resolves <paramref name="path"/> to its absolute form via <see cref="PathScope.Normalize"/> —
-    /// the same routine <c>SandboxedPathGuard</c> normalizes real file access through, so a genuine
-    /// <c>..</c> segment is actually resolved rather than silently discarded, and platform quirks
-    /// (e.g. a Windows trailing-dot path component) are handled identically on both sides of the
-    /// comparison — then link-resolves through <see cref="_pathCanonicalizer"/> when one is
-    /// registered. Returns <see langword="null"/> on any input that is not already fully qualified
-    /// (checked via <c>Path.IsPathFullyQualified</c>, not <c>Path.IsPathRooted</c> — the latter answers
-    /// <see langword="true"/> for a Windows drive-relative path like <c>"C:secrets\creds.txt"</c>,
-    /// which still resolves against the current directory on that drive, not an absolute location) or
-    /// that the runtime cannot parse at all. Applied to both a requested path and a configured boundary
-    /// identically: neither side has any base directory of its own to resolve a relative path against
-    /// that the other side would agree with.
-    /// </summary>
-    private string? NormalizeAndCanonicalize(string path)
-    {
-        if (!Path.IsPathFullyQualified(path))
-            return null;
-
-        try
-        {
-            var normalized = PathScope.Normalize(path);
-            return _pathCanonicalizer?.Canonicalize(normalized) ?? normalized;
-        }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
-        {
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// Returns the first requested host that violates <paramref name="profile"/>'s deny/allow lists,
-    /// or <see langword="null"/> if every host is permitted. Deny-overrides-allow, mirroring
-    /// <see cref="ValidatePaths"/> (#418, restored from pre-#405 history).
-    /// </summary>
-    private static string? ValidateHosts(IReadOnlyList<string> requestedHosts, ToolPermissionProfile profile)
-    {
-        foreach (var host in requestedHosts)
-        {
-            if (profile.DeniedHosts.Any(denied => HostMatches(host, denied)))
-                return host;
-
-            if (profile.AllowedHosts.Count > 0 &&
-                !profile.AllowedHosts.Any(allowed => HostMatches(host, allowed)))
-            {
-                return host;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Matches <paramref name="host"/> against <paramref name="pattern"/>, which may be an exact host
-    /// name or a <c>*.suffix</c> wildcard. Both sides go through <see cref="NormalizeHostForMatch"/>
-    /// identically — a configured pattern is operator-authored, not attacker-controlled, but a
-    /// port/scheme/whitespace mismatch on that side is just as fail-open as one on the requested host,
-    /// so both are held to the same normalization rather than only the request.
-    /// </summary>
-    private static bool HostMatches(string host, string pattern)
-    {
-        var normalizedHost = NormalizeHostForMatch(host);
-        var normalizedPattern = NormalizeHostForMatch(pattern);
-
-        if (normalizedPattern.StartsWith("*."))
-        {
-            var suffix = normalizedPattern[1..];
-            return normalizedHost.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
-                   || normalizedHost.Equals(normalizedPattern[2..], StringComparison.OrdinalIgnoreCase);
-        }
-
-        return normalizedHost.Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase);
-    }
-
-    /// <summary>
-    /// Reduces a host value — whether a requested host or a configured deny/allow entry — to a bare,
-    /// comparable host name. A value that parses as an absolute URI is reduced via <see cref="Uri.Host"/>
-    /// itself, which correctly drops a scheme, userinfo (<c>user@</c>), port, and path/query in one
-    /// step — <em>not</em> an ad-hoc scan for <c>"://"</c>, which matches the first occurrence anywhere
-    /// in the string rather than only a leading scheme and so can be pointed at an unrelated embedded
-    /// URL later in the value. A value that isn't itself an absolute URI falls back to a trailing-port
-    /// strip and a root-terminating FQDN dot trim. Applying the identical reduction to both sides of a
-    /// <see cref="HostMatches"/> comparison is what keeps an operator's plain <c>"evil.com"</c> entry
-    /// matching every equivalent spelling of that same host a caller might supply.
-    /// </summary>
-    private static string NormalizeHostForMatch(string value)
-    {
-        var trimmed = value.Trim();
-
-        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host))
-            return uri.Host.TrimEnd('.');
-
-        return StripPort(trimmed).TrimEnd('.');
-    }
-
-    /// <summary>
-    /// Strips a trailing <c>:port</c> from <paramref name="host"/>, recognizing the bracketed IPv6
-    /// form (<c>[::1]:443</c>) and leaving a <em>bare</em> IPv6 literal (<c>::1</c>) untouched — more
-    /// than one colon with no brackets is never a host:port pair, so treating the last colon as a
-    /// port separator there would truncate the address itself (<c>::1</c> otherwise becomes <c>:</c>
-    /// and can never match a configured deny/allow entry for it).
-    /// </summary>
-    private static string StripPort(string host)
-    {
-        if (host.StartsWith('['))
-        {
-            var closeBracket = host.IndexOf(']');
-            return closeBracket > 0 ? host[1..closeBracket] : host;
-        }
-
-        if (host.Count(c => c == ':') != 1)
-            return host;
-
-        var colonIndex = host.IndexOf(':');
-        return colonIndex > 0 && host[(colonIndex + 1)..].All(char.IsDigit)
-            ? host[..colonIndex]
-            : host;
     }
 
     private static string FormatMissingCapabilities(ToolCapability missing)

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
@@ -55,64 +55,99 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     {
         var profile = _resolver.Resolve(toolName);
 
+        if (EnforceCapabilities(toolName, grantedCapabilities, profile) is { } capabilityViolation)
+            return Task.FromResult(capabilityViolation);
+
+        if (EnforcePathScoping(toolName, requestedPaths, profile) is { } pathViolation)
+            return Task.FromResult(pathViolation);
+
+        if (EnforceHostScoping(toolName, requestedHosts, profile) is { } hostViolation)
+            return Task.FromResult(hostViolation);
+
+        return Task.FromResult(Result.Success());
+    }
+
+    /// <summary>
+    /// Checks the caller's granted capabilities (narrowed by any per-tool deny override) against the
+    /// tool's requirement. Returns <see langword="null"/> on a pass, or the refusal to return.
+    /// </summary>
+    private Result? EnforceCapabilities(string toolName, ToolCapability grantedCapabilities, ToolPermissionProfile profile)
+    {
         // A tool whose requirement intersects its own per-tool deny is refused outright, not
         // silently let through on a shrunk requirement — see ToolPermissionProfile's remarks (#405).
         var effectivelyGranted = grantedCapabilities & ~profile.DeniedCapabilities;
         var missing = profile.RequiredCapabilities & ~effectivelyGranted;
-        if (missing != ToolCapability.None)
-        {
-            var missingNames = FormatMissingCapabilities(missing);
-            _logger.LogWarning(
-                "Tool {ToolName} requires capabilities not granted: {Missing}",
-                toolName, missingNames);
-            return Task.FromResult(Result.Forbidden(
-                $"Tool '{toolName}' requires capabilities not granted: {missingNames}"));
-        }
+        if (missing == ToolCapability.None)
+            return null;
 
-        // #418: a profile with path/host scoping configured but no requested value to check against
-        // must refuse, not silently allow — this is deliberately NOT `is { Count: > 0 }`, which is
-        // the fail-open shape #405 shipped (null and [] were treated identically, so scoping was
-        // configured but never actually enforced against a call whose resource usage was simply
-        // never determined). See ToolCallResourceRequest's remarks for why null vs. empty matters.
+        var missingNames = FormatMissingCapabilities(missing);
+        _logger.LogWarning("Tool {ToolName} requires capabilities not granted: {Missing}", toolName, missingNames);
+        return Result.Forbidden($"Tool '{toolName}' requires capabilities not granted: {missingNames}");
+    }
+
+    /// <summary>
+    /// Checks <paramref name="requestedPaths"/> against the profile's path scoping, when any is
+    /// configured. Returns <see langword="null"/> on a pass, or the refusal to return.
+    /// </summary>
+    /// <remarks>
+    /// #418: a profile with path scoping configured but no requested value to check against must
+    /// refuse, not silently allow — this is deliberately NOT <c>is { Count: > 0 }</c>, which is the
+    /// fail-open shape #405 shipped (null and <c>[]</c> were treated identically, so scoping was
+    /// configured but never actually enforced against a call whose resource usage was simply never
+    /// determined). See <see cref="Domain.AI.Sandbox.ToolCallResourceRequest"/>'s remarks for why
+    /// null vs. empty matters.
+    /// </remarks>
+    private Result? EnforcePathScoping(string toolName, IReadOnlyList<string>? requestedPaths, ToolPermissionProfile profile)
+    {
         var hasPathScoping = profile.AllowedPaths.Count > 0 || profile.DeniedPaths.Count > 0;
-        if (hasPathScoping)
-        {
-            if (requestedPaths is null)
-            {
-                _logger.LogWarning(
-                    "Tool {ToolName} has path scoping configured but no requested path could be determined for this call",
-                    toolName);
-                return Task.FromResult(Result.Forbidden(
-                    $"Tool '{toolName}' has path scoping configured but no requested path could be determined for this call."));
-            }
+        if (!hasPathScoping)
+            return null;
 
-            if (requestedPaths.Count > 0 && ValidatePaths(requestedPaths, profile) is { } pathViolation)
-            {
-                _logger.LogWarning("Tool {ToolName} path denied: {Path}", toolName, pathViolation);
-                return Task.FromResult(Result.Forbidden($"Tool '{toolName}' path denied: {pathViolation}"));
-            }
+        if (requestedPaths is null)
+        {
+            _logger.LogWarning(
+                "Tool {ToolName} has path scoping configured but no requested path could be determined for this call",
+                toolName);
+            return Result.Forbidden(
+                $"Tool '{toolName}' has path scoping configured but no requested path could be determined for this call.");
         }
 
+        if (requestedPaths.Count > 0 && ValidatePaths(requestedPaths, profile) is { } pathViolation)
+        {
+            _logger.LogWarning("Tool {ToolName} path denied: {Path}", toolName, pathViolation);
+            return Result.Forbidden($"Tool '{toolName}' path denied: {pathViolation}");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Checks <paramref name="requestedHosts"/> against the profile's host scoping, when any is
+    /// configured. Returns <see langword="null"/> on a pass, or the refusal to return. Mirrors
+    /// <see cref="EnforcePathScoping"/>.
+    /// </summary>
+    private Result? EnforceHostScoping(string toolName, IReadOnlyList<string>? requestedHosts, ToolPermissionProfile profile)
+    {
         var hasHostScoping = profile.AllowedHosts.Count > 0 || profile.DeniedHosts.Count > 0;
-        if (hasHostScoping)
-        {
-            if (requestedHosts is null)
-            {
-                _logger.LogWarning(
-                    "Tool {ToolName} has host scoping configured but no requested host could be determined for this call",
-                    toolName);
-                return Task.FromResult(Result.Forbidden(
-                    $"Tool '{toolName}' has host scoping configured but no requested host could be determined for this call."));
-            }
+        if (!hasHostScoping)
+            return null;
 
-            if (requestedHosts.Count > 0 && ValidateHosts(requestedHosts, profile) is { } hostViolation)
-            {
-                _logger.LogWarning("Tool {ToolName} host denied: {Host}", toolName, hostViolation);
-                return Task.FromResult(Result.Forbidden($"Tool '{toolName}' host denied: {hostViolation}"));
-            }
+        if (requestedHosts is null)
+        {
+            _logger.LogWarning(
+                "Tool {ToolName} has host scoping configured but no requested host could be determined for this call",
+                toolName);
+            return Result.Forbidden(
+                $"Tool '{toolName}' has host scoping configured but no requested host could be determined for this call.");
         }
 
-        return Task.FromResult(Result.Success());
+        if (requestedHosts.Count > 0 && ValidateHosts(requestedHosts, profile) is { } hostViolation)
+        {
+            _logger.LogWarning("Tool {ToolName} host denied: {Host}", toolName, hostViolation);
+            return Result.Forbidden($"Tool '{toolName}' host denied: {hostViolation}");
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -125,17 +160,17 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
         foreach (var path in requestedPaths)
         {
             // A model-supplied path this class cannot safely resolve — one carrying a traversal
-            // pattern, or one the runtime rejects outright — is treated as a violation rather than
-            // compared. CI caught the alternative: a naive normalizer silently dropped a leading
-            // ".." instead of resolving it, so "../secrets/creds.txt" matched no configured
-            // boundary at all. CapabilityEnforcer has no base directory of its own to resolve a
-            // relative traversal against (that is IFileSystemService's own, separately-configured
+            // pattern, a relative path, or one the runtime rejects outright — is treated as a
+            // violation rather than compared. CI caught the alternative: a naive normalizer silently
+            // dropped a leading ".." instead of resolving it, so "../secrets/creds.txt" matched no
+            // configured boundary at all. CapabilityEnforcer has no base directory of its own to
+            // resolve a relative path against (that is IFileSystemService's own, separately-configured
             // concern), so refusing outright — mirroring SandboxedPathGuard.ResolveAndValidate's own
             // first check — is the only answer that cannot be tricked into comparing the wrong path.
             if (NormalizeRequestedPath(path) is not { } normalized)
                 return path;
 
-            if (profile.DeniedPaths.Any(denied => IsPathWithin(normalized, NormalizeBoundary(denied))))
+            if (IsDeniedPath(normalized, profile))
                 return path;
 
             if (profile.AllowedPaths.Count > 0 &&
@@ -146,6 +181,26 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="normalized"/> falls within any of <paramref name="profile"/>'s denied
+    /// paths. A configured deny entry the runtime cannot normalize is treated as matching every
+    /// candidate, not excluded from the check — unlike an allow entry (see <see cref="NormalizeBoundary"/>),
+    /// treating an unparsable deny entry as "never matches" would silently turn a misconfigured deny
+    /// rule into a no-op instead of the refusal it was written to enforce, which is the fail-open shape
+    /// this whole mechanism exists to prevent.
+    /// </summary>
+    private bool IsDeniedPath(string normalized, ToolPermissionProfile profile)
+    {
+        foreach (var denied in profile.DeniedPaths)
+        {
+            var normalizedDenied = NormalizeAndCanonicalize(denied);
+            if (normalizedDenied is null || IsPathWithin(normalized, normalizedDenied))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>
@@ -165,9 +220,10 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// <summary>
     /// Normalizes and canonicalizes a model-supplied path for a scoping comparison, refusing
     /// (returning <see langword="null"/>) rather than guessing when the input carries a traversal
-    /// pattern, is not already rooted, or the runtime cannot parse it at all.
+    /// pattern, is not fully qualified, or the runtime cannot parse it at all.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// A <em>relative</em> path is refused outright, not resolved — CI caught the alternative:
     /// resolving it against <see cref="PathScope.Normalize"/>'s implicit base (the process's current
     /// directory) answers a different question than the one that matters, because the tool that
@@ -176,18 +232,28 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// visibility into and no business assuming. The two resolutions can name different files
     /// entirely, so a relative path is unsafe to compare here at all, exactly like a traversal
     /// pattern is.
+    /// </para>
+    /// <para>
+    /// Checked via <c>Path.IsPathFullyQualified</c>, not <c>Path.IsPathRooted</c> — the
+    /// latter answers <see langword="true"/> for a Windows drive-relative path like
+    /// <c>"C:secrets\creds.txt"</c>, which is exactly the CWD-dependent ambiguity this guard exists to
+    /// reject: it still resolves against the current directory on that drive, not an absolute location.
+    /// </para>
     /// </remarks>
     private string? NormalizeRequestedPath(string path) =>
-        Path.IsPathRooted(path) && SecureInputValidatorHelper.ValidateFilePath(path)
+        Path.IsPathFullyQualified(path) && SecureInputValidatorHelper.ValidateFilePath(path)
             ? NormalizeAndCanonicalize(path)
             : null;
 
     /// <summary>
-    /// Normalizes and canonicalizes an operator-configured boundary the same way as a requested path
-    /// (#418) — both sides must go through identical treatment, or a boundary reached only through a
-    /// symlink would compare unequal to an already-resolved candidate. Falls back to the raw
-    /// configured string on a normalization failure rather than refusing: a typo in one operator
-    /// entry should degrade that one comparison, not take down every call that consults the list.
+    /// Normalizes and canonicalizes an operator-configured <em>allow</em> boundary the same way as a
+    /// requested path (#418) — both sides must go through identical treatment, or a boundary reached
+    /// only through a symlink would compare unequal to an already-resolved candidate. Falls back to
+    /// the raw configured string on a normalization failure, which for an allow entry safely excludes
+    /// it (a raw, non-normalized string will not match a normalized candidate) rather than throwing —
+    /// a typo in one operator entry should degrade that one comparison, not take down every call that
+    /// consults the list. Deny entries use the stricter <see cref="IsDeniedPath"/> instead, where the
+    /// same fallback would be fail-open rather than fail-closed.
     /// </summary>
     private string NormalizeBoundary(string configuredPath) => NormalizeAndCanonicalize(configuredPath) ?? configuredPath;
 
@@ -258,9 +324,12 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
 
     /// <summary>
     /// Reduces a host value — whether a requested host or a configured deny/allow entry — to a bare,
-    /// comparable host name: trims whitespace, strips a URL scheme and any path/query that followed it
-    /// (<c>"https://Evil.com/x"</c> → <c>"Evil.com"</c>), strips a trailing port, and trims a
-    /// root-terminating FQDN dot. Applying the identical reduction to both sides of a
+    /// comparable host name. A value that parses as an absolute URI is reduced via <see cref="Uri.Host"/>
+    /// itself, which correctly drops a scheme, userinfo (<c>user@</c>), port, and path/query in one
+    /// step — <em>not</em> an ad-hoc scan for <c>"://"</c>, which matches the first occurrence anywhere
+    /// in the string rather than only a leading scheme and so can be pointed at an unrelated embedded
+    /// URL later in the value. A value that isn't itself an absolute URI falls back to a trailing-port
+    /// strip and a root-terminating FQDN dot trim. Applying the identical reduction to both sides of a
     /// <see cref="HostMatches"/> comparison is what keeps an operator's plain <c>"evil.com"</c> entry
     /// matching every equivalent spelling of that same host a caller might supply.
     /// </summary>
@@ -268,13 +337,8 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     {
         var trimmed = value.Trim();
 
-        var schemeIndex = trimmed.IndexOf("://", StringComparison.Ordinal);
-        if (schemeIndex >= 0)
-            trimmed = trimmed[(schemeIndex + 3)..];
-
-        var slashIndex = trimmed.IndexOf('/');
-        if (slashIndex >= 0)
-            trimmed = trimmed[..slashIndex];
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host))
+            return uri.Host.TrimEnd('.');
 
         return StripPort(trimmed).TrimEnd('.');
     }

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
@@ -8,7 +8,8 @@ namespace Application.AI.Common.Services.Sandbox;
 /// <summary>
 /// Enforces capability-based permission checks by resolving a tool's permission profile and
 /// validating the caller's granted capabilities against it, honoring any per-tool
-/// <see cref="ToolPermissionProfile.DeniedCapabilities"/> override (#405).
+/// <see cref="ToolPermissionProfile.DeniedCapabilities"/> override (#405), and validating any
+/// requested filesystem paths/network hosts against the profile's deny-overrides-allow scoping (#418).
 /// </summary>
 public sealed class CapabilityEnforcer : ICapabilityEnforcer
 {
@@ -38,6 +39,8 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     public Task<Result> EnforceAsync(
         string toolName,
         ToolCapability grantedCapabilities,
+        IReadOnlyList<string>? requestedPaths = null,
+        IReadOnlyList<string>? requestedHosts = null,
         CancellationToken ct = default)
     {
         var profile = _resolver.Resolve(toolName);
@@ -56,7 +59,164 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
                 $"Tool '{toolName}' requires capabilities not granted: {missingNames}"));
         }
 
+        // #418: a profile with path/host scoping configured but no requested value to check against
+        // must refuse, not silently allow — this is deliberately NOT `is { Count: > 0 }`, which is
+        // the fail-open shape #405 shipped (null and [] were treated identically, so scoping was
+        // configured but never actually enforced against a call whose resource usage was simply
+        // never determined). See ToolCallResourceRequest's remarks for why null vs. empty matters.
+        var hasPathScoping = profile.AllowedPaths.Count > 0 || profile.DeniedPaths.Count > 0;
+        if (hasPathScoping)
+        {
+            if (requestedPaths is null)
+            {
+                _logger.LogWarning(
+                    "Tool {ToolName} has path scoping configured but no requested path could be determined for this call",
+                    toolName);
+                return Task.FromResult(Result.Forbidden(
+                    $"Tool '{toolName}' has path scoping configured but no requested path could be determined for this call."));
+            }
+
+            if (requestedPaths.Count > 0 && ValidatePaths(requestedPaths, profile) is { } pathViolation)
+            {
+                _logger.LogWarning("Tool {ToolName} path denied: {Path}", toolName, pathViolation);
+                return Task.FromResult(Result.Forbidden($"Tool '{toolName}' path denied: {pathViolation}"));
+            }
+        }
+
+        var hasHostScoping = profile.AllowedHosts.Count > 0 || profile.DeniedHosts.Count > 0;
+        if (hasHostScoping)
+        {
+            if (requestedHosts is null)
+            {
+                _logger.LogWarning(
+                    "Tool {ToolName} has host scoping configured but no requested host could be determined for this call",
+                    toolName);
+                return Task.FromResult(Result.Forbidden(
+                    $"Tool '{toolName}' has host scoping configured but no requested host could be determined for this call."));
+            }
+
+            if (requestedHosts.Count > 0 && ValidateHosts(requestedHosts, profile) is { } hostViolation)
+            {
+                _logger.LogWarning("Tool {ToolName} host denied: {Host}", toolName, hostViolation);
+                return Task.FromResult(Result.Forbidden($"Tool '{toolName}' host denied: {hostViolation}"));
+            }
+        }
+
         return Task.FromResult(Result.Success());
+    }
+
+    /// <summary>
+    /// Returns the first requested path that violates <paramref name="profile"/>'s deny/allow lists,
+    /// or <see langword="null"/> if every path is permitted. Deny-overrides-allow: a deny match wins
+    /// even when the same path also matches an allow entry (#418, restored from pre-#405 history).
+    /// </summary>
+    private static string? ValidatePaths(IReadOnlyList<string> requestedPaths, ToolPermissionProfile profile)
+    {
+        foreach (var path in requestedPaths)
+        {
+            var normalized = NormalizePath(path);
+
+            if (profile.DeniedPaths.Any(denied => IsPathWithin(normalized, NormalizePath(denied))))
+                return path;
+
+            if (profile.AllowedPaths.Count > 0 &&
+                !profile.AllowedPaths.Any(allowed => IsPathWithin(normalized, NormalizePath(allowed))))
+            {
+                return path;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="candidate"/> is the same as, or a descendant of,
+    /// <paramref name="boundary"/>, comparing on path-segment boundaries rather than raw string
+    /// prefixes. This prevents sibling-directory bypass (e.g. boundary "C:/sandbox/work" must NOT
+    /// match "C:/sandbox/work-evil"). Both inputs are expected to be already normalized via
+    /// <see cref="NormalizePath"/> (slash-separated, no empty/relative segments, no trailing slash).
+    /// </summary>
+    private static bool IsPathWithin(string candidate, string boundary)
+    {
+        // An empty boundary (e.g. root after normalization) confines everything.
+        if (boundary.Length == 0)
+            return true;
+
+        if (candidate.Equals(boundary, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Descendant must start with "boundary/" so the next character is a true segment boundary.
+        return candidate.Length > boundary.Length
+            && candidate[boundary.Length] == '/'
+            && candidate.StartsWith(boundary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Returns the first requested host that violates <paramref name="profile"/>'s deny/allow lists,
+    /// or <see langword="null"/> if every host is permitted. Deny-overrides-allow, mirroring
+    /// <see cref="ValidatePaths"/> (#418, restored from pre-#405 history).
+    /// </summary>
+    private static string? ValidateHosts(IReadOnlyList<string> requestedHosts, ToolPermissionProfile profile)
+    {
+        foreach (var host in requestedHosts)
+        {
+            if (profile.DeniedHosts.Any(denied => HostMatches(host, denied)))
+                return host;
+
+            if (profile.AllowedHosts.Count > 0 &&
+                !profile.AllowedHosts.Any(allowed => HostMatches(host, allowed)))
+            {
+                return host;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Matches <paramref name="host"/> (port stripped) against <paramref name="pattern"/>, which may
+    /// be an exact host name or a <c>*.suffix</c> wildcard.
+    /// </summary>
+    private static bool HostMatches(string host, string pattern)
+    {
+        var normalizedHost = StripPort(host);
+
+        if (pattern.StartsWith("*."))
+        {
+            var suffix = pattern[1..];
+            return normalizedHost.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
+                   || normalizedHost.Equals(pattern[2..], StringComparison.OrdinalIgnoreCase);
+        }
+
+        return normalizedHost.Equals(pattern, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string StripPort(string host)
+    {
+        var colonIndex = host.LastIndexOf(':');
+        return colonIndex > 0 && host[(colonIndex + 1)..].All(char.IsDigit)
+            ? host[..colonIndex]
+            : host;
+    }
+
+    /// <summary>
+    /// Normalizes path separators to <c>/</c> and resolves <c>.</c>/<c>..</c> segments so
+    /// <see cref="IsPathWithin"/> compares like-for-like regardless of how the caller or the config
+    /// wrote a path.
+    /// </summary>
+    private static string NormalizePath(string path)
+    {
+        var segments = path.Replace('\\', '/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        var result = new List<string>();
+        foreach (var segment in segments)
+        {
+            if (segment == ".") continue;
+            if (segment == ".." && result.Count > 0 && result[^1] != "..")
+                result.RemoveAt(result.Count - 1);
+            else if (segment != "..")
+                result.Add(segment);
+        }
+        return string.Join('/', result);
     }
 
     private static string FormatMissingCapabilities(ToolCapability missing)

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.cs
@@ -165,11 +165,22 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     /// <summary>
     /// Normalizes and canonicalizes a model-supplied path for a scoping comparison, refusing
     /// (returning <see langword="null"/>) rather than guessing when the input carries a traversal
-    /// pattern or the runtime cannot parse it at all. See <see cref="ValidatePaths"/>'s remarks for
-    /// why a relative traversal cannot be safely resolved at this layer.
+    /// pattern, is not already rooted, or the runtime cannot parse it at all.
     /// </summary>
+    /// <remarks>
+    /// A <em>relative</em> path is refused outright, not resolved — CI caught the alternative:
+    /// resolving it against <see cref="PathScope.Normalize"/>'s implicit base (the process's current
+    /// directory) answers a different question than the one that matters, because the tool that
+    /// actually opens the file resolves the identical string against its own, separately-configured
+    /// sandbox base path (<c>SandboxedPathGuard.ResolveRelative</c>) — a base this class has no
+    /// visibility into and no business assuming. The two resolutions can name different files
+    /// entirely, so a relative path is unsafe to compare here at all, exactly like a traversal
+    /// pattern is.
+    /// </remarks>
     private string? NormalizeRequestedPath(string path) =>
-        SecureInputValidatorHelper.ValidateFilePath(path) ? NormalizeAndCanonicalize(path) : null;
+        Path.IsPathRooted(path) && SecureInputValidatorHelper.ValidateFilePath(path)
+            ? NormalizeAndCanonicalize(path)
+            : null;
 
     /// <summary>
     /// Normalizes and canonicalizes an operator-configured boundary the same way as a requested path
@@ -224,13 +235,16 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
     }
 
     /// <summary>
-    /// Matches <paramref name="host"/> (port stripped, trailing FQDN dot trimmed) against
-    /// <paramref name="pattern"/>, which may be an exact host name or a <c>*.suffix</c> wildcard.
+    /// Matches <paramref name="host"/> against <paramref name="pattern"/>, which may be an exact host
+    /// name or a <c>*.suffix</c> wildcard. Both sides go through <see cref="NormalizeHostForMatch"/>
+    /// identically — a configured pattern is operator-authored, not attacker-controlled, but a
+    /// port/scheme/whitespace mismatch on that side is just as fail-open as one on the requested host,
+    /// so both are held to the same normalization rather than only the request.
     /// </summary>
     private static bool HostMatches(string host, string pattern)
     {
-        var normalizedHost = StripPort(host).TrimEnd('.');
-        var normalizedPattern = pattern.TrimEnd('.');
+        var normalizedHost = NormalizeHostForMatch(host);
+        var normalizedPattern = NormalizeHostForMatch(pattern);
 
         if (normalizedPattern.StartsWith("*."))
         {
@@ -240,6 +254,29 @@ public sealed class CapabilityEnforcer : ICapabilityEnforcer
         }
 
         return normalizedHost.Equals(normalizedPattern, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Reduces a host value — whether a requested host or a configured deny/allow entry — to a bare,
+    /// comparable host name: trims whitespace, strips a URL scheme and any path/query that followed it
+    /// (<c>"https://Evil.com/x"</c> → <c>"Evil.com"</c>), strips a trailing port, and trims a
+    /// root-terminating FQDN dot. Applying the identical reduction to both sides of a
+    /// <see cref="HostMatches"/> comparison is what keeps an operator's plain <c>"evil.com"</c> entry
+    /// matching every equivalent spelling of that same host a caller might supply.
+    /// </summary>
+    private static string NormalizeHostForMatch(string value)
+    {
+        var trimmed = value.Trim();
+
+        var schemeIndex = trimmed.IndexOf("://", StringComparison.Ordinal);
+        if (schemeIndex >= 0)
+            trimmed = trimmed[(schemeIndex + 3)..];
+
+        var slashIndex = trimmed.IndexOf('/');
+        if (slashIndex >= 0)
+            trimmed = trimmed[..slashIndex];
+
+        return StripPort(trimmed).TrimEnd('.');
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -86,7 +86,8 @@ public sealed class ToolPermissionProfileResolver
     public ToolPermissionProfile Resolve(string toolName)
     {
         var (baseCapabilities, baseIsolation) = ResolveBase(toolName);
-        var (deniedCaps, effectiveIsolation) = ResolveOverride(toolName, baseIsolation);
+        _config.CurrentValue.ToolOverrides.TryGetValue(toolName, out var overrideConfig);
+        var (deniedCaps, effectiveIsolation) = ResolveOverride(overrideConfig, baseIsolation);
 
         return new ToolPermissionProfile
         {
@@ -94,12 +95,19 @@ public sealed class ToolPermissionProfileResolver
             // ToolPermissionProfile.EffectiveCapabilities for the value consumers should read.
             RequiredCapabilities = baseCapabilities,
             DeniedCapabilities = deniedCaps,
-            MinimumIsolation = effectiveIsolation
+            MinimumIsolation = effectiveIsolation,
+            // Path/host scoping (#418) has no "base declaration" the way capabilities and isolation
+            // do — a tool never declares its own allow/deny boundaries, only an operator does via
+            // config — so this is a straight passthrough of the override, not a merge.
+            DeniedPaths = overrideConfig?.DeniedPaths ?? [],
+            AllowedPaths = overrideConfig?.AllowedPaths ?? [],
+            DeniedHosts = overrideConfig?.DeniedHosts ?? [],
+            AllowedHosts = overrideConfig?.AllowedHosts ?? []
         };
     }
 
     /// <summary>
-    /// Parses <paramref name="toolName"/>'s <see cref="ToolOverrideConfig"/>, if any, into a
+    /// Parses <paramref name="overrideConfig"/>, if any, into a
     /// <c>DeniedCapabilities</c> value and an isolation floor merged with <paramref name="baseIsolation"/>
     /// — the override-parsing logic shared by <see cref="Resolve"/> and
     /// <see cref="ResolveForUngovernedDispatch"/>, factored out so the latter no longer needs a second
@@ -107,10 +115,9 @@ public sealed class ToolPermissionProfileResolver
     /// real keyed-DI resolution, not a dictionary read, so the duplicate lookup was a real, if small,
     /// per-call cost on a hot dispatch path).
     /// </summary>
-    private (ToolCapability DeniedCapabilities, SandboxIsolationLevel EffectiveIsolation) ResolveOverride(
-        string toolName, SandboxIsolationLevel baseIsolation)
+    private static (ToolCapability DeniedCapabilities, SandboxIsolationLevel EffectiveIsolation) ResolveOverride(
+        ToolOverrideConfig? overrideConfig, SandboxIsolationLevel baseIsolation)
     {
-        _config.CurrentValue.ToolOverrides.TryGetValue(toolName, out var overrideConfig);
         if (overrideConfig is null)
             return (ToolCapability.None, baseIsolation);
 
@@ -223,7 +230,8 @@ public sealed class ToolPermissionProfileResolver
         }
 
         var baseIsolation = firstPartyTool?.MinimumIsolation ?? SandboxIsolationLevel.None;
-        var (deniedCaps, overrideIsolation) = ResolveOverride(toolName, baseIsolation);
+        _config.CurrentValue.ToolOverrides.TryGetValue(toolName, out var overrideConfig);
+        var (deniedCaps, overrideIsolation) = ResolveOverride(overrideConfig, baseIsolation);
 
         var denied = requiredCapabilities & deniedCaps;
         if (denied != ToolCapability.None)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/AIToolConverter.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/AIToolConverter.cs
@@ -30,6 +30,18 @@ namespace Application.AI.Common.Services.Tools;
 /// </remarks>
 public sealed class AIToolConverter : IToolConverter
 {
+    /// <summary>
+    /// The wire-format argument name for the operation string. Published so
+    /// <see cref="GovernedAIFunction"/> can read it off the raw <c>AIFunctionArguments</c> — before
+    /// this class's own <c>AIFunctionFactory</c>-generated binding runs — to extract a call's
+    /// requested paths/hosts (#418), the same acknowledged coupling to this converter's wire shape
+    /// <see cref="GovernedAIFunction"/> already has via <see cref="ConvertedToolFailure"/>.
+    /// </summary>
+    internal const string OperationArgumentName = "operation";
+
+    /// <summary>The wire-format argument name for the JSON-encoded operation parameters. See <see cref="OperationArgumentName"/>.</summary>
+    internal const string ParametersJsonArgumentName = "parametersJson";
+
     private readonly ILogger<AIToolConverter> _logger;
 
     /// <summary>
@@ -66,8 +78,8 @@ public sealed class AIToolConverter : IToolConverter
             .AddPurpose(tool.Description)
             .AddOperations(activeOperations)
             .AddParameters(
-                ("operation", Required: true, $"One of: {string.Join(", ", activeOperations)}"),
-                ("parametersJson", Required: false, "Object containing operation-specific arguments (e.g. {\"path\": \"src\", \"search_term\": \"foo\"})"))
+                (OperationArgumentName, Required: true, $"One of: {string.Join(", ", activeOperations)}"),
+                (ParametersJsonArgumentName, Required: false, "Object containing operation-specific arguments (e.g. {\"path\": \"src\", \"search_term\": \"foo\"})"))
             .Build();
 
         var aiFunction = AIFunctionFactory.Create(

--- a/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/DirectToolInvoker.cs
@@ -157,24 +157,11 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
         using var deadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         deadline.CancelAfter(effectiveTimeout);
 
-        // Parameters are passed for the same reason the agent path passes them: if a verdict is routed
-        // to a human, approving a bare tool name tells them nothing. This is the surface most exposed
-        // to external callers, so it is the one where an approver most needs to see what they are
-        // signing off on.
-        var admission = await armed.AdmissionPipeline
-            .AdmitAsync(
-                new ToolCallAdmissionRequest(
-                    armed.ToolName, armed.Request.Parameters, CountsTowardLoopDetection: false),
-                deadline.Token)
-            .ConfigureAwait(false);
-
-        if (!admission.IsAllowed)
-        {
-            // The chain's message is already scrubbed for consumption outside the host — rule ids,
-            // paths and policy internals stay in the trace and the structured log.
-            return Refused(DirectToolInvocationStatus.Denied, admission.DeniedMessage!, sw);
-        }
-
+        // Resolved before admission (#418), not after as before: ICapabilityEnforcer.EnforceAsync
+        // needs this call's requested paths/hosts, extracted from armed.Request against the tool's
+        // own ResourceParametersByOperation declaration — which requires the tool itself. Resolving
+        // once and reusing the same reference for both extraction and execution below also removes
+        // what used to be a second keyed-DI lookup for the identical tool.
         var tool = armed.Scope.ServiceProvider.GetKeyedService<ITool>(armed.ToolName);
         if (tool is null)
         {
@@ -183,6 +170,26 @@ public sealed partial class DirectToolInvoker : IDirectToolInvoker
             // it cannot build.
             _logger.LogWarning("Tool {ToolName} is cataloged but did not resolve for invocation", armed.ToolName);
             return Refused(DirectToolInvocationStatus.NotFound, DirectToolInvocationErrors.NoSuchTool, sw);
+        }
+
+        // Parameters are passed for the same reason the agent path passes them: if a verdict is routed
+        // to a human, approving a bare tool name tells them nothing. This is the surface most exposed
+        // to external callers, so it is the one where an approver most needs to see what they are
+        // signing off on.
+        var admission = await armed.AdmissionPipeline
+            .AdmitAsync(
+                new ToolCallAdmissionRequest(
+                    armed.ToolName, armed.Request.Parameters, CountsTowardLoopDetection: false,
+                    ResourceRequest: ResourceParameterExtractor.Extract(
+                        armed.Request.Operation, armed.Request.Parameters, tool.ResourceParametersByOperation)),
+                deadline.Token)
+            .ConfigureAwait(false);
+
+        if (!admission.IsAllowed)
+        {
+            // The chain's message is already scrubbed for consumption outside the host — rule ids,
+            // paths and policy internals stay in the trace and the structured log.
+            return Refused(DirectToolInvocationStatus.Denied, admission.DeniedMessage!, sw);
         }
 
         ToolResult result;

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -188,12 +188,29 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
         };
     }
 
+    /// <summary>
+    /// Reads the raw <c>parametersJson</c> argument, accepting both shapes <see cref="ReadOperation"/>
+    /// already does — a plain CLR <see cref="string"/> or a <see cref="JsonElement"/> — rather than
+    /// only the latter. A caller outside the standard Microsoft.Extensions.AI pipeline (which always
+    /// supplies a <see cref="JsonElement"/>) that put a raw string here would otherwise silently lose
+    /// it: <c>null</c> here becomes <c>ToolCallResourceRequest.Empty</c> via <see cref="ToolParameters.FromJson"/>
+    /// and <see cref="ResourceParameterExtractor.Extract"/>, which <c>CapabilityEnforcer</c> trusts as
+    /// "determined, and there is none" and skips validating — the exact null-vs-empty conflation this
+    /// whole mechanism exists to prevent, reintroduced one level up. Re-wrapping a string as a
+    /// <see cref="JsonElement"/> costs nothing extra: <see cref="ToolParameters.FromJson"/> already
+    /// parses a string-valued element as JSON (its own double-encoded-string handling).
+    /// </summary>
     private static JsonElement? ReadParametersJson(AIFunctionArguments arguments)
     {
         if (!arguments.TryGetValue(AIToolConverter.ParametersJsonArgumentName, out var value))
             return null;
 
-        return value as JsonElement?;
+        return value switch
+        {
+            JsonElement je => je,
+            string s => JsonSerializer.SerializeToElement(s),
+            _ => null
+        };
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -89,7 +89,8 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
         var admission = await admissionPipeline
             .AdmitAsync(
                 new ToolCallAdmissionRequest(
-                    Name, arguments, CountsTowardLoopDetection: true, CompositionTaint: _compositionTaint),
+                    Name, arguments, CountsTowardLoopDetection: true, CompositionTaint: _compositionTaint,
+                    ResourceRequest: ExtractResourceRequest(arguments)),
                 cancellationToken)
             .ConfigureAwait(false);
 
@@ -145,6 +146,54 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
         return await admissionPipeline
             .ApplyOutputPolicyAsync(admission, Name, Unwrap(result), CancellationToken.None)
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Extracts this call's requested paths/hosts (#418), when the wrapped function is a
+    /// <see cref="ResourceParameterDeclaringAIFunction"/> — i.e. the underlying tool declared which
+    /// of its named parameters are paths/hosts (<c>ITool.ResourceParametersByOperation</c>). Returns
+    /// <see langword="null"/> for every other tool, which <c>ICapabilityEnforcer.EnforceAsync</c>
+    /// only treats as significant when the tool's profile has path/host scoping configured at all —
+    /// see <c>Domain.AI.Sandbox.ToolCallResourceRequest</c>'s remarks.
+    /// </summary>
+    /// <remarks>
+    /// Reads <paramref name="arguments"/> directly, before the wrapped function's own
+    /// <c>AIFunctionFactory</c>-generated binding runs — the same raw dictionary
+    /// <c>AIToolConverter</c>'s wire format populates (<c>operation</c> as a string,
+    /// <c>parametersJson</c> as a <see cref="JsonElement"/>?), confirmed against this repo's own
+    /// <c>AIToolConverterTests</c> regression coverage for exactly these two keys. Read defensively
+    /// regardless: <paramref name="arguments"/> is a plain <c>object?</c> dictionary with no
+    /// compile-time guarantee of either shape.
+    /// </remarks>
+    private Domain.AI.Sandbox.ToolCallResourceRequest? ExtractResourceRequest(AIFunctionArguments arguments)
+    {
+        if (InnerFunction is not ResourceParameterDeclaringAIFunction resourceDeclaring)
+            return null;
+
+        var operation = ReadOperation(arguments);
+        var parameters = ToolParameters.FromJson(ReadParametersJson(arguments));
+        return ResourceParameterExtractor.Extract(operation, parameters, resourceDeclaring.ResourceParametersByOperation);
+    }
+
+    private static string? ReadOperation(AIFunctionArguments arguments)
+    {
+        if (!arguments.TryGetValue(AIToolConverter.OperationArgumentName, out var value))
+            return null;
+
+        return value switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+            _ => null
+        };
+    }
+
+    private static JsonElement? ReadParametersJson(AIFunctionArguments arguments)
+    {
+        if (!arguments.TryGetValue(AIToolConverter.ParametersJsonArgumentName, out var value))
+            return null;
+
+        return value as JsonElement?;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterDeclaringAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterDeclaringAIFunction.cs
@@ -1,0 +1,48 @@
+using Application.AI.Common.Interfaces.Tools;
+using Domain.AI.Sandbox;
+using Microsoft.Extensions.AI;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// Pure passthrough wrapper that carries an <see cref="ITool"/>'s
+/// <see cref="Application.AI.Common.Interfaces.Tools.ITool.ResourceParametersByOperation"/>
+/// declaration forward onto the converted <see cref="AIFunction"/>, so
+/// <see cref="GovernedAIFunction"/> can find it regardless of which <c>IToolConverter</c> produced
+/// the function (#418).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Applied once, at <c>ToolChainBuilder.ResolveToolByName</c> — the one place a raw <see cref="ITool"/>
+/// and its just-converted <see cref="AIFunction"/> are both in hand. Converter-agnostic by design:
+/// it wraps whatever <see cref="AIFunction"/> a converter produced rather than requiring the
+/// converter itself to know about resource-parameter declarations, so a future tool-specific
+/// (priority-100) converter gets this for free.
+/// </para>
+/// <para>
+/// Survives <c>ToolChainBuilder.ApplyCompositionTaint</c>'s later re-wrap unchanged: that re-wrap
+/// constructs a new <c>GovernedAIFunction</c> around the existing <c>GovernedAIFunction.Inner</c> —
+/// the same instance of this class — so the map is never lost or duplicated across that step. Never
+/// collides with <see cref="McpFailureNormalizingAIFunction"/>: MCP-sourced tools never flow through
+/// <c>ResolveToolByName</c>, the only place this wrapper is ever applied.
+/// </para>
+/// </remarks>
+internal sealed class ResourceParameterDeclaringAIFunction : DelegatingAIFunction
+{
+    /// <summary>The wrapped tool's per-operation resource-parameter declaration.</summary>
+    public IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>> ResourceParametersByOperation { get; }
+
+    /// <param name="innerFunction">The already-converted function to wrap.</param>
+    /// <param name="resourceParametersByOperation">
+    /// The declaring tool's <c>ResourceParametersByOperation</c> — must be non-empty; the caller
+    /// (<c>ToolChainBuilder</c>) only wraps when the tool actually declares something.
+    /// </param>
+    public ResourceParameterDeclaringAIFunction(
+        AIFunction innerFunction,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>> resourceParametersByOperation)
+        : base(innerFunction)
+    {
+        ArgumentNullException.ThrowIfNull(resourceParametersByOperation);
+        ResourceParametersByOperation = resourceParametersByOperation;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterExtractor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterExtractor.cs
@@ -1,0 +1,68 @@
+using Domain.AI.Sandbox;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// The single routine that turns a tool's own <c>ResourceParametersByOperation</c> declaration plus
+/// one call's already-flattened parameters into a <see cref="ToolCallResourceRequest"/> — shared by
+/// both entry points a tool call reaches governance from (#418): the agent-turn path
+/// (<see cref="GovernedAIFunction"/>, which flattens its raw JSON arguments first) and the
+/// direct-invoke HTTP path (<c>DirectToolInvoker</c>, whose parameters are already flat).
+/// </summary>
+public static class ResourceParameterExtractor
+{
+    /// <summary>
+    /// Extracts the requested paths/hosts for one tool call.
+    /// </summary>
+    /// <param name="operation">The operation this call names, or <see langword="null"/> if unreadable.</param>
+    /// <param name="parameters">The call's already-flattened parameters, or <see langword="null"/>.</param>
+    /// <param name="resourceParametersByOperation">
+    /// The tool's own declaration (<c>ITool.ResourceParametersByOperation</c>).
+    /// </param>
+    /// <returns>
+    /// <see langword="null"/> when the tool declares nothing, or <paramref name="operation"/> could
+    /// not be read — resource usage for this call is unknown, and <c>CapabilityEnforcer</c> must
+    /// treat that as a reason to refuse when scoping is configured, not as "nothing to check".
+    /// <see cref="ToolCallResourceRequest.Empty"/> when the tool declares resource parameters for
+    /// OTHER operations but affirmatively declares none for this one. Otherwise the paths/hosts found
+    /// among <paramref name="parameters"/> for this operation's declared keys.
+    /// </returns>
+    public static ToolCallResourceRequest? Extract(
+        string? operation,
+        IReadOnlyDictionary<string, object?>? parameters,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>? resourceParametersByOperation)
+    {
+        if (resourceParametersByOperation is not { Count: > 0 } declaredByOperation)
+            return null;
+
+        if (operation is null)
+            return null;
+
+        if (!declaredByOperation.TryGetValue(operation, out var declaredParameters) || declaredParameters.Count == 0)
+            return ToolCallResourceRequest.Empty;
+
+        var paths = new List<string>();
+        var hosts = new List<string>();
+
+        foreach (var (parameterName, kind) in declaredParameters)
+        {
+            if (parameters is null || !parameters.TryGetValue(parameterName, out var value))
+                continue;
+
+            if (value is not string { Length: > 0 } text)
+                continue;
+
+            switch (kind)
+            {
+                case ResourceParameterKind.Path:
+                    paths.Add(text);
+                    break;
+                case ResourceParameterKind.Host:
+                    hosts.Add(text);
+                    break;
+            }
+        }
+
+        return new ToolCallResourceRequest(paths, hosts);
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterExtractor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterExtractor.cs
@@ -38,7 +38,7 @@ public static class ResourceParameterExtractor
         if (operation is null)
             return null;
 
-        if (!declaredByOperation.TryGetValue(operation, out var declaredParameters) || declaredParameters.Count == 0)
+        if (!TryFindDeclaration(declaredByOperation, operation, out var declaredParameters) || declaredParameters.Count == 0)
             return ToolCallResourceRequest.Empty;
 
         var paths = new List<string>();
@@ -64,5 +64,40 @@ public static class ResourceParameterExtractor
         }
 
         return new ToolCallResourceRequest(paths, hosts);
+    }
+
+    /// <summary>
+    /// Looks up <paramref name="operation"/> in <paramref name="declaredByOperation"/>, matching
+    /// case-insensitively so a casing difference can never downgrade a genuinely-declared operation
+    /// to "affirmatively nothing scoped" (<see cref="ToolCallResourceRequest.Empty"/>) — which
+    /// <see cref="Application.AI.Common.Services.Sandbox.CapabilityEnforcer"/> treats as trusted and
+    /// skips validating. Every other stage that admits an operation name — <c>AIToolConverter</c>'s
+    /// operation validation and <c>DirectToolInvoker</c>'s — accepts it case-insensitively, and
+    /// <c>FileSystemTool.ExecuteAsync</c> itself dispatches via <c>ToLowerInvariant()</c>; an
+    /// ordinal-only lookup here was the one link in that chain that disagreed, letting
+    /// <c>operation: "Read"</c> bypass a <c>DeniedPaths</c> configured for <c>"read"</c> entirely.
+    /// </summary>
+    private static bool TryFindDeclaration(
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>> declaredByOperation,
+        string operation,
+        out IReadOnlyDictionary<string, ResourceParameterKind> declaredParameters)
+    {
+        if (declaredByOperation.TryGetValue(operation, out var exact))
+        {
+            declaredParameters = exact;
+            return true;
+        }
+
+        foreach (var (key, value) in declaredByOperation)
+        {
+            if (string.Equals(key, operation, StringComparison.OrdinalIgnoreCase))
+            {
+                declaredParameters = value;
+                return true;
+            }
+        }
+
+        declaredParameters = new Dictionary<string, ResourceParameterKind>();
+        return false;
     }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -831,10 +831,22 @@ public partial class ToolChainBuilder : IToolChainBuilder
         {
             var converted = _toolConverter.Convert(tool);
             if (converted != null)
-                return [converted];
+                return [AttachResourceParameters(converted, tool)];
         }
 
         _logger.LogWarning("Tool {ToolName} found in keyed DI but no IToolConverter available to convert it", toolName);
         return [];
     }
+
+    /// <summary>
+    /// Wraps <paramref name="converted"/> in a <see cref="ResourceParameterDeclaringAIFunction"/> when
+    /// <paramref name="tool"/> declares any resource parameters (#418) — the one place a raw
+    /// <see cref="ITool"/> and its converted <see cref="AITool"/> are both in hand, so this is the only
+    /// call site that needs to know about the declaration at all. A tool that declares nothing is
+    /// returned unwrapped, unchanged from before this feature existed.
+    /// </summary>
+    private static AITool AttachResourceParameters(AITool converted, ITool tool) =>
+        converted is AIFunction fn && tool.ResourceParametersByOperation is { Count: > 0 } map
+            ? new ResourceParameterDeclaringAIFunction(fn, map)
+            : converted;
 }

--- a/src/Content/Domain/Domain.AI/Sandbox/ResourceParameterKind.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/ResourceParameterKind.cs
@@ -1,0 +1,16 @@
+namespace Domain.AI.Sandbox;
+
+/// <summary>
+/// What a tool operation's named parameter represents, for the per-tool path/host capability
+/// scoping <see cref="ToolPermissionProfile"/> carries (#418). Deliberately narrow — this is not a
+/// general parameter-type system, only the two resource kinds <see cref="ToolPermissionProfile"/>
+/// has allow/deny lists for.
+/// </summary>
+public enum ResourceParameterKind
+{
+    /// <summary>The parameter's value is a filesystem path.</summary>
+    Path,
+
+    /// <summary>The parameter's value is a network host (optionally with a port).</summary>
+    Host
+}

--- a/src/Content/Domain/Domain.AI/Sandbox/ToolCallResourceRequest.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/ToolCallResourceRequest.cs
@@ -1,0 +1,35 @@
+namespace Domain.AI.Sandbox;
+
+/// <summary>
+/// The paths and hosts one tool call actually requested, extracted from its arguments before
+/// <c>ICapabilityEnforcer.EnforceAsync</c> runs (#418).
+/// </summary>
+/// <remarks>
+/// <strong>This type itself being <see langword="null"/> versus <see cref="Empty"/> is
+/// load-bearing</strong> at every call site that carries it (<c>ToolCallAdmissionRequest</c>,
+/// <c>IToolInvocationGovernor.AuthorizeAsync</c>, <c>ICapabilityEnforcer.EnforceAsync</c>):
+/// <list type="bullet">
+///   <item><description>
+///     <see langword="null"/> means this call's resource usage could not be determined — the tool
+///     declared resource parameters but the call's shape couldn't be read, or the call reached
+///     enforcement through a path that never extracts one at all. When the tool's
+///     <c>ToolPermissionProfile</c> has any path/deny scoping configured, this must refuse the
+///     call rather than silently let it through — see <c>CapabilityEnforcer.EnforceAsync</c>'s
+///     remarks for why treating "unknown" as "nothing" was the exact class of bug #405 shipped.
+///   </description></item>
+///   <item><description>
+///     <see cref="Empty"/> means resource usage was genuinely determined and there is none — the
+///     tool affirmatively declared this operation touches nothing scoped. This is the tool's own
+///     trust boundary, the same model <c>ITool.RequiredCapabilities</c> already uses.
+///   </description></item>
+/// </list>
+/// </remarks>
+/// <param name="RequestedPaths">Filesystem paths this call named, in the order they appeared.</param>
+/// <param name="RequestedHosts">Network hosts this call named, in the order they appeared.</param>
+public sealed record ToolCallResourceRequest(
+    IReadOnlyList<string> RequestedPaths,
+    IReadOnlyList<string> RequestedHosts)
+{
+    /// <summary>Resource usage was determined, and this call touches no scoped path or host.</summary>
+    public static readonly ToolCallResourceRequest Empty = new([], []);
+}

--- a/src/Content/Domain/Domain.AI/Sandbox/ToolPermissionProfile.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/ToolPermissionProfile.cs
@@ -42,4 +42,29 @@ public sealed record ToolPermissionProfile
     /// The capability enforcer will never downgrade below this level.
     /// </summary>
     public SandboxIsolationLevel MinimumIsolation { get; init; } = SandboxIsolationLevel.Process;
+
+    /// <summary>
+    /// Filesystem-path boundaries a requested path must fall within, when non-empty. Deny-overrides-allow:
+    /// checked before <see cref="AllowedPaths"/>, and a match here refuses the call regardless of any
+    /// allow entry. See <c>CapabilityEnforcer.EnforceAsync</c> for the matching algorithm (#418).
+    /// </summary>
+    public IReadOnlyList<string> DeniedPaths { get; init; } = [];
+
+    /// <summary>
+    /// Filesystem-path boundaries a requested path must fall within. Empty means unrestricted
+    /// (subject to <see cref="DeniedPaths"/>) — only a non-empty list requires membership (#418).
+    /// </summary>
+    public IReadOnlyList<string> AllowedPaths { get; init; } = [];
+
+    /// <summary>
+    /// Network-host patterns (exact or <c>*.suffix</c> wildcard) a requested host must match, when
+    /// non-empty. Deny-overrides-allow, mirroring <see cref="DeniedPaths"/>/<see cref="AllowedPaths"/> (#418).
+    /// </summary>
+    public IReadOnlyList<string> DeniedHosts { get; init; } = [];
+
+    /// <summary>
+    /// Network-host patterns a requested host must match. Empty means unrestricted (subject to
+    /// <see cref="DeniedHosts"/>) — only a non-empty list requires membership (#418).
+    /// </summary>
+    public IReadOnlyList<string> AllowedHosts { get; init; } = [];
 }

--- a/src/Content/Domain/Domain.AI/Sandbox/ToolPermissionProfile.cs
+++ b/src/Content/Domain/Domain.AI/Sandbox/ToolPermissionProfile.cs
@@ -46,7 +46,13 @@ public sealed record ToolPermissionProfile
     /// <summary>
     /// Filesystem-path boundaries a requested path must fall within, when non-empty. Deny-overrides-allow:
     /// checked before <see cref="AllowedPaths"/>, and a match here refuses the call regardless of any
-    /// allow entry. See <c>CapabilityEnforcer.EnforceAsync</c> for the matching algorithm (#418).
+    /// allow entry — in EITHER direction: the requested path falling under a denied boundary, or a
+    /// denied boundary sitting under the requested path. The latter direction matters for a
+    /// subtree-reading operation (e.g. <c>file_system</c>'s <c>search</c>/<c>list</c>, which walk
+    /// everything beneath the single declared path argument) — without it, naming an ANCESTOR of a
+    /// denied directory would silently read through the deny rather than triggering it, because the
+    /// one string this profile validates was never itself inside the denied boundary. See
+    /// <c>CapabilityEnforcer.EnforceAsync</c> for the matching algorithm (#418).
     /// </summary>
     public IReadOnlyList<string> DeniedPaths { get; init; } = [];
 

--- a/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
@@ -34,4 +34,16 @@ public sealed class ToolOverrideConfig
 
     /// <summary>Per-tool execution timeout override in seconds. Null uses system default.</summary>
     public int? TimeoutSeconds { get; init; }
+
+    /// <summary>Filesystem-path boundaries to deny (#418). Checked before <see cref="AllowedPaths"/>.</summary>
+    public List<string> DeniedPaths { get; init; } = [];
+
+    /// <summary>Filesystem-path boundaries a requested path must fall within, when non-empty (#418).</summary>
+    public List<string> AllowedPaths { get; init; } = [];
+
+    /// <summary>Network-host patterns to deny (#418, exact or <c>*.suffix</c> wildcard). Checked before <see cref="AllowedHosts"/>.</summary>
+    public List<string> DeniedHosts { get; init; } = [];
+
+    /// <summary>Network-host patterns a requested host must match, when non-empty (#418).</summary>
+    public List<string> AllowedHosts { get; init; } = [];
 }

--- a/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
@@ -5,11 +5,34 @@ namespace Domain.Common.Config.AI.Sandbox;
 /// <c>ITool.RequiredCapabilities</c> declaration.
 /// </summary>
 /// <remarks>
+/// <para>
 /// <see cref="DeniedCapabilities"/> genuinely restricts the tool (#405): it is kept apart from
 /// the tool's own declaration on <c>ToolPermissionProfile.RequiredCapabilities</c> and only
 /// narrows what <c>CapabilityEnforcer</c> will grant and what
 /// <c>ToolPermissionProfile.EffectiveCapabilities</c> — the value sandbox provisioning reads —
 /// resolves to. It cannot restrict a tool that never runs through the sandbox.
+/// </para>
+/// <para>
+/// <see cref="DeniedPaths"/>/<see cref="AllowedPaths"/>/<see cref="DeniedHosts"/>/<see cref="AllowedHosts"/>
+/// (#418) carry the identical limitation on two further paths, tracked for follow-up rather than
+/// covered by #418 itself:
+/// </para>
+/// <list type="bullet">
+/// <item><description>
+/// <c>ToolPermissionProfileResolver.ResolveForUngovernedDispatch</c> — used by whole-shell-command
+/// tools like <c>WorkspaceCommandRunner</c>/<c>IacSandboxRunner</c> that bypass
+/// <c>ICapabilityEnforcer</c> entirely — never copies these four fields onto the profile it returns,
+/// so configuring them against a tool reached only through that path is silently inert.
+/// </description></item>
+/// <item><description>
+/// The plan/DAG executor (<c>ToolUseStepExecutor</c>) admits a step's tool call without extracting a
+/// <c>ToolCallResourceRequest</c> the way <c>GovernedAIFunction</c> and <c>DirectToolInvoker</c> both
+/// do (#418 only wired those two entry points). Configuring path/host scoping for a tool ALSO
+/// reachable from a plan step therefore fails that step outright — <c>CapabilityEnforcer</c>'s own
+/// fail-closed design (a configured scope with no determined request refuses) has no way to
+/// distinguish "unknown" from "this admission path was never taught to ask" here.
+/// </description></item>
+/// </list>
 /// </remarks>
 public sealed class ToolOverrideConfig
 {

--- a/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
@@ -30,7 +30,7 @@ namespace Domain.Common.Config.AI.Sandbox;
 /// do (#418 only wired those two entry points). Configuring path/host scoping for a tool ALSO
 /// reachable from a plan step therefore fails that step outright — <c>CapabilityEnforcer</c>'s own
 /// fail-closed design (a configured scope with no determined request refuses) has no way to
-/// distinguish "unknown" from "this admission path was never taught to ask" here.
+/// distinguish "unknown" from "this admission path was never taught to ask" here. Tracked as #587.
 /// </description></item>
 /// </list>
 /// </remarks>

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.Tools.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Observability;
 using Application.AI.Common.Interfaces.RAG;
+using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Azure.AI.Agents.Persistent;
 using Azure.AI.OpenAI;
@@ -55,6 +56,11 @@ public static partial class DependencyInjection
                 sp.GetRequiredService<ILogger<FileSystemService>>(),
                 allowedBasePaths,
                 protectedPaths));
+
+        // #418: lets CapabilityEnforcer (Application layer, no filesystem access of its own) resolve
+        // symlinks/junctions the same way SandboxedPathGuard does, so a DeniedPaths/AllowedPaths
+        // comparison cannot be defeated by a link the sandbox itself would follow.
+        services.AddSingleton<IPathCanonicalizer, FileSystemPathCanonicalizer>();
 
         // Boot-time assertion that the governance-state directory does not sit inside an allowed
         // base path. That geometry is a misconfiguration worth refusing on, but note what it does

--- a/src/Content/Infrastructure/Infrastructure.AI/Iac/IacSandboxRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Iac/IacSandboxRunner.cs
@@ -28,10 +28,12 @@ namespace Infrastructure.AI.Iac;
 /// the single source of truth this runner used to duplicate as a hardcoded literal (#387). Network
 /// access is scoped to the provider/module registries via the egress preflight below
 /// (<see cref="SandboxExecutionRequest.EgressPrecheckTargets"/>), not via the permission profile.
-/// The module directory itself is not part of the profile at all — the profile's old
-/// <c>AllowedPaths</c>/<c>DeniedPaths</c>/<c>AllowedHosts</c>/<c>DeniedHosts</c> were removed as
-/// dead config (#405): nothing on this dispatch path (which bypasses
-/// <c>CapabilityEnforcer</c> entirely, see below) ever read them.
+/// The module directory itself is not part of the profile at all —
+/// <c>AllowedPaths</c>/<c>DeniedPaths</c>/<c>AllowedHosts</c>/<c>DeniedHosts</c> are restored and
+/// live elsewhere (#418; see <c>ToolOverrideConfig</c>'s remarks), but
+/// <c>ToolPermissionProfileResolver.ResolveForUngovernedDispatch</c> never populates them on the
+/// profile it returns: nothing on this dispatch path (which bypasses
+/// <c>CapabilityEnforcer</c> entirely, see below) ever reads them.
 /// </para>
 /// <para>
 /// Egress enforcement is the registry allowlist from

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemPathCanonicalizer.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemPathCanonicalizer.cs
@@ -1,0 +1,14 @@
+using Application.AI.Common.Interfaces.Sandbox;
+
+namespace Infrastructure.AI.Tools;
+
+/// <summary>
+/// Adapts <see cref="SandboxPathCanonicalizer"/> — the filesystem-facing resolver
+/// <see cref="SandboxedPathGuard"/> already uses — as an <see cref="IPathCanonicalizer"/> for
+/// <c>CapabilityEnforcer</c> (Application layer), which cannot reference the filesystem directly.
+/// </summary>
+internal sealed class FileSystemPathCanonicalizer : IPathCanonicalizer
+{
+    /// <inheritdoc />
+    public string Canonicalize(string normalizedPath) => SandboxPathCanonicalizer.Canonicalize(normalizedPath);
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
@@ -70,6 +70,18 @@ public sealed class FileSystemTool : ITool
     public IReadOnlyList<string> SupportedOperations => Operations;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Every operation's <c>"path"</c> parameter is a filesystem path (#418) — the first, and
+    /// currently only, tool populating this declaration, matching how <see cref="ExecuteAsync"/>
+    /// itself reads every operation's <c>path</c> argument via <c>GetRequiredString</c>.
+    /// </remarks>
+    public IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>> ResourceParametersByOperation { get; } =
+        Operations.ToDictionary(
+            op => op,
+            IReadOnlyDictionary<string, ResourceParameterKind> (op) =>
+                new Dictionary<string, ResourceParameterKind> { ["path"] = ResourceParameterKind.Path });
+
+    /// <inheritdoc />
     public async Task<ToolResult> ExecuteAsync(
         string operation,
         IReadOnlyDictionary<string, object?> parameters,

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/FileSystemTool.cs
@@ -32,6 +32,10 @@ public sealed class FileSystemTool : ITool
     private static readonly IReadOnlyList<string> Operations =
         ["read", "write", "list", "search", "exists"];
 
+    /// <summary>The single shared declaration every operation maps to — see <see cref="ResourceParametersByOperation"/>.</summary>
+    private static readonly IReadOnlyDictionary<string, ResourceParameterKind> PathOnly =
+        new Dictionary<string, ResourceParameterKind> { ["path"] = ResourceParameterKind.Path };
+
     private readonly IFileSystemService _fileSystem;
 
     /// <summary>
@@ -76,10 +80,7 @@ public sealed class FileSystemTool : ITool
     /// itself reads every operation's <c>path</c> argument via <c>GetRequiredString</c>.
     /// </remarks>
     public IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>> ResourceParametersByOperation { get; } =
-        Operations.ToDictionary(
-            op => op,
-            IReadOnlyDictionary<string, ResourceParameterKind> (op) =>
-                new Dictionary<string, ResourceParameterKind> { ["path"] = ResourceParameterKind.Path });
+        Operations.ToDictionary(op => op, _ => PathOnly);
 
     /// <inheritdoc />
     public async Task<ToolResult> ExecuteAsync(

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceCommandRunner.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/Workspace/WorkspaceCommandRunner.cs
@@ -41,7 +41,10 @@ public static class WorkspaceCommandRunner
     /// <param name="commandLine">The whitespace-delimited command line. First token is the program; remaining tokens are arguments.</param>
     /// <param name="workspace">
     /// The active workspace context. Not itself an enforced filesystem boundary on this dispatch
-    /// path — the profile's old <c>AllowedPaths</c> was removed as dead config (#405); the caller
+    /// path — <c>ToolPermissionProfileResolver.ResolveForUngovernedDispatch</c> never populates
+    /// <c>AllowedPaths</c>/<c>DeniedPaths</c> on the profile it returns (#418; see
+    /// <c>ToolOverrideConfig</c>'s remarks), so a profile configured for a tool reached only through
+    /// this dispatch path carries no path scoping regardless; the caller
     /// (<c>WorkspaceRunTestsTool</c>/<c>WorkspaceRunLintTool</c>) reads the command to run from it
     /// before calling here.
     /// </param>

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -291,6 +291,50 @@ public sealed class CapabilityEnforcementTests
     }
 
     [Fact]
+    public async Task DeniedPath_WindowsDriveRelative_Refuses()
+    {
+        // Windows-only: "C:secrets\creds.txt" (no separator after the drive letter) is
+        // Path.IsPathRooted == true but Path.IsPathFullyQualified == false — it still resolves
+        // against that drive's current directory, the same CWD-dependent ambiguity a plain relative
+        // path has. A rootedness-only check would have let it slip through the guard meant to catch
+        // exactly this.
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: ["C:secrets\\creds.txt"]);
+
+        result.IsSuccess.Should().BeFalse("a drive-relative path is not fully qualified and must not be silently allowed");
+    }
+
+    [Fact]
+    public async Task DeniedPath_ConfiguredEntryUnparsable_StillRefuses()
+    {
+        // A configured DeniedPaths entry the runtime cannot normalize (here, an embedded NUL — one
+        // of Path.GetInvalidPathChars() on every platform) must not be silently excluded from
+        // matching — that would turn an operator's deny rule into a no-op instead of the refusal it
+        // was written to enforce. The entry itself, not the requested path, is what's malformed here.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/bad\0name"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: [$"{Root}sandbox/unrelated.txt"]);
+
+        result.IsSuccess.Should().BeFalse("an unparsable deny entry must fail closed, not silently exclude itself");
+    }
+
+    [Fact]
     public async Task DeniedPath_WinsOverAllowedPath()
     {
         var config = new SandboxConfig
@@ -460,6 +504,29 @@ public sealed class CapabilityEnforcementTests
             requestedHosts: ["https://evil.com/exfil"]);
 
         result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AllowedHost_UrlWithEmbeddedSchemeLaterInString_DoesNotMatchTheEmbeddedHost()
+    {
+        // Regression: an unanchored scan for "://" matches the FIRST occurrence anywhere in the
+        // string, so a value like "good.com/redirect?to=http://evil.com" would incorrectly reduce to
+        // "evil.com" — misdirecting the comparison at a host embedded later in the string rather than
+        // the value's own leading host. Uri.TryCreate(..., UriKind.Absolute) refuses to parse this
+        // (no leading scheme), so it must NOT be treated as if its host were "evil.com" — an
+        // AllowedHosts entry for "good.com" must not silently reject it as if it named "evil.com".
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { AllowedHosts = ["evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["good.com/redirect?to=http://evil.com"]);
+
+        result.IsSuccess.Should().BeFalse(
+            "the value has no leading scheme so it must not be reduced to the unrelated embedded host \"evil.com\"");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -22,6 +22,14 @@ namespace Application.AI.Common.Tests.Behaviors;
 /// </summary>
 public sealed class CapabilityEnforcementTests
 {
+    // CapabilityEnforcer now refuses any requested path that is not OS-rooted (#418 CI hardening —
+    // a relative path is unsafe to compare here at all, since it would resolve against a base this
+    // class has no visibility into). A literal "C:/..." fixture is rooted on Windows but NOT on
+    // Linux (CI runs on ubuntu-latest), so every path fixture below is built from this OS-correct
+    // root rather than hardcoded, or every "should be allowed"/"sibling doesn't match" assertion
+    // would silently become "always refused" off this machine.
+    private static readonly string Root = OperatingSystem.IsWindows() ? "C:/" : "/";
+
     private static ITool FileTool() => Mock.Of<ITool>(t =>
         t.RequiredCapabilities == (ToolCapability.FileRead | ToolCapability.FileWrite));
 
@@ -210,13 +218,13 @@ public sealed class CapabilityEnforcementTests
     {
         var config = new SandboxConfig
         {
-            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
         };
         var (_, enforcer) = Build(config, ("file_system", FileTool()));
 
         var result = await enforcer.EnforceAsync(
             "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
-            requestedPaths: ["C:/sandbox/secrets/creds.txt"]);
+            requestedPaths: [$"{Root}sandbox/secrets/creds.txt"]);
 
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain(e => e.Contains("path denied"));
@@ -226,16 +234,16 @@ public sealed class CapabilityEnforcementTests
     public async Task DeniedPath_SiblingDirectory_DoesNotMatch()
     {
         // The sibling-directory bypass IsPathWithin exists to prevent: a boundary of
-        // "C:/sandbox/work" must not match "C:/sandbox/work-evil" via a raw string prefix check.
+        // ".../sandbox/work" must not match ".../sandbox/work-evil" via a raw string prefix check.
         var config = new SandboxConfig
         {
-            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/work"] } }
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/work"] } }
         };
         var (_, enforcer) = Build(config, ("file_system", FileTool()));
 
         var result = await enforcer.EnforceAsync(
             "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
-            requestedPaths: ["C:/sandbox/work-evil/file.txt"]);
+            requestedPaths: [$"{Root}sandbox/work-evil/file.txt"]);
 
         result.IsSuccess.Should().BeTrue();
     }
@@ -250,7 +258,7 @@ public sealed class CapabilityEnforcementTests
         // outright rather than guess where it points.
         var config = new SandboxConfig
         {
-            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
         };
         var (_, enforcer) = Build(config, ("file_system", FileTool()));
 
@@ -262,6 +270,27 @@ public sealed class CapabilityEnforcementTests
     }
 
     [Fact]
+    public async Task DeniedPath_RelativeNonTraversal_Refuses()
+    {
+        // CI-caught regression: an ordinary relative path with no ".." at all still cannot be safely
+        // compared here — CapabilityEnforcer would resolve it against the process's own working
+        // directory, while IFileSystemService resolves the identical string against its own,
+        // separately-configured sandbox base. The two can name different files entirely, so any
+        // non-rooted path is refused outright, not just one that looks like a traversal attempt.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: ["secrets/creds.txt"]);
+
+        result.IsSuccess.Should().BeFalse("a relative path resolves against an unknown base and must not be silently allowed");
+    }
+
+    [Fact]
     public async Task DeniedPath_WinsOverAllowedPath()
     {
         var config = new SandboxConfig
@@ -270,8 +299,8 @@ public sealed class CapabilityEnforcementTests
             {
                 ["file_system"] = new ToolOverrideConfig
                 {
-                    AllowedPaths = ["C:/sandbox"],
-                    DeniedPaths = ["C:/sandbox/secrets"]
+                    AllowedPaths = [$"{Root}sandbox"],
+                    DeniedPaths = [$"{Root}sandbox/secrets"]
                 }
             }
         };
@@ -279,7 +308,7 @@ public sealed class CapabilityEnforcementTests
 
         var result = await enforcer.EnforceAsync(
             "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
-            requestedPaths: ["C:/sandbox/secrets/creds.txt"]);
+            requestedPaths: [$"{Root}sandbox/secrets/creds.txt"]);
 
         result.IsSuccess.Should().BeFalse("deny overrides allow even when the path is also within an allowed boundary");
     }
@@ -289,13 +318,13 @@ public sealed class CapabilityEnforcementTests
     {
         var config = new SandboxConfig
         {
-            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { AllowedPaths = ["C:/sandbox/work"] } }
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { AllowedPaths = [$"{Root}sandbox/work"] } }
         };
         var (_, enforcer) = Build(config, ("file_system", FileTool()));
 
         var result = await enforcer.EnforceAsync(
             "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
-            requestedPaths: ["C:/other/place.txt"]);
+            requestedPaths: [$"{Root}other/place.txt"]);
 
         result.IsSuccess.Should().BeFalse();
     }
@@ -308,7 +337,7 @@ public sealed class CapabilityEnforcementTests
         // (requestedPaths: null and [] were treated identically).
         var config = new SandboxConfig
         {
-            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
         };
         var (_, enforcer) = Build(config, ("file_system", FileTool()));
 
@@ -336,7 +365,7 @@ public sealed class CapabilityEnforcementTests
         // distinct from null ("could not be determined").
         var config = new SandboxConfig
         {
-            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
         };
         var (_, enforcer) = Build(config, ("file_system", FileTool()));
 
@@ -411,6 +440,42 @@ public sealed class CapabilityEnforcementTests
         var result = await enforcer.EnforceAsync(
             "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
             requestedHosts: ["::1"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeniedHost_UrlSchemeAndPath_StillMatches()
+    {
+        // A resource-parameter of Host kind could carry a full URL, not a bare host — the old
+        // single-colon check treated the whole string as unstrippable and compared it verbatim.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["https://evil.com/exfil"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeniedHost_ConfiguredEntryCarriesPort_StillMatchesBareRequestedHost()
+    {
+        // The port was only ever stripped from the requested host, never from the configured
+        // pattern — an operator entry of "evil.com:443" could never match anything.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["evil.com:443"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["evil.com"]);
 
         result.IsSuccess.Should().BeFalse();
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -241,6 +241,27 @@ public sealed class CapabilityEnforcementTests
     }
 
     [Fact]
+    public async Task DeniedPath_RelativeTraversal_Refuses()
+    {
+        // CI-caught regression: the naive normalizer this replaced silently dropped a leading ".."
+        // instead of resolving or rejecting it, so "../secrets/creds.txt" matched no configured
+        // boundary at all. CapabilityEnforcer has no base directory to resolve a relative traversal
+        // against (that's IFileSystemService's own concern), so it must refuse any traversal pattern
+        // outright rather than guess where it points.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: ["../secrets/creds.txt"]);
+
+        result.IsSuccess.Should().BeFalse("a path this class cannot safely resolve must not be silently allowed");
+    }
+
+    [Fact]
     public async Task DeniedPath_WinsOverAllowedPath()
     {
         var config = new SandboxConfig
@@ -356,6 +377,42 @@ public sealed class CapabilityEnforcementTests
             requestedHosts: ["api.example.com:8443"]);
 
         result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeniedHost_TrailingDotFqdn_StillMatches()
+    {
+        // A root-terminated FQDN ("host.") is the same name as "host" — a raw EndsWith comparison
+        // let the trailing dot defeat a *.suffix deny entry entirely.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["api.evil.com."]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeniedHost_BareIPv6Literal_StillMatches()
+    {
+        // StripPort's old "last colon, digits after" rule truncated a bare IPv6 literal ("::1"
+        // becomes ":"), so a deny entry for it could never match.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["::1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["::1"]);
+
+        result.IsSuccess.Should().BeFalse();
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -202,4 +202,174 @@ public sealed class CapabilityEnforcementTests
         profile.MinimumIsolation.Should().Be(SandboxIsolationLevel.Process);
         profile.DeniedCapabilities.Should().Be(ToolCapability.FileRead);
     }
+
+    // --- Path/host scoping (#418) ---
+
+    [Fact]
+    public async Task DeniedPath_ExactMatch_Refuses()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: ["C:/sandbox/secrets/creds.txt"]);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("path denied"));
+    }
+
+    [Fact]
+    public async Task DeniedPath_SiblingDirectory_DoesNotMatch()
+    {
+        // The sibling-directory bypass IsPathWithin exists to prevent: a boundary of
+        // "C:/sandbox/work" must not match "C:/sandbox/work-evil" via a raw string prefix check.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/work"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: ["C:/sandbox/work-evil/file.txt"]);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeniedPath_WinsOverAllowedPath()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["file_system"] = new ToolOverrideConfig
+                {
+                    AllowedPaths = ["C:/sandbox"],
+                    DeniedPaths = ["C:/sandbox/secrets"]
+                }
+            }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: ["C:/sandbox/secrets/creds.txt"]);
+
+        result.IsSuccess.Should().BeFalse("deny overrides allow even when the path is also within an allowed boundary");
+    }
+
+    [Fact]
+    public async Task AllowedPathConfigured_RequestOutsideIt_Refuses()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { AllowedPaths = ["C:/sandbox/work"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: ["C:/other/place.txt"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PathScopingConfigured_RequestedPathsIsNull_RefusesFailClosed()
+    {
+        // The actual fix #418 delivers: a configured deny that cannot verify a call's resource
+        // usage must refuse, not silently let it through — the exact fail-open shape #405 shipped
+        // (requestedPaths: null and [] were treated identically).
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite, requestedPaths: null);
+
+        result.IsSuccess.Should().BeFalse("a configured deny with unknown resource usage must refuse, not pass through");
+    }
+
+    [Fact]
+    public async Task NoPathScopingConfigured_RequestedPathsIsNull_PassesThrough()
+    {
+        var (_, enforcer) = Build(tools: ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite, requestedPaths: null);
+
+        result.IsSuccess.Should().BeTrue("no scoping is configured, so an unknown request is not a violation");
+    }
+
+    [Fact]
+    public async Task PathScopingConfigured_RequestedPathsIsEmpty_PassesThrough()
+    {
+        // Empty means "determined, and there is none" — the tool's own affirmative declaration,
+        // distinct from null ("could not be determined").
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite, requestedPaths: []);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeniedHost_WildcardMatch_Refuses()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["api.evil.com:443"]);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("host denied"));
+    }
+
+    [Fact]
+    public async Task AllowedHostConfigured_ExactMatchWithPortStripped_PassesThrough()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { AllowedHosts = ["api.example.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["api.example.com:8443"]);
+
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HostScopingConfigured_RequestedHostsIsNull_RefusesFailClosed()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess, requestedHosts: null);
+
+        result.IsSuccess.Should().BeFalse();
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -335,6 +335,48 @@ public sealed class CapabilityEnforcementTests
     }
 
     [Fact]
+    public async Task DeniedPath_ConfiguredEntryIsRelative_StillRefuses()
+    {
+        // Regression: the fully-qualified check was originally applied only to the requested path,
+        // not to a configured boundary — a relative DeniedPaths entry like "sandbox/secrets" would
+        // silently resolve against the host process's own working directory via PathScope.Normalize
+        // and then never match any real, fully-qualified requested path, turning the deny rule into a
+        // permanent no-op. Neither side of this comparison has a base directory the other would agree
+        // with, so a relative config entry must fail closed exactly like a relative requested path does.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["sandbox/secrets"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: [$"{Root}sandbox/unrelated.txt"]);
+
+        result.IsSuccess.Should().BeFalse("a relative deny entry must fail closed, not silently become a no-op");
+    }
+
+    [Fact]
+    public async Task AllowedPath_ConfiguredEntryIsRelative_ExcludesRatherThanFalsePositiveAllow()
+    {
+        // The allow-side mirror of the deny regression above: a relative AllowedPaths entry must not
+        // resolve against the host process's own CWD and coincidentally grant access nothing was
+        // meant to grant. It should be excluded from the allowlist (never matches), which for a
+        // profile whose only entry is relative means every request is refused.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { AllowedPaths = ["sandbox/work"] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: [$"{Root}sandbox/work/notes.txt"]);
+
+        result.IsSuccess.Should().BeFalse("a relative allow entry must not grant access via a CWD coincidence");
+    }
+
+    [Fact]
     public async Task DeniedPath_WinsOverAllowedPath()
     {
         var config = new SandboxConfig

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -400,6 +400,105 @@ public sealed class CapabilityEnforcementTests
     }
 
     [Fact]
+    public async Task DeniedPath_NestedInsideRequestedAncestor_Refuses()
+    {
+        // CI-caught HIGH: FileSystemTool's "search"/"list" operations recursively read everything
+        // beneath the single declared "path" argument, but the enforcer only ever validated that one
+        // named string. A denied boundary NESTED INSIDE the requested path (the requested path is an
+        // ANCESTOR of the deny entry, not a descendant of it) previously passed unnoticed, silently
+        // reading through a subdirectory the operator explicitly denied. Checked in both directions
+        // now: a deny match on EITHER "requested is under denied" OR "denied is under requested".
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["file_system"] = new ToolOverrideConfig
+                {
+                    AllowedPaths = [$"{Root}work"],
+                    DeniedPaths = [$"{Root}work/.secrets"]
+                }
+            }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        // A "search"/"list"-shaped call names the allowed root itself, not the denied child.
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: [$"{Root}work"]);
+
+        result.IsSuccess.Should().BeFalse(
+            "a subtree read from an ancestor of a denied boundary must not silently read through it");
+    }
+
+    [Fact]
+    public async Task DeniedPath_SiblingOfDeniedBoundary_StillAllowed()
+    {
+        // The mirror of the regression above: a requested path that is a SIBLING of a denied
+        // boundary (neither an ancestor nor a descendant of it) must not be caught by the new
+        // both-directions check — only genuine ancestor/descendant containment should refuse.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["file_system"] = new ToolOverrideConfig
+                {
+                    AllowedPaths = [$"{Root}work"],
+                    DeniedPaths = [$"{Root}work/.secrets"]
+                }
+            }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: [$"{Root}work/public"]);
+
+        result.IsSuccess.Should().BeTrue("a sibling of a denied boundary is not itself denied");
+    }
+
+    [Fact]
+    public async Task AllowedPath_ConfiguredEntryIsEmptyString_ExcludesRatherThanMatchingEverything()
+    {
+        // CI-caught MEDIUM: NormalizeBoundary's raw-string fallback on a normalization failure is
+        // meant to safely EXCLUDE a malformed allow entry, but an empty/whitespace configured string
+        // coincided with IsPathWithin's own "empty boundary confines everything" rule for a
+        // genuinely-normalized root path, silently matching every candidate instead of none.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { AllowedPaths = [""] } }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: [$"{Root}anywhere/at/all.txt"]);
+
+        result.IsSuccess.Should().BeFalse("an empty allow entry must exclude, not silently match everything");
+    }
+
+    [Fact]
+    public async Task DeniedPath_ConfiguredListContainsNullEntry_DoesNotThrow()
+    {
+        // Advisory: a literal JSON `null` in DeniedPaths binds to a null List<string> element despite
+        // the non-nullable element type, and used to NRE inside NormalizeAndCanonicalize rather than
+        // being treated like any other unparsable entry.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["file_system"] = new ToolOverrideConfig { DeniedPaths = [null!, $"{Root}sandbox/secrets"] }
+            }
+        };
+        var (_, enforcer) = Build(config, ("file_system", FileTool()));
+
+        var act = () => enforcer.EnforceAsync(
+            "file_system", ToolCapability.FileRead | ToolCapability.FileWrite,
+            requestedPaths: [$"{Root}sandbox/secrets/creds.txt"]);
+
+        (await act.Should().NotThrowAsync()).Which.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task AllowedPathConfigured_RequestOutsideIt_Refuses()
     {
         var config = new SandboxConfig

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
@@ -67,7 +67,7 @@ public sealed class ToolBehaviorPostureTests
             .ReturnsAsync(PermissionDecision.Allow("allowed by default"));
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
         _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
         _approvalRouter

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
@@ -50,7 +50,7 @@ public sealed class ToolCompositionPostureTests
             .ReturnsAsync(PermissionDecision.Allow("allowed by default"));
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Domain.Common.Result.Success());
         _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
         _approvalRouter

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
@@ -59,7 +59,7 @@ public sealed class ToolInvocationGovernorEnvelopeTests
             .ReturnsAsync(PermissionDecision.Deny("outside the envelope"));
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
         _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
         _approvalRouter

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -62,7 +62,7 @@ public sealed class ToolInvocationGovernorTests
             .ReturnsAsync(PermissionDecision.Allow("allowed by default"));
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
         _policyEngine.SetupGet(x => x.HasPolicies).Returns(false);
         _behavior.Setup(x => x.Resolve(It.IsAny<string>())).Returns(ToolBehavior.Unknown);
@@ -218,7 +218,7 @@ public sealed class ToolInvocationGovernorTests
     {
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Fail("filesystem capability not granted"));
         var governor = Build();
 
@@ -334,7 +334,7 @@ public sealed class ToolInvocationGovernorTests
         RouterAnswers(ToolApprovalResult.Approved("approved by alice", Guid.NewGuid()));
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Fail("tool requires a capability the sandbox did not grant"));
         var governor = Build();
 
@@ -370,7 +370,7 @@ public sealed class ToolInvocationGovernorTests
         AskingPermission();
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Fail("tool requires a capability the sandbox did not grant"));
         var governor = Build();
 
@@ -619,9 +619,9 @@ public sealed class ToolInvocationGovernorTests
         Domain.AI.Sandbox.ToolCapability granted = default;
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, Domain.AI.Sandbox.ToolCapability, CancellationToken>(
-                (_, caps, _) => granted = caps)
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Domain.AI.Sandbox.ToolCapability, IReadOnlyList<string>?, IReadOnlyList<string>?, CancellationToken>(
+                (_, caps, _, _, _) => granted = caps)
             .ReturnsAsync(Result.Success());
 
         _sandbox.DefaultGrantedCapabilities.Clear();
@@ -643,9 +643,9 @@ public sealed class ToolInvocationGovernorTests
         Domain.AI.Sandbox.ToolCapability granted = default;
         _capabilities
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, Domain.AI.Sandbox.ToolCapability, CancellationToken>(
-                (_, caps, _) => granted = caps)
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, Domain.AI.Sandbox.ToolCapability, IReadOnlyList<string>?, IReadOnlyList<string>?, CancellationToken>(
+                (_, caps, _, _, _) => granted = caps)
             .ReturnsAsync(Result.Success());
 
         _sandbox.DefaultGrantedCapabilities.Clear();

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -33,12 +33,16 @@ namespace Application.AI.Common.Tests.Governance;
 /// </summary>
 public sealed class ToolPathScopingEndToEndTests
 {
-    private const string DeniedPath = "C:/sandbox/secrets/creds.txt";
-    private const string AllowedPath = "C:/sandbox/work/notes.txt";
+    // CapabilityEnforcer refuses any requested path that isn't OS-rooted (#418 CI hardening); a
+    // literal "C:/..." path is rooted on Windows but not on Linux (CI runs on ubuntu-latest), so
+    // every fixture below is built from this OS-correct root.
+    private static readonly string Root = OperatingSystem.IsWindows() ? "C:/" : "/";
+    private static readonly string DeniedPath = $"{Root}sandbox/secrets/creds.txt";
+    private static readonly string AllowedPath = $"{Root}sandbox/work/notes.txt";
 
     private static SandboxConfig DenyingSandboxConfig() => new()
     {
-        ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+        ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
     };
 
     /// <summary>A real <see cref="FileSystemTool"/> over a mocked <see cref="IFileSystemService"/>, keyed
@@ -114,6 +118,37 @@ public sealed class ToolPathScopingEndToEndTests
     };
 
     // --- Agent-turn path (GovernedAIFunction / ToolChainBuilder) ---
+
+    [Fact]
+    public async Task AgentTurnPath_DeniedPath_ParametersJsonArrivesAsRawString_StillRefuses()
+    {
+        // Regression: GovernedAIFunction.ReadParametersJson used to accept only a boxed JsonElement,
+        // silently discarding any other CLR shape (including a plain, well-formed JSON string) as
+        // "no parameters" — which downgrades to ToolCallResourceRequest.Empty and CapabilityEnforcer
+        // trusts that and skips validating. AIFunctionArguments never carries a bare string here via
+        // the real Microsoft.Extensions.AI pipeline, but a caller outside it could.
+        var (_, fileSystem, toolProvider) = BuildToolFixture();
+        var context = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "test-agent");
+        var (governor, trace) = BuildGovernor(toolProvider, DenyingSandboxConfig(), context);
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, toolProvider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+        var aiFunction = (AIFunction)builder.BuildToolsByName(["file_system"], "test-agent").Single();
+
+        using var _ = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor, executionContext: context));
+
+        var args = new AIFunctionArguments
+        {
+            ["operation"] = "read",
+            ["parametersJson"] = JsonSerializer.Serialize(new { path = DeniedPath })
+        };
+
+        var result = await aiFunction.InvokeAsync(args);
+
+        result.Should().BeOfType<string>();
+        trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
+        fileSystem.Verify(fs => fs.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
 
     [Fact]
     public async Task AgentTurnPath_DeniedPath_RefusesBeforeFileSystemServiceReached()

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -107,9 +107,9 @@ public sealed class ToolPathScopingEndToEndTests
         return (governor, trace);
     }
 
-    private static AIFunctionArguments ReadArgs(string path) => new()
+    private static AIFunctionArguments ReadArgs(string path, string operation = "read") => new()
     {
-        ["operation"] = "read",
+        ["operation"] = operation,
         ["parametersJson"] = JsonSerializer.SerializeToElement(new { path })
     };
 
@@ -132,6 +132,30 @@ public sealed class ToolPathScopingEndToEndTests
 
         // The model-facing text is deliberately generic (never leaks capability/path detail to the
         // LLM) — the trace is where the specific reason, and proof this was path scoping, lives.
+        result.Should().BeOfType<string>();
+        trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
+        fileSystem.Verify(fs => fs.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AgentTurnPath_DeniedPath_OperationCasingDiffers_StillRefuses()
+    {
+        // Regression for the case-sensitivity bypass caught in review: AIToolConverter accepts an
+        // operation case-insensitively and FileSystemTool.ExecuteAsync dispatches via
+        // ToLowerInvariant(), so "Read" must be denied exactly like "read" — not silently pass because
+        // ResourceParameterExtractor's declaration lookup missed on casing and returned Empty.
+        var (_, fileSystem, toolProvider) = BuildToolFixture();
+        var context = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "test-agent");
+        var (governor, trace) = BuildGovernor(toolProvider, DenyingSandboxConfig(), context);
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, toolProvider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+        var aiFunction = (AIFunction)builder.BuildToolsByName(["file_system"], "test-agent").Single();
+
+        using var _ = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor, executionContext: context));
+
+        var result = await aiFunction.InvokeAsync(ReadArgs(DeniedPath, operation: "Read"));
+
         result.Should().BeOfType<string>();
         trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
         fileSystem.Verify(fs => fs.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -191,6 +215,53 @@ public sealed class ToolPathScopingEndToEndTests
         {
             ToolName = "file_system",
             Operation = "read",
+            Parameters = new Dictionary<string, object?> { ["path"] = DeniedPath },
+            OwnerId = "caller-1",
+            Envelope = new CapabilityEnvelope { AllowedTools = ["file_system"] }
+        };
+
+        var outcome = await invoker.InvokeAsync(request, CancellationToken.None);
+
+        outcome.Status.Should().Be(DirectToolInvocationStatus.Denied);
+        capturedTrace.Should().NotBeNull();
+        capturedTrace!.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
+        fileSystem.Verify(fs => fs.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DirectToolInvokerPath_DeniedPath_OperationCasingDiffers_StillRefuses()
+    {
+        // Same casing regression as the agent-turn path, exercised through the HTTP-facing surface —
+        // the one the correctness/security review both called out as "most exposed to external callers".
+        var fileSystem = new Mock<IFileSystemService>();
+        var tool = new FileSystemTool(fileSystem.Object);
+        var sandboxConfig = DenyingSandboxConfig();
+
+        GovernanceTraceRecorder? capturedTrace = null;
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", tool);
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddScoped<IToolCallAdmissionPipeline>(sp =>
+        {
+            var (governor, trace) = BuildGovernor(sp, sandboxConfig, sp.GetRequiredService<IAgentExecutionContext>());
+            capturedTrace = trace;
+            return AdmissionHarness.Pipeline(
+                governor: governor, executionContext: sp.GetRequiredService<IAgentExecutionContext>(), trace: trace);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var invoker = new DirectToolInvoker(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            new ToolCatalog(provider, ["file_system"], NullLogger<ToolCatalog>.Instance),
+            Mock.Of<IOptionsMonitor<DirectToolInvocationConfig>>(
+                m => m.CurrentValue == new DirectToolInvocationConfig { Enabled = true }),
+            NullLogger<DirectToolInvoker>.Instance);
+
+        var request = new DirectToolInvocationRequest
+        {
+            ToolName = "file_system",
+            Operation = "Read",
             Parameters = new Dictionary<string, object?> { ["path"] = DeniedPath },
             OwnerId = "caller-1",
             Envelope = new CapabilityEnvelope { AllowedTools = ["file_system"] }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using Application.AI.Common.Interfaces.Agent;
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Permissions;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Agent;
+using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Sandbox;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Bundles;
+using Domain.AI.Changes;
+using Domain.AI.Governance;
+using Domain.AI.Permissions;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.DirectToolInvocation;
+using Domain.Common.Config.AI.Permissions;
+using Domain.Common.Config.AI.Sandbox;
+using FluentAssertions;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// #418 end-to-end: a real <see cref="FileSystemTool"/>, converted through the real
+/// <see cref="AIToolConverter"/> and <see cref="ToolChainBuilder"/>, admitted through a real
+/// <see cref="ToolInvocationGovernor"/>/<see cref="CapabilityEnforcer"/> chain — proving the whole
+/// wiring this feature added actually connects, not just each piece in isolation.
+/// </summary>
+public sealed class ToolPathScopingEndToEndTests
+{
+    private const string DeniedPath = "C:/sandbox/secrets/creds.txt";
+    private const string AllowedPath = "C:/sandbox/work/notes.txt";
+
+    private static SandboxConfig DenyingSandboxConfig() => new()
+    {
+        ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = ["C:/sandbox/secrets"] } }
+    };
+
+    /// <summary>A real <see cref="FileSystemTool"/> over a mocked <see cref="IFileSystemService"/>, keyed
+    /// into a provider both the governor's tool lookup and <see cref="ToolChainBuilder"/> resolve from.</summary>
+    private static (ITool Tool, Mock<IFileSystemService> FileSystem, IServiceProvider Provider) BuildToolFixture()
+    {
+        var fileSystem = new Mock<IFileSystemService>();
+        var tool = new FileSystemTool(fileSystem.Object);
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", tool);
+        return (tool, fileSystem, services.BuildServiceProvider());
+    }
+
+    /// <summary>
+    /// A real <see cref="ToolInvocationGovernor"/> wired to a real <see cref="CapabilityEnforcer"/>
+    /// (itself backed by a real <see cref="ToolPermissionProfileResolver"/> reading <paramref name="sandboxConfig"/>),
+    /// with every OTHER gate permissive — matching <c>ToolInvocationGovernorTests.Build</c>'s pattern, so
+    /// this test isolates the path/host scoping wiring rather than re-proving every other gate. Also
+    /// returns the trace recorder: the governor deliberately returns a generic model-facing denial for
+    /// every refusal (never leaking capability/path detail to the LLM), so the specific reason — proof
+    /// this was a path-scoping denial and not some other gate — is only observable via the governance
+    /// trace, not the returned/reported message.
+    /// </summary>
+    private static (ToolInvocationGovernor Governor, GovernanceTraceRecorder Trace) BuildGovernor(
+        IServiceProvider toolProvider, SandboxConfig sandboxConfig, IAgentExecutionContext context)
+    {
+        var sandboxMonitor = Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == sandboxConfig);
+        var lookup = new FirstPartyToolLookup(toolProvider, new HashSet<string> { "file_system" });
+        var resolver = new ToolPermissionProfileResolver(lookup, sandboxMonitor);
+        var enforcer = new CapabilityEnforcer(resolver, NullLogger<CapabilityEnforcer>.Instance);
+
+        var governance = new GovernanceConfig { EnforceToolInvocation = true, Enabled = false, EnableAudit = true };
+        var governanceMonitor = Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == governance);
+        var riskClassifier = Mock.Of<IToolRiskClassifier>(c => c.Classify(It.IsAny<string>()) == new ToolRiskProfile(BlastRadius.Low, true));
+        var trace = new GovernanceTraceRecorder(governanceMonitor, riskClassifier);
+
+        var permissions = new Mock<IToolPermissionService>();
+        permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("allowed by default"));
+
+        var approvalRouter = new Mock<IToolApprovalRouter>();
+        approvalRouter
+            .Setup(x => x.RequestApprovalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<BlastRadius>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ToolApprovalResult.NotRouted("tool approval routing is disabled"));
+
+        var governor = new ToolInvocationGovernor(
+            context,
+            permissions.Object,
+            riskClassifier,
+            Mock.Of<IToolBehaviorRegistry>(b => b.Resolve(It.IsAny<string>()) == ToolBehavior.Unknown),
+            Mock.Of<IAutonomyDecisionEvaluator>(),
+            Mock.Of<IGovernancePolicyEngine>(p => p.HasPolicies == false),
+            Mock.Of<IGovernanceAuditService>(),
+            Mock.Of<IDenialTracker>(),
+            enforcer,
+            approvalRouter.Object,
+            trace,
+            governanceMonitor,
+            Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == new PermissionsConfig()),
+            sandboxMonitor,
+            NullLogger<ToolInvocationGovernor>.Instance);
+
+        return (governor, trace);
+    }
+
+    private static AIFunctionArguments ReadArgs(string path) => new()
+    {
+        ["operation"] = "read",
+        ["parametersJson"] = JsonSerializer.SerializeToElement(new { path })
+    };
+
+    // --- Agent-turn path (GovernedAIFunction / ToolChainBuilder) ---
+
+    [Fact]
+    public async Task AgentTurnPath_DeniedPath_RefusesBeforeFileSystemServiceReached()
+    {
+        var (_, fileSystem, toolProvider) = BuildToolFixture();
+        var context = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "test-agent");
+        var (governor, trace) = BuildGovernor(toolProvider, DenyingSandboxConfig(), context);
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, toolProvider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+        var aiFunction = (AIFunction)builder.BuildToolsByName(["file_system"], "test-agent").Single();
+
+        using var _ = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor, executionContext: context));
+
+        var result = await aiFunction.InvokeAsync(ReadArgs(DeniedPath));
+
+        // The model-facing text is deliberately generic (never leaks capability/path detail to the
+        // LLM) — the trace is where the specific reason, and proof this was path scoping, lives.
+        result.Should().BeOfType<string>();
+        trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
+        fileSystem.Verify(fs => fs.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AgentTurnPath_AllowedPath_ReachesFileSystemAndSucceeds()
+    {
+        var (_, fileSystem, toolProvider) = BuildToolFixture();
+        fileSystem.Setup(fs => fs.ReadFileAsync(AllowedPath, It.IsAny<CancellationToken>())).ReturnsAsync("hello world");
+        var context = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "test-agent");
+        var (governor, _) = BuildGovernor(toolProvider, DenyingSandboxConfig(), context);
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, toolProvider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+        var aiFunction = (AIFunction)builder.BuildToolsByName(["file_system"], "test-agent").Single();
+
+        using var _ = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor, executionContext: context));
+
+        var result = await aiFunction.InvokeAsync(ReadArgs(AllowedPath));
+
+        JsonSerializer.Serialize(result).Should().Contain("hello world");
+        fileSystem.Verify(fs => fs.ReadFileAsync(AllowedPath, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // --- Direct-invocation path (DirectToolInvoker) ---
+
+    [Fact]
+    public async Task DirectToolInvokerPath_DeniedPath_RefusesBeforeFileSystemServiceReached()
+    {
+        var fileSystem = new Mock<IFileSystemService>();
+        var tool = new FileSystemTool(fileSystem.Object);
+        var sandboxConfig = DenyingSandboxConfig();
+
+        GovernanceTraceRecorder? capturedTrace = null;
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", tool);
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddScoped<IToolCallAdmissionPipeline>(sp =>
+        {
+            var (governor, trace) = BuildGovernor(sp, sandboxConfig, sp.GetRequiredService<IAgentExecutionContext>());
+            capturedTrace = trace;
+            return AdmissionHarness.Pipeline(
+                governor: governor, executionContext: sp.GetRequiredService<IAgentExecutionContext>(), trace: trace);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var invoker = new DirectToolInvoker(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            new ToolCatalog(provider, ["file_system"], NullLogger<ToolCatalog>.Instance),
+            Mock.Of<IOptionsMonitor<DirectToolInvocationConfig>>(
+                m => m.CurrentValue == new DirectToolInvocationConfig { Enabled = true }),
+            NullLogger<DirectToolInvoker>.Instance);
+
+        var request = new DirectToolInvocationRequest
+        {
+            ToolName = "file_system",
+            Operation = "read",
+            Parameters = new Dictionary<string, object?> { ["path"] = DeniedPath },
+            OwnerId = "caller-1",
+            Envelope = new CapabilityEnvelope { AllowedTools = ["file_system"] }
+        };
+
+        var outcome = await invoker.InvokeAsync(request, CancellationToken.None);
+
+        outcome.Status.Should().Be(DirectToolInvocationStatus.Denied);
+        capturedTrace.Should().NotBeNull();
+        capturedTrace!.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
+        fileSystem.Verify(fs => fs.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/DirectToolInvokerTests.cs
@@ -965,7 +965,8 @@ public sealed class DirectToolInvokerTests
         public async ValueTask<ToolInvocationDecision> AuthorizeAsync(
             string toolName, CancellationToken cancellationToken,
             IReadOnlyDictionary<string, object?>? arguments = null,
-            Domain.AI.Governance.ToolCompositionTaint? composition = null)
+            Domain.AI.Governance.ToolCompositionTaint? composition = null,
+            Domain.AI.Sandbox.ToolCallResourceRequest? resourceRequest = null)
         {
             record.AgentIdWhenAuthorizing = executionContext.AgentId;
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
@@ -59,6 +59,21 @@ public sealed class ResourceParameterExtractorTests
     }
 
     [Fact]
+    public void Extract_OperationCasingDiffers_StillMatchesDeclaration()
+    {
+        // Regression: every other stage that admits an operation name (AIToolConverter,
+        // DirectToolInvoker) accepts it case-insensitively, and FileSystemTool.ExecuteAsync itself
+        // dispatches via ToLowerInvariant() — an ordinal-only lookup here would silently downgrade
+        // "Read" to "affirmatively nothing scoped" (Empty), which CapabilityEnforcer trusts and skips
+        // validating, bypassing scoping entirely for a call whose casing merely differs.
+        var result = ResourceParameterExtractor.Extract(
+            "Read", new Dictionary<string, object?> { ["path"] = "src/File.cs" }, FileSystemMap);
+
+        result.Should().NotBeNull();
+        result!.RequestedPaths.Should().ContainSingle().Which.Should().Be("src/File.cs");
+    }
+
+    [Fact]
     public void Extract_DeclaredOperationWithNoParameters_ReturnsEmpty()
     {
         var map = new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
@@ -1,0 +1,132 @@
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Sandbox;
+using FluentAssertions;
+
+namespace Application.AI.Common.Tests.Services.Tools;
+
+/// <summary>
+/// #418: <see cref="ResourceParameterExtractor.Extract"/> is the one routine that turns a tool's
+/// <c>ResourceParametersByOperation</c> declaration plus one call's parameters into a
+/// <see cref="ToolCallResourceRequest"/> — and its null/empty/populated three-way return is exactly
+/// what <c>CapabilityEnforcer</c> distinguishes fail-closed behavior on.
+/// </summary>
+public sealed class ResourceParameterExtractorTests
+{
+    private static readonly IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>> FileSystemMap =
+        new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>
+        {
+            ["read"] = new Dictionary<string, ResourceParameterKind> { ["path"] = ResourceParameterKind.Path },
+            ["write"] = new Dictionary<string, ResourceParameterKind> { ["path"] = ResourceParameterKind.Path },
+        };
+
+    [Fact]
+    public void Extract_ToolDeclaresNothing_ReturnsNull()
+    {
+        var result = ResourceParameterExtractor.Extract(
+            "read", new Dictionary<string, object?> { ["path"] = "src" }, resourceParametersByOperation: null);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Extract_ToolDeclaresNothing_EmptyMap_ReturnsNull()
+    {
+        var result = ResourceParameterExtractor.Extract(
+            "read", new Dictionary<string, object?> { ["path"] = "src" },
+            new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>());
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Extract_OperationIsNull_ReturnsNull()
+    {
+        var result = ResourceParameterExtractor.Extract(
+            operation: null, new Dictionary<string, object?> { ["path"] = "src" }, FileSystemMap);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Extract_OperationNotDeclared_ReturnsEmpty()
+    {
+        // "exists" is a real file_system operation but not one of FileSystemMap's two declared
+        // operations — the tool affirmatively declares nothing scoped for it, distinct from "unknown".
+        var result = ResourceParameterExtractor.Extract(
+            "exists", new Dictionary<string, object?> { ["path"] = "src" }, FileSystemMap);
+
+        result.Should().Be(ToolCallResourceRequest.Empty);
+    }
+
+    [Fact]
+    public void Extract_DeclaredOperationWithNoParameters_ReturnsEmpty()
+    {
+        var map = new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>
+        {
+            ["list"] = new Dictionary<string, ResourceParameterKind>()
+        };
+
+        var result = ResourceParameterExtractor.Extract(
+            "list", new Dictionary<string, object?> { ["path"] = "src" }, map);
+
+        result.Should().Be(ToolCallResourceRequest.Empty);
+    }
+
+    [Fact]
+    public void Extract_DeclaredPathParameterPresent_ReturnsIt()
+    {
+        var result = ResourceParameterExtractor.Extract(
+            "read", new Dictionary<string, object?> { ["path"] = "src/File.cs" }, FileSystemMap);
+
+        result.Should().NotBeNull();
+        result!.RequestedPaths.Should().ContainSingle().Which.Should().Be("src/File.cs");
+        result.RequestedHosts.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Extract_DeclaredHostParameterPresent_ReturnsIt()
+    {
+        var map = new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>
+        {
+            ["fetch"] = new Dictionary<string, ResourceParameterKind> { ["url_host"] = ResourceParameterKind.Host }
+        };
+
+        var result = ResourceParameterExtractor.Extract(
+            "fetch", new Dictionary<string, object?> { ["url_host"] = "example.com" }, map);
+
+        result.Should().NotBeNull();
+        result!.RequestedHosts.Should().ContainSingle().Which.Should().Be("example.com");
+        result.RequestedPaths.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Extract_DeclaredParameterMissingFromCall_ReturnsEmptyRequest()
+    {
+        // The declared key isn't in this call's parameters at all — not "couldn't determine",
+        // since the operation itself IS declared; this call just didn't supply the parameter.
+        var result = ResourceParameterExtractor.Extract(
+            "read", new Dictionary<string, object?>(), FileSystemMap);
+
+        result.Should().NotBeNull();
+        result!.RequestedPaths.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Extract_DeclaredParameterIsNonStringValue_IsIgnored()
+    {
+        var result = ResourceParameterExtractor.Extract(
+            "read", new Dictionary<string, object?> { ["path"] = 42L }, FileSystemMap);
+
+        result.Should().NotBeNull();
+        result!.RequestedPaths.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Extract_ParametersIsNullButOperationIsDeclared_ReturnsEmptyRequest()
+    {
+        var result = ResourceParameterExtractor.Extract("read", parameters: null, FileSystemMap);
+
+        result.Should().NotBeNull();
+        result!.RequestedPaths.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
+using Domain.AI.Sandbox;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using Domain.Common.Config.AI;
@@ -589,6 +590,58 @@ public class ToolChainBuilderTests
 
         tools.Should().ContainSingle();
         tools[0].Name.Should().Be("file_system");
+    }
+
+    [Fact]
+    public void BuildToolsByName_ToolDeclaresResourceParameters_WrapsInResourceParameterDeclaringAIFunction()
+    {
+        // #418: AttachResourceParameters is the one call site that knows about a tool's
+        // ResourceParametersByOperation declaration at all — this proves it actually wraps.
+        var resourceMap = new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>
+        {
+            ["read"] = new Dictionary<string, ResourceParameterKind> { ["path"] = ResourceParameterKind.Path }
+        };
+        var toolMock = new Mock<ITool>();
+        toolMock.Setup(t => t.Name).Returns("file_system");
+        toolMock.Setup(t => t.ResourceParametersByOperation).Returns(resourceMap);
+
+        var convertedTool = AIFunctionFactory.Create(() => "converted", "file_system");
+        var converter = new Mock<IToolConverter>();
+        converter.Setup(c => c.Convert(toolMock.Object, null)).Returns(convertedTool);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", toolMock.Object);
+
+        var builder = CreateBuilder(toolConverter: converter.Object, serviceProvider: services.BuildServiceProvider());
+
+        var tools = builder.BuildToolsByName(["file_system"]);
+
+        tools.Should().ContainSingle();
+        var governed = tools[0].Should().BeOfType<GovernedAIFunction>().Subject;
+        governed.Inner.Should().BeOfType<ResourceParameterDeclaringAIFunction>();
+    }
+
+    [Fact]
+    public void BuildToolsByName_ToolDeclaresNoResourceParameters_DoesNotWrap()
+    {
+        var toolMock = new Mock<ITool>();
+        toolMock.Setup(t => t.Name).Returns("file_system");
+        // ResourceParametersByOperation not set — default null, matching every tool before #418.
+
+        var convertedTool = AIFunctionFactory.Create(() => "converted", "file_system");
+        var converter = new Mock<IToolConverter>();
+        converter.Setup(c => c.Convert(toolMock.Object, null)).Returns(convertedTool);
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", toolMock.Object);
+
+        var builder = CreateBuilder(toolConverter: converter.Object, serviceProvider: services.BuildServiceProvider());
+
+        var tools = builder.BuildToolsByName(["file_system"]);
+
+        tools.Should().ContainSingle();
+        var governed = tools[0].Should().BeOfType<GovernedAIFunction>().Subject;
+        governed.Inner.Should().NotBeOfType<ResourceParameterDeclaringAIFunction>();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -154,7 +154,7 @@ public sealed class SubPlanEnvelopeConfinementTests
         var capabilityEnforcer = new Mock<ICapabilityEnforcer>();
         capabilityEnforcer
             .Setup(x => x.EnforceAsync(It.IsAny<string>(), It.IsAny<Domain.AI.Sandbox.ToolCapability>(),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary

#405 removed `ToolPermissionProfile`'s `AllowedPaths`/`DeniedPaths`/`AllowedHosts`/`DeniedHosts` and `CapabilityEnforcer`'s matching logic as dead code — the one call site never populated the requested paths/hosts the check needed, so the whole mechanism was inert. This restores it for real:

- Tools declare which of their named parameters are paths/hosts via a new `ITool.ResourceParametersByOperation` (`FileSystemTool` is the first to declare it).
- `ResourceParameterExtractor` turns a call's operation + parameters into a `ToolCallResourceRequest`, with a deliberate `null` (unknown, fail closed) vs `Empty` (determined, nothing to check) distinction — the exact conflation #405 shipped.
- Both live admission paths — the agent-turn path (`GovernedAIFunction`) and the direct-invocation HTTP path (`DirectToolInvoker`) — extract this request and thread it into `CapabilityEnforcer.EnforceAsync`, which enforces deny-overrides-allow path/host scoping, canonicalizing paths (via a new `IPathCanonicalizer`, Infrastructure-implemented) so a symlink can't defeat the check the way a raw string comparison could.

## Hardening beyond the initial restoration

Five review rounds (grader/correctness/security, run against `run-gates.sh`) plus two `/code-review` passes and one `/simplify` pass caught and fixed real defects along the way:

- Case-insensitive operation-name lookup (an `operation: "Read"` call was silently downgrading to "nothing scoped" and bypassing `DeniedPaths` entirely).
- Relative-path and Windows drive-relative-path handling (a relative path resolves against an unknown base and must be refused, not guessed at) — on both the requested-path and the configured-boundary side.
- Host matching: bare IPv6, trailing-dot FQDNs, URL-shaped values with embedded schemes/userinfo/ports, all normalized via `Uri.TryCreate` rather than ad-hoc string scanning.
- **A HIGH finding on the last pass**: `file_system`'s `search`/`list` operations recursively read everything beneath the single declared `path` argument, but the enforcer only checked whether the *requested* path fell inside a denied boundary — not whether a denied boundary sat *inside* the requested path. Fixed by checking containment in both directions.
- `CapabilityEnforcer` (grown to ~390 lines through the hardening rounds) split into `.PathScoping.cs`/`.HostScoping.cs` partials, matching this repo's existing large-class convention, plus hoisting redundant per-pair normalization out of the comparison loops.

## Known, deliberately deferred gaps (documented in `ToolOverrideConfig`'s remarks)

- `ToolPermissionProfileResolver.ResolveForUngovernedDispatch` (whole-shell-command tools like `WorkspaceCommandRunner`/`IacSandboxRunner`) never copies the new fields onto the profile it returns — was already out of scope per the approved plan.
- The plan/DAG executor (`ToolUseStepExecutor`) doesn't extract a `ToolCallResourceRequest` at all — a third, architecturally distinct admission path (a sandboxed subprocess boundary) outside this PR's scope, currently inert since no tool ships with scoping configured by default. Tracked as #587, with design guidance added there.

Closes #418

## Test plan

- [x] Unit tests: `CapabilityEnforcementTests.cs` (33 cases covering deny/allow, deny-overrides-allow, sibling-directory non-match, traversal/relative-path refusal, host normalization edge cases, the subtree-read fix, null/empty config entries)
- [x] `ResourceParameterExtractorTests.cs` (11 cases for the null/Empty/populated three-way extraction logic, including the case-insensitivity regression)
- [x] `ToolChainBuilderTests.cs` additions for the resource-parameter attachment wiring
- [x] End-to-end: `ToolPathScopingEndToEndTests.cs` — a real `FileSystemTool` through the real `ToolChainBuilder`/`GovernedAIFunction` and through `DirectToolInvoker`, proving a configured deny actually refuses a matching call and an allowed call still succeeds
- [x] Every new guard mutation-tested (broken → confirmed the corresponding test fails → reverted)
- [x] Full solution build + test suite green
- [x] `run-gates.sh` clean (build/test/owasp/grader/correctness/security/docs-drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVKDxbkyu6kqeZd6qCLJM6