### PR TITLE
fix: wire per-skill egress allowlists into real enforcement

### DIFF
--- a/plugins/iac-skill/skills/iac-authoring/SKILL.md
+++ b/plugins/iac-skill/skills/iac-authoring/SKILL.md
@@ -23,9 +23,15 @@ tools:
     description: "Security-scan the module (Checkov + tfsec / ARM-TTK + Checkov); reports normalised findings and a pass/fail verdict."
 egress:
   allowlist:
-    - "registry.terraform.io"
-    - "releases.hashicorp.com"
-    - "mcr.microsoft.com"
+    - host: "registry.terraform.io"
+      schemes: ["https"]
+      ports: [443]
+    - host: "releases.hashicorp.com"
+      schemes: ["https"]
+      ports: [443]
+    - host: "mcr.microsoft.com"
+      schemes: ["https"]
+      ports: [443]
 ---
 
 You are the IaC authoring skill. You scaffold infrastructure-as-code modules,

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -30,6 +30,18 @@ namespace Application.AI.Common.Services.Agent;
 /// template other consumers extend, so it is written down rather than left implicit.
 /// </para>
 /// <para>
+/// <strong>Known limitation: no per-skill egress scope on this channel either (#531, tracked as #589).</strong> The
+/// same missing provenance that blocks MCP-failure normalization above also blocks
+/// <see cref="GovernedAIFunction"/>'s skill-scoped egress wiring: <see cref="Govern"/>'s
+/// <c>new GovernedAIFunction(fn)</c> call always passes a null skill id, so a tool reaching the model
+/// through this channel — <c>run_skill_script</c> notably, the one tool here that IS fully governed —
+/// runs with whatever skill scope (if any) happens to already be ambient from an outer call, never one
+/// attributed to the skill that actually contributed it. Fails closed (the egress resolver falls back
+/// to the harness-wide default allowlist), never open. Giving this channel real per-tool skill
+/// attribution is the same larger, separate change the MCP-provenance gap above already calls for —
+/// not something to bolt onto one tool here without doing it for the whole channel.
+/// </para>
+/// <para>
 /// Register this provider <em>last</em> in the <c>AIContextProviders</c> list (after the skills
 /// provider and <see cref="ToolPermissionFilter"/>) so it sees the final, filtered tool set.
 /// Already-wrapped functions and non-function tools pass through unchanged, so it composes safely

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Escalation;
 using Domain.AI.Governance;
@@ -56,16 +57,35 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     private const string ReportedBy = "agent-turn";
 
     private readonly ToolCompositionTaint? _compositionTaint;
+    private readonly ICurrentSkillAccessor? _currentSkillAccessor;
+    private readonly string? _skillId;
 
     /// <param name="innerFunction">The tool function this wrapper governs.</param>
     /// <param name="compositionTaint">
     /// The tool-composition findings that implicate this tool as a sink, when any were found — see
     /// <see cref="ToolChainBuilder.ApplyCompositionTaint"/>.
     /// </param>
-    public GovernedAIFunction(AIFunction innerFunction, ToolCompositionTaint? compositionTaint = null)
+    /// <param name="currentSkillAccessor">
+    /// Establishes <paramref name="skillId"/> as the ambient current skill (#531) for the duration of
+    /// this call, so a per-skill policy resolver (the egress allowlist resolver) sees the right skill
+    /// without the caller threading it through every method. Null when this tool was not built from a
+    /// skill context (e.g. <c>ToolChainBuilder.BuildToolsByName</c>, used for delegated subagents) —
+    /// the call then runs with whatever skill scope, if any, is already ambient.
+    /// </param>
+    /// <param name="skillId">
+    /// The id of the skill this tool was resolved for. Null has the same "no scope to establish"
+    /// effect as a null <paramref name="currentSkillAccessor"/>.
+    /// </param>
+    public GovernedAIFunction(
+        AIFunction innerFunction,
+        ToolCompositionTaint? compositionTaint = null,
+        ICurrentSkillAccessor? currentSkillAccessor = null,
+        string? skillId = null)
         : base(innerFunction)
     {
         _compositionTaint = compositionTaint;
+        _currentSkillAccessor = currentSkillAccessor;
+        _skillId = skillId;
     }
 
     /// <summary>
@@ -78,10 +98,24 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     /// </summary>
     internal AIFunction Inner => InnerFunction;
 
+    /// <summary>
+    /// The skill this tool was resolved for (#531), so <c>ToolChainBuilder.ApplyCompositionTaint</c>'s
+    /// re-wrap can carry it forward onto the new instance instead of silently losing the scope.
+    /// </summary>
+    internal string? SkillId => _skillId;
+
+    /// <summary>
+    /// The accessor supplied at construction, for the same re-wrap-forwarding reason as
+    /// <see cref="SkillId"/>.
+    /// </summary>
+    internal ICurrentSkillAccessor? CurrentSkillAccessor => _currentSkillAccessor;
+
     protected override async ValueTask<object?> InvokeCoreAsync(
         AIFunctionArguments arguments,
         CancellationToken cancellationToken)
     {
+        using var skillScope = BeginSkillScope();
+
         var admissionPipeline = ToolAdmissionAccessor.Current;
         if (admissionPipeline is null)
             return Unwrap(await base.InvokeCoreAsync(arguments, cancellationToken).ConfigureAwait(false));
@@ -147,6 +181,15 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
             .ApplyOutputPolicyAsync(admission, Name, Unwrap(result), CancellationToken.None)
             .ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Establishes <see cref="_skillId"/> as the ambient current skill for this call's duration
+    /// (#531), or returns null (no-op scope) when either half is missing. Called once, wrapping the
+    /// whole method body, so both the early-return-no-admission-pipeline branch and the main path get
+    /// the same scope without duplicating the check.
+    /// </summary>
+    private IDisposable? BeginSkillScope() =>
+        _skillId is not null ? _currentSkillAccessor?.BeginScope(_skillId) : null;
 
     /// <summary>
     /// Extracts this call's requested paths/hosts (#418), when the wrapped function is a

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -189,7 +189,7 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     /// the same scope without duplicating the check.
     /// </summary>
     private IDisposable? BeginSkillScope() =>
-        _skillId is not null ? _currentSkillAccessor?.BeginScope(_skillId) : null;
+        !string.IsNullOrWhiteSpace(_skillId) ? _currentSkillAccessor?.BeginScope(_skillId) : null;
 
     /// <summary>
     /// Extracts this call's requested paths/hosts (#418), when the wrapped function is a

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
@@ -116,6 +116,23 @@ public partial class ToolChainBuilder
     /// one that was actually scanned. Also returns which surviving names are MCP-attributed, decided in
     /// the same pass rather than re-derived by the caller.
     /// </summary>
+    /// <remarks>
+    /// <strong>Known limitation: two skills sharing a first-party tool name pin the published
+    /// instance's per-skill egress scope (#531, tracked as #589) to whichever skill enumerated
+    /// first.</strong> Each
+    /// skill's tools are already wrapped as <see cref="GovernedAIFunction"/> — one <c>SkillId</c>
+    /// baked in per instance — before <paramref name="allProvisioned"/> reaches this method
+    /// (<c>BuildProvisionedToolsAsync</c>/<c>FinalizeChain</c> runs per skill, upstream). The
+    /// first-party dedup loop below (<c>seen.Add(p.Tool.Name)</c>) keeps only the first-enumerated
+    /// skill's instance, so a call to that shared tool always resolves the first skill's egress
+    /// allowlist, even during a turn the model is conceptually driving from the second skill. Not a
+    /// security hole — the resolved policy is still a real, valid skill's policy, never the harness
+    /// default's absence of one — but it can silently withhold a second skill's declared allowlist
+    /// addition for a tool the two skills happen to share by name. Fixing this precisely needs a
+    /// design decision this PR doesn't make: whether a shared tool name should union every
+    /// contributing skill's allowlist, or something else. Tracked for follow-up rather than guessed at
+    /// here.
+    /// </remarks>
     private static (List<AITool> Tools, HashSet<string> McpAttributedNames) ProjectSurvivors(
         List<ProvisionedTool> allProvisioned,
         List<ProvisionedTool> mcpCandidates,

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -60,7 +60,9 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// A tool paired with where it was resolved from — recorded at the moment of resolution, before
     /// dedup, the reserved-name filter, or governance wrapping run. <see langword="null"/>
     /// <see cref="McpServerName"/> means first-party (keyed DI or caller-supplied); a non-null value
-    /// names the MCP server that advertised it.
+    /// names the MCP server that advertised it. <see cref="SkillId"/> is the second provenance
+    /// dimension (#531): the skill this tool was resolved for, or <see langword="null"/> for the
+    /// skill-agnostic <see cref="BuildToolsByName"/> path.
     /// </summary>
     /// <remarks>
     /// This is the single source of truth for "where did this tool come from" used by
@@ -71,9 +73,13 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// tool's description verbatim onto a same-named MCP tool, making both instances indistinguishable
     /// and causing the exclusion to drop them both. Tracking provenance positionally as each tool is
     /// produced makes both failure modes structurally impossible: origin is a label attached at
-    /// creation, never re-derived from content.
+    /// creation, never re-derived from content. <see cref="SkillId"/> lives on this struct rather than
+    /// as a separate scalar parameter threaded through <see cref="FinalizeChain"/>/<see cref="WrapGoverned"/>
+    /// for the same reason: a per-tool carrier is what a future cross-skill union policy (#589) would
+    /// need to look at, and a scalar "every tool in this batch shares one skill" parameter can never
+    /// express that even though today's one-skill-per-build-call shape means the two are equivalent.
     /// </remarks>
-    private readonly record struct ProvisionedTool(AITool Tool, string? McpServerName);
+    private readonly record struct ProvisionedTool(AITool Tool, string? McpServerName, string? SkillId = null);
 
     /// <summary>
     /// Resolves one skill's tools. Runs the same first-party-precedence and collision/shadowing/drift
@@ -128,12 +134,12 @@ public partial class ToolChainBuilder : IToolChainBuilder
             // config a bundle registers into, so a colon in the name is not evidence of bundle ownership.
             var isBundleOwned = envelope?.IsBundleOwnedMcpServer(serverName) ?? false;
             foreach (var t in serverTools)
-                injected.Add(new ProvisionedTool(PublishServerTool(t, serverName, isBundleOwned), serverName));
+                injected.Add(new ProvisionedTool(PublishServerTool(t, serverName, isBundleOwned), serverName, skill.Id));
         }
 
         if (options.AdditionalTools?.Count > 0)
             foreach (var t in options.AdditionalTools)
-                injected.Add(new ProvisionedTool(t, null));
+                injected.Add(new ProvisionedTool(t, null, skill.Id));
 
         injected = ApplyPluginBoundaryIfPluginSkill(skill, injected);
 
@@ -149,7 +155,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // No call-once candidates flow through this path: Injected mode never calls ProvisionToolAsync
         // (the only place a ToolDeclaration's CallOncePerConversation is tagged), so there is nothing
         // for FinalizeChain to carry forward here.
-        return FinalizeChain(injected, DescribeSource(skill, "injected MCP tool resolution"), skillId: skill.Id);
+        return FinalizeChain(injected, DescribeSource(skill, "injected MCP tool resolution"));
     }
 
     private async Task<List<ProvisionedTool>> BuildManagedModeToolsAsync(
@@ -162,11 +168,11 @@ public partial class ToolChainBuilder : IToolChainBuilder
 
         if (skill.Tools?.Count > 0)
             foreach (var t in skill.Tools)
-                managed.Add(new ProvisionedTool(t, null));
+                managed.Add(new ProvisionedTool(t, null, skill.Id));
 
         if (skill.ToolDeclarations?.Count > 0)
         {
-            var provisionTasks = skill.ToolDeclarations.Select(d => ProvisionToolAsync(d, callOnceCandidates, cancellationToken));
+            var provisionTasks = skill.ToolDeclarations.Select(d => ProvisionToolAsync(d, skill.Id, callOnceCandidates, cancellationToken));
             var results = await Task.WhenAll(provisionTasks);
             foreach (var provisioned in results)
                 if (provisioned != null)
@@ -180,13 +186,13 @@ public partial class ToolChainBuilder : IToolChainBuilder
                 var resolved = ResolveToolByName(toolName);
                 if (resolved != null)
                     foreach (var t in resolved)
-                        managed.Add(new ProvisionedTool(t, null));
+                        managed.Add(new ProvisionedTool(t, null, skill.Id));
             }
         }
 
         if (options.AdditionalTools?.Count > 0)
             foreach (var t in options.AdditionalTools)
-                managed.Add(new ProvisionedTool(t, null));
+                managed.Add(new ProvisionedTool(t, null, skill.Id));
 
         managed = ApplyPluginBoundaryIfPluginSkill(skill, managed);
 
@@ -199,7 +205,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // whole-agent-set exit (BuildToolsAsync, BuildMergedToolsWithSourcesAsync) can register it
         // later, against the FULLY resolved surface — see RegisterSurvivingCallOnceTools's remarks for
         // why registering at this per-skill, pre-cross-skill-dedup point was unsafe.
-        return FinalizeChain(managed, DescribeSource(skill, "managed tool resolution"), callOnceCandidates, skill.Id);
+        return FinalizeChain(managed, DescribeSource(skill, "managed tool resolution"), callOnceCandidates);
     }
 
     /// <summary>
@@ -279,23 +285,17 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// <param name="callOnceCandidates">
     /// Optional. When supplied, any tool present in this set that survives the reserved-capability
     /// filter below has its NEW, governance-wrapped instance added too — see
-    /// <see cref="WrapGoverned(IEnumerable{ProvisionedTool}, ConcurrentDictionary{AITool,byte}?, string?)"/>'s
+    /// <see cref="WrapGoverned(IEnumerable{ProvisionedTool}, ConcurrentDictionary{AITool,byte}?)"/>'s
     /// remarks for why the wrap would otherwise sever reference-based candidate tracking.
-    /// </param>
-    /// <param name="skillId">
-    /// The id of the one skill every tool in <paramref name="provisioned"/> was resolved for (#531) —
-    /// each of this builder's per-skill resolution methods calls here with exactly one skill in scope.
-    /// Null for the skill-agnostic <see cref="BuildToolsByName"/> path (delegated subagents), which
-    /// correctly leaves those tools with no skill-scoped egress allowlist.
     /// </param>
     private List<ProvisionedTool> FinalizeChain(
         List<ProvisionedTool> provisioned, string source,
-        ConcurrentDictionary<AITool, byte>? callOnceCandidates = null, string? skillId = null)
+        ConcurrentDictionary<AITool, byte>? callOnceCandidates = null)
     {
         var survivors = ReservedPlanCapabilityFilter.Exclude(provisioned.Select(p => p.Tool), source, _logger);
         var afterReservedFilter = KeepSurviving(provisioned, survivors);
 
-        var wrapped = WrapGoverned(afterReservedFilter, callOnceCandidates, skillId);
+        var wrapped = WrapGoverned(afterReservedFilter, callOnceCandidates);
         return afterReservedFilter.Zip(wrapped, (p, w) => p with { Tool = w }).ToList();
     }
 
@@ -340,15 +340,15 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// resolved ad hoc from <see cref="_serviceProvider"/> — the same pattern already used for
     /// <see cref="Interfaces.Plugins.IPluginRegistry"/> in <see cref="ApplyPluginBoundaryIfPluginSkill"/>
     /// — rather than a constructor dependency, since it is needed only here. Every tool wrapped in one
-    /// call shares the one resolved instance and the one <paramref name="skillId"/>; both are carried
-    /// into <see cref="GovernedAIFunction"/> so a per-skill policy resolver (the egress allowlist
-    /// resolver) sees the right skill scope for the duration of each tool's own invocation.
+    /// call shares the one resolved accessor instance; each tool's own <see cref="ProvisionedTool.SkillId"/>
+    /// is carried into <see cref="GovernedAIFunction"/> alongside it, so a per-skill policy resolver (the
+    /// egress allowlist resolver) sees the right skill scope for the duration of each tool's own
+    /// invocation.
     /// </para>
     /// </remarks>
     private List<AITool> WrapGoverned(
         IEnumerable<ProvisionedTool> provisioned,
-        ConcurrentDictionary<AITool, byte>? callOnceCandidates = null,
-        string? skillId = null)
+        ConcurrentDictionary<AITool, byte>? callOnceCandidates = null)
     {
         var currentSkillAccessor = _serviceProvider.GetService<ICurrentSkillAccessor>();
         var result = new List<AITool>();
@@ -357,7 +357,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
             var wrapped = p.Tool is AIFunction fn and not GovernedAIFunction
                 ? new GovernedAIFunction(
                     p.McpServerName is not null ? new McpFailureNormalizingAIFunction(fn) : fn,
-                    currentSkillAccessor: currentSkillAccessor, skillId: skillId)
+                    currentSkillAccessor: currentSkillAccessor, skillId: p.SkillId)
                 : p.Tool;
 
             if (callOnceCandidates is not null && callOnceCandidates.ContainsKey(p.Tool))
@@ -557,6 +557,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// </summary>
     private async Task<List<ProvisionedTool>?> ProvisionToolAsync(
         Domain.AI.Tools.ToolDeclaration declaration,
+        string skillId,
         ConcurrentDictionary<AITool, byte> callOnceCandidates,
         CancellationToken cancellationToken = default)
     {
@@ -583,7 +584,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
                     // tool auto-granted by advertising a same-named tool of its own. See
                     // CapabilityEnvelope.IsBundleOwnedMcpServer and BundleOwnedMcpToolNaming.
                     var provisionedMcpTools = mcpTools
-                        .Select(t => new ProvisionedTool(PublishServerTool(t, effectiveServerName, isBundleOwned), effectiveServerName))
+                        .Select(t => new ProvisionedTool(PublishServerTool(t, effectiveServerName, isBundleOwned), effectiveServerName, skillId))
                         .ToList();
                     TagCallOnceCandidates(declaration, provisionedMcpTools, callOnceCandidates);
                     return provisionedMcpTools;
@@ -599,7 +600,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         var resolved = ResolveToolByName(declaration.Name);
         if (resolved != null)
         {
-            var provisionedFirstParty = resolved.Select(t => new ProvisionedTool(t, null)).ToList();
+            var provisionedFirstParty = resolved.Select(t => new ProvisionedTool(t, null, skillId)).ToList();
             TagCallOnceCandidates(declaration, provisionedFirstParty, callOnceCandidates);
             return provisionedFirstParty;
         }
@@ -611,7 +612,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
             {
                 _logger.LogInformation("Using fallback tool {Fallback} for {ToolName}",
                     declaration.Fallback, declaration.Name);
-                var provisionedFallback = resolved.Select(t => new ProvisionedTool(t, null)).ToList();
+                var provisionedFallback = resolved.Select(t => new ProvisionedTool(t, null, skillId)).ToList();
                 TagCallOnceCandidates(declaration, provisionedFallback, callOnceCandidates);
                 return provisionedFallback;
             }
@@ -683,7 +684,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// a declaration that never had authority over it — reintroducing the exact class of defect
     /// <see cref="ProvisionedTool"/>'s own remarks warn against for provenance tracking generally. Instead,
     /// <paramref name="callOnceCandidates"/> is populated with the ORIGINAL resolved instance in
-    /// <see cref="TagCallOnceCandidates"/>, and <see cref="WrapGoverned(IEnumerable{ProvisionedTool},ConcurrentDictionary{AITool,byte}?,string?)"/>
+    /// <see cref="TagCallOnceCandidates"/>, and <see cref="WrapGoverned(IEnumerable{ProvisionedTool},ConcurrentDictionary{AITool,byte}?)"/>
     /// carries that membership forward onto the new <see cref="GovernedAIFunction"/> instance as each
     /// tool is wrapped — so checking <paramref name="survivors"/> by reference here still correctly
     /// distinguishes "the specific instance a call-once declaration actually produced" from "any tool

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Domain.AI.Governance;
@@ -148,7 +149,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // No call-once candidates flow through this path: Injected mode never calls ProvisionToolAsync
         // (the only place a ToolDeclaration's CallOncePerConversation is tagged), so there is nothing
         // for FinalizeChain to carry forward here.
-        return FinalizeChain(injected, DescribeSource(skill, "injected MCP tool resolution"));
+        return FinalizeChain(injected, DescribeSource(skill, "injected MCP tool resolution"), skillId: skill.Id);
     }
 
     private async Task<List<ProvisionedTool>> BuildManagedModeToolsAsync(
@@ -198,7 +199,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // whole-agent-set exit (BuildToolsAsync, BuildMergedToolsWithSourcesAsync) can register it
         // later, against the FULLY resolved surface — see RegisterSurvivingCallOnceTools's remarks for
         // why registering at this per-skill, pre-cross-skill-dedup point was unsafe.
-        return FinalizeChain(managed, DescribeSource(skill, "managed tool resolution"), callOnceCandidates);
+        return FinalizeChain(managed, DescribeSource(skill, "managed tool resolution"), callOnceCandidates, skill.Id);
     }
 
     /// <summary>
@@ -278,16 +279,23 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// <param name="callOnceCandidates">
     /// Optional. When supplied, any tool present in this set that survives the reserved-capability
     /// filter below has its NEW, governance-wrapped instance added too — see
-    /// <see cref="WrapGoverned(IEnumerable{ProvisionedTool}, ConcurrentDictionary{AITool,byte}?)"/>'s
+    /// <see cref="WrapGoverned(IEnumerable{ProvisionedTool}, ConcurrentDictionary{AITool,byte}?, string?)"/>'s
     /// remarks for why the wrap would otherwise sever reference-based candidate tracking.
     /// </param>
+    /// <param name="skillId">
+    /// The id of the one skill every tool in <paramref name="provisioned"/> was resolved for (#531) —
+    /// each of this builder's per-skill resolution methods calls here with exactly one skill in scope.
+    /// Null for the skill-agnostic <see cref="BuildToolsByName"/> path (delegated subagents), which
+    /// correctly leaves those tools with no skill-scoped egress allowlist.
+    /// </param>
     private List<ProvisionedTool> FinalizeChain(
-        List<ProvisionedTool> provisioned, string source, ConcurrentDictionary<AITool, byte>? callOnceCandidates = null)
+        List<ProvisionedTool> provisioned, string source,
+        ConcurrentDictionary<AITool, byte>? callOnceCandidates = null, string? skillId = null)
     {
         var survivors = ReservedPlanCapabilityFilter.Exclude(provisioned.Select(p => p.Tool), source, _logger);
         var afterReservedFilter = KeepSurviving(provisioned, survivors);
 
-        var wrapped = WrapGoverned(afterReservedFilter, callOnceCandidates);
+        var wrapped = WrapGoverned(afterReservedFilter, callOnceCandidates, skillId);
         return afterReservedFilter.Zip(wrapped, (p, w) => p with { Tool = w }).ToList();
     }
 
@@ -327,15 +335,29 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// instance already inside it; it never lets a name substitute for a reference the way the general
     /// provenance problem above forbids.
     /// </para>
+    /// <para>
+    /// Resolves <see cref="ICurrentSkillAccessor"/> once per call (#531), an optional collaborator
+    /// resolved ad hoc from <see cref="_serviceProvider"/> — the same pattern already used for
+    /// <see cref="Interfaces.Plugins.IPluginRegistry"/> in <see cref="ApplyPluginBoundaryIfPluginSkill"/>
+    /// — rather than a constructor dependency, since it is needed only here. Every tool wrapped in one
+    /// call shares the one resolved instance and the one <paramref name="skillId"/>; both are carried
+    /// into <see cref="GovernedAIFunction"/> so a per-skill policy resolver (the egress allowlist
+    /// resolver) sees the right skill scope for the duration of each tool's own invocation.
+    /// </para>
     /// </remarks>
     private List<AITool> WrapGoverned(
-        IEnumerable<ProvisionedTool> provisioned, ConcurrentDictionary<AITool, byte>? callOnceCandidates = null)
+        IEnumerable<ProvisionedTool> provisioned,
+        ConcurrentDictionary<AITool, byte>? callOnceCandidates = null,
+        string? skillId = null)
     {
+        var currentSkillAccessor = _serviceProvider.GetService<ICurrentSkillAccessor>();
         var result = new List<AITool>();
         foreach (var p in provisioned)
         {
             var wrapped = p.Tool is AIFunction fn and not GovernedAIFunction
-                ? new GovernedAIFunction(p.McpServerName is not null ? new McpFailureNormalizingAIFunction(fn) : fn)
+                ? new GovernedAIFunction(
+                    p.McpServerName is not null ? new McpFailureNormalizingAIFunction(fn) : fn,
+                    currentSkillAccessor: currentSkillAccessor, skillId: skillId)
                 : p.Tool;
 
             if (callOnceCandidates is not null && callOnceCandidates.ContainsKey(p.Tool))
@@ -488,9 +510,13 @@ public partial class ToolChainBuilder : IToolChainBuilder
             // finding discovered by THIS analysis means unwrapping to the same inner function and
             // rewrapping — never double-governing, since InnerFunction always points at the real tool.
             // governed.Inner already carries any McpFailureNormalizingAIFunction wrapping intact —
-            // there is no separate provenance flag left to forward.
+            // there is no separate provenance flag left to forward. governed.CurrentSkillAccessor/
+            // SkillId (#531) DO need forwarding explicitly — unlike Inner, they are not implicit in
+            // the wrapped function, so a re-wrap that forgot them would silently drop the tool's skill
+            // scope the moment a composition finding implicates it.
             return (AITool)new GovernedAIFunction(
-                governed.Inner, new ToolCompositionTaint(findings));
+                governed.Inner, new ToolCompositionTaint(findings),
+                governed.CurrentSkillAccessor, governed.SkillId);
         }).ToList();
     }
 
@@ -657,7 +683,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// a declaration that never had authority over it — reintroducing the exact class of defect
     /// <see cref="ProvisionedTool"/>'s own remarks warn against for provenance tracking generally. Instead,
     /// <paramref name="callOnceCandidates"/> is populated with the ORIGINAL resolved instance in
-    /// <see cref="TagCallOnceCandidates"/>, and <see cref="WrapGoverned(IEnumerable{ProvisionedTool},ConcurrentDictionary{AITool,byte}?)"/>
+    /// <see cref="TagCallOnceCandidates"/>, and <see cref="WrapGoverned(IEnumerable{ProvisionedTool},ConcurrentDictionary{AITool,byte}?,string?)"/>
     /// carries that membership forward onto the new <see cref="GovernedAIFunction"/> instance as each
     /// tool is wrapped — so checking <paramref name="survivors"/> by reference here still correctly
     /// distinguishes "the specific instance a call-once declaration actually produced" from "any tool

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
@@ -46,12 +46,6 @@ namespace Infrastructure.AI.Egress;
 /// </remarks>
 public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
 {
-    /// <summary>
-    /// Cache key reserved for the "no skill active" path. Distinct from any
-    /// valid skill id (skill ids cannot contain spaces in the discovery flow).
-    /// </summary>
-    private const string NoSkillKey = "<no-skill>";
-
     private readonly ICurrentSkillAccessor _currentSkill;
     private readonly ISkillMetadataRegistry _skillRegistry;
     private readonly IOptionsMonitor<AppConfig> _appConfig;
@@ -59,7 +53,18 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     private readonly ILogger<DefaultEgressPolicy> _policyLogger;
     private readonly TimeProvider _timeProvider;
 
-    private readonly ConcurrentDictionary<string, IEgressPolicy> _cache = new(StringComparer.OrdinalIgnoreCase);
+    // Two separate caches rather than one keyed by skill id plus a reserved sentinel string (#531
+    // security-review finding): the prior design's sentinel ("<no-skill>") relied on no real skill
+    // ever being named that, case-insensitively, in a case-insensitive cache — a property nothing
+    // enforced, and one the sentinel's own doc comment misstated (it claimed the safety came from
+    // skill ids never containing spaces, which the sentinel itself doesn't contain and so proves
+    // nothing about). A skill an operator names any case variant of the sentinel would collide in
+    // the shared dictionary with the reserved "no skill" entry, in whichever direction lost the
+    // race to populate the cache first — leaking that skill's widened allowlist onto every
+    // unscoped call, or vice versa. Splitting the "no skill" case onto its own field makes the
+    // collision structurally impossible rather than relying on a string never being reused.
+    private readonly Lazy<IEgressPolicy> _noSkillPolicy;
+    private readonly ConcurrentDictionary<string, IEgressPolicy> _skillCache = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Initializes a new <see cref="SkillManifestEgressPolicyResolver"/>.</summary>
     public SkillManifestEgressPolicyResolver(
@@ -83,6 +88,7 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         _logger = logger;
         _policyLogger = policyLogger;
         _timeProvider = timeProvider;
+        _noSkillPolicy = new Lazy<IEgressPolicy>(BuildDefaultOnlyPolicy);
     }
 
     /// <inheritdoc />
@@ -90,18 +96,19 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     {
         ArgumentNullException.ThrowIfNull(identity);
 
-        var key = _currentSkill.CurrentSkillId ?? NoSkillKey;
-        return _cache.GetOrAdd(key, BuildPolicy);
+        var skillId = _currentSkill.CurrentSkillId;
+        return skillId is null ? _noSkillPolicy.Value : _skillCache.GetOrAdd(skillId, BuildPolicyForSkill);
     }
 
-    private IEgressPolicy BuildPolicy(string key)
+    private IEgressPolicy BuildDefaultOnlyPolicy()
     {
         var defaultEntries = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
+        return new DefaultEgressPolicy(defaultEntries, _policyLogger, _timeProvider);
+    }
 
-        if (string.Equals(key, NoSkillKey, StringComparison.Ordinal))
-        {
-            return new DefaultEgressPolicy(defaultEntries, _policyLogger, _timeProvider);
-        }
+    private IEgressPolicy BuildPolicyForSkill(string key)
+    {
+        var defaultEntries = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
 
         var skill = _skillRegistry.TryGet(key);
         if (skill is null)

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillDiscoveryServiceCollectionExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillDiscoveryServiceCollectionExtensions.cs
@@ -46,9 +46,17 @@ public static class SkillDiscoveryServiceCollectionExtensions
     /// standalone MCP server, per this method's own remarks above) never runs
     /// <c>AddApplicationAIDependencies</c>'s <c>AddValidatorsFromAssembly</c> at all, so without this
     /// line <see cref="SkillMetadataParser"/> would fail to construct there outright, not merely with
-    /// the wrong lifetime. A caller that DOES also run the assembly scan ends up with two registrations
-    /// for the same service; the last one registered wins for direct resolution, so composition order
-    /// decides nothing here — this singleton always satisfies the constructor.
+    /// the wrong lifetime.
+    /// </para>
+    /// <para>
+    /// <b>Composition order still matters for a caller that also runs the assembly scan.</b> .NET DI
+    /// resolves the LAST registration of a service type for direct injection, so this singleton wins
+    /// only because <c>AddGlobalProjectDependencies</c> calls <c>AddApplicationAIDependencies</c>
+    /// (line ~532, the scoped scan) before <c>AddInfrastructureAIDependencies</c> → this method
+    /// (line ~543). A future reordering of those two calls would silently restore the captive-dependency
+    /// failure this fix closes — <c>ValidateOnBuild</c> would catch it, but only at container-build
+    /// time, not at compile time. Keep this registration downstream of any consumer's own
+    /// <c>AddValidatorsFromAssembly</c> call over an assembly that scans <see cref="EgressManifestValidator"/>.
     /// </para>
     /// </remarks>
     /// <param name="services">The service collection to register into.</param>

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillDiscoveryServiceCollectionExtensions.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillDiscoveryServiceCollectionExtensions.cs
@@ -1,5 +1,8 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Skills;
+using Domain.AI.Skills;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure.AI.Skills;
@@ -31,6 +34,22 @@ public static class SkillDiscoveryServiceCollectionExtensions
     /// skill loading behind a sandbox — would let the model rewrite its own <c>SKILL.md</c> files,
     /// <c>allowed-tools</c> list included. See <see cref="ISkillFileReader"/>.
     /// </para>
+    /// <para>
+    /// <b>On the egress validator (#531).</b> <see cref="SkillMetadataParser"/> also needs
+    /// <c>IValidator&lt;EgressManifest&gt;</c>, registered here as a singleton rather than left to
+    /// <c>AddValidatorsFromAssembly</c>'s default scoped lifetime — <see cref="EgressManifestValidator"/>
+    /// is stateless (a pure FluentValidation rule tree with no mutable state), so a singleton is safe,
+    /// and it must be one: <see cref="SkillMetadataParser"/> is itself a singleton, and a singleton
+    /// cannot consume a scoped service (<c>ValidateOnBuild</c> catches this — a captive dependency —
+    /// the moment any host builds its container). Registering it here, not only via the assembly scan,
+    /// closes the same gap #247 already fixed once for the reader: a caller of just this method (the
+    /// standalone MCP server, per this method's own remarks above) never runs
+    /// <c>AddApplicationAIDependencies</c>'s <c>AddValidatorsFromAssembly</c> at all, so without this
+    /// line <see cref="SkillMetadataParser"/> would fail to construct there outright, not merely with
+    /// the wrong lifetime. A caller that DOES also run the assembly scan ends up with two registrations
+    /// for the same service; the last one registered wins for direct resolution, so composition order
+    /// decides nothing here — this singleton always satisfies the constructor.
+    /// </para>
     /// </remarks>
     /// <param name="services">The service collection to register into.</param>
     /// <returns>The same collection, for chaining.</returns>
@@ -39,6 +58,7 @@ public static class SkillDiscoveryServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.AddSingleton<ISkillFileReader, SkillFileReader>();
+        services.AddSingleton<IValidator<EgressManifest>, EgressManifestValidator>();
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.Egress.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.Egress.cs
@@ -1,0 +1,34 @@
+using Application.AI.Common.Exceptions;
+using Domain.AI.Skills;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Skills;
+
+/// <summary>
+/// Egress-manifest validation half of <see cref="SkillMetadataParser"/> — split out to keep the
+/// main file under this repo's 400-line convention (#531).
+/// </summary>
+public sealed partial class SkillMetadataParser
+{
+    /// <summary>
+    /// Validates a non-null <paramref name="egress"/> manifest against the same SSRF-narrow rules
+    /// the runtime egress policy applies (#531), throwing <see cref="SkillParsingException"/> if it
+    /// fails — a malformed manifest must never reach the policy resolver. Mirrors
+    /// <see cref="ScanOrRefuse"/>'s "refuse to construct the definition" shape for a different
+    /// class of manifest defect (schema validity, not content safety).
+    /// </summary>
+    private void ValidateEgressOrRefuse(EgressManifest? egress, string skillFilePath)
+    {
+        if (egress is null)
+            return;
+
+        var result = _egressValidator.Validate(egress);
+        if (result.IsValid)
+            return;
+
+        var reason = string.Join("; ", result.Errors.Select(e => e.ErrorMessage));
+        _logger.LogWarning(
+            "Refusing skill manifest at {Path}: invalid egress allowlist: {Reason}", skillFilePath, reason);
+        throw new SkillParsingException(skillFilePath, $"Invalid egress manifest: {reason}");
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
@@ -6,6 +6,7 @@ using Domain.AI.Egress;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using Domain.Common.Config.AI;
+using FluentValidation;
 using Infrastructure.AI.Governance;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -39,6 +40,7 @@ public sealed partial class SkillMetadataParser
     private readonly ISkillFileReader _fileReader;
     private readonly IMcpSecurityScanner _scanner;
     private readonly IOptionsMonitor<AIConfig> _config;
+    private readonly IValidator<EgressManifest> _egressValidator;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SkillMetadataParser"/> class.
@@ -58,21 +60,30 @@ public sealed partial class SkillMetadataParser
     /// <see cref="GovernanceConfig.McpToolBlockThreshold"/>); read per call so a config reload takes
     /// effect, matching <c>ScanningMcpToolProvider</c>'s convention for the same policy.
     /// </param>
+    /// <param name="egressValidator">
+    /// Validates a parsed <see cref="EgressManifest"/> against the same SSRF-narrow rules the
+    /// runtime egress policy applies (#531) — auto-discovered via <c>AddValidatorsFromAssembly</c> on
+    /// the <c>Application.AI.Common</c> assembly, so no manual registration is needed beyond this
+    /// constructor injection giving it a real caller.
+    /// </param>
     public SkillMetadataParser(
         ILogger<SkillMetadataParser> logger,
         ISkillFileReader fileReader,
         IMcpSecurityScanner scanner,
-        IOptionsMonitor<AIConfig> config)
+        IOptionsMonitor<AIConfig> config,
+        IValidator<EgressManifest> egressValidator)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(fileReader);
         ArgumentNullException.ThrowIfNull(scanner);
         ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(egressValidator);
 
         _logger = logger;
         _fileReader = fileReader;
         _scanner = scanner;
         _config = config;
+        _egressValidator = egressValidator;
     }
 
     /// <summary>
@@ -169,6 +180,9 @@ public sealed partial class SkillMetadataParser
 
         ScanOrRefuse(name, description, body, toolDeclarations, skillFilePath);
 
+        var egress = frontmatter.Egress();
+        ValidateEgressOrRefuse(egress, skillFilePath);
+
         var metaBlock = frontmatter.ScalarBlock("metadata");
 
         return new SkillDefinition
@@ -196,8 +210,30 @@ public sealed partial class SkillMetadataParser
             LoadedAt = DateTime.UtcNow,
 
             PluginSource = pluginSource,
-            Egress = frontmatter.Egress(),
+            Egress = egress,
         };
+    }
+
+    /// <summary>
+    /// Validates a non-null <paramref name="egress"/> manifest against the same SSRF-narrow rules
+    /// the runtime egress policy applies (#531), throwing <see cref="SkillParsingException"/> if it
+    /// fails — a malformed manifest must never reach the policy resolver. Mirrors
+    /// <see cref="ScanOrRefuse"/>'s "refuse to construct the definition" shape for a different
+    /// class of manifest defect (schema validity, not content safety).
+    /// </summary>
+    private void ValidateEgressOrRefuse(EgressManifest? egress, string skillFilePath)
+    {
+        if (egress is null)
+            return;
+
+        var result = _egressValidator.Validate(egress);
+        if (result.IsValid)
+            return;
+
+        var reason = string.Join("; ", result.Errors.Select(e => e.ErrorMessage));
+        _logger.LogWarning(
+            "Refusing skill manifest at {Path}: invalid egress allowlist: {Reason}", skillFilePath, reason);
+        throw new SkillParsingException(skillFilePath, $"Invalid egress manifest: {reason}");
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
@@ -2,7 +2,6 @@ using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Skills;
 using Application.Common.Helpers;
-using Domain.AI.Egress;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using Domain.Common.Config.AI;
@@ -213,28 +212,6 @@ public sealed partial class SkillMetadataParser
             PluginSource = pluginSource,
             Egress = egress,
         };
-    }
-
-    /// <summary>
-    /// Validates a non-null <paramref name="egress"/> manifest against the same SSRF-narrow rules
-    /// the runtime egress policy applies (#531), throwing <see cref="SkillParsingException"/> if it
-    /// fails — a malformed manifest must never reach the policy resolver. Mirrors
-    /// <see cref="ScanOrRefuse"/>'s "refuse to construct the definition" shape for a different
-    /// class of manifest defect (schema validity, not content safety).
-    /// </summary>
-    private void ValidateEgressOrRefuse(EgressManifest? egress, string skillFilePath)
-    {
-        if (egress is null)
-            return;
-
-        var result = _egressValidator.Validate(egress);
-        if (result.IsValid)
-            return;
-
-        var reason = string.Join("; ", result.Errors.Select(e => e.ErrorMessage));
-        _logger.LogWarning(
-            "Refusing skill manifest at {Path}: invalid egress allowlist: {Reason}", skillFilePath, reason);
-        throw new SkillParsingException(skillFilePath, $"Invalid egress manifest: {reason}");
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/SkillMetadataParser.cs
@@ -62,9 +62,10 @@ public sealed partial class SkillMetadataParser
     /// </param>
     /// <param name="egressValidator">
     /// Validates a parsed <see cref="EgressManifest"/> against the same SSRF-narrow rules the
-    /// runtime egress policy applies (#531) — auto-discovered via <c>AddValidatorsFromAssembly</c> on
-    /// the <c>Application.AI.Common</c> assembly, so no manual registration is needed beyond this
-    /// constructor injection giving it a real caller.
+    /// runtime egress policy applies (#531). Registered explicitly as a singleton in
+    /// <c>SkillDiscoveryServiceCollectionExtensions.AddSkillDiscovery</c> — see that method's remarks
+    /// for why a plain <c>AddValidatorsFromAssembly</c> registration (scoped by default) is not
+    /// sufficient here.
     /// </param>
     public SkillMetadataParser(
         ILogger<SkillMetadataParser> logger,

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/SkillEgressScopeActivationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/SkillEgressScopeActivationTests.cs
@@ -1,0 +1,156 @@
+using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Governance;
+using Domain.AI.Skills;
+using Domain.Common.Config.AI.Governance;
+using FluentAssertions;
+using Infrastructure.AI.Skills;
+using Infrastructure.AI.Tools;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Application.AI.Common.Tests.Governance;
+
+/// <summary>
+/// #531: proves the missing wire — <see cref="ToolChainBuilder"/> and <see cref="GovernedAIFunction"/>
+/// actually establish <see cref="ICurrentSkillAccessor.CurrentSkillId"/> for the duration of a tool
+/// call built from a skill, which is the one thing standing between
+/// <c>SkillManifestEgressPolicyResolver</c>'s already-correct merge logic and it ever running in
+/// production. Uses the real <see cref="CurrentSkillAccessor"/> (Infrastructure), not a mock — the
+/// mechanism under test IS the AsyncLocal flow, so a fake accessor would prove nothing.
+/// </summary>
+public sealed class SkillEgressScopeActivationTests
+{
+    private static (ITool Tool, Mock<IFileSystemService> FileSystem, ICurrentSkillAccessor Accessor, IServiceProvider Provider)
+        BuildFixture()
+    {
+        var fileSystem = new Mock<IFileSystemService>();
+        var tool = new FileSystemTool(fileSystem.Object);
+        var accessor = new CurrentSkillAccessor();
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("file_system", tool);
+        services.AddSingleton<ICurrentSkillAccessor>(accessor);
+
+        return (tool, fileSystem, accessor, services.BuildServiceProvider());
+    }
+
+    [Fact]
+    public async Task ToolBuiltFromSkill_EstablishesCurrentSkillId_ForTheDurationOfTheCall()
+    {
+        var (_, fileSystem, accessor, provider) = BuildFixture();
+
+        string? observedDuringCall = null;
+        fileSystem
+            .Setup(fs => fs.ReadFileAsync("notes.txt", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                observedDuringCall = accessor.CurrentSkillId;
+                return "hello world";
+            });
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, provider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+
+        var skill = new SkillDefinition { Id = "reader-skill", Name = "reader-skill", AllowedTools = ["file_system"] };
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+        var aiFunction = (AIFunction)tools.Single();
+
+        accessor.CurrentSkillId.Should().BeNull("no skill scope should be active before the call");
+
+        var args = new AIFunctionArguments
+        {
+            ["operation"] = "read",
+            ["parametersJson"] = System.Text.Json.JsonSerializer.SerializeToElement(new { path = "notes.txt" })
+        };
+        await aiFunction.InvokeAsync(args);
+
+        observedDuringCall.Should().Be("reader-skill", "the resolver reads CurrentSkillId from inside the tool's own execution");
+        accessor.CurrentSkillId.Should().BeNull("the scope must be restored once the call returns, not leaked to the next call");
+    }
+
+    [Fact]
+    public async Task ToolBuiltWithoutASkill_BuildToolsByName_NeverEstablishesASkillScope()
+    {
+        // BuildToolsByName (delegated subagents) has no skill context — this must stay a documented
+        // no-op, not silently inherit whatever happens to be ambient from an unrelated caller.
+        var (_, fileSystem, accessor, provider) = BuildFixture();
+
+        string? observedDuringCall = "not-yet-observed";
+        fileSystem
+            .Setup(fs => fs.ReadFileAsync("notes.txt", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                observedDuringCall = accessor.CurrentSkillId;
+                return "hello world";
+            });
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, provider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+        var aiFunction = (AIFunction)builder.BuildToolsByName(["file_system"], "test-agent").Single();
+
+        var args = new AIFunctionArguments
+        {
+            ["operation"] = "read",
+            ["parametersJson"] = System.Text.Json.JsonSerializer.SerializeToElement(new { path = "notes.txt" })
+        };
+        await aiFunction.InvokeAsync(args);
+
+        observedDuringCall.Should().BeNull();
+    }
+
+    /// <summary>Always reports one finding naming <c>file_system</c> as the sink, forcing
+    /// <c>ToolChainBuilder.ApplyCompositionTaint</c> to re-wrap it.</summary>
+    private sealed class AlwaysFindsCompositionAnalyzer : IToolCompositionAnalyzer
+    {
+        public ToolCompositionAssessment Analyze(IReadOnlyList<AITool> tools) => new(
+            [new ToolCompositionFinding(
+                "some_source_tool", ToolCompositionCapability.IngestsUntrustedInput,
+                "file_system", ToolCompositionCapability.WritesFiles,
+                ToolCapabilityOrigin.FirstParty, ToolCapabilityOrigin.FirstParty)],
+            []);
+    }
+
+    [Fact]
+    public async Task CompositionTaintRewrap_CarriesTheSkillScopeForward()
+    {
+        // Regression for the exact "second caller of a fixed pattern forgets the fix" trap this repo's
+        // CLAUDE.md records against PR #545: ToolChainBuilder.ApplyCompositionTaint re-wraps a
+        // GovernedAIFunction when a composition finding implicates it — drives the REAL rewrap path
+        // (not a hand-rolled restatement of what it should do), since a unit-style test that just
+        // re-implements the expected shape cannot catch a regression in the rewrap itself. A prior
+        // version of this test did exactly that and was proven blind by mutation-testing the rewrap.
+        var (_, fileSystem, accessor, provider) = BuildFixture();
+
+        string? observedDuringCall = null;
+        fileSystem
+            .Setup(fs => fs.ReadFileAsync("notes.txt", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                observedDuringCall = accessor.CurrentSkillId;
+                return "hello world";
+            });
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, provider, new AIToolConverter(NullLogger<AIToolConverter>.Instance),
+            compositionAnalyzer: new AlwaysFindsCompositionAnalyzer());
+
+        var skill = new SkillDefinition { Id = "reader-skill", Name = "reader-skill", AllowedTools = ["file_system"] };
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+        var aiFunction = (AIFunction)tools.Single();
+
+        var args = new AIFunctionArguments
+        {
+            ["operation"] = "read",
+            ["parametersJson"] = System.Text.Json.JsonSerializer.SerializeToElement(new { path = "notes.txt" })
+        };
+        await aiFunction.InvokeAsync(args);
+
+        observedDuringCall.Should().Be(
+            "reader-skill", "the re-wrapped instance must still carry the skill scope forward");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
@@ -43,7 +44,8 @@ public sealed class AgentMetadataRegistryTests
                 NullLogger<AgentMetadataParser>.Instance, TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig()),
             new SkillMetadataParser(
                 NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-                TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig()),
+                TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+                new EgressManifestValidator()),
             new UnsandboxedSkillFileReader(),
             ownedSkills);
     }
@@ -143,6 +145,8 @@ public sealed class AgentMetadataRegistryTests
         services.AddSingleton<AgentMetadataParser>();
         services.AddSingleton<Application.AI.Common.Interfaces.Skills.ISkillFileReader,
             Infrastructure.AI.Skills.SkillFileReader>();
+        services.AddSingleton<FluentValidation.IValidator<Domain.AI.Skills.EgressManifest>,
+            Application.AI.Common.Skills.EgressManifestValidator>();
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<IAgentOwnedSkillStore, AgentOwnedSkillStore>();
         services.AddSingleton<IAgentMetadataRegistry, AgentMetadataRegistry>();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/AgentMetadataRegistryTests.cs
@@ -1,6 +1,5 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Skills;
-using Application.AI.Common.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
@@ -45,7 +44,7 @@ public sealed class AgentMetadataRegistryTests
             new SkillMetadataParser(
                 NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
                 TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-                new EgressManifestValidator()),
+                TestMcpSecurityScanner.RealEgressValidator()),
             new UnsandboxedSkillFileReader(),
             ownedSkills);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -2,7 +2,6 @@ using System.IO.Compression;
 using System.Text;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Plugins;
-using Application.AI.Common.Skills;
 using Domain.AI.Governance;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
@@ -738,7 +737,7 @@ public sealed class BundleStagingServiceTests : IDisposable
                 NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
                 skillScanner ?? TestMcpSecurityScanner.AlwaysSafe(),
                 Mock.Of<IOptionsMonitor<AIConfig>>(m => m.CurrentValue == appConfig.AI),
-                new EgressManifestValidator()),
+                TestMcpSecurityScanner.RealEgressValidator()),
             new UnsandboxedSkillFileReader(),
             pluginReader ?? new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
             bundleOwnedMcpServers ?? new BundleOwnedMcpServerRegistry(),

--- a/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Bundles/BundleStagingServiceTests.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Text;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Skills;
 using Domain.AI.Governance;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
@@ -736,7 +737,8 @@ public sealed class BundleStagingServiceTests : IDisposable
             new SkillMetadataParser(
                 NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
                 skillScanner ?? TestMcpSecurityScanner.AlwaysSafe(),
-                Mock.Of<IOptionsMonitor<AIConfig>>(m => m.CurrentValue == appConfig.AI)),
+                Mock.Of<IOptionsMonitor<AIConfig>>(m => m.CurrentValue == appConfig.AI),
+                new EgressManifestValidator()),
             new UnsandboxedSkillFileReader(),
             pluginReader ?? new PluginManifestReader(NullLogger<PluginManifestReader>.Instance),
             bundleOwnedMcpServers ?? new BundleOwnedMcpServerRegistry(),

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/SkillManifestEgressPolicyResolverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/SkillManifestEgressPolicyResolverTests.cs
@@ -229,6 +229,43 @@ public sealed class SkillManifestEgressPolicyResolverTests
     }
 
     /// <summary>
+    /// Security-review finding on #531: a skill literally named a case variant of the resolver's
+    /// former reserved sentinel string must resolve its OWN policy, never collide with the no-skill
+    /// default — proving the fix (separate cache/field for the two cases) rather than relying on the
+    /// sentinel string never being reused by a real skill id.
+    /// </summary>
+    [Fact]
+    public async Task ResolveFor_SkillNamedLikeTheOldSentinel_ResolvesItsOwnPolicy_NotTheDefault()
+    {
+        var accessor = new CurrentSkillAccessor();
+        var skill = SkillWithAllowlist("<NO-SKILL>", new EgressAllowlistEntry
+        {
+            Host = "widened.example.com",
+            Schemes = ["https"],
+            Ports = [443]
+        });
+
+        var registry = new Mock<ISkillMetadataRegistry>(MockBehavior.Strict);
+        registry.Setup(r => r.TryGet("<NO-SKILL>")).Returns(skill);
+
+        var resolver = NewResolver(accessor, registry.Object,
+            new EgressAllowlistConfigEntry { Host = "default.example.com", Schemes = ["https"], Ports = [443] });
+
+        // No-skill policy resolved first, so any shared-cache collision would already have poisoned
+        // the entry the skill lookup below reads.
+        var noSkillPolicy = resolver.ResolveFor(TestIdentity.Default);
+        var noSkillVerdict = await noSkillPolicy.AllowAsync(
+            new Uri("https://widened.example.com/"), TestIdentity.Default, CancellationToken.None);
+        noSkillVerdict.Allowed.Should().BeFalse("the no-skill policy must never carry a skill's widened allowlist");
+
+        using var _ = accessor.BeginScope("<NO-SKILL>");
+        var skillPolicy = resolver.ResolveFor(TestIdentity.Default);
+        var skillVerdict = await skillPolicy.AllowAsync(
+            new Uri("https://widened.example.com/"), TestIdentity.Default, CancellationToken.None);
+        skillVerdict.Allowed.Should().BeTrue("the skill's own allowlist addition must still apply for its own scope");
+    }
+
+    /// <summary>
     /// CurrentSkillAccessor: nested BeginScope() composes — the inner activation
     /// restores the previous skill id on dispose. Guards against a stale
     /// identifier leaking across logical scopes.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/EchoTestSkillManifestTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/EchoTestSkillManifestTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using Infrastructure.AI.Skills;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -31,7 +32,8 @@ public sealed class EchoTestSkillManifestTests
     {
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         var skillPath = RepoRoot.Combine("skills", "echo-test");
         var filePath = Path.Combine(skillPath, "SKILL.md");
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/EchoTestSkillManifestTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/EchoTestSkillManifestTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using Infrastructure.AI.Skills;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -33,7 +32,7 @@ public sealed class EchoTestSkillManifestTests
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         var skillPath = RepoRoot.Combine("skills", "echo-test");
         var filePath = Path.Combine(skillPath, "SKILL.md");
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
+using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
@@ -81,7 +82,8 @@ public sealed class PluginGovernanceWiringTests : IDisposable
             new OptionsMonitorStub(appConfig),
             new SkillMetadataParser(
                 NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-                TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig()),
+                TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+                new EgressManifestValidator()),
             new UnsandboxedSkillFileReader(),
             pluginRegistry);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/PluginGovernanceWiringTests.cs
@@ -2,7 +2,6 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Tools;
-using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
@@ -83,7 +82,7 @@ public sealed class PluginGovernanceWiringTests : IDisposable
             new SkillMetadataParser(
                 NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
                 TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-                new EgressManifestValidator()),
+                TestMcpSecurityScanner.RealEgressValidator()),
             new UnsandboxedSkillFileReader(),
             pluginRegistry);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Skills;
+using Application.AI.Common.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.BundleExecution;
@@ -226,7 +227,8 @@ public sealed class SkillFileReaderTests : IDisposable
         var reader = CreateReader();
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, reader,
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
 
         var act = () => NestedSkillScanner.Scan(
             _outsideRoot, parser, reader, NullLogger<SkillFileReaderTests>.Instance);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFileReaderTests.cs
@@ -1,5 +1,4 @@
 using Application.AI.Common.Interfaces.Skills;
-using Application.AI.Common.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.BundleExecution;
@@ -228,7 +227,7 @@ public sealed class SkillFileReaderTests : IDisposable
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, reader,
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
 
         var act = () => NestedSkillScanner.Scan(
             _outsideRoot, parser, reader, NullLogger<SkillFileReaderTests>.Instance);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFrontmatterContractTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFrontmatterContractTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -22,7 +21,7 @@ public sealed class SkillFrontmatterContractTests : IDisposable
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"frontmatter-contract-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFrontmatterContractTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillFrontmatterContractTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -20,7 +21,8 @@ public sealed class SkillFrontmatterContractTests : IDisposable
     {
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"frontmatter-contract-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,7 +21,8 @@ public sealed class SkillMetadataParserEgressTests : IDisposable
     {
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"egress-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }
@@ -105,8 +107,10 @@ public sealed class SkillMetadataParserEgressTests : IDisposable
             "",
             "    - host: \"api.example.com\"",
             "      schemes: [\"https\"]",
+            "      ports: [443]",
             "    - hostPattern: \"*.azure-api.net\"",
             "      schemes: [\"https\"]",
+            "      ports: [443]",
             "---",
             "Body content here.");
 
@@ -162,5 +166,34 @@ public sealed class SkillMetadataParserEgressTests : IDisposable
 
         skill.Egress.Should().NotBeNull();
         skill.Egress!.Allowlist.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// #531: a semantically invalid allowlist entry — a multi-label wildcard, an SSRF-vector shape
+    /// <see cref="EgressAllowlistEntryValidator"/> rejects — must refuse the whole skill at parse
+    /// time, never reach <see cref="Domain.AI.Skills.SkillDefinition.Egress"/> unvalidated.
+    /// </summary>
+    [Fact]
+    public void ParseFromFile_MultiLabelWildcardHostPattern_ThrowsSkillParsingException()
+    {
+        var content = """
+            ---
+            name: "bad-egress"
+            description: "Declares an invalid hostPattern"
+            egress:
+              allowlist:
+                - hostPattern: "*.evil.*.com"
+                  schemes: ["https"]
+                  ports: [443]
+            ---
+            Body content here.
+            """;
+
+        var path = WriteSkillFile(content);
+
+        var act = () => _sut.ParseFromFile(path, _tempDir);
+
+        act.Should().Throw<Application.AI.Common.Exceptions.SkillParsingException>()
+            .WithMessage("*Invalid egress manifest*");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserEgressTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -22,7 +21,7 @@ public sealed class SkillMetadataParserEgressTests : IDisposable
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"egress-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }
@@ -170,7 +169,7 @@ public sealed class SkillMetadataParserEgressTests : IDisposable
 
     /// <summary>
     /// #531: a semantically invalid allowlist entry — a multi-label wildcard, an SSRF-vector shape
-    /// <see cref="EgressAllowlistEntryValidator"/> rejects — must refuse the whole skill at parse
+    /// <see cref="Application.AI.Common.Skills.EgressAllowlistEntryValidator"/> rejects — must refuse the whole skill at parse
     /// time, never reach <see cref="Domain.AI.Skills.SkillDefinition.Egress"/> unvalidated.
     /// </summary>
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserFrontmatterDelimiterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserFrontmatterDelimiterTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -34,7 +33,7 @@ public sealed class SkillMetadataParserFrontmatterDelimiterTests : IDisposable
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-parser-delimiter-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserFrontmatterDelimiterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserFrontmatterDelimiterTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -32,7 +33,8 @@ public sealed class SkillMetadataParserFrontmatterDelimiterTests : IDisposable
     {
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-parser-delimiter-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserManifestScanningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserManifestScanningTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Skills;
 using Domain.AI.Governance;
 using Domain.Common.Config.AI;
 using Infrastructure.AI.Skills;
@@ -121,7 +122,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBody);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            WithheldScanner().Object, ConfigWithSecurityEnabled());
+            WithheldScanner().Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
 
         var ex = Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
 
@@ -140,7 +141,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBody);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            WithheldScanner().Object, ConfigWithSecurityEnabled());
+            WithheldScanner().Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
 
         var ex = Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
 
@@ -154,7 +155,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBody);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), ConfigWithSecurityEnabled());
+            TestMcpSecurityScanner.AlwaysSafe(), ConfigWithSecurityEnabled(), new EgressManifestValidator());
 
         var skill = parser.ParseFromFile(path, _tempDir);
 
@@ -176,7 +177,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
 
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            mock.Object, ConfigWithSecurityEnabled(ThreatLevel.High));
+            mock.Object, ConfigWithSecurityEnabled(ThreatLevel.High), new EgressManifestValidator());
 
         var skill = parser.ParseFromFile(path, _tempDir);
 
@@ -197,7 +198,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
 
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            mock.Object, disabledConfig);
+            mock.Object, disabledConfig, new EgressManifestValidator());
 
         var skill = parser.ParseFromFile(path, _tempDir);
 
@@ -217,7 +218,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBodyWithObjectivesPayload);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled());
+            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
 
         Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
     }
@@ -233,7 +234,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBodyWithToolDeclarationPayload);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled());
+            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
 
         Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserManifestScanningTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserManifestScanningTests.cs
@@ -1,6 +1,5 @@
 using Application.AI.Common.Exceptions;
 using Application.AI.Common.Interfaces.Governance;
-using Application.AI.Common.Skills;
 using Domain.AI.Governance;
 using Domain.Common.Config.AI;
 using Infrastructure.AI.Skills;
@@ -122,7 +121,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBody);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            WithheldScanner().Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
+            WithheldScanner().Object, ConfigWithSecurityEnabled(), TestMcpSecurityScanner.RealEgressValidator());
 
         var ex = Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
 
@@ -141,7 +140,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBody);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            WithheldScanner().Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
+            WithheldScanner().Object, ConfigWithSecurityEnabled(), TestMcpSecurityScanner.RealEgressValidator());
 
         var ex = Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
 
@@ -155,7 +154,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBody);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), ConfigWithSecurityEnabled(), new EgressManifestValidator());
+            TestMcpSecurityScanner.AlwaysSafe(), ConfigWithSecurityEnabled(), TestMcpSecurityScanner.RealEgressValidator());
 
         var skill = parser.ParseFromFile(path, _tempDir);
 
@@ -177,7 +176,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
 
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            mock.Object, ConfigWithSecurityEnabled(ThreatLevel.High), new EgressManifestValidator());
+            mock.Object, ConfigWithSecurityEnabled(ThreatLevel.High), TestMcpSecurityScanner.RealEgressValidator());
 
         var skill = parser.ParseFromFile(path, _tempDir);
 
@@ -198,7 +197,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
 
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            mock.Object, disabledConfig, new EgressManifestValidator());
+            mock.Object, disabledConfig, TestMcpSecurityScanner.RealEgressValidator());
 
         var skill = parser.ParseFromFile(path, _tempDir);
 
@@ -218,7 +217,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBodyWithObjectivesPayload);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
+            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled(), TestMcpSecurityScanner.RealEgressValidator());
 
         Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
     }
@@ -234,7 +233,7 @@ public sealed class SkillMetadataParserManifestScanningTests : IDisposable
         var path = WriteSkillFile(SkillBodyWithToolDeclarationPayload);
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled(), new EgressManifestValidator());
+            ScannerFlaggingContent("MARKER_PAYLOAD").Object, ConfigWithSecurityEnabled(), TestMcpSecurityScanner.RealEgressValidator());
 
         Assert.Throws<ManifestRefusedException>(() => parser.ParseFromFile(path, _tempDir));
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserNestedYamlTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserNestedYamlTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -19,7 +18,7 @@ public sealed class SkillMetadataParserNestedYamlTests : IDisposable
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-nested-yaml-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserNestedYamlTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserNestedYamlTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -17,7 +18,8 @@ public sealed class SkillMetadataParserNestedYamlTests : IDisposable
     {
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-nested-yaml-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserPrerequisiteTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserPrerequisiteTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -18,7 +19,8 @@ public sealed class SkillMetadataParserPrerequisiteTests : IDisposable
     {
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"prereq-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserPrerequisiteTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserPrerequisiteTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,7 +19,7 @@ public sealed class SkillMetadataParserPrerequisiteTests : IDisposable
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"prereq-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -21,7 +20,7 @@ public sealed class SkillMetadataParserTests : IDisposable
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -19,7 +20,8 @@ public sealed class SkillMetadataParserTests : IDisposable
     {
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"skill-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -29,7 +28,7 @@ public sealed class SkillMetadataParserToolDeclarationTests : IDisposable
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"tooldecl-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataParserToolDeclarationTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using Domain.AI.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
@@ -27,7 +28,8 @@ public sealed class SkillMetadataParserToolDeclarationTests : IDisposable
     {
         _sut = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         _tempDir = Path.Combine(Path.GetTempPath(), $"tooldecl-parser-tests-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_tempDir);
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
@@ -33,7 +34,8 @@ public sealed class SkillMetadataRegistryTests
         var logger = NullLogger<SkillMetadataRegistry>.Instance;
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
 
         return new SkillMetadataRegistry(logger, optionsMonitor, parser, new UnsandboxedSkillFileReader());
     }
@@ -62,7 +64,8 @@ public sealed class SkillMetadataRegistryTests
             new OptionsMonitorStub(appConfig),
             new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig()),
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator()),
             new UnsandboxedSkillFileReader(),
             pluginRegistry: null);
 
@@ -174,6 +177,8 @@ public sealed class SkillMetadataRegistryTests
         services.AddSingleton(TestMcpSecurityScanner.DefaultConfig());
         services.AddSingleton<Application.AI.Common.Interfaces.Skills.ISkillFileReader,
             Infrastructure.AI.Skills.SkillFileReader>();
+        services.AddSingleton<FluentValidation.IValidator<Domain.AI.Skills.EgressManifest>,
+            Application.AI.Common.Skills.EgressManifestValidator>();
         services.AddSingleton<SkillMetadataParser>();
         services.AddSingleton<ISkillMetadataRegistry, SkillMetadataRegistry>();
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillMetadataRegistryTests.cs
@@ -1,5 +1,4 @@
 using Application.AI.Common.Interfaces;
-using Application.AI.Common.Skills;
 using Domain.Common.Config;
 using Domain.Common.Config.AI;
 using FluentAssertions;
@@ -35,7 +34,7 @@ public sealed class SkillMetadataRegistryTests
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
 
         return new SkillMetadataRegistry(logger, optionsMonitor, parser, new UnsandboxedSkillFileReader());
     }
@@ -65,7 +64,7 @@ public sealed class SkillMetadataRegistryTests
             new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator()),
+            TestMcpSecurityScanner.RealEgressValidator()),
             new UnsandboxedSkillFileReader(),
             pluginRegistry: null);
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillParserExtensionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillParserExtensionTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -14,7 +13,7 @@ public sealed class SkillParserExtensionTests
     private static SkillMetadataParser CreateParser() =>
         new(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
 
     [Fact]
     public void SkillParser_WithObjectivesSection_ExtractsObjectivesContent()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillParserExtensionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/SkillParserExtensionTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -12,7 +13,8 @@ public sealed class SkillParserExtensionTests
 {
     private static SkillMetadataParser CreateParser() =>
         new(NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
 
     [Fact]
     public void SkillParser_WithObjectivesSection_ExtractsObjectivesContent()

--- a/src/Content/Tests/Infrastructure.AI.Tests/Skills/TestMcpSecurityScanner.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Skills/TestMcpSecurityScanner.cs
@@ -1,6 +1,9 @@
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Skills;
 using Domain.AI.Governance;
+using Domain.AI.Skills;
 using Domain.Common.Config.AI;
+using FluentValidation;
 using Microsoft.Extensions.Options;
 using Moq;
 
@@ -31,4 +34,10 @@ internal static class TestMcpSecurityScanner
     /// <summary>An <see cref="IOptionsMonitor{AIConfig}"/> exposing a default (governance-off) <see cref="AIConfig"/>.</summary>
     public static IOptionsMonitor<AIConfig> DefaultConfig() =>
         Mock.Of<IOptionsMonitor<AIConfig>>(m => m.CurrentValue == new AIConfig());
+
+    /// <summary>
+    /// The real <see cref="EgressManifestValidator"/> (#531) — stateless (a pure FluentValidation
+    /// rule tree), so a fresh instance per call costs nothing and there is no reason to mock it.
+    /// </summary>
+    public static IValidator<EgressManifest> RealEgressValidator() => new EgressManifestValidator();
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillManifestTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillManifestTests.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -24,7 +25,8 @@ public sealed class WorkspaceSkillManifestTests
 
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
-            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig());
+            TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
+            new EgressManifestValidator());
         var skill = parser.ParseFromFile(skillPath, Path.GetDirectoryName(skillPath)!, pluginSource: "workspace-skill");
 
         skill.Name.Should().Be("workspace");

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillManifestTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/Workspace/WorkspaceSkillManifestTests.cs
@@ -1,4 +1,3 @@
-using Application.AI.Common.Skills;
 using FluentAssertions;
 using Infrastructure.AI.Skills;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -26,7 +25,7 @@ public sealed class WorkspaceSkillManifestTests
         var parser = new SkillMetadataParser(
             NullLogger<SkillMetadataParser>.Instance, new UnsandboxedSkillFileReader(),
             TestMcpSecurityScanner.AlwaysSafe(), TestMcpSecurityScanner.DefaultConfig(),
-            new EgressManifestValidator());
+            TestMcpSecurityScanner.RealEgressValidator());
         var skill = parser.ParseFromFile(skillPath, Path.GetDirectoryName(skillPath)!, pluginSource: "workspace-skill");
 
         skill.Name.Should().Be("workspace");

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -956,8 +956,11 @@ public sealed class SecurityControlHasACallerTests
     [Fact]
     public void SkillEgressConsumerResolvedExemptions_AreStillInvoked()
     {
+        // SkillMetadataParser.Egress.cs, not SkillMetadataParser.cs: ValidateEgressOrRefuse (and the
+        // .Validate() call this control anchors on) lives in that partial-class file, split out to
+        // keep the main file under this repo's 400-line convention.
         var parserPath = Path.Combine(
-            RepoRoot.Path, "src", "Content", "Infrastructure", "Infrastructure.AI", "Skills", "SkillMetadataParser.cs");
+            RepoRoot.Path, "src", "Content", "Infrastructure", "Infrastructure.AI", "Skills", "SkillMetadataParser.Egress.cs");
         File.Exists(parserPath).Should().BeTrue("the consumer that justifies the EgressManifest exemption must exist");
 
         var parserSource = SourceScan.StripCommentsAndStrings(File.ReadAllText(parserPath));

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -301,7 +301,10 @@ public sealed class SecurityControlHasACallerTests
     /// silently skipped. It is a different meaning from "a consumer resolves this", so it is a
     /// different list — the same reasoning CLAUDE.md records for not overloading one field with two
     /// meanings. <see cref="KnownDeadValidators_AreStillDead"/> fails the moment one gains a caller,
-    /// so the exemption cannot outlive the defect it documents.
+    /// so the exemption cannot outlive the defect it documents. Empty as of #531 — the egress
+    /// manifest pair that populated it is now genuinely invoked (see
+    /// <see cref="SkillEgressConsumerResolvedTypes"/>) — kept, not deleted, as the mechanism a future
+    /// confirmed-dead validator uses.
     /// </para>
     /// <para>
     /// <strong>Six false alarms, and what each one taught.</strong> Matching on filename swept in
@@ -383,7 +386,9 @@ public sealed class SecurityControlHasACallerTests
         // but it would surface as dozens of false alarms, so prove the classifier works.
         mediatrRequests.Should().NotBeEmpty("the MediatR request types this exemption rests on must be detectable");
 
-        var consumerResolvedTypes = ConsumerResolvedValidatedTypes.ToHashSet(StringComparer.Ordinal);
+        var consumerResolvedTypes = ConsumerResolvedValidatedTypes
+            .Concat(SkillEgressConsumerResolvedTypes)
+            .ToHashSet(StringComparer.Ordinal);
         var knownDead = KnownDeadValidators.ToHashSet(StringComparer.Ordinal);
 
         // In scope unless an invocation mechanism is PROVEN. An unparsable or unrecognised type
@@ -842,21 +847,14 @@ public sealed class SecurityControlHasACallerTests
     /// </para>
     /// <para>
     /// This is <strong>not</strong> a place to park an inconvenient failure. An entry is admissible
-    /// only with a filed issue and a measured reason the defect is not urgent. The egress pair
-    /// qualifies on both counts: their validated types are parsed onto
-    /// <c>SkillDefinition.Egress</c> and read by nothing, so validating them would change no
-    /// behaviour, and the runtime <c>DefaultEgressPolicy</c> still enforces scheme and allowlist
-    /// matching on every request — the gap fails closed. #531 carries the decision of whether to wire
-    /// per-skill egress or remove it.
+    /// only with a filed issue and a measured reason the defect is not urgent — see
+    /// <see cref="ConsumerResolvedValidatedTypes"/>'s remarks for what happened the first time this
+    /// file's own guard could not see the egress manifest pair's shape. Currently empty: #531's fix
+    /// wired the pair into <c>SkillMetadataParser</c>, so they moved to
+    /// <see cref="SkillEgressConsumerResolvedTypes"/> below instead of staying parked here.
     /// </para>
     /// </remarks>
-    private static readonly string[] KnownDeadValidators =
-    [
-        // #531: SkillDefinition.Egress is parsed, mapped, stored, and consumed by nothing, so neither
-        // validator has anything to validate. Fails closed — DefaultEgressPolicy still enforces.
-        "EgressManifestValidator",
-        "EgressAllowlistEntryValidator"
-    ];
+    private static readonly string[] KnownDeadValidators = [];
 
     /// <summary>
     /// Every entry on <see cref="KnownDeadValidators"/> must still be dead, so the exemption cannot
@@ -867,6 +865,15 @@ public sealed class SecurityControlHasACallerTests
     /// #531 asks for — this test reports that the exemption is now false and must be removed, rather
     /// than letting a newly-live validator sit permanently outside the guard's scope. A dead-control
     /// exemption that survives the control coming alive is how the scope of a guard quietly shrinks.
+    /// <para>
+    /// Checks two caller shapes, not one — a mutation-test run against #531's own fix (deliberately
+    /// re-adding "EgressManifestValidator" here while its real DI-resolved caller in
+    /// <c>SkillMetadataParser</c> stood) found the bare-name check alone gives a false "still dead":
+    /// a consumer that resolves <c>IValidator&lt;TValidated&gt;</c> via constructor injection —
+    /// exactly how #531 wires <c>SkillMetadataParser</c> — never spells the concrete validator class
+    /// name anywhere, so a name-only scan is blind to it. The second check closes that gap by looking
+    /// for the validated TYPE inside an <c>IValidator&lt;&gt;</c> mention instead.
+    /// </para>
     /// </remarks>
     [Fact]
     public void KnownDeadValidators_AreStillDead()
@@ -884,17 +891,23 @@ public sealed class SecurityControlHasACallerTests
             // A caller is any production mention outside the file that declares it. The declaring file
             // is excluded because a parent validator legitimately names its child via SetValidator,
             // which is self-reference, not a consumer.
-            var declaring = production
+            var declaringFiles = production
                 .Where(f => Regex.IsMatch(f.Code, $@"\bclass\s+{validator}\b"))
-                .Select(f => f.Path)
                 .ToArray();
 
-            declaring.Should().ContainSingle(
+            declaringFiles.Select(f => f.Path).Should().ContainSingle(
                 $"{validator} must still be declared exactly once for this exemption to describe anything real");
 
+            var declaringPath = declaringFiles[0].Path;
+            var validated = FindValidatorDeclarations(declaringFiles[0].Code)
+                .FirstOrDefault(d => d.Validator == validator).Validated;
+
             var callers = production
-                .Where(f => !string.Equals(f.Path, declaring[0], StringComparison.OrdinalIgnoreCase))
-                .Where(f => Regex.IsMatch(f.Code, $@"\b{validator}\b"))
+                .Where(f => !string.Equals(f.Path, declaringPath, StringComparison.OrdinalIgnoreCase))
+                .Where(f => Regex.IsMatch(f.Code, $@"\b{validator}\b")
+                    // A DI-resolved caller (constructor injection of IValidator<TValidated>) never
+                    // spells the concrete class name — see the remarks above.
+                    || (validated is not null && Regex.IsMatch(f.Code, $@"\bIValidator\s*<\s*{validated}\s*>")))
                 .Select(f => Path.GetRelativePath(contentRoot, f.Path))
                 .ToArray();
 
@@ -907,6 +920,59 @@ public sealed class SecurityControlHasACallerTests
             + "excused it is now false and is holding a live validator outside this guard's scope. "
             + "Remove the entry — and if this is the #531 fix landing, remove both. Revived: "
             + string.Join("; ", revived));
+    }
+
+    /// <summary>
+    /// #531: <c>SkillMetadataParser</c> resolves <c>IValidator&lt;EgressManifest&gt;</c> via
+    /// constructor injection and calls <c>.Validate()</c> on it directly — a genuine consumer-resolved
+    /// mechanism, but a different shape from <see cref="ConsumerResolvedValidatedTypes"/>'s (which is
+    /// anchored specifically to <c>PlanValidator</c>'s generic dispatch-arm pattern and would never
+    /// match a direct field-call site). Given its own list and its own staleness check rather than
+    /// folded into that one, for the same reason <see cref="KnownDeadValidators"/> is its own list:
+    /// two different mechanisms proven two different ways must not collapse into one, or a future
+    /// reader cannot tell which proof backs which entry.
+    /// </summary>
+    private static readonly string[] SkillEgressConsumerResolvedTypes =
+    [
+        // EgressManifestValidator's validated type — proven invoked below by finding the actual
+        // .Validate() call in SkillMetadataParser.cs.
+        "EgressManifest",
+        // EgressAllowlistEntryValidator's validated type. Never resolved directly — EgressManifestValidator
+        // composes it as a child via RuleForEach(...).SetValidator(...), which FluentValidation
+        // runs unconditionally as part of the parent's own Validate() call. Proven below by finding
+        // that composition, not by a separate top-level call site (there is none).
+        "EgressAllowlistEntry"
+    ];
+
+    /// <summary>
+    /// Both entries on <see cref="SkillEgressConsumerResolvedTypes"/> must still be genuinely invoked,
+    /// so the exemption cannot outlive the wiring #531 put in place.
+    /// </summary>
+    /// <remarks>
+    /// Two independent proofs, matching the two different invocation shapes the list documents: a
+    /// direct <c>.Validate()</c> call site for the parent, and a <c>SetValidator</c> composition for
+    /// the child. Either regressing independently reopens the exact gap #531 closed for that half.
+    /// </remarks>
+    [Fact]
+    public void SkillEgressConsumerResolvedExemptions_AreStillInvoked()
+    {
+        var parserPath = Path.Combine(
+            RepoRoot.Path, "src", "Content", "Infrastructure", "Infrastructure.AI", "Skills", "SkillMetadataParser.cs");
+        File.Exists(parserPath).Should().BeTrue("the consumer that justifies the EgressManifest exemption must exist");
+
+        var parserSource = SourceScan.StripCommentsAndStrings(File.ReadAllText(parserPath));
+        Regex.IsMatch(parserSource, @"_egressValidator\.Validate\(").Should().BeTrue(
+            "control: SkillMetadataParser must actually call .Validate() on the injected "
+            + "IValidator<EgressManifest> for the EgressManifest exemption to describe anything real");
+
+        var validatorPath = Path.Combine(
+            RepoRoot.Path, "src", "Content", "Application", "Application.AI.Common", "Skills", "EgressManifestValidator.cs");
+        File.Exists(validatorPath).Should().BeTrue("the parent validator that composes the child must exist");
+
+        var validatorSource = SourceScan.StripCommentsAndStrings(File.ReadAllText(validatorPath));
+        Regex.IsMatch(validatorSource, @"SetValidator\(new EgressAllowlistEntryValidator\(\)\)").Should().BeTrue(
+            "control: EgressManifestValidator must still compose EgressAllowlistEntryValidator as a "
+            + "child, or the EgressAllowlistEntry exemption is stale and the validator is unreachable");
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

- `SkillManifestEgressPolicyResolver` already merged a skill's declared egress allowlist with the harness-wide default, but nothing ever set the ambient "current skill" it reads — so the merge never ran in production. `GovernedAIFunction` now establishes that scope for the duration of each tool call built from a skill; the composition-taint rewrap path carries it forward so a re-wrapped tool doesn't silently lose it.
- `EgressManifestValidator`/`EgressAllowlistEntryValidator` were dead code — registered but never resolved. `SkillMetadataParser` now validates a skill's egress manifest at parse time and refuses a malformed one, mirroring its existing prompt-injection scan. Registered as a singleton in `AddSkillDiscovery` itself (not left to the default scoped `AddValidatorsFromAssembly` lifetime) so every host that calls it — including the standalone MCP server, which never runs the full `Application.AI.Common` registration — gets a working, non-captive dependency.
- Fixed the one shipped skill manifest (`plugins/iac-skill/skills/iac-authoring/SKILL.md`) whose bare-string egress allowlist was silently dropped by the frontmatter parser — the one manifest that would have exercised the new validator, invisible to it until fixed.
- Fixed a pre-existing cache-key collision in `SkillManifestEgressPolicyResolver` (a skill named a case-variant of the internal "no skill" sentinel could collide with it in the shared cache) — unreachable before this PR since nothing ever set a real skill id, made reachable by this PR's own fix.
- Unified skill provenance onto `ProvisionedTool` (alongside the existing `McpServerName`) instead of a parallel scalar parameter, per `/simplify`'s altitude review.

## Deliberately deferred (tracked as #589)

Two narrower gaps in the same per-skill scoping design, both documented in-code and both fail-closed (never fail-open):
1. The `AIContext.Tools` channel (`GoverningToolContextProvider`, e.g. `run_skill_script`) gets no per-skill scope — same pre-existing provenance gap that already blocks MCP-failure normalization there.
2. Two skills sharing a first-party tool name in one merged agent pin the shared instance's egress scope to whichever skill enumerated first.

Fixing either precisely needs a design decision (real per-tool attribution on the `AIContext.Tools` channel; a union-vs-first-wins policy for shared tool names) this PR doesn't make unilaterally.

## Test plan

- [x] Full solution build, 0 errors/0 warnings introduced
- [x] Full solution test suite green (one known, pre-existing `ProcessSandboxExecutorTests` flake unrelated to this change, confirmed passing in isolation)
- [x] New `SkillEgressScopeActivationTests`: proves the skill scope is actually live during a tool call (not just constructed), restored after, absent on the skill-agnostic `BuildToolsByName` path, and survives the composition-taint re-wrap (driving the real rewrap path, not a restatement)
- [x] New `SkillMetadataParserEgressTests` case: malformed egress manifest refuses skill load
- [x] New `SkillManifestEgressPolicyResolverTests` case: skill named like the old cache sentinel resolves its own policy
- [x] `SecurityControlHasACallerTests` strengthened: the two egress validators move off the dead-validator exemption list with two independent invocation-shape proofs; the dead-validator caller-detection guard itself gained a second detection shape after a mutation test found the name-only scan blind to DI-injected `IValidator<T>` consumers
- [x] Every new guard mutation-tested (break → confirm test fails → revert)
- [x] `run-gates.sh`: build/test/owasp/grader/correctness/security all pass, 3 full rounds across the PR's iteration

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVKDxbkyu6kqeZd6qCLJM6