### PR TITLE
fix: remaining plan-step argument fallout from #595

### DIFF
--- a/documentation/security/05-sandbox-and-execution.html
+++ b/documentation/security/05-sandbox-and-execution.html
@@ -333,10 +333,11 @@
                         <code>CapabilityEnforcer</code> checks a call's requested paths/hosts against these lists
                         whenever the tool declares which of its parameters carry them, and this is enforced
                         identically across all three tool-invocation entry points: the agent's conversational
-                        turn, the direct-invoke HTTP surface, and plan/DAG steps. Two narrow gaps remain, tracked
+                        turn, the direct-invoke HTTP surface, and plan/DAG steps. One narrow gap remains, tracked
                         for follow-up rather than fixed: whole-shell-command tools that bypass the capability
-                        enforcer entirely, and a plan step chaining a path/host value from an upstream step's
-                        output rather than declaring it directly.)
+                        enforcer entirely. (A plan step chaining a path/host value from an upstream step's output
+                        used to bypass scoping the same way; that's now fixed — such a value is normalized
+                        identically to a directly-declared one before the check runs.)
                     </p>
 
                     <div class="callout callout-warning">

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -61,6 +61,14 @@ public sealed partial class CapabilityEnforcer
         {
             var normalizedHost = NormalizeHostForMatch(host);
 
+            // Mirrors ValidatePaths' unconditional rejection of an unparsable path (#595
+            // code-review): an empty/unparsable host is refused regardless of whether AllowedHosts
+            // is configured, not only when it fails to match an allow entry. Without this, a
+            // deny-list-only configuration (no AllowedHosts, so the allow-check below never runs)
+            // would silently admit an empty host that matches no configured deny pattern.
+            if (string.IsNullOrEmpty(normalizedHost))
+                return host;
+
             if (deniedPatterns.Any(pattern => HostPatternMatches(normalizedHost, pattern)))
                 return host;
 

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -61,11 +61,15 @@ public sealed partial class CapabilityEnforcer
         {
             var normalizedHost = NormalizeHostForMatch(host);
 
-            // Mirrors ValidatePaths' unconditional rejection of an unparsable path (#595
-            // code-review): an empty/unparsable host is refused regardless of whether AllowedHosts
-            // is configured, not only when it fails to match an allow entry. Without this, a
-            // deny-list-only configuration (no AllowedHosts, so the allow-check below never runs)
-            // would silently admit an empty host that matches no configured deny pattern.
+            // Closes only the empty-string case of the gap ValidatePaths' unconditional rejection
+            // closes more broadly for paths (#595 code-review) — an empty host is refused regardless
+            // of whether AllowedHosts is configured, not only when it fails to match an allow entry.
+            // Without this, a deny-list-only configuration (no AllowedHosts, so the allow-check below
+            // never runs) would silently admit an empty host that matches no configured deny pattern.
+            // NOT a full mirror of ValidatePaths: a non-empty but malformed host (embedded control
+            // characters, oversized input) still falls through to ordinary deny/allow matching here,
+            // unlike a path, which SecureInputValidatorHelper.ValidateFilePath rejects outright.
+            // Broadening this to match is tracked separately, not part of what #595 set out to fix.
             if (string.IsNullOrEmpty(normalizedHost))
                 return host;
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterExtractor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ResourceParameterExtractor.cs
@@ -25,10 +25,12 @@ public static class ResourceParameterExtractor
     /// resource usage for this call is unknown, and <c>CapabilityEnforcer</c> must treat that as a
     /// reason to refuse when scoping is configured, not as "nothing to check". An operation string
     /// that fails to match anything is exactly as unknown as a missing one: both could be an
-    /// upstream-corrupted value (#587 — a plan step's merged arguments can carry raw, quote-wrapped
-    /// JSON text for an upstream-sourced value) as easily as a genuinely unrecognized name, and
-    /// treating either as "nothing to check" would silently allow a call this method has no basis to
-    /// vouch for.
+    /// upstream-corrupted value (#587 — historically, a plan step's merged arguments could carry raw,
+    /// quote-wrapped JSON text for an upstream-sourced string value; #595 fixed that specific
+    /// mechanism for the plan-step path, but this method has no way to know which caller produced
+    /// <paramref name="operation"/> or whether some other path still can) as easily as a genuinely
+    /// unrecognized name, and treating either as "nothing to check" would silently allow a call this
+    /// method has no basis to vouch for.
     /// <see cref="ToolCallResourceRequest.Empty"/> only when the tool affirmatively recognizes
     /// <paramref name="operation"/> and declares no resource parameters for it. Otherwise the
     /// paths/hosts found among <paramref name="parameters"/> for this operation's declared keys.
@@ -58,7 +60,14 @@ public static class ResourceParameterExtractor
             if (parameters is null || !parameters.TryGetValue(parameterName, out var value))
                 continue;
 
-            if (value is not string { Length: > 0 } text)
+            // Length is deliberately NOT checked here (#595 code-review): a declared parameter that
+            // resolves to a genuinely empty string is a present-but-invalid path/host value, not an
+            // absent one. Excluding it here would drop it from the request entirely, and
+            // CapabilityEnforcer treats an empty request as "nothing to check" and passes it —
+            // silently bypassing scoping instead of letting the empty value reach path/host
+            // validation, which correctly denies it as unparsable. Only a non-string value (including
+            // null) means no usable value was supplied.
+            if (value is not string text)
                 continue;
 
             switch (kind)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
@@ -168,6 +168,36 @@ public static class ToolParameters
     };
 
     /// <summary>
+    /// Same string-unwrap rule as <see cref="NormalizeScalar"/>, but for a caller that must always
+    /// hand back a <see cref="string"/> — a non-string <see cref="JsonElement"/> falls back to
+    /// <see cref="JsonElement.GetRawText"/> instead of passing the element through unchanged.
+    /// </summary>
+    /// <remarks>
+    /// A sibling, not a parameter on <see cref="NormalizeScalar"/> itself (#595 code-review): the two
+    /// have genuinely different contracts a caller picks between, not two modes of one operation.
+    /// <see cref="NormalizeScalar"/>'s callers merge a value back into a CLR object graph they may
+    /// serialize later, where a passed-through <see cref="JsonElement"/> serializes correctly on its
+    /// own; <c>ToolUseStepExecutor.BuildToolArguments</c> merges every upstream property into a
+    /// <c>Dictionary&lt;string, object?&gt;</c> whose values were always raw JSON text as a
+    /// <see cref="string"/> before #595 touched it — switching a non-string value to a passed-through
+    /// element there would change what a tool actually receives for every existing non-string
+    /// upstream-merged argument (a JSON number stops being double-encoded as a quoted string), a
+    /// behavior change well outside what #595 set out to fix.
+    /// </remarks>
+    /// <param name="value">The value to normalize — any CLR scalar, or a boxed <see cref="JsonElement"/>.</param>
+    /// <returns>
+    /// The unwrapped <see cref="string"/> when <paramref name="value"/> is a string-valued
+    /// <see cref="JsonElement"/>; that element's raw JSON text when it is a non-string
+    /// <see cref="JsonElement"/>; otherwise <paramref name="value"/> itself, unchanged.
+    /// </returns>
+    public static object? NormalizeScalarToText(object? value) => value switch
+    {
+        JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
+        JsonElement je => je.GetRawText(),
+        _ => value
+    };
+
+    /// <summary>
     /// The shared answer for "no parameters". A fresh dictionary per call would allocate on the
     /// commonest path, since several operations take no arguments at all.
     /// </summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
@@ -190,12 +190,15 @@ public static class ToolParameters
     /// <see cref="JsonElement"/>; that element's raw JSON text when it is a non-string
     /// <see cref="JsonElement"/>; otherwise <paramref name="value"/> itself, unchanged.
     /// </returns>
-    public static object? NormalizeScalarToText(object? value) => value switch
+    public static object? NormalizeScalarToText(object? value)
     {
-        JsonElement { ValueKind: JsonValueKind.String } je => je.GetString(),
-        JsonElement je => je.GetRawText(),
-        _ => value
-    };
+        // Delegates the string-unwrap rule to NormalizeScalar instead of re-matching it (/simplify):
+        // a string-valued JsonElement is already unwrapped to a plain string by NormalizeScalar, so it
+        // never reaches the JsonElement check below; anything NormalizeScalar left as a JsonElement is
+        // by definition non-string here.
+        var normalized = NormalizeScalar(value);
+        return normalized is JsonElement je ? je.GetRawText() : normalized;
+    }
 
     /// <summary>
     /// The shared answer for "no parameters". A fresh dictionary per call would allocate on the

--- a/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
+++ b/src/Content/Domain/Domain.Common/Config/AI/Sandbox/ToolOverrideConfig.cs
@@ -34,14 +34,15 @@ namespace Domain.Common.Config.AI.Sandbox;
 /// parameters is scoped identically across all three entry points.
 /// </para>
 /// <para>
-/// <strong>One narrower gap remains on the plan path specifically:</strong> when a path/host value is
+/// <strong>The narrower gap that once existed here is closed:</strong> when a path/host value is
 /// chained from an upstream step's output rather than declared directly on the step, it arrives via
-/// <c>ToolUseStepExecutor.BuildToolArguments</c>' JSON-merge as <c>JsonElement.GetRawText()</c> —
-/// literal, quote-wrapped JSON text, not the plain string every other producer supplies. That value
-/// fails path/host normalization and the call is refused — never silently allowed, since #587's
-/// <c>ResourceParameterExtractor.Extract</c> fix (code-review round) treats an operation or value it
-/// cannot read as unknown rather than "nothing to check" — but a plan legitimately chaining a
-/// path/host between steps cannot use scoping today. Tracked for follow-up, not covered here.
+/// <c>ToolUseStepExecutor.BuildToolArguments</c>' JSON-merge. That merge used to call
+/// <c>JsonElement.GetRawText()</c> unconditionally, keeping literal quote characters on a chained
+/// string value and failing path/host normalization every time — refused, never silently allowed
+/// (#587's <c>ResourceParameterExtractor.Extract</c> fix treats a value it cannot read as unknown
+/// rather than "nothing to check"), but unusable for scoping. #595 fixed the merge itself
+/// (<c>ToolParameters.NormalizeScalarToText</c> unwraps a string value the same way a directly-declared
+/// parameter arrives), so a chained path/host now scopes identically to a directly-declared one.
 /// </para>
 /// </remarks>
 public sealed class ToolOverrideConfig

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ConditionalBranchStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ConditionalBranchStepExecutor.cs
@@ -78,6 +78,11 @@ public sealed class ConditionalBranchStepExecutor : IPlanStepExecutor
             try
             {
                 using var doc = JsonDocument.Parse(output);
+                // #595: a non-object root (a bare array or number) is valid JSON, so it reaches here
+                // rather than the catch below, but EnumerateObject() throws InvalidOperationException
+                // on it — uncaught. Skip it the same way malformed (non-JSON) output already is.
+                if (doc.RootElement.ValueKind != JsonValueKind.Object) continue;
+
                 foreach (var prop in doc.RootElement.EnumerateObject())
                 {
                     context[prop.Name] = prop.Value.ValueKind switch

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ConditionalBranchStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ConditionalBranchStepExecutor.cs
@@ -73,32 +73,21 @@ public sealed class ConditionalBranchStepExecutor : IPlanStepExecutor
 
         foreach (var (_, output) in upstreamOutputs)
         {
-            if (string.IsNullOrEmpty(output)) continue;
-
-            try
+            // UpstreamJsonProperties (#595 code-review) centralizes the parse/non-object-root-guard/
+            // catch boilerplate this loop shares with ToolUseStepExecutor.BuildToolArguments; only the
+            // per-property value conversion below (typed CLR values, not JSON-encoded text) is this
+            // method's own.
+            foreach (var prop in UpstreamJsonProperties.Parse(output))
             {
-                using var doc = JsonDocument.Parse(output);
-                // #595: a non-object root (a bare array or number) is valid JSON, so it reaches here
-                // rather than the catch below, but EnumerateObject() throws InvalidOperationException
-                // on it — uncaught. Skip it the same way malformed (non-JSON) output already is.
-                if (doc.RootElement.ValueKind != JsonValueKind.Object) continue;
-
-                foreach (var prop in doc.RootElement.EnumerateObject())
+                context[prop.Name] = prop.Value.ValueKind switch
                 {
-                    context[prop.Name] = prop.Value.ValueKind switch
-                    {
-                        JsonValueKind.Number => prop.Value.GetDouble(),
-                        JsonValueKind.True => true,
-                        JsonValueKind.False => false,
-                        JsonValueKind.String => prop.Value.GetString(),
-                        JsonValueKind.Null => null,
-                        _ => prop.Value.GetRawText()
-                    };
-                }
-            }
-            catch (JsonException)
-            {
-                // Non-JSON output — skip
+                    JsonValueKind.Number => prop.Value.GetDouble(),
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.String => prop.Value.GetString(),
+                    JsonValueKind.Null => null,
+                    _ => prop.Value.GetRawText()
+                };
             }
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -501,12 +501,11 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
                 {
                     // A string property keeps its literal quote characters under GetRawText() (e.g. a
                     // "path" value becomes "\"C:\\foo\"", not "C:\\foo"), which breaks path/host scoping
-                    // validation for a value legitimately chained from an upstream step. GetString() for
-                    // strings; GetRawText() stays for every other kind, which downstream consumers still
-                    // expect as JSON-encoded text.
-                    merged.TryAdd(prop.Name, prop.Value.ValueKind == JsonValueKind.String
-                        ? prop.Value.GetString()
-                        : prop.Value.GetRawText());
+                    // validation for a value legitimately chained from an upstream step.
+                    // ToolParameters.NormalizeScalarToText unwraps a string kind the same way and keeps
+                    // GetRawText() for every other kind, which downstream consumers still expect as
+                    // JSON-encoded text.
+                    merged.TryAdd(prop.Name, ToolParameters.NormalizeScalarToText(prop.Value));
                 }
             }
             catch (JsonException) { }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -491,24 +491,19 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         // value of the same name, across casing now too — see the class remarks above.
         foreach (var (_, output) in upstreamOutputs)
         {
-            if (string.IsNullOrEmpty(output)) continue;
-            try
+            // UpstreamJsonProperties (#595 code-review) centralizes the parse/non-object-root-guard/
+            // catch boilerplate this loop shares with ConditionalBranchStepExecutor.
+            // BuildEvaluationContext; only the per-property value conversion below is this method's own.
+            foreach (var prop in UpstreamJsonProperties.Parse(output))
             {
-                using var doc = JsonDocument.Parse(output);
-                if (doc.RootElement.ValueKind != JsonValueKind.Object) continue;
-
-                foreach (var prop in doc.RootElement.EnumerateObject())
-                {
-                    // A string property keeps its literal quote characters under GetRawText() (e.g. a
-                    // "path" value becomes "\"C:\\foo\"", not "C:\\foo"), which breaks path/host scoping
-                    // validation for a value legitimately chained from an upstream step.
-                    // ToolParameters.NormalizeScalarToText unwraps a string kind the same way and keeps
-                    // GetRawText() for every other kind, which downstream consumers still expect as
-                    // JSON-encoded text.
-                    merged.TryAdd(prop.Name, ToolParameters.NormalizeScalarToText(prop.Value));
-                }
+                // A string property keeps its literal quote characters under GetRawText() (e.g. a
+                // "path" value becomes "\"C:\\foo\"", not "C:\\foo"), which breaks path/host scoping
+                // validation for a value legitimately chained from an upstream step.
+                // ToolParameters.NormalizeScalarToText unwraps a string kind the same way and keeps
+                // GetRawText() for every other kind, which downstream consumers still expect as
+                // JSON-encoded text.
+                merged.TryAdd(prop.Name, ToolParameters.NormalizeScalarToText(prop.Value));
             }
-            catch (JsonException) { }
         }
 
         return merged;

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -495,9 +495,18 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
             try
             {
                 using var doc = JsonDocument.Parse(output);
+                if (doc.RootElement.ValueKind != JsonValueKind.Object) continue;
+
                 foreach (var prop in doc.RootElement.EnumerateObject())
                 {
-                    merged.TryAdd(prop.Name, prop.Value.GetRawText());
+                    // A string property keeps its literal quote characters under GetRawText() (e.g. a
+                    // "path" value becomes "\"C:\\foo\"", not "C:\\foo"), which breaks path/host scoping
+                    // validation for a value legitimately chained from an upstream step. GetString() for
+                    // strings; GetRawText() stays for every other kind, which downstream consumers still
+                    // expect as JSON-encoded text.
+                    merged.TryAdd(prop.Name, prop.Value.ValueKind == JsonValueKind.String
+                        ? prop.Value.GetString()
+                        : prop.Value.GetRawText());
                 }
             }
             catch (JsonException) { }

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/UpstreamJsonProperties.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/UpstreamJsonProperties.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+
+namespace Infrastructure.AI.Planner.StepExecutors;
+
+/// <summary>
+/// Parses an upstream plan step's JSON output and yields its top-level properties, tolerating
+/// malformed input the same way every caller already did independently before this was extracted.
+/// </summary>
+/// <remarks>
+/// #595 code-review: <c>ToolUseStepExecutor.BuildToolArguments</c> and
+/// <c>ConditionalBranchStepExecutor.BuildEvaluationContext</c> each independently implemented the
+/// identical "parse, guard a non-object root, enumerate, catch <see cref="JsonException"/>" shape —
+/// and the non-object-root guard was added to one during this PR's own review and missed in the
+/// other until a later round, the exact drift class this extraction exists to prevent. What is NOT
+/// shared: how a caller converts each <see cref="JsonProperty"/>'s value — <c>BuildToolArguments</c>
+/// needs JSON-encoded text for re-serialization, <c>BuildEvaluationContext</c> needs typed CLR values
+/// for condition evaluation. Those are genuinely different value semantics per consumer, so each
+/// caller keeps its own conversion switch; only the parsing boilerplate is centralized here.
+/// </remarks>
+internal static class UpstreamJsonProperties
+{
+    /// <summary>
+    /// Yields <paramref name="output"/>'s top-level properties, or nothing at all when
+    /// <paramref name="output"/> is null/empty, is not valid JSON, or does not parse to a JSON object
+    /// (a bare array or number is valid JSON but has no properties to enumerate) — every case a
+    /// malformed or unexpectedly-shaped upstream output can take, none of them thrown as an exception
+    /// to the caller.
+    /// </summary>
+    public static IEnumerable<JsonProperty> Parse(string? output)
+    {
+        if (string.IsNullOrEmpty(output))
+            yield break;
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(output);
+        }
+        catch (JsonException)
+        {
+            yield break;
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                yield break;
+
+            foreach (var property in document.RootElement.EnumerateObject())
+                yield return property;
+        }
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -578,6 +578,26 @@ public sealed class CapabilityEnforcementTests
     }
 
     [Fact]
+    public async Task DeniedHostOnly_RequestedHostIsEmptyString_Refuses()
+    {
+        // #595 code-review: a deny-list-only config has no AllowedHosts, so the allow-check in
+        // ValidateHosts never runs — before this fix, an empty-string requested host matched no
+        // configured deny pattern either, and the loop fell through with no violation, silently
+        // admitting it. Mirrors ValidatePaths' unconditional rejection of an unparsable path.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: [""]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task AllowedHostConfigured_ExactMatchWithPortStripped_PassesThrough()
     {
         var config = new SandboxConfig

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -612,15 +612,19 @@ public sealed class ToolPathScopingEndToEndTests
     }
 
     [Fact]
-    public async Task PlanExecutorPath_OperationSourcedFromUpstreamOutput_CorruptedByRawTextQuoting_StillRefuses()
+    public async Task PlanExecutorPath_OperationAndPathSourcedFromUpstreamOutput_RefusesViaRealPathScoping()
     {
-        // Regression (code-review on #587): BuildToolArguments merges an upstream step's JSON output
-        // via JsonElement.GetRawText(), which keeps the literal JSON quote characters on string values
-        // — so an operation name sourced purely from upstream output arrives as "\"read\"", not "read".
-        // Before ResourceParameterExtractor.Extract's fix, an operation that fails to match any declared
-        // name returned ToolCallResourceRequest.Empty (not null), which CapabilityEnforcer trusts as
-        // "nothing to check" and allows — silently defeating path scoping for exactly the plan-executor
-        // path #587 set out to close.
+        // Regression (code-review on #587, updated by #595): BuildToolArguments used to merge an
+        // upstream step's JSON output via JsonElement.GetRawText() unconditionally, which kept the
+        // literal JSON quote characters on string values — so an operation name sourced purely from
+        // upstream output arrived as "\"read\"", not "read", and a denied path arrived the same way.
+        // Before ResourceParameterExtractor.Extract's #587 fix, an operation that fails to match any
+        // declared name returned ToolCallResourceRequest.Empty (not null), which CapabilityEnforcer
+        // trusts as "nothing to check" and allows — silently defeating path scoping. #595 closed the
+        // quoting mechanism itself for string values, so operation and path now arrive clean and are
+        // correctly recognized — this call is refused through genuine path-scoping validation (the
+        // path IS denied), not through the fallback "couldn't determine" safety net #587 added. Either
+        // refusal reason proves the call didn't slip through; this asserts the one that is now correct.
         var fileSystem = new Mock<IFileSystemService>();
         var (executor, sandboxExecutor, trace) = BuildPlanExecutorFixture(DenyingSandboxConfig(), fileSystem);
 
@@ -639,8 +643,41 @@ public sealed class ToolPathScopingEndToEndTests
 
         result.Status.Should().Be(StepExecutionStatus.Failed);
         result.IsPolicyDenial.Should().BeTrue();
-        trace.Snapshot().ToolDecisions.Should().ContainSingle(
-            d => d.Reason.Contains("no requested path could be determined"));
+        trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
+        sandboxExecutor.Verify(
+            s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task PlanExecutorPath_UpstreamChainedPathResolvesToEmptyString_StillRefuses()
+    {
+        // Regression (code-review on #595 item 5): fixing GetRawText()'s literal-quote bug for a
+        // chained upstream string value (this PR) meant a genuinely empty string now reaches
+        // ResourceParameterExtractor as a real 0-length string instead of the 2-char quoted garbage
+        // that used to fail path validation. ResourceParameterExtractor.Extract's own value filter
+        // used to treat an empty string identically to "parameter not supplied" (skipped, not added
+        // to RequestedPaths) — which made CapabilityEnforcer.EnforcePathScoping see an empty request
+        // and treat that as "nothing to check", passing the call with path scoping configured. The
+        // fix keeps a present-but-empty value in the request so path validation denies it as
+        // unparsable, same as any other invalid path.
+        var fileSystem = new Mock<IFileSystemService>();
+        var (executor, sandboxExecutor, trace) = BuildPlanExecutorFixture(DenyingSandboxConfig(), fileSystem);
+
+        var step = BuildToolStep(new ToolUseConfig
+        {
+            ToolName = "file_system",
+            InputParameters = new Dictionary<string, object?> { ["operation"] = "read" }
+        });
+        var upstreamOutputs = new Dictionary<PlanStepId, string>
+        {
+            [new PlanStepId(Guid.NewGuid())] = JsonSerializer.Serialize(new { path = "" })
+        };
+
+        var result = await executor.ExecuteAsync(step, upstreamOutputs, CancellationToken.None);
+
+        result.Status.Should().Be(StepExecutionStatus.Failed);
+        result.IsPolicyDenial.Should().BeTrue();
+        trace.Snapshot().ToolDecisions.Should().ContainSingle(d => d.Reason.Contains("path denied"));
         sandboxExecutor.Verify(
             s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
@@ -142,6 +142,20 @@ public sealed class ResourceParameterExtractorTests
     }
 
     [Fact]
+    public void Extract_DeclaredParameterIsEmptyString_IsIncludedNotIgnored()
+    {
+        // #595 code-review: an empty string is a present-but-invalid path value, not an absent one.
+        // Excluding it here (as the non-string case above correctly does) would make RequestedPaths
+        // empty, and CapabilityEnforcer treats an empty request as "nothing to check" and passes it —
+        // silently bypassing scoping. Including it lets path validation deny it as unparsable instead.
+        var result = ResourceParameterExtractor.Extract(
+            "read", new Dictionary<string, object?> { ["path"] = "" }, FileSystemMap);
+
+        result.Should().NotBeNull();
+        result!.RequestedPaths.Should().ContainSingle().Which.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Extract_ParametersIsNullButOperationIsDeclared_ReturnsEmptyRequest()
     {
         var result = ResourceParameterExtractor.Extract("read", parameters: null, FileSystemMap);

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ResourceParameterExtractorTests.cs
@@ -156,6 +156,23 @@ public sealed class ResourceParameterExtractorTests
     }
 
     [Fact]
+    public void Extract_DeclaredHostParameterIsEmptyString_IsIncludedNotIgnored()
+    {
+        // Symmetric with the Path case above (round-6 code-review): the same present-but-invalid
+        // reasoning applies to a declared Host parameter, not just Path.
+        var map = new Dictionary<string, IReadOnlyDictionary<string, ResourceParameterKind>>
+        {
+            ["fetch"] = new Dictionary<string, ResourceParameterKind> { ["url_host"] = ResourceParameterKind.Host }
+        };
+
+        var result = ResourceParameterExtractor.Extract(
+            "fetch", new Dictionary<string, object?> { ["url_host"] = "" }, map);
+
+        result.Should().NotBeNull();
+        result!.RequestedHosts.Should().ContainSingle().Which.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Extract_ParametersIsNullButOperationIsDeclared_ReturnsEmptyRequest()
     {
         var result = ResourceParameterExtractor.Extract("read", parameters: null, FileSystemMap);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ConditionalBranchStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ConditionalBranchStepExecutorTests.cs
@@ -59,6 +59,35 @@ public sealed class ConditionalBranchStepExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_UpstreamOutputIsNonObjectJson_SkipsItWithoutThrowing()
+    {
+        // #595 code-review: BuildEvaluationContext has the identical parse-then-EnumerateObject()
+        // shape as ToolUseStepExecutor.BuildToolArguments, which had the same bug fixed elsewhere in
+        // this PR — a non-object JSON root (a bare array or number) is valid JSON, so it isn't caught
+        // by catch(JsonException), but EnumerateObject() throws InvalidOperationException on it.
+        var trueTarget = new PlanStepId(Guid.NewGuid());
+        var falseTarget = new PlanStepId(Guid.NewGuid());
+        var config = new ConditionalBranchConfig
+        {
+            ConditionExpression = "score > 5",
+            TrueEdgeTargetId = trueTarget,
+            FalseEdgeTargetId = falseTarget
+        };
+        var step = CreateStep(config);
+        var upstreamId = new PlanStepId(Guid.NewGuid());
+        var outputs = new Dictionary<PlanStepId, string> { [upstreamId] = "[1,2,3]" };
+
+        var result = await _sut.ExecuteAsync(step, outputs, CancellationToken.None);
+
+        // The point of this test is that ExecuteAsync returns a normal result at all — before the
+        // fix, EnumerateObject() throws InvalidOperationException uncaught, and this call never
+        // returns. "score" was never populated (the non-object output is skipped, not merged), so the
+        // condition evaluates false and the executor still completes, taking the false edge.
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        Assert.Equal(falseTarget, result.ActiveEdgeTarget);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_FalseCondition_ReturnsFalseEdgeTarget()
     {
         var trueTarget = new PlanStepId(Guid.NewGuid());

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -12,6 +12,7 @@ using Domain.AI.Planner;
 using Domain.Common.Config.AI;
 using Domain.AI.Sandbox;
 using Infrastructure.AI.Planner.StepExecutors;
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -603,6 +604,62 @@ public sealed class ToolUseStepExecutorTests
         Assert.Contains("\"op\"", captured!.Input);
         Assert.Contains("5", captured.Input);
         Assert.Contains("3", captured.Input);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpstreamStringValue_DoesNotRetainLiteralJsonQuotes()
+    {
+        // #595 item 5: a plan step legitimately chaining a path/host value from an upstream step's
+        // JSON output must receive the plain string, not one still wrapped in the quote characters
+        // GetRawText() preserves — the latter fails path/host scoping validation on every call.
+        var config = new ToolUseConfig
+        {
+            ToolName = "file_system",
+            InputParameters = new Dictionary<string, object?> { ["operation"] = "read" }
+        };
+        var step = CreateStep(config);
+        var upstreamId = new PlanStepId(Guid.NewGuid());
+        var outputs = new Dictionary<PlanStepId, string> { [upstreamId] = """{"path": "C:\\foo\\bar.txt"}""" };
+
+        SandboxExecutionRequest? captured = null;
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SandboxExecutionRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
+
+        await _sut.ExecuteAsync(step, outputs, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        using var doc = JsonDocument.Parse(captured!.Input);
+        var path = doc.RootElement.GetProperty("path").GetString();
+        Assert.Equal("C:\\foo\\bar.txt", path);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UpstreamOutputIsNonObjectJson_SkipsItWithoutThrowing()
+    {
+        // #595: an upstream step whose output parses as a non-object JSON root (a bare array or
+        // number) used to throw InvalidOperationException from EnumerateObject(), uncaught locally —
+        // burning a full retry attempt with a generic error on every retry instead of just ignoring
+        // that upstream contribution, the same way malformed (non-JSON) output already is.
+        var config = new ToolUseConfig
+        {
+            ToolName = "calculator",
+            InputParameters = new Dictionary<string, object?> { ["op"] = "add" }
+        };
+        var step = CreateStep(config);
+        var upstreamId = new PlanStepId(Guid.NewGuid());
+        var outputs = new Dictionary<PlanStepId, string> { [upstreamId] = "[1,2,3]" };
+
+        SandboxExecutionRequest? captured = null;
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<SandboxExecutionRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new SandboxExecutionResult { Success = true, Output = "ok", ResourceUsage = new ResourceUsage() });
+
+        var result = await _sut.ExecuteAsync(step, outputs, CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        Assert.NotNull(captured);
+        Assert.Contains("\"op\"", captured!.Input);
     }
 
     // ===== #325 execution reporting =====


### PR DESCRIPTION
## Summary

Closes the remaining scope of #595 (deferred out of PR #596 to keep that PR's review from
running even longer): a plan step chaining a path/host value from an upstream step's output
kept literal JSON quote characters and always failed scoping validation, and a malformed
(non-object) upstream JSON output crashed a step instead of being skipped.

Both fixes went through several rounds of `/code-review` and `/simplify`, each surfacing a
real follow-on issue in the same area — summarized here rather than in the diff itself:

- **#595 item 5** — `ToolUseStepExecutor.BuildToolArguments` now unwraps a chained upstream
  string value via a shared `ToolParameters.NormalizeScalarToText` helper instead of
  `GetRawText()`, so it scopes identically to a directly-declared value.
- **Non-object JSON root crash** — both `ToolUseStepExecutor.BuildToolArguments` and
  `ConditionalBranchStepExecutor.BuildEvaluationContext` had the identical bug (a bare JSON
  array/number from an upstream step threw `InvalidOperationException`, uncaught). Fixed in
  both, and the shared parse/guard/catch boilerplate is now centralized in a new
  `UpstreamJsonProperties` helper.
- **Real regression caught mid-review**: fixing the quote-wrapping bug exposed a genuine
  empty-string scoping bypass — `ResourceParameterExtractor.Extract` was treating an empty
  path/host value identically to an absent one, letting `CapabilityEnforcer` skip validation
  entirely instead of denying it as unparsable. Fixed for both paths and hosts (the host side
  had an equivalent, independent gap once the same fix was applied there).

## Follow-ups filed during review (deliberately out of scope here)

- #604 — `ResourceParameterExtractor.Extract` also silently drops a non-string (or JSON
  `null`) value for a declared path/host parameter, the same shape as the empty-string bug
  fixed here, but reverses an existing tested design decision rather than fixing a
  regression — needs its own design discussion.
- #605 — `CapabilityEnforcer.ValidateHosts` still lacks a general-purpose malformed-input
  validator the way `ValidatePaths` has via `SecureInputValidatorHelper`; this PR closes only
  the empty-string case.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] Full solution test suite (`dotnet test`, Release) — 3477 tests, 0 failures (one
      unrelated pre-existing flake in `ProcessSandboxExecutorTests`, confirmed by 3/3 passes
      in isolation and unrelated to any file this PR touches)
- [x] New regression tests for every fix, each proven against the pre-fix code (fails without
      the fix, passes with it)
- [x] `run-gates.sh` clean: build, test, owasp, grader, correctness, security, docs-drift
- [x] `/code-review` — 7 rounds across this PR's evolution, no correctness bug survived the
      final round
- [x] `/simplify` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVKDxbkyu6kqeZd6qCLJM6