### PR TITLE
fix: harden plan-step resource scoping (#595)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -223,12 +223,10 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
         if (!arguments.TryGetValue(AIToolConverter.OperationArgumentName, out var value))
             return null;
 
-        return value switch
-        {
-            string s => s,
-            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
-            _ => null
-        };
+        // ToolParameters.NormalizeScalar unwraps a string-valued JsonElement; anything it doesn't
+        // return as a string (a CLR non-string, or a non-string JsonElement) falls out here as null,
+        // preserving this method's original three-arm behavior (#595).
+        return ToolParameters.NormalizeScalar(value) as string;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
@@ -144,14 +144,23 @@ public static class ToolParameters
     /// CLR scalar, or a non-string <see cref="JsonElement"/>) passes through unchanged.
     /// </summary>
     /// <remarks>
-    /// Extracted (#595) from three independent copies of the same switch arm —
-    /// <c>GovernedAIFunction.ReadOperation</c>, <c>ToolUseStepExecutor.NormalizeScalar</c>, and a
-    /// broader version in <c>LlmPlanOutputMapper.GetJsonValue</c> — that had already drifted apart
-    /// once (one handled only the string case, one passed everything else through, one handled
-    /// numbers/bools/null too). A caller needing only the string-unwrap behavior calls this directly;
-    /// <c>GetJsonValue</c>'s broader scalar conversion is a separate concern (parsing a whole JSON
-    /// value at rest, not normalizing one already-extracted argument) and is not folded in here.
+    /// Extracted (#595) from what turned out to be FOUR independent copies of the same switch arm —
+    /// <c>GovernedAIFunction.ReadOperation</c>, <c>ToolUseStepExecutor.NormalizeScalar</c>,
+    /// <c>K8sGptAnalyzeTool.ReadFilters</c>, and a broader version in
+    /// <c>LlmPlanOutputMapper.GetJsonValue</c> — that had already drifted apart once (one handled only
+    /// the string case, one passed everything else through, one handled numbers/bools/null too). A
+    /// caller needing only the string-unwrap behavior calls this directly; <c>GetJsonValue</c>'s
+    /// broader scalar conversion is a separate concern (parsing a whole JSON value at rest, not
+    /// normalizing one already-extracted argument) and is not folded in here. A similar, more involved
+    /// duplicate lives in <c>ConditionalBranchStepExecutor.BuildEvaluationContext</c> (typed CLR
+    /// conversion, not just string-unwrap) — tracked separately (#595 follow-up) rather than folded in
+    /// here, since reconciling it changes that executor's own semantics.
     /// </remarks>
+    /// <param name="value">The value to normalize — any CLR scalar, or a boxed <see cref="JsonElement"/>.</param>
+    /// <returns>
+    /// The unwrapped <see cref="string"/> when <paramref name="value"/> is a string-valued
+    /// <see cref="JsonElement"/>; otherwise <paramref name="value"/> itself, unchanged.
+    /// </returns>
     public static object? NormalizeScalar(object? value) => value switch
     {
         JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
@@ -139,6 +139,26 @@ public static class ToolParameters
     }
 
     /// <summary>
+    /// Unwraps a string-valued <see cref="JsonElement"/> to the plain <see cref="string"/> a caller
+    /// that matches by CLR type (<c>value is string</c>) actually needs; every other shape (already a
+    /// CLR scalar, or a non-string <see cref="JsonElement"/>) passes through unchanged.
+    /// </summary>
+    /// <remarks>
+    /// Extracted (#595) from three independent copies of the same switch arm —
+    /// <c>GovernedAIFunction.ReadOperation</c>, <c>ToolUseStepExecutor.NormalizeScalar</c>, and a
+    /// broader version in <c>LlmPlanOutputMapper.GetJsonValue</c> — that had already drifted apart
+    /// once (one handled only the string case, one passed everything else through, one handled
+    /// numbers/bools/null too). A caller needing only the string-unwrap behavior calls this directly;
+    /// <c>GetJsonValue</c>'s broader scalar conversion is a separate concern (parsing a whole JSON
+    /// value at rest, not normalizing one already-extracted argument) and is not folded in here.
+    /// </remarks>
+    public static object? NormalizeScalar(object? value) => value switch
+    {
+        JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+        _ => value
+    };
+
+    /// <summary>
     /// The shared answer for "no parameters". A fresh dictionary per call would allocate on the
     /// commonest path, since several operations take no arguments at all.
     /// </summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -449,6 +449,7 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
     /// into the effective argument set the tool will be invoked with.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Case-insensitive by construction (#595 — root-cause fix, correctness/security review on #587
     /// round 3-4): matches <c>ToolParameters.Flatten</c>'s convention on the agent-turn path, and
     /// eliminates the case-variant-duplicate-key ambiguity at its source instead of detecting and
@@ -462,6 +463,21 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
     /// empirically that overload throws <see cref="ArgumentException"/> when the source (ordinal)
     /// dictionary already holds two case-variant keys and the new comparer is case-insensitive, the
     /// same crash class fixed once already in this method's history.
+    /// </para>
+    /// <para>
+    /// <strong>Two collision policies, by design, not by accident (code-review on #595):</strong> a
+    /// declared parameter always wins over an upstream-produced value of the same (case-insensitive)
+    /// name — the upstream-merge loop below uses <c>TryAdd</c>, which never overwrites an entry the
+    /// first loop already placed — because a step's own declared arguments are the plan author's
+    /// explicit intent and an upstream step's output is untrusted-relative-to-that-intent data flowing
+    /// in. Within EACH loop, though, a genuine collision (two declared keys, or two upstream keys, that
+    /// are case-variants of each other) resolves by index assignment / last-write-wins, which depends
+    /// on <paramref name="config"/>.<c>InputParameters</c>'s own enumeration order — an implementation
+    /// detail of whatever <see cref="IReadOnlyDictionary{TKey,TValue}"/> a producer supplies, not a
+    /// contractual guarantee. That ambiguity is harmless from a security standpoint (whichever value
+    /// wins is both the one checked and the one dispatched — see above), but which specific value wins
+    /// is not itself guaranteed stable across producers or runtimes.
+    /// </para>
     /// </remarks>
     private static Dictionary<string, object?> BuildToolArguments(
         ToolUseConfig config,
@@ -471,6 +487,8 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         foreach (var (key, value) in config.InputParameters)
             merged[key] = value;
 
+        // TryAdd (not index assignment): a declared parameter always wins over an upstream-produced
+        // value of the same name, across casing now too — see the class remarks above.
         foreach (var (_, output) in upstreamOutputs)
         {
             if (string.IsNullOrEmpty(output)) continue;

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -386,75 +386,42 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
     /// <c>object?</c>-typed dictionary values bind as <see cref="JsonElement"/>, not <see cref="string"/>.
     /// Left unhandled, that producer's calls would silently never populate a resource request at all —
     /// fail-closed (no bypass), but #587's own goal of enforcing identically across all three admission
-    /// paths would quietly not hold for it. <see cref="NormalizeScalar"/> unwraps a string-valued
-    /// <see cref="JsonElement"/> the same way <see cref="GovernedAIFunction"/> already does for its own
-    /// wire shape, so both plan-authoring producers reach <see cref="ResourceParameterExtractor.Extract"/>
-    /// on equal footing.
+    /// paths would quietly not hold for it. <see cref="ToolParameters.NormalizeScalar"/> unwraps a
+    /// string-valued <see cref="JsonElement"/> the same way <see cref="GovernedAIFunction"/> already
+    /// does for its own wire shape (both now call the same shared helper, #595), so both
+    /// plan-authoring producers reach <see cref="ResourceParameterExtractor.Extract"/> on equal footing.
     /// </para>
     /// <para>
-    /// Case-insensitive by construction (correctness review on #587), matching both other admission
-    /// paths: <c>ToolParameters.Flatten</c> (the agent-turn path) hands <see cref="ResourceParameterExtractor.Extract"/>
-    /// an <see cref="StringComparer.OrdinalIgnoreCase"/> dictionary, and a step naming a declared
-    /// parameter with different casing (e.g. <c>"Path"</c> against a declared <c>"path"</c>) must not
-    /// silently miss the match — that would resolve to <see cref="Domain.AI.Sandbox.ToolCallResourceRequest.Empty"/>,
-    /// which <c>CapabilityEnforcer</c> treats as "nothing to check" and allows.
-    /// </para>
-    /// <para>
-    /// <paramref name="arguments"/> is itself ordinal — <c>BuildToolArguments</c> merges an upstream
-    /// step's JSON output into the step's own declared parameters via <c>TryAdd</c> on a case-sensitive
-    /// dictionary — so it can legitimately hold two keys that are case-variants of each other (e.g. a
-    /// declared <c>"path"</c> alongside an upstream-produced <c>"Path"</c>). Re-keying that with
-    /// <see cref="Enumerable.ToDictionary{TSource,TKey,TElement}(IEnumerable{TSource},Func{TSource,TKey},Func{TSource,TElement})"/>
-    /// threw <see cref="ArgumentException"/> on the colliding key (grader/correctness review, round 3).
-    /// A last-write-wins loop fixed the throw but introduced a worse defect (security review, round 4):
-    /// the enforcer would then validate only whichever value won the collision, while
-    /// <c>RunSandboxAsync</c> still serializes and dispatches the WHOLE original dictionary — both
-    /// keys — to the tool. A plan step could name the denied path under one casing and an in-bounds
-    /// decoy under the other, win the check with the decoy, and have the sandboxed tool still read the
-    /// denied one under its own declared (differently-cased) key. Checked value must equal consumed
-    /// value; when a collision makes that impossible to guarantee, refuse rather than pick one side of
-    /// the ambiguity to trust — the same fail-closed posture as an unreadable operation.
+    /// <paramref name="arguments"/> is already case-insensitive — <c>BuildToolArguments</c> (#595)
+    /// merges into an <see cref="StringComparer.OrdinalIgnoreCase"/> dictionary from the start, the
+    /// same convention <c>ToolParameters.Flatten</c> uses on the agent-turn path — so a step naming a
+    /// declared parameter with different casing (e.g. <c>"Path"</c> against a declared <c>"path"</c>)
+    /// already matches by the time it reaches this method, and two keys that are case-variants of each
+    /// other have already collapsed into one entry (whichever was written last) before either this
+    /// check or <c>RunSandboxAsync</c>'s dispatch ever sees them — no collision is possible here to
+    /// detect. (Earlier revisions of this method built their own case-insensitive copy and had to
+    /// detect and refuse such a collision themselves; #595 moved the fix to its actual source.)
     /// </para>
     /// </remarks>
     private Domain.AI.Sandbox.ToolCallResourceRequest? ExtractResourceRequest(
         string toolName, IReadOnlyDictionary<string, object?> arguments)
     {
         // Resolved first so a tool with no resource-parameter declaration (or one outside the bounded
-        // first-party set) skips the dictionary copy below entirely — Extract would return null anyway.
+        // first-party set) skips the normalization pass below entirely — Extract would return null anyway.
         var tool = _firstPartyToolLookup.Resolve(toolName);
         if (tool?.ResourceParametersByOperation is not { Count: > 0 } declared)
             return null;
 
         var normalizedArguments = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
         foreach (var (key, value) in arguments)
-        {
-            // TryAdd fails only on a case-variant collision — arguments' own (ordinal) key set is
-            // already unique, so this is the first point two differently-cased keys can coincide.
-            // Refuse outright rather than let one arbitrarily win: see the class remarks above.
-            if (!normalizedArguments.TryAdd(key, NormalizeScalar(value)))
-                return null;
-        }
+            normalizedArguments[key] = ToolParameters.NormalizeScalar(value);
 
-        // Read from the normalized dictionary, not the raw arguments, so a differently-cased key
-        // ("Operation") matches the same way every declared resource-parameter name already does.
         var operation = normalizedArguments.TryGetValue(AIToolConverter.OperationArgumentName, out var operationValue)
             ? operationValue as string
             : null;
 
         return ResourceParameterExtractor.Extract(operation, normalizedArguments, declared);
     }
-
-    /// <summary>
-    /// Unwraps a string-valued <see cref="JsonElement"/> to the plain <see cref="string"/>
-    /// <see cref="ResourceParameterExtractor.Extract"/> expects; every other shape (already a CLR
-    /// scalar, or a non-string <see cref="JsonElement"/> that could never be a path/host anyway) passes
-    /// through unchanged.
-    /// </summary>
-    private static object? NormalizeScalar(object? value) => value switch
-    {
-        JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
-        _ => value
-    };
 
     private static SandboxIsolationLevel DetermineIsolation(
         ToolUseConfig config,
@@ -481,11 +448,28 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
     /// Merges the step's declared parameters with any JSON object fields produced by upstream steps
     /// into the effective argument set the tool will be invoked with.
     /// </summary>
+    /// <remarks>
+    /// Case-insensitive by construction (#595 — root-cause fix, correctness/security review on #587
+    /// round 3-4): matches <c>ToolParameters.Flatten</c>'s convention on the agent-turn path, and
+    /// eliminates the case-variant-duplicate-key ambiguity at its source instead of detecting and
+    /// refusing it downstream in <see cref="ExtractResourceRequest"/>. A declared parameter and an
+    /// upstream-produced value that are case-variants of each other (e.g. <c>"path"</c> and
+    /// <c>"Path"</c>) now collapse into ONE entry before either the resource check or
+    /// <see cref="RunSandboxAsync"/>'s dispatch ever sees them — the same value is checked and
+    /// consumed, structurally, rather than by convention. The initial copy from
+    /// <paramref name="config"/>.<see cref="ToolUseConfig.InputParameters"/> uses index assignment,
+    /// not <c>Dictionary</c>'s <c>(source, comparer)</c> copy constructor overload — verified
+    /// empirically that overload throws <see cref="ArgumentException"/> when the source (ordinal)
+    /// dictionary already holds two case-variant keys and the new comparer is case-insensitive, the
+    /// same crash class fixed once already in this method's history.
+    /// </remarks>
     private static Dictionary<string, object?> BuildToolArguments(
         ToolUseConfig config,
         IReadOnlyDictionary<PlanStepId, string> upstreamOutputs)
     {
-        var merged = new Dictionary<string, object?>(config.InputParameters);
+        var merged = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (key, value) in config.InputParameters)
+            merged[key] = value;
 
         foreach (var (_, output) in upstreamOutputs)
         {

--- a/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/K8sGptAnalyzeTool.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Tools/GitOps/K8sGptAnalyzeTool.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.AI.Common.Interfaces.GitOps;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Changes;
 using Domain.AI.Models;
 using Domain.AI.Sandbox;
@@ -113,7 +114,10 @@ public sealed class K8sGptAnalyzeTool : ITool
         if (!parameters.TryGetValue("filters", out var v) || v is null)
             return [];
 
-        return v switch
+        // ToolParameters.NormalizeScalar (#595) unwraps a string-valued JsonElement to a plain string
+        // before the switch runs, so the CLR-string and JsonElement-string cases collapse into the
+        // same arm below — this used to be a fourth independent copy of that unwrap logic.
+        return ToolParameters.NormalizeScalar(v) switch
         {
             IEnumerable<string> list => list.Where(static x => !string.IsNullOrWhiteSpace(x)).ToArray(),
             string csv => SplitCsv(csv),
@@ -123,7 +127,6 @@ public sealed class K8sGptAnalyzeTool : ITool
                    .Where(static x => !string.IsNullOrWhiteSpace(x))
                    .Select(static x => x!)
                    .ToArray(),
-            JsonElement { ValueKind: JsonValueKind.String } str => SplitCsv(str.GetString() ?? string.Empty),
             _ => [],
         };
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -528,12 +528,16 @@ public sealed class ToolPathScopingEndToEndTests
         // read a denied value under its own declared casing.
         //
         // #595 fixed this at the actual source: BuildToolArguments now merges case-insensitively, so
-        // the two keys collapse into ONE entry — whichever was declared last — before either the
-        // resource check or the sandbox dispatch ever sees them. There is no longer a second value for
-        // the tool to read that the check didn't see: the same value is checked AND consumed, by
-        // construction. This test proves both halves — the winning ("Path") value is what gets
-        // checked (call succeeds, since it's in-bounds) AND it's the only value serialized to the
-        // sandbox (the shadowed "path"/denied value never reaches dispatch at all).
+        // the two keys collapse into ONE entry before either the resource check or the sandbox
+        // dispatch ever sees them. There is no longer a second value for the tool to read that the
+        // check didn't see: the same value is checked AND consumed, by construction — proven here
+        // regardless of WHICH value survives the collapse. Which one wins depends on
+        // config.InputParameters's own enumeration order (an implementation detail of whatever
+        // IReadOnlyDictionary a producer supplies, not a contractual guarantee — code-review finding);
+        // this test pins today's Dictionary-insertion-order behavior ("Path", declared second, wins)
+        // without asserting that order is itself guaranteed. This test proves both halves — the
+        // winning value is what gets checked (call succeeds, since it's in-bounds) AND it's the only
+        // value serialized to the sandbox (the shadowed "path"/denied value never reaches dispatch).
         var fileSystem = new Mock<IFileSystemService>();
         var (executor, sandboxExecutor, _) = BuildPlanExecutorFixture(DenyingSandboxConfig(), fileSystem);
         sandboxExecutor
@@ -557,6 +561,52 @@ public sealed class ToolPathScopingEndToEndTests
         sandboxExecutor.Verify(
             s => s.ExecuteAsync(
                 It.Is<SandboxExecutionRequest>(r => r.Input.Contains(AllowedPath) && !r.Input.Contains(DeniedPath)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task PlanExecutorPath_DeclaredParameterCollidesWithUpstreamKey_DeclaredWinsAcrossCasing()
+    {
+        // Regression (code-review on #595): the earlier collision test only covers two keys declared
+        // together in the SAME step's own InputParameters. This covers the other shape the fix must
+        // also hold for: a declared parameter colliding (case-insensitively) with a key an UPSTREAM
+        // step's JSON output produces. BuildToolArguments's upstream-merge loop uses TryAdd specifically
+        // so a declared parameter always wins over upstream-produced data of the same name — proven
+        // here to hold across casing too, not just exact-name collisions.
+        //
+        // Deliberately asserts SUCCESS, not refusal: an upstream-merged value is always GetRawText()
+        // quoted JSON text (#587/#595 item 5, tracked separately), so if the upstream decoy wrongly won
+        // the collision, the call would ALSO be refused — just for an unrelated reason (the quoted text
+        // fails path normalization), not because TryAdd worked. That shape would make an "expect
+        // refusal" assertion pass regardless of which value won, hiding the exact bug this test exists
+        // to catch (confirmed by mutation-testing: index-assignment instead of TryAdd here produced an
+        // unexpected PASS against the original, refusal-based version of this test). Asserting success
+        // with the DECLARED (in-bounds) value, and that the dispatched payload contains it while the
+        // upstream decoy text never appears, is the one shape where the two outcomes genuinely diverge.
+        var fileSystem = new Mock<IFileSystemService>();
+        var (executor, sandboxExecutor, _) = BuildPlanExecutorFixture(DenyingSandboxConfig(), fileSystem);
+        sandboxExecutor
+            .Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "hello world" });
+
+        const string upstreamDecoyText = "upstream-decoy-should-never-win";
+        var step = BuildToolStep(new ToolUseConfig
+        {
+            ToolName = "file_system",
+            InputParameters = new Dictionary<string, object?> { ["operation"] = "read", ["path"] = AllowedPath }
+        });
+        var upstreamOutputs = new Dictionary<PlanStepId, string>
+        {
+            [new PlanStepId(Guid.NewGuid())] = JsonSerializer.Serialize(new { Path = upstreamDecoyText })
+        };
+
+        var result = await executor.ExecuteAsync(step, upstreamOutputs, CancellationToken.None);
+
+        result.Status.Should().Be(StepExecutionStatus.Completed);
+        sandboxExecutor.Verify(
+            s => s.ExecuteAsync(
+                It.Is<SandboxExecutionRequest>(r => r.Input.Contains(AllowedPath) && !r.Input.Contains(upstreamDecoyText)),
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -13,6 +13,7 @@ using Application.AI.Common.Services.Tools;
 using Domain.AI.Bundles;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
+using Domain.AI.Models;
 using Domain.AI.Permissions;
 using Domain.AI.Planner;
 using Domain.AI.Sandbox;
@@ -73,10 +74,11 @@ public sealed class ToolPathScopingEndToEndTests
     /// trace, not the returned/reported message.
     /// </summary>
     private static (ToolInvocationGovernor Governor, GovernanceTraceRecorder Trace) BuildGovernor(
-        IServiceProvider toolProvider, SandboxConfig sandboxConfig, IAgentExecutionContext context)
+        IServiceProvider toolProvider, SandboxConfig sandboxConfig, IAgentExecutionContext context,
+        IReadOnlySet<string>? toolNames = null)
     {
         var sandboxMonitor = Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == sandboxConfig);
-        var lookup = new FirstPartyToolLookup(toolProvider, new HashSet<string> { "file_system" });
+        var lookup = new FirstPartyToolLookup(toolProvider, toolNames ?? new HashSet<string> { "file_system" });
         var resolver = new ToolPermissionProfileResolver(lookup, sandboxMonitor);
         var enforcer = new CapabilityEnforcer(resolver, NullLogger<CapabilityEnforcer>.Instance);
 
@@ -196,6 +198,36 @@ public sealed class ToolPathScopingEndToEndTests
         using var _ = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor, executionContext: context));
 
         var result = await aiFunction.InvokeAsync(ReadArgs(DeniedPath, operation: "Read"));
+
+        result.Should().BeOfType<string>();
+        trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
+        fileSystem.Verify(fs => fs.ReadFileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task AgentTurnPath_DeniedPath_OperationArrivesAsJsonElement_StillRefuses()
+    {
+        // Regression (#595): every other agent-turn test in this file passes "operation" as a plain
+        // CLR string, so GovernedAIFunction.ReadOperation's JsonElement-unwrap arm — now delegating to
+        // the shared ToolParameters.NormalizeScalar (extracted from three independent copies) — was
+        // never actually exercised end-to-end by this path's own test suite. A caller outside the
+        // standard Microsoft.Extensions.AI pipeline can still put a boxed JsonElement there directly.
+        var (_, fileSystem, toolProvider) = BuildToolFixture();
+        var context = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "test-agent");
+        var (governor, trace) = BuildGovernor(toolProvider, DenyingSandboxConfig(), context);
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, toolProvider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+        var aiFunction = (AIFunction)builder.BuildToolsByName(["file_system"], "test-agent").Single();
+
+        using var _ = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor, executionContext: context));
+
+        var args = new AIFunctionArguments
+        {
+            ["operation"] = JsonSerializer.SerializeToElement("read"),
+            ["parametersJson"] = JsonSerializer.SerializeToElement(new { path = DeniedPath })
+        };
+        var result = await aiFunction.InvokeAsync(args);
 
         result.Should().BeOfType<string>();
         trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
@@ -485,21 +517,28 @@ public sealed class ToolPathScopingEndToEndTests
     }
 
     [Fact]
-    public async Task PlanExecutorPath_CaseVariantDuplicateArgumentKeys_DoesNotThrow_AndStillRefuses()
+    public async Task PlanExecutorPath_CaseVariantDuplicateArgumentKeys_LastWriterWins_CheckedValueMatchesDispatched()
     {
-        // Regression (grader/correctness/security review on #587, rounds 3-4): BuildToolArguments
-        // merges an upstream step's JSON output into the step's own declared parameters via TryAdd on
-        // an ordinal dictionary, so the merged set can legitimately hold two keys that are case-variants
-        // of each other. Round 3's ToDictionary threw ArgumentException uncaught on the collision.
-        // Round 4's last-write-wins fix stopped the throw but only checked whichever value won — while
-        // RunSandboxAsync still dispatches BOTH keys to the tool, which reads its own declared casing.
-        // Using DIFFERENT values on the two keys (an allowed decoy for "Path", the actual denied target
-        // for "path") is the discriminating case a same-value fixture cannot prove: if the enforcer
-        // trusted whichever key won the collision, this call would be wrongly allowed. The fix refuses
-        // outright on any collision instead, so it must refuse here regardless of which value would
-        // have won.
+        // Regression (grader/correctness/security review on #587 rounds 3-4, root-caused on #595):
+        // BuildToolArguments used to merge into an ORDINAL dictionary, so two keys that are
+        // case-variants of each other could coexist as separate entries. Round 3's ToDictionary threw
+        // ArgumentException uncaught on that collision; round 4's admission-layer last-write-wins fix
+        // stopped the throw but only checked whichever value won, while RunSandboxAsync still
+        // dispatched BOTH keys — a plan step could win the check with a decoy and have the tool still
+        // read a denied value under its own declared casing.
+        //
+        // #595 fixed this at the actual source: BuildToolArguments now merges case-insensitively, so
+        // the two keys collapse into ONE entry — whichever was declared last — before either the
+        // resource check or the sandbox dispatch ever sees them. There is no longer a second value for
+        // the tool to read that the check didn't see: the same value is checked AND consumed, by
+        // construction. This test proves both halves — the winning ("Path") value is what gets
+        // checked (call succeeds, since it's in-bounds) AND it's the only value serialized to the
+        // sandbox (the shadowed "path"/denied value never reaches dispatch at all).
         var fileSystem = new Mock<IFileSystemService>();
-        var (executor, sandboxExecutor, trace) = BuildPlanExecutorFixture(DenyingSandboxConfig(), fileSystem);
+        var (executor, sandboxExecutor, _) = BuildPlanExecutorFixture(DenyingSandboxConfig(), fileSystem);
+        sandboxExecutor
+            .Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "hello world" });
 
         var step = BuildToolStep(new ToolUseConfig
         {
@@ -508,18 +547,18 @@ public sealed class ToolPathScopingEndToEndTests
             {
                 ["operation"] = "read",
                 ["path"] = DeniedPath,
-                ["Path"] = AllowedPath
+                ["Path"] = AllowedPath // declared last in source order — wins the case-insensitive collapse
             }
         });
 
         var result = await executor.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
-        result.Status.Should().Be(StepExecutionStatus.Failed);
-        result.IsPolicyDenial.Should().BeTrue();
-        trace.Snapshot().ToolDecisions.Should().ContainSingle(
-            d => d.Reason.Contains("no requested path could be determined"));
+        result.Status.Should().Be(StepExecutionStatus.Completed);
         sandboxExecutor.Verify(
-            s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+            s => s.ExecuteAsync(
+                It.Is<SandboxExecutionRequest>(r => r.Input.Contains(AllowedPath) && !r.Input.Contains(DeniedPath)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -554,5 +593,119 @@ public sealed class ToolPathScopingEndToEndTests
             d => d.Reason.Contains("no requested path could be determined"));
         sandboxExecutor.Verify(
             s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // --- Partial-declaration-map coverage on the two pre-existing paths (#595 item 2) ---
+
+    /// <summary>
+    /// Declares resource parameters for only ONE of its two supported operations — proving that
+    /// <see cref="ResourceParameterExtractor.Extract"/>'s null-for-unrecognized-operation fix (#587
+    /// code-review; originally verified only through <see cref="FileSystemTool"/>, which declares
+    /// every operation it supports) also holds for a genuinely partial declaration map, on the two
+    /// admission paths that predate #587 and had no dedicated test for this shape.
+    /// </summary>
+    private sealed class PartiallyDeclaredTool : ITool
+    {
+        public const string Name_ = "partial_tool";
+        public string Name => Name_;
+        public string Description => "Test tool with a partial ResourceParametersByOperation map.";
+        public IReadOnlyList<string> SupportedOperations => ["declared_op", "undeclared_op"];
+
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>? ResourceParametersByOperation { get; } =
+            new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>
+            {
+                ["declared_op"] = new Dictionary<string, ResourceParameterKind> { ["path"] = ResourceParameterKind.Path }
+            };
+
+        public Task<ToolResult> ExecuteAsync(
+            string operation, IReadOnlyDictionary<string, object?> parameters, CancellationToken cancellationToken = default) =>
+            Task.FromResult(ToolResult.Ok("ok"));
+    }
+
+    private static SandboxConfig PartialToolScopingConfig() => new()
+    {
+        ToolOverrides = new()
+        {
+            [PartiallyDeclaredTool.Name_] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] }
+        }
+    };
+
+    [Fact]
+    public async Task AgentTurnPath_UndeclaredOperationOnPartiallyDeclaredTool_RefusesRatherThanAllows()
+    {
+        var tool = new PartiallyDeclaredTool();
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>(PartiallyDeclaredTool.Name_, tool);
+        var toolProvider = services.BuildServiceProvider();
+
+        var context = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "test-agent");
+        var (governor, trace) = BuildGovernor(
+            toolProvider, PartialToolScopingConfig(), context, new HashSet<string> { PartiallyDeclaredTool.Name_ });
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, toolProvider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+        var aiFunction = (AIFunction)builder.BuildToolsByName([PartiallyDeclaredTool.Name_], "test-agent").Single();
+
+        using var _ = ToolAdmissionAccessor.Begin(AdmissionHarness.Pipeline(governor: governor, executionContext: context));
+
+        var args = new AIFunctionArguments
+        {
+            ["operation"] = "undeclared_op",
+            ["parametersJson"] = JsonSerializer.SerializeToElement(new { path = AllowedPath })
+        };
+        var result = await aiFunction.InvokeAsync(args);
+
+        // Before #587's code-review fix, an operation absent from ResourceParametersByOperation
+        // entirely resolved to ToolCallResourceRequest.Empty ("nothing to check") and was ALLOWED —
+        // even though this tool has real path scoping configured. It must now refuse.
+        result.Should().BeOfType<string>();
+        trace.Snapshot().ToolDecisions.Should().ContainSingle(
+            d => d.Reason.Contains("no requested path could be determined"));
+    }
+
+    [Fact]
+    public async Task DirectToolInvokerPath_UndeclaredOperationOnPartiallyDeclaredTool_RefusesRatherThanAllows()
+    {
+        var tool = new PartiallyDeclaredTool();
+        var sandboxConfig = PartialToolScopingConfig();
+
+        GovernanceTraceRecorder? capturedTrace = null;
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>(PartiallyDeclaredTool.Name_, tool);
+        services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
+        services.AddScoped<IToolCallAdmissionPipeline>(sp =>
+        {
+            var (governor, trace) = BuildGovernor(
+                sp, sandboxConfig, sp.GetRequiredService<IAgentExecutionContext>(),
+                new HashSet<string> { PartiallyDeclaredTool.Name_ });
+            capturedTrace = trace;
+            return AdmissionHarness.Pipeline(
+                governor: governor, executionContext: sp.GetRequiredService<IAgentExecutionContext>(), trace: trace);
+        });
+
+        var provider = services.BuildServiceProvider();
+        var invoker = new DirectToolInvoker(
+            provider.GetRequiredService<IServiceScopeFactory>(),
+            new ToolCatalog(provider, [PartiallyDeclaredTool.Name_], NullLogger<ToolCatalog>.Instance),
+            Mock.Of<IOptionsMonitor<DirectToolInvocationConfig>>(
+                m => m.CurrentValue == new DirectToolInvocationConfig { Enabled = true }),
+            NullLogger<DirectToolInvoker>.Instance);
+
+        var request = new DirectToolInvocationRequest
+        {
+            ToolName = PartiallyDeclaredTool.Name_,
+            Operation = "undeclared_op",
+            Parameters = new Dictionary<string, object?> { ["path"] = AllowedPath },
+            OwnerId = "caller-1",
+            Envelope = new CapabilityEnvelope { AllowedTools = [PartiallyDeclaredTool.Name_] }
+        };
+
+        var outcome = await invoker.InvokeAsync(request, CancellationToken.None);
+
+        outcome.Status.Should().Be(DirectToolInvocationStatus.Denied);
+        capturedTrace.Should().NotBeNull();
+        capturedTrace!.Snapshot().ToolDecisions.Should().ContainSingle(
+            d => d.Reason.Contains("no requested path could be determined"));
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -47,9 +47,9 @@ public sealed class ToolPathScopingEndToEndTests
     private static readonly string DeniedPath = $"{Root}sandbox/secrets/creds.txt";
     private static readonly string AllowedPath = $"{Root}sandbox/work/notes.txt";
 
-    private static SandboxConfig DenyingSandboxConfig() => new()
+    private static SandboxConfig DenyingSandboxConfig(string toolName = "file_system") => new()
     {
-        ToolOverrides = new() { ["file_system"] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
+        ToolOverrides = new() { [toolName] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] } }
     };
 
     /// <summary>A real <see cref="FileSystemTool"/> over a mocked <see cref="IFileSystemService"/>, keyed
@@ -672,14 +672,6 @@ public sealed class ToolPathScopingEndToEndTests
             Task.FromResult(ToolResult.Ok("ok"));
     }
 
-    private static SandboxConfig PartialToolScopingConfig() => new()
-    {
-        ToolOverrides = new()
-        {
-            [PartiallyDeclaredTool.Name_] = new ToolOverrideConfig { DeniedPaths = [$"{Root}sandbox/secrets"] }
-        }
-    };
-
     [Fact]
     public async Task AgentTurnPath_UndeclaredOperationOnPartiallyDeclaredTool_RefusesRatherThanAllows()
     {
@@ -690,7 +682,8 @@ public sealed class ToolPathScopingEndToEndTests
 
         var context = Mock.Of<IAgentExecutionContext>(c => c.AgentId == "test-agent");
         var (governor, trace) = BuildGovernor(
-            toolProvider, PartialToolScopingConfig(), context, new HashSet<string> { PartiallyDeclaredTool.Name_ });
+            toolProvider, DenyingSandboxConfig(PartiallyDeclaredTool.Name_), context,
+            new HashSet<string> { PartiallyDeclaredTool.Name_ });
 
         var builder = new ToolChainBuilder(
             NullLogger<ToolChainBuilder>.Instance, toolProvider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
@@ -717,7 +710,7 @@ public sealed class ToolPathScopingEndToEndTests
     public async Task DirectToolInvokerPath_UndeclaredOperationOnPartiallyDeclaredTool_RefusesRatherThanAllows()
     {
         var tool = new PartiallyDeclaredTool();
-        var sandboxConfig = PartialToolScopingConfig();
+        var sandboxConfig = DenyingSandboxConfig(PartiallyDeclaredTool.Name_);
 
         GovernanceTraceRecorder? capturedTrace = null;
 


### PR DESCRIPTION
## Summary

Follow-up to #587/PR #594. Addresses 4 of the 5 items tracked in #595 (item 5, upstream-chained path/host values, changes the actual sandbox dispatch payload shape and is left as its own follow-up):

- **Root-cause fix (item 4):** `ToolUseStepExecutor.BuildToolArguments` now merges a plan step's arguments into a case-insensitive dictionary from the start, matching `ToolParameters.Flatten`'s existing convention on the agent-turn path — the same convention #587's fix should have followed originally. This makes the case-variant-key collision structurally impossible instead of detected-and-refused, which as a direct consequence (item 1) lets `ExtractResourceRequest`'s now-unreachable collision-refusal loop be simplified to a plain normalize pass. Verified empirically that the naive alternative (passing a case-insensitive comparer to `Dictionary`'s copy-constructor overload) reproduces the exact `ArgumentException` crash fixed once already in this method's history — fixed via index assignment instead.
- **Shared helper (item 3):** extracted `ToolParameters.NormalizeScalar` (a `JsonElement`-string-unwrap), replacing what turned out to be **four** independent copies once `/code-review` found a fourth (`K8sGptAnalyzeTool.ReadFilters`) beyond the three already known.
- **Test coverage (item 2):** added regression tests proving the shared `ResourceParameterExtractor.Extract` null-for-unrecognized-operation fix (from #594's own review) also holds on the two pre-existing admission paths (`GovernedAIFunction`, `DirectToolInvoker`) against a tool with a genuinely partial declaration map — previously verified only against `FileSystemTool`, which declares every operation it supports.

Two rounds of independent review (`run-gates.sh`'s AI gates, then a fresh `/code-review` + `/simplify` pass) each found and fixed real issues along the way — including one mutation-testing catch on my own new test (an "unexpected PASS" revealing a blind spot where a refusal-based assertion couldn't discriminate the bug from an unrelated corruption-based refusal) and one instance of this repo's own "verify claims in comments" failure mode (a doc comment claiming something was "tracked" when it wasn't yet — fixed by actually tracking it, on issue #595).

## Test plan
- [x] New/rewritten regression tests in `ToolPathScopingEndToEndTests.cs`: case-variant collision (rewritten to assert the stronger "checked equals dispatched" property), declared-vs-upstream collision (added; caught and fixed a blind spot via mutation-testing), partial-declaration-map coverage for both pre-existing admission paths (added), agent-turn JSON-element-operation coverage (added).
- [x] Every new/modified guard mutation-tested (broken, confirmed the test fails, reverted).
- [x] Full solution build + test suite green throughout.
- [x] `run-gates.sh` (full AI-gated set) passed clean on the final content state; `/code-review` and `/simplify` receipts recorded.

Remaining #595 items (2 narrower ones plus 3 newly-found during this PR's own review) are tracked as comments on #595 rather than folded into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)