### PR TITLE
feat: per-turn context + per-run model override on AG-UI (M1 Section B0)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -131,6 +131,13 @@ public partial class AgentExecutionContextFactory
                 "task-similarity recall");
         }
 
+        // Caller-supplied per-turn context (mood, memory, situational continuity a calling
+        // application recomputes every turn) — unconditional, unlike the two recall providers above:
+        // it needs no tenant-scoped dependency and no config flag, since it contributes nothing
+        // (empty AIContext) unless a caller actually sets CallerTurnContextScope.Current for this
+        // turn. Every agent that doesn't use this feature pays nothing beyond one list entry.
+        providers.Add(new Services.Agent.CallerTurnContextProvider());
+
         // Governance wrapper — added after the recall providers so it wraps the final, filtered tool
         // set, guaranteeing the governor gates every tool the agent can call including the framework
         // progressive-disclosure tools that bypass ToolChainBuilder.

--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.cs
@@ -171,6 +171,14 @@ public partial class AgentExecutionContextFactory
         if (_appConfig.CurrentValue.AI?.ContextManagement?.PromptComposition?.Enabled == true)
             instruction = await ComposeStaticSystemPromptAsync(agentName, instruction);
 
+        // Terminate the stable instruction with the cache-boundary sentinel so PromptCacheInjector
+        // marks this content — not CallerTurnContextProvider's per-turn addition that follows it —
+        // as the cached prefix. Only when caching is actually enabled: with it off, the injector
+        // never runs on any request, so nothing would ever strip the marker back out. See
+        // PromptCacheConventions.CacheBoundaryMarker for the full contract.
+        if (_appConfig.CurrentValue.AI?.AgentFramework?.EnablePromptCaching == true)
+            instruction += Domain.AI.Caching.PromptCacheConventions.CacheBoundaryMarker;
+
         // Agent tool ceiling. Resolve the one effective allowlist that governs this agent (see
         // ResolveEffectiveAllowlist) and drive BOTH enforcement points with it — the merge-time tool
         // filter and the runtime ToolPermissionFilter — so they can never disagree. null means no

--- a/src/Content/Application/Application.AI.Common/Services/Agent/CallerTurnContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/CallerTurnContextProvider.cs
@@ -1,0 +1,55 @@
+using Microsoft.Agents.AI;
+
+namespace Application.AI.Common.Services.Agent;
+
+/// <summary>
+/// An <see cref="AIContextProvider"/> that injects the calling application's per-turn context —
+/// <see cref="CallerTurnContextScope.Current"/> — into the agent's context for this turn only.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Agents are cached as singletons (see <c>IAgentConversationCache</c>), so this provider is
+/// long-lived and shared across requests and tenants, exactly like
+/// <see cref="KnowledgeMemoryContextProvider"/>. Unlike that provider it needs no tenant-scoped
+/// service — the value it reads is a plain string seeded per turn by
+/// <c>ExecuteAgentTurnCommandHandler</c> — so it reads the lighter
+/// <see cref="CallerTurnContextScope"/> ambient rather than resolving through
+/// <see cref="Application.AI.Common.Interfaces.IAmbientRequestScope"/>.
+/// </para>
+/// <para>
+/// Contributes an empty <see cref="AIContext"/> when no caller has set a value, so every agent that
+/// isn't using this feature is unaffected. See <see cref="CallerTurnContextScope"/> for why this
+/// rail — evaluated fresh per invocation — is what keeps the static, cached instructions
+/// byte-identical turn to turn while still delivering content that changes every turn.
+/// </para>
+/// </remarks>
+public sealed class CallerTurnContextProvider : AIContextProvider
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CallerTurnContextProvider"/> class.
+    /// </summary>
+    public CallerTurnContextProvider()
+        : base(
+            provideInputMessageFilter: messages => messages,
+            storeInputRequestMessageFilter: messages => messages,
+            storeInputResponseMessageFilter: messages => messages)
+    {
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns <em>only</em> the caller's block, never the incoming instructions — the base
+    /// implementation merges what it returns into the incoming context as
+    /// <c>Instructions = input + "\n" + provided</c>, so echoing the input here would send the
+    /// entire system prompt to the model twice.
+    /// </remarks>
+    protected override ValueTask<AIContext> ProvideAIContextAsync(
+        InvokingContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var value = CallerTurnContextScope.Current;
+
+        return new ValueTask<AIContext>(
+            string.IsNullOrWhiteSpace(value) ? new AIContext() : new AIContext { Instructions = value });
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/CallerTurnContextScope.cs
+++ b/src/Content/Application/Application.AI.Common/Services/CallerTurnContextScope.cs
@@ -1,0 +1,45 @@
+namespace Application.AI.Common.Services;
+
+/// <summary>
+/// Ambient (<see cref="AsyncLocal{T}"/>) holder for the calling application's per-turn context —
+/// text a caller wants folded into this one turn only (e.g. mood, recently retrieved memory,
+/// situational continuity), distinct from the conversation's persistent
+/// <c>ConversationSettings.SystemPromptOverride</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Exists because the harness caches an agent per conversation (see <c>IAgentConversationCache</c>)
+/// and builds its static instructions — <c>SystemPromptOverride</c> included — once, not per turn.
+/// A caller with content that changes every message (an avatar's present-moment state, for example)
+/// has nowhere to put it in that static path without breaking Anthropic prompt caching, which
+/// requires the cached prefix to stay byte-identical across turns.
+/// <see cref="Application.AI.Common.Services.Agent.CallerTurnContextProvider"/>
+/// reads this ambient value on the framework's separate, genuinely-per-invocation
+/// <c>AIContextProvider</c> rail instead, so the static instructions never change turn to turn while
+/// this content still reaches the model fresh every time.
+/// </para>
+/// <para>
+/// Seeded by <c>ExecuteAgentTurnCommandHandler</c> from <c>ExecuteAgentTurnCommand.TurnContext</c>
+/// immediately before dispatch, mirroring the identical ambient-bridge pattern
+/// <see cref="LlmUsageCapture.Current"/> and <see cref="ReplayedToolCallScope.Current"/> already use
+/// for the same reason — the agent outlives the handler's own scope, so per-turn state has to travel
+/// ambiently rather than by parameter. Cleared in the same <c>finally</c> block those two are, so a
+/// turn that set no context never leaks a stale value to a later, unrelated turn sharing the same
+/// async-local flow.
+/// </para>
+/// </remarks>
+public static class CallerTurnContextScope
+{
+    private static readonly AsyncLocal<string?> s_current = new();
+
+    /// <summary>
+    /// The current turn's caller-supplied context, or <see langword="null"/> when the caller sent
+    /// none (the common case for every agent that isn't using this feature) or no turn has set one
+    /// (e.g. a test constructing the provider directly).
+    /// </summary>
+    public static string? Current
+    {
+        get => s_current.Value;
+        set => s_current.Value = value;
+    }
+}

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommand.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommand.cs
@@ -60,6 +60,15 @@ public record ExecuteAgentTurnCommand : IRequest<AgentTurnResult>, IAgentTurnReq
 	public string? DeploymentOverride { get; init; }
 
 	/// <summary>
+	/// Optional caller-supplied context for this turn only — distinct from
+	/// <see cref="SystemPromptOverride"/>, which is persistent and merged into the agent's cached
+	/// static instructions once per conversation. This travels the per-invocation
+	/// <c>AIContextProvider</c> rail instead (see <c>CallerTurnContextProvider</c>), so it can change
+	/// every turn without invalidating the Anthropic prompt cache on the static instructions.
+	/// </summary>
+	public string? TurnContext { get; init; }
+
+	/// <summary>
 	/// Optional sampling temperature. Null preserves provider defaults.
 	/// </summary>
 	public float? Temperature { get; init; }

--- a/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
+++ b/src/Content/Application/Application.Core/CQRS/Agents/ExecuteAgentTurn/ExecuteAgentTurnCommandHandler.cs
@@ -142,6 +142,12 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 			// records to this handler's scoped ILlmUsageCapture instance.
 			LlmUsageCapture.Current = _usageCapture;
 
+			// Seed this turn's caller-supplied context (mood, memory, etc. — distinct from the
+			// persistent SystemPromptOverride) for CallerTurnContextProvider to pick up on the
+			// per-invocation AIContextProvider rail. Null when the caller sent none, which the
+			// provider treats as "contribute nothing."
+			CallerTurnContextScope.Current = request.TurnContext;
+
 			// Snapshot which tool-call ids are already present in the seed history — a replayed
 			// conversation's FunctionResultContent is indistinguishable, by content alone, from one
 			// this turn is about to produce for real. ToolDiagnosticsMiddleware consults this ambient
@@ -190,6 +196,7 @@ public class ExecuteAgentTurnCommandHandler : IRequestHandler<ExecuteAgentTurnCo
 				{
 					LlmUsageCapture.Current = null;
 					ReplayedToolCallScope.Current = null;
+					CallerTurnContextScope.Current = null;
 				}
 			}
 

--- a/src/Content/Domain/Domain.AI/Caching/PromptCacheConventions.cs
+++ b/src/Content/Domain/Domain.AI/Caching/PromptCacheConventions.cs
@@ -1,0 +1,25 @@
+namespace Domain.AI.Caching;
+
+/// <summary>
+/// Shared conventions between the caller that builds a static system prompt
+/// (<c>Application.AI.Common.Factories.AgentExecutionContextFactory</c>) and the transform that
+/// stamps Anthropic prompt-cache breakpoints onto the outgoing request
+/// (<c>Infrastructure.AI.Caching.PromptCacheInjector</c>). Lives in Domain because Application must
+/// not depend on Infrastructure and vice versa, and both sides need to agree on this exact string.
+/// </summary>
+public static class PromptCacheConventions
+{
+    /// <summary>
+    /// Sentinel appended to the end of stable system content to mark, explicitly, where the
+    /// cache-eligible prefix ends — see <c>PromptCacheInjector</c>'s "Marker-based override" remarks
+    /// for the full rationale. Never sent to the model: the appender
+    /// (<c>AgentExecutionContextFactory</c>) only emits it when
+    /// <c>AppConfig:AI:AgentFramework:EnablePromptCaching</c> is true, which is also the only
+    /// condition under which <c>PromptCacheInjector</c> runs at all — so on every path where the
+    /// marker could appear, something is guaranteed to strip it before the request leaves the
+    /// process. With caching off, no marker is ever appended and per-turn context still reaches the
+    /// model normally through the same <c>AIContextProvider</c> rail; it just isn't cache-isolated,
+    /// which is moot when nothing is being cached.
+    /// </summary>
+    public const string CacheBoundaryMarker = "<<cache-boundary-8f2e6c1a>>";
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Caching/PromptCacheInjector.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Caching/PromptCacheInjector.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Domain.AI.Caching;
 
 namespace Infrastructure.AI.Caching;
 
@@ -28,6 +29,17 @@ namespace Infrastructure.AI.Caching;
 /// tokens for Sonnet/Opus) and the prefix is byte-identical across turns; below that, the provider
 /// silently ignores the breakpoint, so stamping it unconditionally is safe.
 /// </para>
+/// <para>
+/// <strong>Marker-based override.</strong> The "mark whatever is last" rule above is correct only
+/// when nothing after the stable prefix is expected to change. Once a caller attaches a genuinely
+/// per-turn block after it (see <c>CallerTurnContextProvider</c>), marking "last" would mark the
+/// <em>changing</em> content, and the provider would never observe a byte-identical prefix — silent,
+/// permanent cache misses. A caller that needs the boundary placed deliberately terminates its
+/// stable content with <see cref="CacheBoundaryMarker"/>; when present, this transform splits that
+/// system message's text at the marker (marker text removed from the output) and marks only the
+/// piece before it, ignoring the "last message" scan entirely. Absent the marker — every existing
+/// caller — behavior is byte-for-byte what it was before this override existed.
+/// </para>
 /// </remarks>
 public static class PromptCacheInjector
 {
@@ -38,8 +50,16 @@ public static class PromptCacheInjector
     private const string SystemRole = "system";
 
     /// <summary>
-    /// Returns <paramref name="requestJson"/> with a <c>cache_control: ephemeral</c> breakpoint on
-    /// the last system message, or the original string unchanged when no safe injection applies.
+    /// The boundary sentinel — see <see cref="PromptCacheConventions.CacheBoundaryMarker"/> for the
+    /// full contract. Defined in Domain so both this transform and the instruction-building code in
+    /// Application.AI.Common (which cannot depend on this Infrastructure project) agree on the exact
+    /// string.
+    /// </summary>
+    public const string CacheBoundaryMarker = PromptCacheConventions.CacheBoundaryMarker;
+
+    /// <summary>
+    /// Returns <paramref name="requestJson"/> with a <c>cache_control: ephemeral</c> breakpoint
+    /// placed per the rules above, or the original string unchanged when no safe injection applies.
     /// </summary>
     /// <param name="requestJson">The serialized OpenAI chat-completions request body.</param>
     /// <returns>The rewritten body, or <paramref name="requestJson"/> unchanged.</returns>
@@ -61,11 +81,81 @@ public static class PromptCacheInjector
         if (root is not JsonObject body || body[MessagesProperty] is not JsonArray messages)
             return requestJson;
 
+        var markedMessage = FindMarkedSystemMessage(messages);
+        if (markedMessage is not null)
+            return TrySplitAtMarker(markedMessage) ? body.ToJsonString() : requestJson;
+
         var systemMessage = FindLastSystemMessage(messages);
         if (systemMessage is null)
             return requestJson;
 
         return TryMark(systemMessage) ? body.ToJsonString() : requestJson;
+    }
+
+    /// <summary>
+    /// Finds the system message whose plain-string content contains <see cref="CacheBoundaryMarker"/>,
+    /// or <see langword="null"/> when no system message carries one — including when a system
+    /// message's content is already an array (the marker is only ever appended to the plain-string
+    /// static instruction, never to array-shaped content), which correctly falls through to the
+    /// existing "last message" behavior for that case.
+    /// </summary>
+    private static JsonObject? FindMarkedSystemMessage(JsonArray messages)
+    {
+        foreach (var node in messages)
+        {
+            if (node is JsonObject message
+                && message[RoleProperty]?.GetValue<string>() == SystemRole
+                && message[ContentProperty] is JsonValue value
+                && value.TryGetValue<string>(out var text)
+                && text.Contains(CacheBoundaryMarker, StringComparison.Ordinal))
+            {
+                return message;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Splits a marked system message's string content at <see cref="CacheBoundaryMarker"/> into two
+    /// text blocks — the stable prefix (marked cacheable) and whatever a caller appended after it
+    /// (left unmarked, so it is sent fresh every turn without ever being the cached content). Returns
+    /// <see langword="false"/> only if the content shape changed between detection and this call
+    /// (defensive; cannot happen via the single call site above).
+    /// </summary>
+    private static bool TrySplitAtMarker(JsonObject markedMessage)
+    {
+        if (markedMessage[ContentProperty] is not JsonValue value || !value.TryGetValue<string>(out var text))
+            return false;
+
+        var markerIndex = text.IndexOf(CacheBoundaryMarker, StringComparison.Ordinal);
+        if (markerIndex < 0)
+            return false;
+
+        var stable = text[..markerIndex];
+        var rest = text[(markerIndex + CacheBoundaryMarker.Length)..];
+
+        var blocks = new JsonArray
+        {
+            new JsonObject
+            {
+                ["type"] = "text",
+                ["text"] = stable,
+                [CacheControlProperty] = Ephemeral(),
+            },
+        };
+
+        if (rest.Length > 0)
+        {
+            blocks.Add(new JsonObject
+            {
+                ["type"] = "text",
+                ["text"] = rest,
+            });
+        }
+
+        markedMessage[ContentProperty] = blocks;
+        return true;
     }
 
     private static JsonObject? FindLastSystemMessage(JsonArray messages)

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiModels.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiModels.cs
@@ -41,7 +41,11 @@ public sealed record RunAgentInput
     public JsonElement? Tools { get; init; }
 
     /// <summary>
-    /// Optional context object. Accepted for protocol compliance; server does not use this.
+    /// Optional context object. Unlike <see cref="State"/>/<see cref="Tools"/>/
+    /// <see cref="ForwardedProps"/>, this one <em>is</em> read by the server — see
+    /// <see cref="AvatarRunContext.TryParse"/> — as the vehicle for a caller's per-run,
+    /// non-persistent context and model override (<c>{"turnContext": "...", "deploymentOverride":
+    /// "..."}</c>). Any shape the parser doesn't recognise is treated the same as absent.
     /// </summary>
     public JsonElement? Context { get; init; }
 
@@ -49,6 +53,48 @@ public sealed record RunAgentInput
     /// Optional forwarded properties. Accepted for protocol compliance; server does not use this.
     /// </summary>
     public JsonElement? ForwardedProps { get; init; }
+}
+
+/// <summary>
+/// The optional per-run payload a caller may place in <see cref="RunAgentInput.Context"/>: content
+/// for this one turn only, never persisted to <c>ConversationSettings</c>. See
+/// <c>CallerTurnContextProvider</c> for why <see cref="TurnContext"/> exists as a distinct channel
+/// from the conversation's persistent <c>SystemPromptOverride</c>.
+/// </summary>
+/// <param name="TurnContext">
+/// Text folded into the model's context for this turn only (e.g. mood, recently retrieved memory,
+/// situational continuity) — delivered via the per-invocation <c>AIContextProvider</c> rail, never
+/// baked into the cached static instructions.
+/// </param>
+/// <param name="DeploymentOverride">
+/// Model deployment to use for this one call, taking precedence over the conversation's persisted
+/// <c>ConversationSettings.DeploymentName</c>. Lets a caller route an individual turn to a different
+/// model (e.g. an uncensored deployment for explicit content) without a settings round-trip, which
+/// AG-UI callers have no way to make — <c>ConversationSettings</c> updates are reachable only from
+/// the SignalR hub.
+/// </param>
+public sealed record AvatarRunContext(string? TurnContext, string? DeploymentOverride)
+{
+    /// <summary>
+    /// Parses <paramref name="context"/> into an <see cref="AvatarRunContext"/>, defensively: any
+    /// shape this doesn't recognise (absent, wrong type, malformed) yields both fields
+    /// <see langword="null"/> rather than throwing — a caller not using this feature (i.e. every
+    /// caller until the avatar migration) must never have its run fail because of it.
+    /// </summary>
+    public static AvatarRunContext TryParse(JsonElement? context)
+    {
+        if (context is not { ValueKind: JsonValueKind.Object } obj)
+            return new AvatarRunContext(null, null);
+
+        var turnContext = obj.TryGetProperty("turnContext", out var tc) && tc.ValueKind == JsonValueKind.String
+            ? tc.GetString()
+            : null;
+        var deploymentOverride = obj.TryGetProperty("deploymentOverride", out var dep) && dep.ValueKind == JsonValueKind.String
+            ? dep.GetString()
+            : null;
+
+        return new AvatarRunContext(turnContext, deploymentOverride);
+    }
 }
 
 /// <summary>

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -317,6 +317,10 @@ public sealed class AgUiRunHandler
             return;
         }
 
+        // Per-run context/override, never persisted — see AvatarRunContext for why this is a
+        // distinct channel from the conversation's persistent Settings below.
+        var runContext = AvatarRunContext.TryParse(input.Context);
+
         var command = new ExecuteAgentTurnCommand
         {
             AgentName = record.AgentName,
@@ -324,9 +328,13 @@ public sealed class AgUiRunHandler
             ConversationHistory = ToMeaiHistory(history),
             ConversationId = input.ThreadId,
             TurnNumber = turnNumber,
-            DeploymentOverride = record.Settings?.DeploymentName,
+            // A per-run override takes precedence over the conversation's persisted deployment —
+            // this is what lets one call route to a different model (e.g. an uncensored deployment
+            // for explicit content) without a settings round-trip AG-UI has no way to make.
+            DeploymentOverride = runContext.DeploymentOverride ?? record.Settings?.DeploymentName,
             Temperature = record.Settings?.Temperature,
             SystemPromptOverride = record.Settings?.SystemPromptOverride,
+            TurnContext = runContext.TurnContext,
             ObservabilitySessionId = telemetry.SessionId,
         };
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Factories/AgentExecutionContextFactoryRailOrderTests.cs
@@ -170,6 +170,7 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
                 typeof(ToolPermissionFilter),             // everything above it is filtered; nothing below is
                 typeof(KnowledgeMemoryContextProvider),   // instructions only
                 typeof(LearningsRecallContextProvider),   // instructions only
+                typeof(CallerTurnContextProvider),        // instructions only; unconditional, no config gate
                 typeof(GoverningToolContextProvider),     // wraps the finished, filtered tool set
                 typeof(PerTurnBudgetContextProvider)      // measures everything above it, so it is last
             ],
@@ -247,8 +248,9 @@ public sealed class AgentExecutionContextFactoryRailOrderTests : IDisposable
         var rail = context.AIContextProviders!;
 
         // Control: the two rows really do differ, so this is not the same case asserted twice. Without
-        // it, a factory that ignored the flag would satisfy both.
-        rail.Count.Should().Be(5 + (recall ? 2 : 0));
+        // it, a factory that ignored the flag would satisfy both. Base count includes
+        // CallerTurnContextProvider, which — like PeerAgentContextProvider — is unconditional.
+        rail.Count.Should().Be(6 + (recall ? 2 : 0));
 
         rail[^1].Should().BeOfType<PerTurnBudgetContextProvider>(
             "the measurer charges the difference between what it is handed and the baseline it was built "

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/AIContextProviderMergeContractTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Context;
 using Application.AI.Common.Interfaces.KnowledgeGraph;
 using Application.AI.Common.Interfaces.Learnings;
+using Application.AI.Common.Services;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.KnowledgeGraph.Models;
@@ -85,6 +86,7 @@ public sealed class AIContextProviderMergeContractTests
         [nameof(KnowledgeMemoryContextProvider)] = BuildKnowledgeMemory,
         [nameof(LearningsRecallContextProvider)] = BuildLearningsRecall,
         [nameof(PeerAgentContextProvider)] = BuildPeerAgentContext,
+        [nameof(CallerTurnContextProvider)] = BuildCallerTurnContext,
         [nameof(PerTurnBudgetContextProvider)] = () => new PerTurnBudgetContextProvider(
             "MergeContractAgent",
             new Mock<IContextBudgetTracker>().Object,
@@ -213,6 +215,18 @@ public sealed class AIContextProviderMergeContractTests
         return new PeerAgentContextProvider(registry.Object, owningAgentId: "self-agent");
     }
 
+    /// <summary>
+    /// Active configuration for <see cref="CallerTurnContextProvider"/> is a non-blank ambient value —
+    /// the no-op (blank/unset) case is covered separately in <c>CallerTurnContextProviderTests</c>, not
+    /// here, matching this suite's stated purpose of exercising each provider while it is actually doing
+    /// something.
+    /// </summary>
+    private static CallerTurnContextProvider BuildCallerTurnContext()
+    {
+        CallerTurnContextScope.Current = "Mood: relaxed. Recently discussed: the Mac Mini migration.";
+        return new CallerTurnContextProvider();
+    }
+
     // ── the guard: no subclass may escape this suite ─────────────────────────
 
     [Fact]
@@ -292,6 +306,22 @@ public sealed class AIContextProviderMergeContractTests
         result.Instructions.Should().Contain("Handles peer-shaped work.");
         result.Instructions.Should().NotContain("self-agent",
             "the owning agent's own id must never appear as one of its own delegation targets");
+    }
+
+    [Fact]
+    public async Task CallerTurnContext_StillInjectsItsBlockExactlyOnce()
+    {
+        try
+        {
+            var result = await Create(nameof(CallerTurnContextProvider))
+                .InvokingAsync(MakeContext(ActiveInput()));
+
+            CountOccurrences(result.Instructions, "Mood: relaxed").Should().Be(1);
+        }
+        finally
+        {
+            CallerTurnContextScope.Current = null;
+        }
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/CallerTurnContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Agent/CallerTurnContextProviderTests.cs
@@ -1,0 +1,83 @@
+using Application.AI.Common.Services;
+using Application.AI.Common.Services.Agent;
+using FluentAssertions;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Moq;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Services.Agent;
+
+/// <summary>
+/// Tests for <see cref="CallerTurnContextProvider"/> — the rail that delivers
+/// <see cref="CallerTurnContextScope.Current"/> to the model fresh every turn, without touching the
+/// static instructions the agent was built with.
+/// </summary>
+/// <remarks>
+/// Drives the public <see cref="AIContextProvider.InvokingAsync"/> rather than the protected hook,
+/// matching <c>PerTurnBudgetContextProviderTests</c> — the base merge
+/// (<c>Instructions = input + "\n" + provided</c>) is part of the behaviour under test, since a
+/// provider that echoed the input back would duplicate the entire static system prompt every turn.
+/// </remarks>
+public sealed class CallerTurnContextProviderTests : IDisposable
+{
+    private static AIContextProvider.InvokingContext MakeContext(string? staticInstructions) =>
+        new(new Mock<AIAgent>().Object, new Mock<AgentSession>().Object, new AIContext
+        {
+            Instructions = staticInstructions,
+            Messages = new List<ChatMessage> { new(ChatRole.User, "hi") },
+        });
+
+    public void Dispose() => CallerTurnContextScope.Current = null;
+
+    [Fact]
+    public async Task NoAmbientValue_ContributesNothing()
+    {
+        CallerTurnContextScope.Current = null;
+
+        var result = await new CallerTurnContextProvider().InvokingAsync(MakeContext("Static."));
+
+        result.Instructions.Should().Be("Static.",
+            "an agent that never uses this feature must see byte-identical instructions to before");
+    }
+
+    [Fact]
+    public async Task AmbientValueSet_AppendedAfterStaticInstructions()
+    {
+        CallerTurnContextScope.Current = "Mood: relaxed. Recently discussed: the Mac Mini migration.";
+
+        var result = await new CallerTurnContextProvider().InvokingAsync(MakeContext("Static."));
+
+        result.Instructions.Should().Be("Static.\nMood: relaxed. Recently discussed: the Mac Mini migration.");
+    }
+
+    [Fact]
+    public async Task AmbientValueChangesBetweenCalls_EachCallReflectsItsOwnValue()
+    {
+        var provider = new CallerTurnContextProvider();
+
+        CallerTurnContextScope.Current = "Turn one context.";
+        var first = await provider.InvokingAsync(MakeContext("Static."));
+
+        CallerTurnContextScope.Current = "Turn two context — completely different.";
+        var second = await provider.InvokingAsync(MakeContext("Static."));
+
+        // The whole point of this rail: the static instructions stay identical while this changes
+        // every turn, which is what keeps the frozen prefix cache-eligible.
+        first.Instructions.Should().Be("Static.\nTurn one context.");
+        second.Instructions.Should().Be("Static.\nTurn two context — completely different.");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task BlankAmbientValue_ContributesNothing(string? value)
+    {
+        CallerTurnContextScope.Current = value;
+
+        var result = await new CallerTurnContextProvider().InvokingAsync(MakeContext("Static."));
+
+        result.Instructions.Should().Be("Static.");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Caching/PromptCacheInjectorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Caching/PromptCacheInjectorTests.cs
@@ -125,6 +125,89 @@ public sealed class PromptCacheInjectorTests
         result["messages"]![1]!["content"]!.GetValue<string>().Should().Be("User stays a plain string.");
     }
 
+    [Fact]
+    public void InjectSystemCacheControl_MarkerPresent_SplitsAtMarkerNotLastMessage()
+    {
+        // Shape a per-turn caller would actually produce: stable instructions terminated by the
+        // marker, a genuinely-changing per-turn block appended after it by CallerTurnContextProvider,
+        // then the new user turn. Without marker-awareness this would (wrongly) mark "Volatile.".
+        var input = $$"""
+        {"messages":[
+            {"role":"system","content":"Stable instructions.{{PromptCacheInjector.CacheBoundaryMarker}}Volatile."},
+            {"role":"user","content":"Hi"}
+        ]}
+        """;
+
+        var result = Parse(PromptCacheInjector.InjectSystemCacheControl(input));
+
+        var parts = result["messages"]![0]!["content"]!.AsArray();
+        parts.Should().HaveCount(2);
+        parts[0]!["text"]!.GetValue<string>().Should().Be("Stable instructions.");
+        parts[0]!["cache_control"]!["type"]!.GetValue<string>().Should().Be("ephemeral");
+        parts[1]!["text"]!.GetValue<string>().Should().Be("Volatile.");
+        parts[1]!["cache_control"].Should().BeNull("the per-turn block must never be the cached content");
+    }
+
+    [Fact]
+    public void InjectSystemCacheControl_MarkerPresent_TrailingContentEmpty_OmitsSecondBlock()
+    {
+        var input = $$"""
+        {"messages":[
+            {"role":"system","content":"Stable only.{{PromptCacheInjector.CacheBoundaryMarker}}"}
+        ]}
+        """;
+
+        var result = Parse(PromptCacheInjector.InjectSystemCacheControl(input));
+
+        var parts = result["messages"]![0]!["content"]!.AsArray();
+        parts.Should().HaveCount(1);
+        parts[0]!["text"]!.GetValue<string>().Should().Be("Stable only.");
+        parts[0]!["cache_control"]!["type"]!.GetValue<string>().Should().Be("ephemeral");
+    }
+
+    [Fact]
+    public void InjectSystemCacheControl_MarkerAbsent_FallsBackToLastMessageBehaviorUnchanged()
+    {
+        // Same shape as InjectSystemCacheControl_LastSystemMessageIsMarked_NotTheFirst, but this
+        // documents that the fallback still fires when no marker exists anywhere in the request —
+        // the new marker path must never change behavior for a caller that never uses it.
+        const string input = """
+        {"messages":[
+            {"role":"system","content":"First."},
+            {"role":"user","content":"Hi"},
+            {"role":"system","content":"Second."}
+        ]}
+        """;
+
+        var result = Parse(PromptCacheInjector.InjectSystemCacheControl(input));
+
+        result["messages"]![0]!["content"]!.GetValue<string>().Should().Be("First.");
+        result["messages"]![2]!["content"]!.AsArray()[0]!["cache_control"]!["type"]!
+            .GetValue<string>().Should().Be("ephemeral");
+    }
+
+    [Fact]
+    public void InjectSystemCacheControl_MarkerOnlyInArrayContent_FallsBackToLastMessageBehavior()
+    {
+        // The marker is only ever appended to plain-string static instructions — see
+        // FindMarkedSystemMessage's remarks. A marker literally embedded in already-array-shaped
+        // content (not a real production shape) is correctly ignored by the marker scan and falls
+        // through to the existing behavior rather than throwing or silently doing nothing.
+        var input = $$"""
+        {"messages":[
+            {"role":"system","content":[{"type":"text","text":"Has {{PromptCacheInjector.CacheBoundaryMarker}} inside an array."}]}
+        ]}
+        """;
+
+        var result = Parse(PromptCacheInjector.InjectSystemCacheControl(input));
+
+        var parts = result["messages"]![0]!["content"]!.AsArray();
+        parts.Should().HaveCount(1);
+        parts[0]!["cache_control"]!["type"]!.GetValue<string>().Should().Be("ephemeral");
+        parts[0]!["text"]!.GetValue<string>().Should().Contain(PromptCacheInjector.CacheBoundaryMarker,
+            "the marker is only stripped from plain-string content; this documents the array case is unaffected");
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         var count = 0;

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AvatarRunContextTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AvatarRunContextTests.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using FluentAssertions;
+using Presentation.AgentHub.AgUi;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.AgUi;
+
+/// <summary>
+/// Tests for <see cref="AvatarRunContext.TryParse"/> — the defensive parser for
+/// <see cref="RunAgentInput.Context"/>'s avatar-specific payload.
+/// </summary>
+public sealed class AvatarRunContextTests
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public void NullContext_ReturnsBothNull()
+    {
+        var result = AvatarRunContext.TryParse(null);
+
+        result.TurnContext.Should().BeNull();
+        result.DeploymentOverride.Should().BeNull();
+    }
+
+    [Fact]
+    public void BothFieldsPresent_ParsesBoth()
+    {
+        var context = Parse("""{"turnContext":"Mood: relaxed.","deploymentOverride":"euryale-70b"}""");
+
+        var result = AvatarRunContext.TryParse(context);
+
+        result.TurnContext.Should().Be("Mood: relaxed.");
+        result.DeploymentOverride.Should().Be("euryale-70b");
+    }
+
+    [Fact]
+    public void OnlyTurnContextPresent_DeploymentOverrideIsNull()
+    {
+        var context = Parse("""{"turnContext":"Mood: relaxed."}""");
+
+        var result = AvatarRunContext.TryParse(context);
+
+        result.TurnContext.Should().Be("Mood: relaxed.");
+        result.DeploymentOverride.Should().BeNull();
+    }
+
+    [Fact]
+    public void EmptyObject_ReturnsBothNull()
+    {
+        var result = AvatarRunContext.TryParse(Parse("{}"));
+
+        result.TurnContext.Should().BeNull();
+        result.DeploymentOverride.Should().BeNull();
+    }
+
+    [Fact]
+    public void NotAnObject_ReturnsBothNullRatherThanThrowing()
+    {
+        var result = AvatarRunContext.TryParse(Parse("\"just a string\""));
+
+        result.TurnContext.Should().BeNull();
+        result.DeploymentOverride.Should().BeNull();
+    }
+
+    [Fact]
+    public void WrongTypeForField_TreatedAsAbsent()
+    {
+        // A caller that sends turnContext as a number rather than a string must not crash the run —
+        // this is exactly the "server is authoritative, accept but tolerate" contract the rest of
+        // RunAgentInput's unused fields already follow.
+        var context = Parse("""{"turnContext":42}""");
+
+        var result = AvatarRunContext.TryParse(context);
+
+        result.TurnContext.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

project-avatar's M1 migration (the harness runs a Sage-style avatar's whole
conversation turn over the network) needs two things the AG-UI `/ag-ui/run`
endpoint has no channel for today:

- Content that changes every turn (mood, recently retrieved memory) without
  invalidating the static-prompt cache that makes repeated turns cheap.
- A way for one specific turn to ask for a different model (an uncensored
  deployment for explicit-content turns) without a persistent settings
  change — `ConversationSettings` updates are only reachable from the
  SignalR hub today, which this migration isn't using.

Both now travel on `RunAgentInput`'s previously-unused `Context` field as
`{turnContext, deploymentOverride}` (`AvatarRunContext`), parsed defensively
— absent or malformed is a no-op for every existing caller.

## What changed

- `turnContext` rides the framework's per-invocation `AIContextProvider`
  rail (new `CallerTurnContextProvider` + `CallerTurnContextScope`,
  mirroring the existing `LlmUsageCapture`/`ReplayedToolCallScope` ambient
  pattern) rather than the cached static instructions, so the static prompt
  never changes turn to turn.
- `deploymentOverride` takes precedence over the conversation's persisted
  `DeploymentName` for that one call only.
- `PromptCacheInjector` gains an additive, backward-compatible marker path:
  a caller-appended boundary sentinel (`PromptCacheConventions`, in Domain
  so both the Application-side appender and this Infrastructure-side
  transform can share it without an illegal cross-layer reference) splits
  the static prefix from the per-turn block so only the unchanging part is
  ever marked cacheable. Absent the marker, all 7 pre-existing tests are
  unaffected.

## Test plan

- [x] Full suite green on all four touched projects (~7,800 tests):
      `Application.AI.Common.Tests`, `Application.Core.Tests`,
      `Infrastructure.AI.Tests`, `Presentation.AgentHub.Tests`.
- [x] New targeted tests cover: marker-present splitting, marker-absent
      unchanged behavior, `TurnContext` reaching the model fresh every
      turn without touching static instructions, `AvatarRunContext`
      defensive parsing (absent/malformed/wrong-type).
- [x] Live-verified end to end against real Claude via OpenRouter (Haiku
      and Sonnet): a conversation was created, a large static block and a
      small per-turn block both arrived intact — confirmed via token
      counts and a content-recall probe asking the model to repeat back a
      detail that only existed in the per-turn content.
- [ ] Not re-confirmed live: the harness's own cache-hit readout. That
      specific figure is separately known-broken (the generation-stats
      enrichment that would populate `AgentTurnResult.CacheRead` is
      fire-and-forget, never awaited before the turn result returns) —
      but the underlying Anthropic cache mechanism on this same
      OpenRouter path was already proven working during the earlier M0
      spike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)