### PR TITLE
fix: plugin tool-boundary existence check with fail-closed Pending/Faulted states (#524)

### DIFF
--- a/documentation/onboarding/10-observability.html
+++ b/documentation/onboarding/10-observability.html
@@ -291,6 +291,14 @@ docker run -d --name jaeger \
                         blast radius — a third-party plugin can read files but never write them, regardless of the
                         agent's own permissions.
                     </p>
+                    <p>
+                        An <code>AllowedTools</code>/<code>DeniedTools</code> entry that matches no real tool — first-
+                        party or MCP — is fail-closed, not a silent no-op. If resolvable at startup (no MCP server is
+                        configured anywhere on the host), the host refuses to boot. Otherwise it's checked once the
+                        entry's tool is discovered on some configured server; if still unresolved once every server
+                        has reported, the whole plugin's boundary is marked faulted and every tool from its skills is
+                        denied.
+                    </p>
 
                     <h3>5 · The sandbox</h3>
                     <p>

--- a/documentation/onboarding/10-observability.html
+++ b/documentation/onboarding/10-observability.html
@@ -297,7 +297,10 @@ docker run -d --name jaeger \
                         configured anywhere on the host), the host refuses to boot. Otherwise it's checked once the
                         entry's tool is discovered on some configured server; if still unresolved once every server
                         has reported, the whole plugin's boundary is marked faulted and every tool from its skills is
-                        denied.
+                        denied. This denial isn't limited to the plugin in question, and it starts as soon as any
+                        plugin's boundary is unresolved — not only once it's confirmed faulted: every first-party
+                        tool is denied agent-wide for as long as any plugin's boundary hasn't verified, since
+                        there's no way to know which global tool an unresolved entry was meant to protect.
                     </p>
 
                     <h3>5 · The sandbox</h3>

--- a/documentation/onboarding/11-extending.html
+++ b/documentation/onboarding/11-extending.html
@@ -497,6 +497,21 @@ You are the team's automated code review assistant. For each pull request:
                                     </p>
                                 </div>
                             </div>
+                            <div class="callout callout-info">
+                                <span class="callout-icon">i</span>
+                                <div class="callout-body">
+                                    <div class="callout-title">A typo in AllowedTools/DeniedTools now fails closed</div>
+                                    <p style="margin: 0">
+                                        An entry that matches no real tool — first-party or MCP — is no longer a
+                                        silent no-op. With no MCP server configured on the host, it fails startup
+                                        outright. Otherwise it's resolved lazily as each configured server's tools
+                                        are discovered; if it's still unmatched once every server has reported,
+                                        every tool from this plugin's skills is denied. See
+                                        <a href="10-observability.html">Observability &amp; Safety</a> for the full
+                                        mechanics.
+                                    </p>
+                                </div>
+                            </div>
                         </li>
 
                         <li class="step">

--- a/documentation/onboarding/11-extending.html
+++ b/documentation/onboarding/11-extending.html
@@ -506,7 +506,9 @@ You are the team's automated code review assistant. For each pull request:
                                         silent no-op. With no MCP server configured on the host, it fails startup
                                         outright. Otherwise it's resolved lazily as each configured server's tools
                                         are discovered; if it's still unmatched once every server has reported,
-                                        every tool from this plugin's skills is denied. See
+                                        every first-party tool is denied agent-wide, not just this plugin's own —
+                                        even while resolution is still pending, not only once it's confirmed
+                                        faulted. See
                                         <a href="10-observability.html">Observability &amp; Safety</a> for the full
                                         mechanics.
                                     </p>

--- a/documentation/reference/patterns-and-technologies.html
+++ b/documentation/reference/patterns-and-technologies.html
@@ -395,11 +395,16 @@ know the exact filename. Cite file paths in `path:line` form.</code></pre>
                         (<code>AllowedTools</code>, <code>DeniedTools</code>, <code>AutonomyLevel</code>). The
                         <code>PluginPermissionRuleProvider</code> turns those declarations into MediatR rules — and
                         <code>DeniedTools</code> is bypass-immune: it can't be overridden by auto-approve modes.
+                        Since #524, <code>IPluginToolBoundaryTracker</code> additionally verifies every
+                        <code>AllowedTools</code>/<code>DeniedTools</code> entry resolves to a real tool (first-party
+                        at startup, MCP-provided lazily on discovery); an entry that never resolves marks the
+                        plugin's boundary faulted and <code>ToolChainBuilder</code> denies all of its tools.
                     </p>
                     <ul>
                         <li>Manifest reader: <code>Infrastructure.AI/Plugins/PluginManifestReader.cs</code> (verify path — see "Locating plugin internals" note below)</li>
                         <li>Permissions: <code>Application.Core/Permissions/PluginPermissionRuleProvider.cs</code></li>
                         <li>Declaration types: <code>Domain.Common/Config/AI/Plugins/PluginDeclaration.cs</code></li>
+                        <li>Existence check: <code>Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs</code>, <code>Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs</code></li>
                     </ul>
 
                     <h3 id="agent-manifest">Agent manifest (AGENT.md)</h3>

--- a/documentation/reference/patterns-and-technologies.html
+++ b/documentation/reference/patterns-and-technologies.html
@@ -397,8 +397,11 @@ know the exact filename. Cite file paths in `path:line` form.</code></pre>
                         <code>DeniedTools</code> is bypass-immune: it can't be overridden by auto-approve modes.
                         Since #524, <code>IPluginToolBoundaryTracker</code> additionally verifies every
                         <code>AllowedTools</code>/<code>DeniedTools</code> entry resolves to a real tool (first-party
-                        at startup, MCP-provided lazily on discovery); an entry that never resolves marks the
-                        plugin's boundary faulted and <code>ToolChainBuilder</code> denies all of its tools.
+                        at startup, MCP-provided lazily on discovery); while any plugin's boundary is unresolved
+                        or faulted, <code>ToolChainBuilder</code> denies that plugin's own tools and
+                        <code>PluginPermissionRuleProvider</code> additionally denies every first-party tool
+                        agent-wide, since a corrupted <code>DeniedTools</code> entry could have been meant to
+                        protect any of them.
                     </p>
                     <ul>
                         <li>Manifest reader: <code>Infrastructure.AI/Plugins/PluginManifestReader.cs</code> (verify path — see "Locating plugin internals" note below)</li>

--- a/documentation/security/04-tools-and-permissions.html
+++ b/documentation/security/04-tools-and-permissions.html
@@ -334,14 +334,17 @@
                         <div class="callout-body">
                             <div class="callout-title">A boundary entry that names no real tool now fails closed, not silently</div>
                             <p style="margin: 0">
-                                At startup, if a plugin declares no MCP servers, every <code>AllowedTools</code> /
-                                <code>DeniedTools</code> entry must match a real first-party tool or the host refuses
-                                to boot. For a plugin that does use MCP servers, entries are checked lazily as each
-                                server's tools are discovered — no eager connection just to validate. If an entry is
-                                proven to match nothing, the harness treats the whole boundary as untrustworthy and
-                                denies <strong>every</strong> tool from that plugin's skills rather than run with a
-                                partially-broken policy, because an unrecognized <code>DeniedTools</code> entry is
-                                otherwise a silent no-op that would defeat the bypass-immune guarantee below.
+                                At startup, if <strong>no MCP server is configured anywhere on the host</strong>,
+                                every <code>AllowedTools</code> / <code>DeniedTools</code> entry must match a real
+                                first-party tool or the host refuses to boot. Whenever at least one MCP server is
+                                configured — even one a plugin doesn't declare itself, since a skill's tool
+                                declaration can resolve against any configured server — entries are checked lazily
+                                as each server's tools are discovered — no eager connection just to validate. If an
+                                entry is still unmatched once every configured server has reported, the harness
+                                treats the whole boundary as untrustworthy and denies <strong>every</strong> tool
+                                from that plugin's skills rather than run with a partially-broken policy, because an
+                                unrecognized <code>DeniedTools</code> entry is otherwise a silent no-op that would
+                                defeat the bypass-immune guarantee below.
                             </p>
                         </div>
                     </div>

--- a/documentation/security/04-tools-and-permissions.html
+++ b/documentation/security/04-tools-and-permissions.html
@@ -332,6 +332,23 @@
                     <div class="callout callout-info">
                         <span class="callout-icon">i</span>
                         <div class="callout-body">
+                            <div class="callout-title">A boundary entry that names no real tool now fails closed, not silently</div>
+                            <p style="margin: 0">
+                                At startup, if a plugin declares no MCP servers, every <code>AllowedTools</code> /
+                                <code>DeniedTools</code> entry must match a real first-party tool or the host refuses
+                                to boot. For a plugin that does use MCP servers, entries are checked lazily as each
+                                server's tools are discovered — no eager connection just to validate. If an entry is
+                                proven to match nothing, the harness treats the whole boundary as untrustworthy and
+                                denies <strong>every</strong> tool from that plugin's skills rather than run with a
+                                partially-broken policy, because an unrecognized <code>DeniedTools</code> entry is
+                                otherwise a silent no-op that would defeat the bypass-immune guarantee below.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="callout callout-info">
+                        <span class="callout-icon">i</span>
+                        <div class="callout-body">
                             <div class="callout-title">Scope: <code>DeniedTools</code> is plugin-wide and turn-global, not per-skill</div>
                             <p style="margin: 0">
                                 <code>AllowedTools</code>, <code>DeniedTools</code>, and <code>AutonomyLevel</code> are

--- a/documentation/security/04-tools-and-permissions.html
+++ b/documentation/security/04-tools-and-permissions.html
@@ -346,6 +346,15 @@
                                 unrecognized <code>DeniedTools</code> entry is otherwise a silent no-op that would
                                 defeat the bypass-immune guarantee below.
                             </p>
+                            <p style="margin: 0.75rem 0 0">
+                                The deny isn't scoped to the plugin under suspicion, and it doesn't wait for the
+                                entry to be proven fake: the moment any loaded plugin's boundary is anything other
+                                than fully verified — including the ordinary window while a lazy MCP check is
+                                still pending — <code>PluginPermissionRuleProvider</code> adds a bypass-immune
+                                Deny rule for every first-party tool, agent-wide, because a corrupted or unresolved
+                                <code>DeniedTools</code> entry gives no way to know which specific global tool it
+                                was meant to protect.
+                            </p>
                         </div>
                     </div>
 

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -410,11 +410,5 @@ public static class DependencyInjection
     /// non-string key could not be supplied on the wire anyway.
     /// </remarks>
     private static IReadOnlyList<string> KeyedToolRegistrationKeys(IServiceCollection services) =>
-    [
-        .. services
-            .Where(descriptor => descriptor.IsKeyedService && descriptor.ServiceType == typeof(ITool))
-            .Select(descriptor => descriptor.ServiceKey as string)
-            .Where(key => !string.IsNullOrWhiteSpace(key))
-            .Select(key => key!)
-    ];
+        [.. Services.Tools.KeyedToolRegistrationScan.Names(services)];
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
@@ -16,4 +16,21 @@ public interface IPluginRegistry
 
     /// <summary>Registers a loaded plugin.</summary>
     void Register(LoadedPlugin plugin);
+
+    /// <summary>
+    /// Whether <paramref name="pluginName"/>'s tool boundary (<c>AllowedTools</c>/<c>DeniedTools</c>)
+    /// has been marked faulted by <see cref="MarkBoundaryFaulted"/> — see that method's remarks.
+    /// </summary>
+    bool IsBoundaryFaulted(string pluginName);
+
+    /// <summary>
+    /// Marks <paramref name="pluginName"/>'s tool boundary as faulted: at least one of its
+    /// <c>AllowedTools</c>/<c>DeniedTools</c> entries has been proven to match no real tool (#524).
+    /// A boundary that can't be trusted is treated fail-closed — <c>ToolChainBuilder</c> denies every
+    /// tool for a faulted plugin rather than run with a partially-broken policy, since a typo in
+    /// <c>DeniedTools</c> (documented as bypass-immune) silently defeats that guarantee otherwise.
+    /// </summary>
+    /// <param name="pluginName">The plugin whose boundary is faulted.</param>
+    /// <param name="reason">Human-readable reason, for logging/diagnostics.</param>
+    void MarkBoundaryFaulted(string pluginName, string reason);
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
@@ -18,17 +18,41 @@ public interface IPluginRegistry
     void Register(LoadedPlugin plugin);
 
     /// <summary>
-    /// Whether <paramref name="pluginName"/>'s tool boundary (<c>AllowedTools</c>/<c>DeniedTools</c>)
-    /// has been marked faulted by <see cref="MarkBoundaryFaulted"/> — see that method's remarks.
+    /// <paramref name="pluginName"/>'s tool boundary (<c>AllowedTools</c>/<c>DeniedTools</c>) trust
+    /// state — see <see cref="PluginBoundaryStatus"/>'s remarks for why this is three states, not a
+    /// boolean. Defaults to <see cref="PluginBoundaryStatus.Verified"/> for a plugin never marked
+    /// otherwise (no boundary declaration, or nothing to verify).
     /// </summary>
-    bool IsBoundaryFaulted(string pluginName);
+    PluginBoundaryStatus GetBoundaryStatus(string pluginName);
 
     /// <summary>
-    /// Marks <paramref name="pluginName"/>'s tool boundary as faulted: at least one of its
-    /// <c>AllowedTools</c>/<c>DeniedTools</c> entries has been proven to match no real tool (#524).
-    /// A boundary that can't be trusted is treated fail-closed — <c>ToolChainBuilder</c> denies every
-    /// tool for a faulted plugin rather than run with a partially-broken policy, since a typo in
-    /// <c>DeniedTools</c> (documented as bypass-immune) silently defeats that guarantee otherwise.
+    /// Marks <paramref name="pluginName"/>'s tool boundary <see cref="PluginBoundaryStatus.Pending"/>:
+    /// at least one <c>AllowedTools</c>/<c>DeniedTools</c> entry could not be resolved against any
+    /// already-known tool and awaits an MCP server's tool list (#524). Treated fail-closed exactly
+    /// like <see cref="PluginBoundaryStatus.Faulted"/> until it resolves — see
+    /// <see cref="MarkBoundaryVerified"/>/<see cref="MarkBoundaryFaulted"/>.
+    /// </summary>
+    /// <param name="pluginName">The plugin whose boundary has an unresolved entry.</param>
+    void MarkBoundaryPending(string pluginName);
+
+    /// <summary>
+    /// Marks <paramref name="pluginName"/>'s tool boundary <see cref="PluginBoundaryStatus.Verified"/>:
+    /// every entry that was <see cref="PluginBoundaryStatus.Pending"/> has now been confirmed to match
+    /// a real tool. A no-op — never a downgrade — if the plugin is already
+    /// <see cref="PluginBoundaryStatus.Faulted"/>: that state is terminal, and a caller resolving a
+    /// pending entry has no way to know whether some OTHER entry already faulted this plugin through
+    /// a different call, so the registry itself must be the one place this can't be gotten wrong.
+    /// </summary>
+    /// <param name="pluginName">The plugin whose boundary is now fully verified.</param>
+    void MarkBoundaryVerified(string pluginName);
+
+    /// <summary>
+    /// Marks <paramref name="pluginName"/>'s tool boundary <see cref="PluginBoundaryStatus.Faulted"/>:
+    /// at least one of its <c>AllowedTools</c>/<c>DeniedTools</c> entries has been proven to match no
+    /// real tool (#524). A boundary that can't be trusted is treated fail-closed — <c>ToolChainBuilder</c>
+    /// denies every tool for a faulted plugin rather than run with a partially-broken policy, since a
+    /// typo in <c>DeniedTools</c> (documented as bypass-immune) silently defeats that guarantee
+    /// otherwise. Terminal: once faulted, always faulted for the process lifetime.
     /// </summary>
     /// <param name="pluginName">The plugin whose boundary is faulted.</param>
     /// <param name="reason">Human-readable reason, for logging/diagnostics.</param>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -1,0 +1,60 @@
+using Domain.Common.Config.AI.Plugins;
+
+namespace Application.AI.Common.Interfaces.Plugins;
+
+/// <summary>
+/// One <see cref="PluginDeclaration.AllowedTools"/>/<see cref="PluginDeclaration.DeniedTools"/>
+/// entry that has been confirmed to not match any known tool — first-party or MCP-provided.
+/// </summary>
+/// <param name="PluginName">The plugin whose boundary declared the entry.</param>
+/// <param name="ListKind">Either <c>"AllowedTools"</c> or <c>"DeniedTools"</c>, for the error message.</param>
+/// <param name="ToolName">The offending entry itself.</param>
+public sealed record PluginToolBoundaryViolation(string PluginName, string ListKind, string ToolName);
+
+/// <summary>
+/// Tracks whether every <c>AllowedTools</c>/<c>DeniedTools</c> entry a loaded plugin declares
+/// actually matches a real tool — first-party (keyed-DI, known at startup) or MCP-provided (known
+/// only once the owning server's tool list has been discovered at least once).
+/// </summary>
+/// <remarks>
+/// See #524: a plugin boundary entry that matches nothing is a silent no-op today — most
+/// dangerously for <c>DeniedTools</c>, which is documented as bypass-immune. This tracker is what
+/// turns that into a loud, fail-closed fault instead. <see cref="Seed"/> resolves what's decidable
+/// immediately (a plugin with no MCP servers at all has no other source its entries could resolve
+/// from); <see cref="ReportServerToolsDiscovered"/> resolves the rest lazily, as MCP servers are
+/// organically discovered during normal operation — never by connecting to a server early just to
+/// check.
+/// </remarks>
+public interface IPluginToolBoundaryTracker
+{
+    /// <summary>
+    /// Called once at startup, after plugins are loaded. Returns the entries that are immediately,
+    /// provably fake — a plugin declares zero MCP servers, so every one of its boundary entries must
+    /// be a first-party name; anything <paramref name="isKnownFirstPartyToolName"/> rejects is a
+    /// definite typo, decidable right now. Every other unresolved entry (belonging to a plugin that
+    /// does declare MCP servers) is retained internally, pending <see cref="ReportServerToolsDiscovered"/>.
+    /// </summary>
+    /// <param name="loadedPlugins">Every currently loaded plugin.</param>
+    /// <param name="isKnownFirstPartyToolName">
+    /// Bounded first-party (keyed-DI) tool-name membership check. Must match names
+    /// case-insensitively, the same way <c>ToolChainBuilder.ApplyPluginToolBoundary</c> matches a
+    /// boundary entry against a tool's real published name — a case-sensitive check here would
+    /// falsely flag a real, just differently-cased, tool name as nonexistent.
+    /// </param>
+    IReadOnlyList<PluginToolBoundaryViolation> Seed(
+        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName);
+
+    /// <summary>
+    /// Called every time an MCP server's tool list is successfully discovered (the existing lazy
+    /// discovery path — this method never triggers a connection itself). Resolves any pending entry
+    /// <paramref name="discoveredToolNames"/> now accounts for. When this was the LAST MCP server a
+    /// plugin depends on to report, and that plugin still has unresolved entries left, those entries
+    /// are now provably fake: this method marks the plugin's boundary faulted
+    /// (<see cref="IPluginRegistry.MarkBoundaryFaulted"/>) and returns them. Returns an empty list in
+    /// the common case (nothing pending for this server, or everything pending just got resolved).
+    /// </summary>
+    /// <param name="serverName">The namespaced (<c>{pluginName}:{serverName}</c>) MCP server name.</param>
+    /// <param name="discoveredToolNames">The raw tool names the server just reported.</param>
+    IReadOnlyList<PluginToolBoundaryViolation> ReportServerToolsDiscovered(
+        string serverName, IReadOnlyCollection<string> discoveredToolNames);
+}

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -20,19 +20,19 @@ public sealed record PluginToolBoundaryViolation(string PluginName, string ListK
 /// See #524: a plugin boundary entry that matches nothing is a silent no-op today — most
 /// dangerously for <c>DeniedTools</c>, which is documented as bypass-immune. This tracker is what
 /// turns that into a loud, fail-closed fault instead. <see cref="Seed"/> resolves what's decidable
-/// immediately (a plugin with no MCP servers at all has no other source its entries could resolve
-/// from); <see cref="ReportServerToolsDiscovered"/> resolves the rest lazily, as MCP servers are
-/// organically discovered during normal operation — never by connecting to a server early just to
-/// check.
+/// immediately (no MCP server is configured anywhere on the host, so nothing could ever resolve an
+/// unmatched entry); <see cref="ReportServerToolsDiscovered"/> resolves the rest lazily, as MCP
+/// servers are organically discovered during normal operation — never by connecting to a server
+/// early just to check.
 /// </remarks>
 public interface IPluginToolBoundaryTracker
 {
     /// <summary>
     /// Called once at startup, after plugins are loaded. Returns the entries that are immediately,
-    /// provably fake — a plugin declares zero MCP servers, so every one of its boundary entries must
-    /// be a first-party name; anything <paramref name="isKnownFirstPartyToolName"/> rejects is a
-    /// definite typo, decidable right now. Every other unresolved entry (belonging to a plugin that
-    /// does declare MCP servers) is retained internally, pending <see cref="ReportServerToolsDiscovered"/>.
+    /// provably fake — no MCP server is configured anywhere on the host, so every boundary entry
+    /// must be a first-party name; anything <paramref name="isKnownFirstPartyToolName"/> rejects is a
+    /// definite typo, decidable right now. Every other unresolved entry is retained internally,
+    /// pending <see cref="ReportServerToolsDiscovered"/>.
     /// </summary>
     /// <param name="loadedPlugins">Every currently loaded plugin.</param>
     /// <param name="isKnownFirstPartyToolName">
@@ -41,8 +41,20 @@ public interface IPluginToolBoundaryTracker
     /// boundary entry against a tool's real published name — a case-sensitive check here would
     /// falsely flag a real, just differently-cased, tool name as nonexistent.
     /// </param>
+    /// <param name="allConfiguredMcpServerNames">
+    /// Every enabled MCP server name configured anywhere on the host — <strong>not</strong> narrowed
+    /// to any one plugin's own declared servers. A review-round finding traced
+    /// <c>ToolChainBuilder.ResolveEffectiveMcpServerName</c> and confirmed a plugin skill's
+    /// <c>ToolDeclaration</c> can resolve against ANY host-configured MCP server when no capability
+    /// envelope restricts it — so a plugin that declares zero MCP servers of its own can still
+    /// legitimately reference a host-level server's tool in its boundary. Narrowing this list to a
+    /// per-plugin one previously crashed boot (or permanently denied every tool) on exactly that
+    /// valid configuration.
+    /// </param>
     IReadOnlyList<PluginToolBoundaryViolation> Seed(
-        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName);
+        IReadOnlyList<LoadedPlugin> loadedPlugins,
+        Func<string, bool> isKnownFirstPartyToolName,
+        IReadOnlyCollection<string> allConfiguredMcpServerNames);
 
     /// <summary>
     /// Called every time an MCP server's tool list is successfully discovered (the existing lazy

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -21,9 +21,12 @@ public sealed record PluginToolBoundaryViolation(string PluginName, string ListK
 /// dangerously for <c>DeniedTools</c>, which is documented as bypass-immune. This tracker is what
 /// turns that into a loud, fail-closed fault instead. <see cref="Seed"/> resolves what's decidable
 /// immediately (no MCP server is configured anywhere on the host, so nothing could ever resolve an
-/// unmatched entry); <see cref="ReportServerToolsDiscovered"/> resolves the rest lazily, as MCP
-/// servers are organically discovered during normal operation — never by connecting to a server
-/// early just to check.
+/// unmatched entry); everything else is left <see cref="PluginBoundaryStatus.Pending"/> (untrusted,
+/// not silently allowed — see that enum's remarks) until <see cref="ReportServerToolsDiscovered"/>
+/// resolves it, whether from the harness's own normal MCP use or from
+/// <c>PluginToolBoundaryStartupValidator</c> proactively querying <see cref="PendingServerNames"/>
+/// right after boot specifically so a server nothing else happens to use doesn't leave a plugin
+/// pending — and therefore denied — for the rest of the process lifetime.
 /// </remarks>
 public interface IPluginToolBoundaryTracker
 {
@@ -69,4 +72,16 @@ public interface IPluginToolBoundaryTracker
     /// <param name="discoveredToolNames">The raw tool names the server just reported.</param>
     IReadOnlyList<PluginToolBoundaryViolation> ReportServerToolsDiscovered(
         string serverName, IReadOnlyCollection<string> discoveredToolNames);
+
+    /// <summary>
+    /// Every MCP server name at least one plugin's boundary was <see cref="PluginBoundaryStatus.Pending"/>
+    /// on immediately after the most recent <see cref="Seed"/> call. Meant to be read exactly once,
+    /// right after <see cref="Seed"/> returns — by <c>PluginToolBoundaryStartupValidator</c>, to decide
+    /// which servers to proactively query so pending entries resolve promptly instead of only if the
+    /// running session happens to need that server anyway. NOT pruned as entries resolve via
+    /// <see cref="ReportServerToolsDiscovered"/> — a server every pending plugin has since resolved
+    /// against still appears here — so a caller reading this well after boot gets a superset of what
+    /// is genuinely still pending, not a live count.
+    /// </summary>
+    IReadOnlyCollection<string> PendingServerNames { get; }
 }

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/PluginBoundaryStatus.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/PluginBoundaryStatus.cs
@@ -1,0 +1,27 @@
+namespace Application.AI.Common.Interfaces.Plugins;
+
+/// <summary>
+/// A plugin's <c>AllowedTools</c>/<c>DeniedTools</c> boundary trust state (#524).
+/// </summary>
+/// <remarks>
+/// Deliberately three states, not a boolean: collapsing "still waiting to find out" into "not yet
+/// proven broken" is what let a plugin boundary stay trusted indefinitely when a dependent MCP server
+/// was never queried in a given process's lifetime — the exact gap that made the original
+/// existence-check ineffective on a multi-server host. <see cref="Faulted"/> is terminal (no
+/// transition back to <see cref="Verified"/>); <see cref="Pending"/> is the fail-closed default for
+/// anything not yet proven either way.
+/// </remarks>
+public enum PluginBoundaryStatus
+{
+    /// <summary>No <c>AllowedTools</c>/<c>DeniedTools</c> entry needs existence verification, or
+    /// every entry that did has been confirmed to match a real tool.</summary>
+    Verified,
+
+    /// <summary>At least one entry still awaits an MCP server's tool list before it can be confirmed
+    /// or refuted — treated as untrusted (deny all) until it resolves.</summary>
+    Pending,
+
+    /// <summary>At least one entry has been proven to match no real tool. Terminal for the process
+    /// lifetime.</summary>
+    Faulted,
+}

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -38,10 +38,13 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
 
     /// <inheritdoc />
     public IReadOnlyList<PluginToolBoundaryViolation> Seed(
-        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName)
+        IReadOnlyList<LoadedPlugin> loadedPlugins,
+        Func<string, bool> isKnownFirstPartyToolName,
+        IReadOnlyCollection<string> allConfiguredMcpServerNames)
     {
         ArgumentNullException.ThrowIfNull(loadedPlugins);
         ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+        ArgumentNullException.ThrowIfNull(allConfiguredMcpServerNames);
 
         var immediate = new List<PluginToolBoundaryViolation>();
 
@@ -61,9 +64,17 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             if (unresolved.Count == 0)
                 continue;
 
-            if (plugin.McpServerNames.Count == 0)
+            if (allConfiguredMcpServerNames.Count == 0)
             {
-                // No other source these could ever resolve from — provably fake, right now.
+                // No MCP server exists ANYWHERE on this host — no other source these could ever
+                // resolve from, provably fake right now. Deliberately NOT scoped to plugin.McpServerNames
+                // (the plugin's own declared servers): a review round finding traced
+                // ToolChainBuilder.ResolveEffectiveMcpServerName and confirmed a plugin skill's
+                // ToolDeclaration can resolve against ANY host-configured MCP server, not only ones
+                // the plugin itself declares — a zero-own-servers plugin can still legitimately
+                // reference a host-level server's tool in its boundary. Narrowing to the plugin's own
+                // servers previously crashed boot (or permanently denied every tool) on exactly that
+                // valid, pre-existing configuration.
                 immediate.AddRange(unresolved.Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name)));
                 continue;
             }
@@ -72,11 +83,11 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             {
                 Lock = new object(),
                 PendingEntries = unresolved.ToDictionary(e => e.Name, e => e.ListKind, StringComparer.OrdinalIgnoreCase),
-                PendingServers = new HashSet<string>(plugin.McpServerNames, StringComparer.OrdinalIgnoreCase),
+                PendingServers = new HashSet<string>(allConfiguredMcpServerNames, StringComparer.OrdinalIgnoreCase),
             };
             _pendingByPlugin[plugin.Name] = pending;
 
-            foreach (var serverName in plugin.McpServerNames)
+            foreach (var serverName in allConfiguredMcpServerNames)
                 _pluginsByServer.GetOrAdd(serverName, _ => []).Add(plugin.Name);
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -89,9 +89,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 // the registry here too means the fault is recorded independently of whether that
                 // caller rethrows — the same defense-in-depth ReportServerToolsDiscovered already
                 // gives the lazy branch.
-                _registry.MarkBoundaryFaulted(
-                    plugin.Name,
-                    $"Tool boundary entries match no known tool: {string.Join(", ", immediateForPlugin.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
+                _registry.MarkBoundaryFaulted(plugin.Name, FaultReason(immediateForPlugin));
                 continue;
             }
 
@@ -158,15 +156,16 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
 
             if (faulted is { Count: > 0 })
             {
-                _registry.MarkBoundaryFaulted(
-                    pluginName,
-                    $"Tool boundary entries match no known tool: {string.Join(", ", faulted.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
+                _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted));
                 violations.AddRange(faulted);
             }
         }
 
         return violations;
     }
+
+    private static string FaultReason(IReadOnlyList<PluginToolBoundaryViolation> violations) =>
+        $"Tool boundary entries match no known tool: {string.Join(", ", violations.Select(v => $"{v.ListKind}:{v.ToolName}"))}";
 
     private static IReadOnlyList<(string Name, string ListKind)> BoundaryEntries(LoadedPlugin plugin)
     {

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -14,6 +14,13 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
         public required object Lock { get; init; }
         public required Dictionary<string, string> PendingEntries { get; init; } // name -> list kind
         public required HashSet<string> PendingServers { get; init; }
+
+        // Guards against firing twice for one plugin: a caller can still hold this same instance
+        // (from its own TryGetValue) after _pendingByPlugin.TryRemove has already dropped it — two
+        // concurrent ReportServerToolsDiscovered calls for THE SAME server can both reach the lock
+        // with PendingServers already empty and PendingEntries never cleared, otherwise faulting
+        // (and logging) the same violation twice.
+        public bool Resolved { get; set; }
     }
 
     private readonly IPluginRegistry _registry;
@@ -41,7 +48,16 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
         foreach (var plugin in loadedPlugins)
         {
             var entries = BoundaryEntries(plugin);
-            var unresolved = entries.Where(e => !isKnownFirstPartyToolName(e.Name)).ToList();
+            // A name can legitimately appear more than once — duplicated within one list, or once
+            // in AllowedTools and once in DeniedTools — and the existence question is identical
+            // either time, so collapse before anything downstream (the ToDictionary below cannot
+            // tolerate a repeated key at all — confirmed by a review round finding it throws
+            // ArgumentException on exactly this shape, crashing a legally-configured plugin's boot).
+            var unresolved = entries
+                .Where(e => !isKnownFirstPartyToolName(e.Name))
+                .GroupBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
+                .ToList();
             if (unresolved.Count == 0)
                 continue;
 
@@ -88,6 +104,12 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             List<PluginToolBoundaryViolation>? faulted = null;
             lock (pending.Lock)
             {
+                // A concurrent report for a DIFFERENT server on this same plugin can already have
+                // resolved it before this thread reached the lock — this thread's own TryGetValue
+                // above ran against a reference that predates that removal, so it must re-check here.
+                if (pending.Resolved)
+                    continue;
+
                 foreach (var name in pending.PendingEntries.Keys.Where(discovered.Contains).ToList())
                     pending.PendingEntries.Remove(name);
 
@@ -104,6 +126,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                         .ToList();
                 }
 
+                pending.Resolved = true;
                 _pendingByPlugin.TryRemove(pluginName, out _);
             }
 

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -9,9 +9,10 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
     private const string AllowedToolsListKind = "AllowedTools";
     private const string DeniedToolsListKind = "DeniedTools";
 
+    // Never exposed outside this file, so locking on the instance itself (lock (pending) at each
+    // call site) is safe and needs no dedicated lock object.
     private sealed class PendingPlugin
     {
-        public required object Lock { get; init; }
         public required Dictionary<string, string> PendingEntries { get; init; } // name -> list kind
         public required HashSet<string> PendingServers { get; init; }
 
@@ -59,7 +60,10 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             var unresolved = entries
                 .Where(e => !isKnownFirstPartyToolName(e.Name))
                 .GroupBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
-                .Select(g => g.First())
+                // A name duplicated across both lists reports as DeniedTools — the list the
+                // bypass-immune security guarantee actually depends on — rather than whichever
+                // list happened to be enumerated first.
+                .Select(g => g.FirstOrDefault(e => e.ListKind == DeniedToolsListKind, g.First()))
                 .ToList();
             if (unresolved.Count == 0)
                 continue;
@@ -75,13 +79,24 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 // reference a host-level server's tool in its boundary. Narrowing to the plugin's own
                 // servers previously crashed boot (or permanently denied every tool) on exactly that
                 // valid, pre-existing configuration.
-                immediate.AddRange(unresolved.Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name)));
+                var immediateForPlugin = unresolved
+                    .Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name))
+                    .ToList();
+                immediate.AddRange(immediateForPlugin);
+
+                // Belt-and-suspenders (review-round finding): enforcement of this branch relies on
+                // PluginToolBoundaryStartupValidator.StartAsync throwing to abort host boot. Marking
+                // the registry here too means the fault is recorded independently of whether that
+                // caller rethrows — the same defense-in-depth ReportServerToolsDiscovered already
+                // gives the lazy branch.
+                _registry.MarkBoundaryFaulted(
+                    plugin.Name,
+                    $"Tool boundary entries match no known tool: {string.Join(", ", immediateForPlugin.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
                 continue;
             }
 
             var pending = new PendingPlugin
             {
-                Lock = new object(),
                 PendingEntries = unresolved.ToDictionary(e => e.Name, e => e.ListKind, StringComparer.OrdinalIgnoreCase),
                 PendingServers = new HashSet<string>(allConfiguredMcpServerNames, StringComparer.OrdinalIgnoreCase),
             };
@@ -113,7 +128,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 continue; // Already resolved and removed by a concurrent report.
 
             List<PluginToolBoundaryViolation>? faulted = null;
-            lock (pending.Lock)
+            lock (pending)
             {
                 // A concurrent report for a DIFFERENT server on this same plugin can already have
                 // resolved it before this thread reached the lock — this thread's own TryGetValue

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -1,0 +1,131 @@
+using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces.Plugins;
+
+namespace Application.AI.Common.Services.Plugins;
+
+/// <inheritdoc cref="IPluginToolBoundaryTracker" />
+public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
+{
+    private const string AllowedToolsListKind = "AllowedTools";
+    private const string DeniedToolsListKind = "DeniedTools";
+
+    private sealed class PendingPlugin
+    {
+        public required object Lock { get; init; }
+        public required Dictionary<string, string> PendingEntries { get; init; } // name -> list kind
+        public required HashSet<string> PendingServers { get; init; }
+    }
+
+    private readonly IPluginRegistry _registry;
+    private readonly ConcurrentDictionary<string, PendingPlugin> _pendingByPlugin = new(StringComparer.OrdinalIgnoreCase);
+
+    // serverName -> plugin names waiting on it, built once at Seed time.
+    private readonly ConcurrentDictionary<string, List<string>> _pluginsByServer = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryTracker"/> class.</summary>
+    public PluginToolBoundaryTracker(IPluginRegistry registry)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        _registry = registry;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<PluginToolBoundaryViolation> Seed(
+        IReadOnlyList<LoadedPlugin> loadedPlugins, Func<string, bool> isKnownFirstPartyToolName)
+    {
+        ArgumentNullException.ThrowIfNull(loadedPlugins);
+        ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+
+        var immediate = new List<PluginToolBoundaryViolation>();
+
+        foreach (var plugin in loadedPlugins)
+        {
+            var entries = BoundaryEntries(plugin);
+            var unresolved = entries.Where(e => !isKnownFirstPartyToolName(e.Name)).ToList();
+            if (unresolved.Count == 0)
+                continue;
+
+            if (plugin.McpServerNames.Count == 0)
+            {
+                // No other source these could ever resolve from — provably fake, right now.
+                immediate.AddRange(unresolved.Select(e => new PluginToolBoundaryViolation(plugin.Name, e.ListKind, e.Name)));
+                continue;
+            }
+
+            var pending = new PendingPlugin
+            {
+                Lock = new object(),
+                PendingEntries = unresolved.ToDictionary(e => e.Name, e => e.ListKind, StringComparer.OrdinalIgnoreCase),
+                PendingServers = new HashSet<string>(plugin.McpServerNames, StringComparer.OrdinalIgnoreCase),
+            };
+            _pendingByPlugin[plugin.Name] = pending;
+
+            foreach (var serverName in plugin.McpServerNames)
+                _pluginsByServer.GetOrAdd(serverName, _ => []).Add(plugin.Name);
+        }
+
+        return immediate;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<PluginToolBoundaryViolation> ReportServerToolsDiscovered(
+        string serverName, IReadOnlyCollection<string> discoveredToolNames)
+    {
+        ArgumentNullException.ThrowIfNull(serverName);
+        ArgumentNullException.ThrowIfNull(discoveredToolNames);
+
+        if (!_pluginsByServer.TryGetValue(serverName, out var pluginNames))
+            return [];
+
+        var discovered = new HashSet<string>(discoveredToolNames, StringComparer.OrdinalIgnoreCase);
+        var violations = new List<PluginToolBoundaryViolation>();
+
+        foreach (var pluginName in pluginNames)
+        {
+            if (!_pendingByPlugin.TryGetValue(pluginName, out var pending))
+                continue; // Already resolved and removed by a concurrent report.
+
+            List<PluginToolBoundaryViolation>? faulted = null;
+            lock (pending.Lock)
+            {
+                foreach (var name in pending.PendingEntries.Keys.Where(discovered.Contains).ToList())
+                    pending.PendingEntries.Remove(name);
+
+                pending.PendingServers.Remove(serverName);
+
+                if (pending.PendingServers.Count > 0)
+                    continue; // Other servers this plugin depends on haven't reported yet.
+
+                // Last pending server just reported. Whatever's still unresolved is now provably fake.
+                if (pending.PendingEntries.Count > 0)
+                {
+                    faulted = pending.PendingEntries
+                        .Select(kv => new PluginToolBoundaryViolation(pluginName, kv.Value, kv.Key))
+                        .ToList();
+                }
+
+                _pendingByPlugin.TryRemove(pluginName, out _);
+            }
+
+            if (faulted is { Count: > 0 })
+            {
+                _registry.MarkBoundaryFaulted(
+                    pluginName,
+                    $"Tool boundary entries match no known tool: {string.Join(", ", faulted.Select(v => $"{v.ListKind}:{v.ToolName}"))}");
+                violations.AddRange(faulted);
+            }
+        }
+
+        return violations;
+    }
+
+    private static IReadOnlyList<(string Name, string ListKind)> BoundaryEntries(LoadedPlugin plugin)
+    {
+        var entries = new List<(string, string)>();
+        if (plugin.Declaration.AllowedTools is { Count: > 0 } allowed)
+            entries.AddRange(allowed.Select(name => (name, AllowedToolsListKind)));
+        if (plugin.Declaration.DeniedTools is { Count: > 0 } denied)
+            entries.AddRange(denied.Select(name => (name, DeniedToolsListKind)));
+        return entries;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -177,6 +177,11 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 }
             }
 
+            // By construction, the "last server reported" branch above only reaches here with
+            // PendingEntries still non-empty (the early-resolve branch already handled the
+            // empty case and set resolvedEarly instead) - so faulted is always populated on
+            // every path that isn't resolvedEarly. No third "clean resolve via last server"
+            // case exists to handle.
             if (resolvedEarly)
             {
                 _registry.MarkBoundaryVerified(pluginName);
@@ -185,14 +190,6 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             {
                 _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted));
                 violations.AddRange(faulted);
-            }
-            else
-            {
-                // Every entry this plugin was waiting on now matches a real tool — the Pending state
-                // Seed set is resolved clean. Without this, the transition out of Pending was never
-                // recorded anywhere; the plugin only stopped appearing in _pendingByPlugin, which
-                // GetBoundaryStatus has no visibility into.
-                _registry.MarkBoundaryVerified(pluginName);
             }
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -27,8 +27,12 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
     private readonly IPluginRegistry _registry;
     private readonly ConcurrentDictionary<string, PendingPlugin> _pendingByPlugin = new(StringComparer.OrdinalIgnoreCase);
 
-    // serverName -> plugin names waiting on it, built once at Seed time.
-    private readonly ConcurrentDictionary<string, List<string>> _pluginsByServer = new(StringComparer.OrdinalIgnoreCase);
+    // serverName -> plugin names waiting on it, built once at Seed time. ConcurrentBag, not List
+    // (#524 round-2 code-review): Seed's .Add and ReportServerToolsDiscovered's foreach were
+    // otherwise an unsynchronized write+enumerate on a plain List<T> if MCP discovery is ever
+    // triggered concurrently with startup — a real, if narrow, race Seed's own single-threaded-in-
+    // practice usage today masks but does not prevent.
+    private readonly ConcurrentDictionary<string, ConcurrentBag<string>> _pluginsByServer = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryTracker"/> class.</summary>
     public PluginToolBoundaryTracker(IPluginRegistry registry)
@@ -130,6 +134,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 continue; // Already resolved and removed by a concurrent report.
 
             List<PluginToolBoundaryViolation>? faulted = null;
+            var resolvedEarly = false;
             lock (pending)
             {
                 // A concurrent report for a DIFFERENT server on this same plugin can already have
@@ -141,24 +146,42 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 foreach (var name in pending.PendingEntries.Keys.Where(discovered.Contains).ToList())
                     pending.PendingEntries.Remove(name);
 
-                pending.PendingServers.Remove(serverName);
-
-                if (pending.PendingServers.Count > 0)
-                    continue; // Other servers this plugin depends on haven't reported yet.
-
-                // Last pending server just reported. Whatever's still unresolved is now provably fake.
-                if (pending.PendingEntries.Count > 0)
+                // #524 round-2 code-review: every entry this plugin was waiting on already matched a
+                // real tool — resolve now, not after every OTHER configured server also reports. A
+                // later report from an unrelated server cannot un-match something already proven to
+                // exist, so waiting for it only stretches how long ToolChainBuilder denies this
+                // plugin's tools (Pending) for no reason tied to this plugin's own boundary at all.
+                if (pending.PendingEntries.Count == 0)
                 {
-                    faulted = pending.PendingEntries
-                        .Select(kv => new PluginToolBoundaryViolation(pluginName, kv.Value, kv.Key))
-                        .ToList();
+                    pending.Resolved = true;
+                    _pendingByPlugin.TryRemove(pluginName, out _);
+                    resolvedEarly = true;
                 }
+                else
+                {
+                    pending.PendingServers.Remove(serverName);
 
-                pending.Resolved = true;
-                _pendingByPlugin.TryRemove(pluginName, out _);
+                    if (pending.PendingServers.Count > 0)
+                        continue; // Other servers this plugin depends on haven't reported yet.
+
+                    // Last pending server just reported. Whatever's still unresolved is now provably fake.
+                    if (pending.PendingEntries.Count > 0)
+                    {
+                        faulted = pending.PendingEntries
+                            .Select(kv => new PluginToolBoundaryViolation(pluginName, kv.Value, kv.Key))
+                            .ToList();
+                    }
+
+                    pending.Resolved = true;
+                    _pendingByPlugin.TryRemove(pluginName, out _);
+                }
             }
 
-            if (faulted is { Count: > 0 })
+            if (resolvedEarly)
+            {
+                _registry.MarkBoundaryVerified(pluginName);
+            }
+            else if (faulted is { Count: > 0 })
             {
                 _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted));
                 violations.AddRange(faulted);

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -38,6 +38,9 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
     }
 
     /// <inheritdoc />
+    public IReadOnlyCollection<string> PendingServerNames => _pluginsByServer.Keys.ToList();
+
+    /// <inheritdoc />
     public IReadOnlyList<PluginToolBoundaryViolation> Seed(
         IReadOnlyList<LoadedPlugin> loadedPlugins,
         Func<string, bool> isKnownFirstPartyToolName,
@@ -99,6 +102,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 PendingServers = new HashSet<string>(allConfiguredMcpServerNames, StringComparer.OrdinalIgnoreCase),
             };
             _pendingByPlugin[plugin.Name] = pending;
+            _registry.MarkBoundaryPending(plugin.Name);
 
             foreach (var serverName in allConfiguredMcpServerNames)
                 _pluginsByServer.GetOrAdd(serverName, _ => []).Add(plugin.Name);
@@ -158,6 +162,14 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             {
                 _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted));
                 violations.AddRange(faulted);
+            }
+            else
+            {
+                // Every entry this plugin was waiting on now matches a real tool — the Pending state
+                // Seed set is resolved clean. Without this, the transition out of Pending was never
+                // recorded anywhere; the plugin only stopped appearing in _pendingByPlugin, which
+                // GetBoundaryStatus has no visibility into.
+                _registry.MarkBoundaryVerified(pluginName);
             }
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/FirstPartyToolLookup.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/FirstPartyToolLookup.cs
@@ -57,4 +57,12 @@ public sealed class FirstPartyToolLookup
         _registeredFirstPartyToolKeys.Contains(toolName)
             ? _serviceProvider.GetKeyedService<ITool>(toolName)
             : null;
+
+    /// <summary>
+    /// Every first-party tool name registered under keyed DI — the same bounded set
+    /// <see cref="Resolve"/> checks membership against, exposed for a caller that needs to enumerate
+    /// rather than look up one name (#524 round-2 code-review: <c>PluginPermissionRuleProvider</c>'s
+    /// fail-closed response to an unverified plugin boundary needs every name to deny, not one).
+    /// </summary>
+    public IReadOnlySet<string> RegisteredFirstPartyToolKeys => _registeredFirstPartyToolKeys;
 }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/KeyedToolRegistrationScan.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/KeyedToolRegistrationScan.cs
@@ -1,0 +1,29 @@
+using Application.AI.Common.Interfaces.Tools;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application.AI.Common.Services.Tools;
+
+/// <summary>
+/// The one place that scans a service collection for keyed <see cref="ITool"/> registration keys —
+/// the bounded "what counts as a first-party tool name" set every consumer of that question needs.
+/// </summary>
+/// <remarks>
+/// Consolidates a scan that had drifted into three independent copies: <see cref="FirstPartyToolLookup"/>'s
+/// own registration (#387, which already consolidated three OTHER independent copies of the same
+/// bounded-lookup pattern), <c>ToolCatalog</c>'s registration, and — until a code-review finding on
+/// #524 — <c>PluginToolBoundaryStartupValidator</c>'s DI wiring. A fourth copy would be exactly the
+/// drift #387 exists to prevent; every future caller should reach for this instead of re-deriving the
+/// same <c>IsKeyedService &amp;&amp; ServiceType == typeof(ITool)</c> filter.
+/// </remarks>
+public static class KeyedToolRegistrationScan
+{
+    /// <summary>
+    /// Every keyed-DI registration key registered as an <see cref="ITool"/> in <paramref name="services"/>.
+    /// </summary>
+    public static IEnumerable<string> Names(IServiceCollection services) =>
+        services
+            .Where(descriptor => descriptor.IsKeyedService && descriptor.ServiceType == typeof(ITool))
+            .Select(descriptor => descriptor.ServiceKey as string)
+            .Where(key => !string.IsNullOrWhiteSpace(key))
+            .Select(key => key!);
+}

--- a/src/Content/Application/Application.AI.Common/Services/Tools/KeyedToolRegistrationScan.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/KeyedToolRegistrationScan.cs
@@ -4,8 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Application.AI.Common.Services.Tools;
 
 /// <summary>
-/// The one place that scans a service collection for keyed <see cref="ITool"/> registration keys —
-/// the bounded "what counts as a first-party tool name" set every consumer of that question needs.
+/// Scans a service collection for keyed <see cref="ITool"/> registration keys — the bounded "what
+/// counts as a first-party tool name" set every consumer of that question needs.
 /// </summary>
 /// <remarks>
 /// Consolidates a scan that had drifted into three independent copies: <see cref="FirstPartyToolLookup"/>'s
@@ -13,7 +13,10 @@ namespace Application.AI.Common.Services.Tools;
 /// bounded-lookup pattern), <c>ToolCatalog</c>'s registration, and — until a code-review finding on
 /// #524 — <c>PluginToolBoundaryStartupValidator</c>'s DI wiring. A fourth copy would be exactly the
 /// drift #387 exists to prevent; every future caller should reach for this instead of re-deriving the
-/// same <c>IsKeyedService &amp;&amp; ServiceType == typeof(ITool)</c> filter.
+/// same <c>IsKeyedService &amp;&amp; ServiceType == typeof(ITool)</c> filter. NOT yet the only copy in
+/// the repo — a round-2 code-review finding on #524 confirmed <c>ReservedPlanCapabilityGuard</c> still
+/// carries its own independent instance of the identical filter, pre-existing and untouched by #524;
+/// migrating it is tracked separately, not folded into this consolidation.
 /// </remarks>
 public static class KeyedToolRegistrationScan
 {

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -229,13 +229,17 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // permissive — most dangerously for DeniedTools, documented as bypass-immune. Once
         // PluginToolBoundaryTracker has proven that (see its remarks), the boundary can no longer
         // be trusted, so this denies every tool from the plugin rather than run with a
-        // partially-broken policy.
-        if (pluginRegistry!.IsBoundaryFaulted(skill.PluginSource))
+        // partially-broken policy. Pending is treated identically to Faulted, not to Verified — an
+        // entry still awaiting an MCP server's tool list is exactly as unproven as one already
+        // confirmed fake, and trusting it in the meantime is the specific gap a review round found:
+        // a server nothing else happens to query left a plugin's boundary silently trusted forever.
+        var status = pluginRegistry!.GetBoundaryStatus(skill.PluginSource);
+        if (status != PluginBoundaryStatus.Verified)
         {
             _logger.LogWarning(
-                "Plugin '{Plugin}' tool boundary is faulted (an AllowedTools/DeniedTools entry " +
-                "matches no known tool) — denying all tools for skill '{Skill}'",
-                skill.PluginSource, skill.Id);
+                "Plugin '{Plugin}' tool boundary is {Status} (an AllowedTools/DeniedTools entry " +
+                "matches no known tool, or still awaits one) — denying all tools for skill '{Skill}'",
+                skill.PluginSource, status, skill.Id);
             return [];
         }
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -225,6 +225,20 @@ public partial class ToolChainBuilder : IToolChainBuilder
         if (loadedPlugin is null)
             return provisioned;
 
+        // #524: a boundary entry that matches no real tool is provably broken, not just
+        // permissive — most dangerously for DeniedTools, documented as bypass-immune. Once
+        // PluginToolBoundaryTracker has proven that (see its remarks), the boundary can no longer
+        // be trusted, so this denies every tool from the plugin rather than run with a
+        // partially-broken policy.
+        if (pluginRegistry!.IsBoundaryFaulted(skill.PluginSource))
+        {
+            _logger.LogWarning(
+                "Plugin '{Plugin}' tool boundary is faulted (an AllowedTools/DeniedTools entry " +
+                "matches no known tool) — denying all tools for skill '{Skill}'",
+                skill.PluginSource, skill.Id);
+            return [];
+        }
+
         return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -79,7 +79,19 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// need to look at, and a scalar "every tool in this batch shares one skill" parameter can never
     /// express that even though today's one-skill-per-build-call shape means the two are equivalent.
     /// </remarks>
-    private readonly record struct ProvisionedTool(AITool Tool, string? McpServerName, string? SkillId = null);
+    /// <param name="ToolKey">
+    /// The keyed-DI registration name this tool was resolved under, when it came from
+    /// <see cref="ResolveToolByName"/> — <see langword="null"/> for MCP-sourced tools and for tools
+    /// handed in pre-resolved (<c>SkillDefinition.Tools</c>, <c>SkillAgentOptions.AdditionalTools</c>).
+    /// A keyed <see cref="Application.AI.Common.Interfaces.Tools.ITool"/> can legitimately report a
+    /// converted <see cref="Tool"/>.Name that disagrees with the key it was registered under
+    /// (<c>ToolCatalogTests.Catalog_ToolWhoseNameDisagreesWithItsKey_...</c> proves this is a real,
+    /// supported shape) — <see cref="ApplyPluginToolBoundary"/> must match a plugin boundary entry
+    /// against this key when it's populated, the same identifier
+    /// <see cref="Plugins.PluginToolBoundaryTracker"/>'s existence check already validates against, or
+    /// a boundary entry naming the key would verify as real but never actually match at filter time.
+    /// </param>
+    private readonly record struct ProvisionedTool(AITool Tool, string? McpServerName, string? SkillId = null, string? ToolKey = null);
 
     /// <summary>
     /// Resolves one skill's tools. Runs the same first-party-precedence and collision/shadowing/drift
@@ -186,7 +198,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
                 var resolved = ResolveToolByName(toolName);
                 if (resolved != null)
                     foreach (var t in resolved)
-                        managed.Add(new ProvisionedTool(t, null, skill.Id));
+                        managed.Add(new ProvisionedTool(t, null, skill.Id, toolName));
             }
         }
 
@@ -550,16 +562,22 @@ public partial class ToolChainBuilder : IToolChainBuilder
     /// </summary>
     private static List<ProvisionedTool> ApplyPluginToolBoundary(List<ProvisionedTool> tools, PluginDeclaration declaration)
     {
+        // Match on ToolKey when the tool came from keyed DI (the same identifier
+        // PluginToolBoundaryTracker's existence check validates against), falling back to the
+        // published AITool.Name for MCP-sourced and pre-resolved tools, which have no DI key at all.
+        // See ProvisionedTool.ToolKey's remarks: a keyed tool's converted name can legitimately
+        // disagree with its registration key, and checking the wrong one here would let a boundary
+        // entry the existence check already proved real silently never match anything.
         if (declaration.AllowedTools is { Count: > 0 } allowed)
         {
             var allowSet = new HashSet<string>(allowed, StringComparer.OrdinalIgnoreCase);
-            tools = tools.Where(t => allowSet.Contains(t.Tool.Name)).ToList();
+            tools = tools.Where(t => allowSet.Contains(t.ToolKey ?? t.Tool.Name)).ToList();
         }
 
         if (declaration.DeniedTools is { Count: > 0 } denied)
         {
             var denySet = new HashSet<string>(denied, StringComparer.OrdinalIgnoreCase);
-            tools = tools.Where(t => !denySet.Contains(t.Tool.Name)).ToList();
+            tools = tools.Where(t => !denySet.Contains(t.ToolKey ?? t.Tool.Name)).ToList();
         }
 
         return tools;
@@ -618,7 +636,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         var resolved = ResolveToolByName(declaration.Name);
         if (resolved != null)
         {
-            var provisionedFirstParty = resolved.Select(t => new ProvisionedTool(t, null, skillId)).ToList();
+            var provisionedFirstParty = resolved.Select(t => new ProvisionedTool(t, null, skillId, declaration.Name)).ToList();
             TagCallOnceCandidates(declaration, provisionedFirstParty, callOnceCandidates);
             return provisionedFirstParty;
         }
@@ -630,7 +648,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
             {
                 _logger.LogInformation("Using fallback tool {Fallback} for {ToolName}",
                     declaration.Fallback, declaration.Name);
-                var provisionedFallback = resolved.Select(t => new ProvisionedTool(t, null, skillId)).ToList();
+                var provisionedFallback = resolved.Select(t => new ProvisionedTool(t, null, skillId, declaration.Fallback)).ToList();
                 TagCallOnceCandidates(declaration, provisionedFallback, callOnceCandidates);
                 return provisionedFallback;
             }

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -134,18 +134,8 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
             // Deny rules. Emitted first so the boundary applies even when AutonomyLevel is unset
             // or invalid.
             if (plugin.Declaration.DeniedTools is { Count: > 0 } denied)
-            {
                 foreach (var deniedTool in denied)
-                {
-                    rules.Add(new ToolPermissionRule(
-                        deniedTool,
-                        null,
-                        PermissionBehaviorType.Deny,
-                        PermissionRuleSource.PluginDeclaration,
-                        Priority: 1,
-                        IsBypassImmune: true));
-                }
-            }
+                    rules.Add(DenyRule(deniedTool));
 
             if (string.IsNullOrEmpty(plugin.Declaration.AutonomyLevel))
                 continue;
@@ -197,21 +187,23 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
         // fail-closed response is broad, not scoped to the one plugin: deny every known first-party
         // tool agent-wide until every plugin's boundary is Verified. See this type's remarks.
         if (anyBoundaryUnverified)
-        {
             foreach (var toolName in _firstPartyToolLookup.RegisteredFirstPartyToolKeys)
-            {
-                rules.Add(new ToolPermissionRule(
-                    toolName,
-                    null,
-                    PermissionBehaviorType.Deny,
-                    PermissionRuleSource.PluginDeclaration,
-                    Priority: 1,
-                    IsBypassImmune: true));
-            }
-        }
+                rules.Add(DenyRule(toolName));
 
         return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
     }
+
+    /// <summary>
+    /// A bypass-immune Deny rule for <paramref name="toolName"/> — the identical shape both the
+    /// per-plugin <c>DeniedTools</c> loop and the unverified-boundary fail-closed response above need.
+    /// </summary>
+    private static ToolPermissionRule DenyRule(string toolName) => new(
+        toolName,
+        null,
+        PermissionBehaviorType.Deny,
+        PermissionRuleSource.PluginDeclaration,
+        Priority: 1,
+        IsBypassImmune: true);
 
     /// <summary>
     /// Collects the distinct tool names declared by every skill attributed to

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Domain.Common.Helpers;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
@@ -52,12 +53,33 @@ namespace Application.Core.Permissions;
 /// on such a plugin must name its tools via the plugin's <c>AllowedTools</c> or per-skill
 /// <c>allowed-tools</c> declarations. (<c>DeniedTools</c> are unaffected — they name tools explicitly.)
 /// </para>
+/// <para>
+/// <b>Unverified boundary (#524 round-2 code-review).</b> This provider's Deny rules trust a plugin's
+/// <c>DeniedTools</c> entries exactly the way <c>ToolChainBuilder</c> used to before #524 — an entry
+/// naming no real tool is a silent no-op, and this is the ONE enforcement path #524's tool-SET
+/// filtering never reaches: <c>DeniedTools</c> exists specifically to let a plugin block a *global*
+/// tool it does not own (the doc above's "backstop for sensitive global tools"), and
+/// <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> only ever filters the tool SET sourced from
+/// the plugin's OWN skill — a global tool reachable through any OTHER skill in the same agent is never
+/// touched by that filter regardless of this plugin's boundary state. When
+/// <see cref="IPluginRegistry.GetBoundaryStatus"/> is not <see cref="PluginBoundaryStatus.Verified"/>
+/// for a plugin, this provider therefore ALSO emits a bypass-immune Deny rule for every first-party
+/// tool name known to the host (<see cref="FirstPartyToolLookup.RegisteredFirstPartyToolKeys"/>) — not
+/// scoped to this plugin, because a corrupted/unresolved entry gives no way to know which specific
+/// global tool it was meant to protect. This is agent-wide and deliberately broad: Matt's explicit call
+/// (this PR's own review) was that the collateral cost of over-blocking shared tools is acceptable
+/// against the alternative of leaving a sensitive tool's only declared protection silently absent. The
+/// existing, correctly-scoped DeniedTools and autonomy-baseline rules below are still emitted
+/// unconditionally alongside this — harmless overlap for first-party names, and still the only
+/// coverage for any additional, validly-named non-first-party (MCP) entry in the same list.
+/// </para>
 /// </remarks>
 public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 {
     private readonly IPluginRegistry _registry;
     private readonly ISkillMetadataRegistry _skillRegistry;
     private readonly IServiceProvider _serviceProvider;
+    private readonly FirstPartyToolLookup _firstPartyToolLookup;
     private readonly ILogger<PluginPermissionRuleProvider> _logger;
 
     /// <summary>
@@ -72,16 +94,22 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
     /// Used to detect globally-registered keyed-DI tools so the autonomy baseline can exclude shared
     /// harness tools the plugin does not own.
     /// </param>
+    /// <param name="firstPartyToolLookup">
+    /// Supplies every known first-party tool name for the unverified-boundary fail-closed response —
+    /// see this type's remarks.
+    /// </param>
     /// <param name="logger">Logger for invalid autonomy level and unscoped-baseline warnings.</param>
     public PluginPermissionRuleProvider(
         IPluginRegistry registry,
         ISkillMetadataRegistry skillRegistry,
         IServiceProvider serviceProvider,
+        FirstPartyToolLookup firstPartyToolLookup,
         ILogger<PluginPermissionRuleProvider> logger)
     {
         _registry = registry;
         _skillRegistry = skillRegistry;
         _serviceProvider = serviceProvider;
+        _firstPartyToolLookup = firstPartyToolLookup;
         _logger = logger;
     }
 
@@ -94,9 +122,13 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
         CancellationToken cancellationToken = default)
     {
         var rules = new List<ToolPermissionRule>();
+        var anyBoundaryUnverified = false;
 
         foreach (var plugin in _registry.GetLoadedPlugins())
         {
+            if (_registry.GetBoundaryStatus(plugin.Name) != PluginBoundaryStatus.Verified)
+                anyBoundaryUnverified = true;
+
             // DeniedTools are bypass-immune and enforced independently of any AutonomyLevel:
             // a plugin that only denies tools (no autonomy override) must still contribute its
             // Deny rules. Emitted first so the boundary applies even when AutonomyLevel is unset
@@ -154,6 +186,27 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
                     PermissionRuleSource.PluginDeclaration,
                     Priority: 5,
                     IsAuthoritativeBaseline: true));
+            }
+        }
+
+        // #524 round-2 code-review: at least one plugin's boundary can't be trusted (an
+        // AllowedTools/DeniedTools entry matches no real tool), and this class's own DeniedTools
+        // rules — the ONLY enforcement path that protects a global tool a plugin does not own — trust
+        // those entries exactly the way ToolChainBuilder used to before #524, with no existence check.
+        // Which specific global tool a corrupted entry was meant to protect is unknowable, so the
+        // fail-closed response is broad, not scoped to the one plugin: deny every known first-party
+        // tool agent-wide until every plugin's boundary is Verified. See this type's remarks.
+        if (anyBoundaryUnverified)
+        {
+            foreach (var toolName in _firstPartyToolLookup.RegisteredFirstPartyToolKeys)
+            {
+                rules.Add(new ToolPermissionRule(
+                    toolName,
+                    null,
+                    PermissionBehaviorType.Deny,
+                    PermissionRuleSource.PluginDeclaration,
+                    Priority: 1,
+                    IsBypassImmune: true));
             }
         }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Infrastructure.AI.MCP.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\Application\Application.AI.Common\Application.AI.Common.csproj" />
     <!-- Infrastructure.AI supplies AntiSsrfHandlerFactory — the SSRF guard the MCP
          client is built on. Hard dependency so SSRF protection cannot be omitted. -->

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.OpenTelemetry.Metrics;
 using Domain.AI.Telemetry.Conventions;
 using Microsoft.Extensions.AI;
@@ -51,17 +52,26 @@ public sealed class McpToolProvider : IMcpToolProvider
 {
     private readonly ILogger<McpToolProvider> _logger;
     private readonly McpConnectionManager _connectionManager;
+    private readonly IPluginToolBoundaryTracker? _boundaryTracker;
     private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="McpToolProvider"/> class.
     /// </summary>
+    /// <param name="boundaryTracker">
+    /// Optional (#524). When supplied, every successful tool-list discovery is reported to it so a
+    /// plugin's AllowedTools/DeniedTools entries can be resolved or fail-closed-faulted against real
+    /// MCP tool names — see <see cref="IPluginToolBoundaryTracker"/>'s remarks. Absent in most tests,
+    /// which have nothing to report to; production DI always supplies it.
+    /// </param>
     public McpToolProvider(
         ILogger<McpToolProvider> logger,
-        McpConnectionManager connectionManager)
+        McpConnectionManager connectionManager,
+        IPluginToolBoundaryTracker? boundaryTracker = null)
     {
         _logger = logger;
         _connectionManager = connectionManager;
+        _boundaryTracker = boundaryTracker;
     }
 
     /// <inheritdoc />
@@ -192,6 +202,8 @@ public sealed class McpToolProvider : IMcpToolProvider
                 "Retrieved {ToolCount} tools from MCP server '{ServerName}'",
                 tools.Count, serverName);
 
+            ReportDiscoveryToBoundaryTracker(serverName, tools);
+
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
         }
@@ -204,6 +216,31 @@ public sealed class McpToolProvider : IMcpToolProvider
         {
             RecordOutcome(start, serverName, McpConventions.StatusValues.Error);
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Reports a server's just-discovered tool names to the plugin tool-boundary tracker (#524), so
+    /// any plugin depending on this server can resolve or fail-closed-fault its
+    /// AllowedTools/DeniedTools entries against them. A no-op when no tracker is wired (most tests)
+    /// or nothing is pending for this server (the overwhelmingly common case). Logged at Critical,
+    /// not thrown — the tracker never throws, and a boundary violation must not disturb this
+    /// otherwise-successful discovery call's own return value; enforcement happens separately, via
+    /// <c>IPluginRegistry.IsBoundaryFaulted</c> denying the plugin's tools on its next resolution.
+    /// </summary>
+    private void ReportDiscoveryToBoundaryTracker(string serverName, IList<McpClientTool> tools)
+    {
+        if (_boundaryTracker is null)
+            return;
+
+        var violations = _boundaryTracker.ReportServerToolsDiscovered(serverName, tools.Select(t => t.Name).ToList());
+        foreach (var violation in violations)
+        {
+            _logger.LogCritical(
+                "Plugin '{Plugin}': {ListKind} entry '{ToolName}' matches no known tool (first-party " +
+                "or MCP) — this entry is a no-op, and the plugin's tool boundary can no longer be " +
+                "trusted, so all tools from this plugin are now denied.",
+                violation.PluginName, violation.ListKind, violation.ToolName);
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -202,7 +202,7 @@ public sealed class McpToolProvider : IMcpToolProvider
                 "Retrieved {ToolCount} tools from MCP server '{ServerName}'",
                 tools.Count, serverName);
 
-            ReportDiscoveryToBoundaryTracker(serverName, tools);
+            ReportDiscoveryToBoundaryTracker(serverName, tools.Select(t => t.Name));
 
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
@@ -228,12 +228,19 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// otherwise-successful discovery call's own return value; enforcement happens separately, via
     /// <c>IPluginRegistry.IsBoundaryFaulted</c> denying the plugin's tools on its next resolution.
     /// </summary>
-    private void ReportDiscoveryToBoundaryTracker(string serverName, IList<McpClientTool> tools)
+    /// <remarks>
+    /// Takes bare tool names rather than <see cref="McpClientTool"/> instances specifically so this
+    /// is unit-testable without a live MCP connection — a real correctness-review finding on #524
+    /// flagged this call site (the untrusted-input half of the feature) as having zero test coverage,
+    /// since no fixture in this project exercises <see cref="DiscoverToolsAsync"/>'s success path.
+    /// <c>internal</c> + <c>InternalsVisibleTo</c> lets <c>McpToolProviderTests</c> call this directly.
+    /// </remarks>
+    internal void ReportDiscoveryToBoundaryTracker(string serverName, IEnumerable<string> discoveredToolNames)
     {
         if (_boundaryTracker is null)
             return;
 
-        var violations = _boundaryTracker.ReportServerToolsDiscovered(serverName, tools.Select(t => t.Name).ToList());
+        var violations = _boundaryTracker.ReportServerToolsDiscovered(serverName, discoveredToolNames.ToList());
         foreach (var violation in violations)
         {
             _logger.LogCritical(

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -85,20 +85,15 @@ public sealed class McpToolProvider : IMcpToolProvider
         {
             // #524 redesign: a server that can't even be connected to (the common "unreachable
             // server" shape, e.g. genuinely down or misconfigured) never reaches DiscoverToolsAsync
-            // at all, so that method's own failure-path report can't cover it. A plugin boundary
-            // entry pending on this server must not wait forever for a connection that will never
-            // succeed — reported the same defensive way as DiscoverToolsAsync's own catch block.
-            try
-            {
-                ReportDiscoveryToBoundaryTracker(serverName, []);
-            }
-            catch (Exception trackerEx)
-            {
-                _logger.LogError(trackerEx,
-                    "Plugin tool-boundary tracker threw reporting {ServerName}'s connection failure — " +
-                    "ignored so it cannot turn an already-degraded call into a thrown exception",
-                    serverName);
-            }
+            // at all. This branch is the genuinely terminal outcome for THIS call — TryConnectAsync
+            // makes no retry attempt of its own for an initial connect failure — so it's the right
+            // place to unblock a plugin boundary entry pending on this server, UNLESS the null came
+            // from the caller cancelling rather than a real connection failure: TryConnectAsync
+            // collapses both to the same null (round-2 code-review finding), and a cancelled call says
+            // nothing about whether the server has matching tools — reporting it would let an
+            // unrelated caller hitting cancel wrongly fault this plugin's boundary.
+            if (!cancellationToken.IsCancellationRequested)
+                SafeReportDiscoveryToBoundaryTracker(serverName, []);
 
             return [];
         }
@@ -181,7 +176,16 @@ public sealed class McpToolProvider : IMcpToolProvider
         var freshClient = await TryConnectAsync(
             ct => _connectionManager.ReconnectAsync(serverName, failedClient, ct), serverName, "reconnect", cancellationToken);
         if (freshClient is null)
+        {
+            // Terminal for this call: no further retry is attempted after a failed reconnect. Same
+            // cancellation guard as GetToolsAsync's own "client is null" branch, for the same reason —
+            // TryConnectAsync collapses a real reconnect failure and a caller cancellation to the same
+            // null (#524 round-2 code-review).
+            if (!cancellationToken.IsCancellationRequested)
+                SafeReportDiscoveryToBoundaryTracker(serverName, []);
+
             return [];
+        }
 
         try
         {
@@ -194,11 +198,36 @@ public sealed class McpToolProvider : IMcpToolProvider
         catch (Exception ex)
         {
             // DiscoverToolsAsync already recorded the Error outcome (with real elapsed time) before
-            // rethrowing — do not record it again here.
+            // rethrowing — do not record it again here. This IS the operation's genuinely terminal
+            // failure — the retry this method exists to perform has now also failed — so this is the
+            // right (and only) place left to report it to the boundary tracker.
             _logger.LogWarning(ex,
                 "Failed to get tools from MCP server '{ServerName}' after reconnecting — skipping",
                 serverName);
+            SafeReportDiscoveryToBoundaryTracker(serverName, []);
             return [];
+        }
+    }
+
+    /// <summary>
+    /// Reports <paramref name="discoveredToolNames"/> for <paramref name="serverName"/> to the plugin
+    /// tool-boundary tracker, swallowing (and logging) any exception it throws — every call site's own
+    /// contract requires it not disturb whatever otherwise-successful-or-already-failed outcome it's
+    /// attached to. Centralizes what was, before #524's round-2 code-review, three independently
+    /// drifting copies of the identical try/catch/log shape.
+    /// </summary>
+    private void SafeReportDiscoveryToBoundaryTracker(string serverName, IEnumerable<string> discoveredToolNames)
+    {
+        try
+        {
+            ReportDiscoveryToBoundaryTracker(serverName, discoveredToolNames);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Plugin tool-boundary tracker threw reporting {ServerName}'s discovery outcome — " +
+                "ignored so it cannot disturb the discovery call it was attached to",
+                serverName);
         }
     }
 
@@ -224,19 +253,9 @@ public sealed class McpToolProvider : IMcpToolProvider
             // #524 code-review: ReportDiscoveryToBoundaryTracker's own doc claims "the tracker never
             // throws," but nothing enforced that — an exception here would fall through to the
             // catch(Exception) below, which records this otherwise-successful discovery as an Error
-            // outcome and rethrows to the caller. Guarded here so the doc's claim is actually true,
-            // not just assumed.
-            try
-            {
-                ReportDiscoveryToBoundaryTracker(serverName, tools.Select(t => t.Name));
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex,
-                    "Plugin tool-boundary tracker threw reporting {ServerName}'s discovered tools — " +
-                    "ignored so it cannot turn a successful discovery into a reported failure",
-                    serverName);
-            }
+            // outcome and rethrows to the caller. Guarded so the doc's claim is actually true, not
+            // just assumed — see SafeReportDiscoveryToBoundaryTracker.
+            SafeReportDiscoveryToBoundaryTracker(serverName, tools.Select(t => t.Name));
 
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
@@ -250,25 +269,16 @@ public sealed class McpToolProvider : IMcpToolProvider
         {
             RecordOutcome(start, serverName, McpConventions.StatusValues.Error);
 
-            // #524 redesign: a plugin boundary entry pending on THIS server must not wait forever
-            // just because the server is unreachable — an empty report is the correct signal either
-            // way (this server has no matching tools, whether because it truly doesn't or because it
-            // couldn't be reached), and lets ReportServerToolsDiscovered's normal resolution/fault
-            // logic run instead of leaving the entry stuck Pending indefinitely. Guarded the same way
-            // as the success-path call above, so a tracker failure here can't mask the real exception
-            // this catch block is about to rethrow.
-            try
-            {
-                ReportDiscoveryToBoundaryTracker(serverName, []);
-            }
-            catch (Exception trackerEx)
-            {
-                _logger.LogError(trackerEx,
-                    "Plugin tool-boundary tracker threw reporting {ServerName}'s failed discovery — " +
-                    "ignored so it cannot mask the original discovery failure",
-                    serverName);
-            }
-
+            // #524 code-review (round 2): do NOT report to the boundary tracker here. This method is
+            // called for both the first attempt and the post-reconnect retry (GetToolsAsync,
+            // RetryAfterReconnectAsync) — its own failure is not necessarily the operation's FINAL
+            // outcome. Reporting here fired before RetryAfterReconnectAsync ever got a chance to run,
+            // so a one-off transient failure (exactly the stale-session case #385's retry exists to
+            // recover from) permanently faulted a plugin on its first, spurious failure — the tracker
+            // only honors the first report per server and silently drops the correct, later one.
+            // Reporting on failure happens exactly once, only at the genuinely terminal points: see
+            // GetToolsAsync's "client is null" branch and RetryAfterReconnectAsync's own two failure
+            // exits.
             throw;
         }
     }
@@ -280,7 +290,8 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// or nothing is pending for this server (the overwhelmingly common case). Logged at Critical,
     /// not thrown — the tracker never throws, and a boundary violation must not disturb this
     /// otherwise-successful discovery call's own return value; enforcement happens separately, via
-    /// <c>IPluginRegistry.IsBoundaryFaulted</c> denying the plugin's tools on its next resolution.
+    /// <c>IPluginRegistry.GetBoundaryStatus</c> denying the plugin's tools on its next resolution
+    /// whenever the status isn't <see cref="Application.AI.Common.Interfaces.Plugins.PluginBoundaryStatus.Verified"/>.
     /// </summary>
     /// <remarks>
     /// Takes bare tool names rather than <see cref="McpClientTool"/> instances specifically so this

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -82,7 +82,26 @@ public sealed class McpToolProvider : IMcpToolProvider
         var client = await TryConnectAsync(
             ct => _connectionManager.GetClientAsync(serverName, ct), serverName, "connect", cancellationToken);
         if (client is null)
+        {
+            // #524 redesign: a server that can't even be connected to (the common "unreachable
+            // server" shape, e.g. genuinely down or misconfigured) never reaches DiscoverToolsAsync
+            // at all, so that method's own failure-path report can't cover it. A plugin boundary
+            // entry pending on this server must not wait forever for a connection that will never
+            // succeed — reported the same defensive way as DiscoverToolsAsync's own catch block.
+            try
+            {
+                ReportDiscoveryToBoundaryTracker(serverName, []);
+            }
+            catch (Exception trackerEx)
+            {
+                _logger.LogError(trackerEx,
+                    "Plugin tool-boundary tracker threw reporting {ServerName}'s connection failure — " +
+                    "ignored so it cannot turn an already-degraded call into a thrown exception",
+                    serverName);
+            }
+
             return [];
+        }
 
         try
         {
@@ -202,7 +221,22 @@ public sealed class McpToolProvider : IMcpToolProvider
                 "Retrieved {ToolCount} tools from MCP server '{ServerName}'",
                 tools.Count, serverName);
 
-            ReportDiscoveryToBoundaryTracker(serverName, tools.Select(t => t.Name));
+            // #524 code-review: ReportDiscoveryToBoundaryTracker's own doc claims "the tracker never
+            // throws," but nothing enforced that — an exception here would fall through to the
+            // catch(Exception) below, which records this otherwise-successful discovery as an Error
+            // outcome and rethrows to the caller. Guarded here so the doc's claim is actually true,
+            // not just assumed.
+            try
+            {
+                ReportDiscoveryToBoundaryTracker(serverName, tools.Select(t => t.Name));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Plugin tool-boundary tracker threw reporting {ServerName}'s discovered tools — " +
+                    "ignored so it cannot turn a successful discovery into a reported failure",
+                    serverName);
+            }
 
             // McpClientTool implements AITool
             return tools.Cast<AITool>().ToList();
@@ -215,6 +249,26 @@ public sealed class McpToolProvider : IMcpToolProvider
         catch (Exception)
         {
             RecordOutcome(start, serverName, McpConventions.StatusValues.Error);
+
+            // #524 redesign: a plugin boundary entry pending on THIS server must not wait forever
+            // just because the server is unreachable — an empty report is the correct signal either
+            // way (this server has no matching tools, whether because it truly doesn't or because it
+            // couldn't be reached), and lets ReportServerToolsDiscovered's normal resolution/fault
+            // logic run instead of leaving the entry stuck Pending indefinitely. Guarded the same way
+            // as the success-path call above, so a tracker failure here can't mask the real exception
+            // this catch block is about to rethrow.
+            try
+            {
+                ReportDiscoveryToBoundaryTracker(serverName, []);
+            }
+            catch (Exception trackerEx)
+            {
+                _logger.LogError(trackerEx,
+                    "Plugin tool-boundary tracker threw reporting {ServerName}'s failed discovery — " +
+                    "ignored so it cannot mask the original discovery failure",
+                    serverName);
+            }
+
             throw;
         }
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -13,6 +13,7 @@ using Application.AI.Common.Interfaces.MetaHarness;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Services.Bundles;
+using Application.AI.Common.Services.Plugins;
 using Application.AI.Common.Interfaces.Prompts;
 using Application.AI.Common.Interfaces.Routing;
 using Application.AI.Common.Interfaces.Tools;
@@ -275,6 +276,28 @@ public static partial class DependencyInjection
         // Startup driver: resolves every declared plugin into the live config + registry before
         // the first (lazy) skill/MCP discovery. Empty Packages list is a clean no-op.
         services.AddHostedService<PluginStartupLoader>();
+
+        // #524: a plugin's AllowedTools/DeniedTools entry that matches no real tool is a silent
+        // no-op today — worst for DeniedTools, documented as bypass-immune. The tracker resolves
+        // MCP-sourced entries lazily as servers are organically discovered (McpToolProvider);
+        // the startup validator below only needs to run AFTER PluginStartupLoader (registration
+        // order = StartAsync order in the Generic Host) so IPluginRegistry is already populated.
+        services.AddSingleton<IPluginToolBoundaryTracker, PluginToolBoundaryTracker>();
+        services.AddHostedService(sp =>
+        {
+            var firstPartyToolNames = new HashSet<string>(
+                services
+                    .Where(d => d.IsKeyedService && d.ServiceType == typeof(ITool))
+                    .Select(d => d.ServiceKey as string)
+                    .Where(key => !string.IsNullOrWhiteSpace(key))!,
+                StringComparer.OrdinalIgnoreCase);
+
+            return new PluginToolBoundaryStartupValidator(
+                sp.GetRequiredService<IPluginRegistry>(),
+                sp.GetRequiredService<IPluginToolBoundaryTracker>(),
+                firstPartyToolNames.Contains,
+                sp.GetRequiredService<ILogger<PluginToolBoundaryStartupValidator>>());
+        });
 
         // --- Tool execution ---
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -286,10 +286,7 @@ public static partial class DependencyInjection
         services.AddHostedService(sp =>
         {
             var firstPartyToolNames = new HashSet<string>(
-                services
-                    .Where(d => d.IsKeyedService && d.ServiceType == typeof(ITool))
-                    .Select(d => d.ServiceKey as string)
-                    .Where(key => !string.IsNullOrWhiteSpace(key))!,
+                Application.AI.Common.Services.Tools.KeyedToolRegistrationScan.Names(services),
                 StringComparer.OrdinalIgnoreCase);
 
             return new PluginToolBoundaryStartupValidator(

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -293,6 +293,7 @@ public static partial class DependencyInjection
                 sp.GetRequiredService<IPluginRegistry>(),
                 sp.GetRequiredService<IPluginToolBoundaryTracker>(),
                 firstPartyToolNames.Contains,
+                sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.AIConfig>>(),
                 sp.GetRequiredService<ILogger<PluginToolBoundaryStartupValidator>>());
         });
 

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -285,8 +285,15 @@ public static partial class DependencyInjection
         services.AddSingleton<IPluginToolBoundaryTracker, PluginToolBoundaryTracker>();
         services.AddHostedService(sp =>
         {
+            // Reuses the same bounded key set FirstPartyToolLookup already built (/simplify finding:
+            // re-scanning `services` here duplicated that scan and needlessly kept the whole
+            // IServiceCollection reachable through this factory's closure for the process lifetime).
+            // Copied into a fresh OrdinalIgnoreCase set rather than used directly: FirstPartyToolLookup's
+            // own set is Ordinal (case-sensitive, by design — see its registration), and this existence
+            // check has always matched a boundary entry case-insensitively.
             var firstPartyToolNames = new HashSet<string>(
-                Application.AI.Common.Services.Tools.KeyedToolRegistrationScan.Names(services),
+                sp.GetRequiredService<Application.AI.Common.Services.Tools.FirstPartyToolLookup>()
+                    .RegisteredFirstPartyToolKeys,
                 StringComparer.OrdinalIgnoreCase);
 
             return new PluginToolBoundaryStartupValidator(

--- a/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/DependencyInjection.cs
@@ -294,6 +294,7 @@ public static partial class DependencyInjection
                 sp.GetRequiredService<IPluginToolBoundaryTracker>(),
                 firstPartyToolNames.Contains,
                 sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.AIConfig>>(),
+                sp.GetRequiredService<Application.AI.Common.Interfaces.IMcpToolProvider>(),
                 sp.GetRequiredService<ILogger<PluginToolBoundaryStartupValidator>>());
         });
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -11,6 +11,9 @@ public sealed class PluginRegistry : IPluginRegistry
     private readonly ConcurrentDictionary<string, LoadedPlugin> _plugins =
         new(StringComparer.OrdinalIgnoreCase);
 
+    private readonly ConcurrentDictionary<string, string> _faultedBoundaries =
+        new(StringComparer.OrdinalIgnoreCase);
+
     /// <inheritdoc />
     public IReadOnlyList<LoadedPlugin> GetLoadedPlugins() =>
         _plugins.Values.ToList();
@@ -26,4 +29,11 @@ public sealed class PluginRegistry : IPluginRegistry
     /// <inheritdoc />
     public void Register(LoadedPlugin plugin) =>
         _plugins[plugin.Name] = plugin;
+
+    /// <inheritdoc />
+    public bool IsBoundaryFaulted(string pluginName) => _faultedBoundaries.ContainsKey(pluginName);
+
+    /// <inheritdoc />
+    public void MarkBoundaryFaulted(string pluginName, string reason) =>
+        _faultedBoundaries[pluginName] = reason;
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -14,12 +14,6 @@ public sealed class PluginRegistry : IPluginRegistry
     private readonly ConcurrentDictionary<string, PluginBoundaryStatus> _boundaryStatus =
         new(StringComparer.OrdinalIgnoreCase);
 
-    // Diagnostics only — GetBoundaryStatus is the source of truth for enforcement. Kept separate
-    // from _boundaryStatus's PluginBoundaryStatus.Faulted entries rather than folded into a richer
-    // value type there, since nothing besides logging needs the reason string.
-    private readonly ConcurrentDictionary<string, string> _faultReasons =
-        new(StringComparer.OrdinalIgnoreCase);
-
     /// <inheritdoc />
     public IReadOnlyList<LoadedPlugin> GetLoadedPlugins() =>
         _plugins.Values.ToList();
@@ -42,7 +36,14 @@ public sealed class PluginRegistry : IPluginRegistry
 
     /// <inheritdoc />
     public void MarkBoundaryPending(string pluginName) =>
-        _boundaryStatus[pluginName] = PluginBoundaryStatus.Pending;
+        // Never downgrades Faulted (terminal) — mirrors MarkBoundaryVerified below (#524 round-2
+        // code-review: this method had no such guard, an asymmetry with no live caller today since
+        // Seed, its only caller, runs once per plugin per startup — but the registry is the shared
+        // trust boundary, not any one caller's discipline, so it should hold regardless of caller count.
+        _boundaryStatus.AddOrUpdate(
+            pluginName,
+            PluginBoundaryStatus.Pending,
+            (_, current) => current == PluginBoundaryStatus.Faulted ? current : PluginBoundaryStatus.Pending);
 
     /// <inheritdoc />
     public void MarkBoundaryVerified(string pluginName) =>
@@ -56,9 +57,11 @@ public sealed class PluginRegistry : IPluginRegistry
             (_, current) => current == PluginBoundaryStatus.Faulted ? current : PluginBoundaryStatus.Verified);
 
     /// <inheritdoc />
-    public void MarkBoundaryFaulted(string pluginName, string reason)
-    {
+    public void MarkBoundaryFaulted(string pluginName, string reason) =>
+        // reason is a human-readable summary of facts (plugin/list-kind/tool-name) the caller already
+        // surfaces separately at the point of fault — McpToolProvider logs the violation list at
+        // Critical, PluginToolBoundaryStartupValidator throws with the same details — so nothing here
+        // needs it back. Deliberately not stored (#524 round-2 code-review: an earlier version kept a
+        // _faultReasons dictionary "for diagnostics" that nothing ever actually read).
         _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
-        _faultReasons[pluginName] = reason;
-    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -11,7 +11,13 @@ public sealed class PluginRegistry : IPluginRegistry
     private readonly ConcurrentDictionary<string, LoadedPlugin> _plugins =
         new(StringComparer.OrdinalIgnoreCase);
 
-    private readonly ConcurrentDictionary<string, string> _faultedBoundaries =
+    private readonly ConcurrentDictionary<string, PluginBoundaryStatus> _boundaryStatus =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    // Diagnostics only — GetBoundaryStatus is the source of truth for enforcement. Kept separate
+    // from _boundaryStatus's PluginBoundaryStatus.Faulted entries rather than folded into a richer
+    // value type there, since nothing besides logging needs the reason string.
+    private readonly ConcurrentDictionary<string, string> _faultReasons =
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc />
@@ -31,9 +37,28 @@ public sealed class PluginRegistry : IPluginRegistry
         _plugins[plugin.Name] = plugin;
 
     /// <inheritdoc />
-    public bool IsBoundaryFaulted(string pluginName) => _faultedBoundaries.ContainsKey(pluginName);
+    public PluginBoundaryStatus GetBoundaryStatus(string pluginName) =>
+        _boundaryStatus.GetValueOrDefault(pluginName, PluginBoundaryStatus.Verified);
 
     /// <inheritdoc />
-    public void MarkBoundaryFaulted(string pluginName, string reason) =>
-        _faultedBoundaries[pluginName] = reason;
+    public void MarkBoundaryPending(string pluginName) =>
+        _boundaryStatus[pluginName] = PluginBoundaryStatus.Pending;
+
+    /// <inheritdoc />
+    public void MarkBoundaryVerified(string pluginName) =>
+        // Never downgrades Faulted (terminal) — see this method's interface remarks. The
+        // AddOrUpdate factory re-reads the current value under the dictionary's own atomicity
+        // rather than a separate check-then-set, so a concurrent MarkBoundaryFaulted for the same
+        // plugin can't race this into wrongly clearing it.
+        _boundaryStatus.AddOrUpdate(
+            pluginName,
+            PluginBoundaryStatus.Verified,
+            (_, current) => current == PluginBoundaryStatus.Faulted ? current : PluginBoundaryStatus.Verified);
+
+    /// <inheritdoc />
+    public void MarkBoundaryFaulted(string pluginName, string reason)
+    {
+        _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
+        _faultReasons[pluginName] = reason;
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -1,0 +1,93 @@
+using Application.AI.Common.Interfaces.Plugins;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Infrastructure.AI.Plugins;
+
+/// <summary>
+/// One-shot startup check for #524: a loaded plugin's <c>AllowedTools</c>/<c>DeniedTools</c> entry
+/// that provably matches no tool at all — because the plugin declares zero MCP servers, so a
+/// first-party (keyed-DI) name is the only kind of name it could ever resolve to — refuses to boot.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is only the immediately-decidable half of #524. A plugin that DOES declare MCP servers may
+/// have entries that are real MCP tool names, only knowable once the harness actually talks to that
+/// server — this validator does not connect to any server itself (that would make host startup
+/// depend on every configured third-party server being reachable, which the existing lazy MCP
+/// connection design deliberately avoids). Those entries are seeded into
+/// <see cref="IPluginToolBoundaryTracker"/> here and resolved or fail-closed-faulted later, lazily,
+/// by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/> the first time the
+/// harness organically discovers that server's tools (see that method's remarks).
+/// </para>
+/// <para>
+/// Registered as <see cref="IHostedService"/>, matching <c>ToolAuthorizationConfigValidator</c>'s
+/// shape rather than <c>AbstractValidator&lt;T&gt;</c> — this needs the live keyed-DI tool-name set,
+/// which a parameterless-constructor FluentValidation validator cannot take as a dependency. Must be
+/// registered <em>after</em> <c>PluginStartupLoader</c> (see the DI registration) so
+/// <see cref="IPluginRegistry"/> is already populated when <see cref="StartAsync"/> runs.
+/// </para>
+/// </remarks>
+public sealed class PluginToolBoundaryStartupValidator : IHostedService
+{
+    private readonly IPluginRegistry _registry;
+    private readonly IPluginToolBoundaryTracker _tracker;
+    private readonly Func<string, bool> _isKnownFirstPartyToolName;
+    private readonly ILogger<PluginToolBoundaryStartupValidator> _logger;
+
+    /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryStartupValidator"/> class.</summary>
+    /// <param name="registry">Source of the loaded plugins to validate.</param>
+    /// <param name="tracker">Seeded with every plugin's boundary entries.</param>
+    /// <param name="isKnownFirstPartyToolName">
+    /// Case-insensitive first-party (keyed-DI) tool-name membership check — see
+    /// <see cref="IPluginToolBoundaryTracker.Seed"/>'s remarks for why case-insensitivity matters.
+    /// </param>
+    /// <param name="logger">Records the validated boundary shape.</param>
+    public PluginToolBoundaryStartupValidator(
+        IPluginRegistry registry,
+        IPluginToolBoundaryTracker tracker,
+        Func<string, bool> isKnownFirstPartyToolName,
+        ILogger<PluginToolBoundaryStartupValidator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(tracker);
+        ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _registry = registry;
+        _tracker = tracker;
+        _isKnownFirstPartyToolName = isKnownFirstPartyToolName;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var loadedPlugins = _registry.GetLoadedPlugins()
+            .Where(p => p.Status == PluginLoadStatus.Loaded)
+            .ToList();
+
+        var immediateViolations = _tracker.Seed(loadedPlugins, _isKnownFirstPartyToolName);
+        if (immediateViolations.Count == 0)
+        {
+            _logger.LogInformation(
+                "Plugin tool boundaries validated: {PluginCount} loaded plugin(s), no immediately " +
+                "unresolvable AllowedTools/DeniedTools entries.",
+                loadedPlugins.Count);
+            return Task.CompletedTask;
+        }
+
+        var lines = immediateViolations.Select(v =>
+            $"Plugin '{v.PluginName}': {v.ListKind} entry '{v.ToolName}' matches no first-party tool, " +
+            "and this plugin declares no MCP server that could ever supply it either.");
+
+        throw new InvalidOperationException(
+            "One or more plugin AllowedTools/DeniedTools entries name a tool that does not exist, so "
+            + "the host refuses to boot (#524 — an unrecognized DeniedTools entry silently denies "
+            + "nothing, which is worse than an error). Fix the following then restart:\n - "
+            + string.Join("\n - ", lines));
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -1,24 +1,28 @@
 using Application.AI.Common.Interfaces.Plugins;
+using Domain.Common.Config.AI;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Infrastructure.AI.Plugins;
 
 /// <summary>
 /// One-shot startup check for #524: a loaded plugin's <c>AllowedTools</c>/<c>DeniedTools</c> entry
-/// that provably matches no tool at all — because the plugin declares zero MCP servers, so a
+/// that provably matches no tool at all — no MCP server is configured anywhere on the host, so a
 /// first-party (keyed-DI) name is the only kind of name it could ever resolve to — refuses to boot.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is only the immediately-decidable half of #524. A plugin that DOES declare MCP servers may
-/// have entries that are real MCP tool names, only knowable once the harness actually talks to that
-/// server — this validator does not connect to any server itself (that would make host startup
-/// depend on every configured third-party server being reachable, which the existing lazy MCP
-/// connection design deliberately avoids). Those entries are seeded into
-/// <see cref="IPluginToolBoundaryTracker"/> here and resolved or fail-closed-faulted later, lazily,
-/// by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/> the first time the
-/// harness organically discovers that server's tools (see that method's remarks).
+/// This is only the immediately-decidable half of #524. Whenever at least one MCP server is
+/// configured on the host, an entry might be a real MCP tool name — a plugin skill's tool
+/// declaration can resolve against ANY host-configured server, not just ones the plugin itself
+/// declares (see <c>ToolChainBuilder.ResolveEffectiveMcpServerName</c>) — only knowable once the
+/// harness actually talks to that server. This validator does not connect to any server itself
+/// (that would make host startup depend on every configured third-party server being reachable,
+/// which the existing lazy MCP connection design deliberately avoids). Those entries are seeded
+/// into <see cref="IPluginToolBoundaryTracker"/> here and resolved or fail-closed-faulted later,
+/// lazily, by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/> the first time
+/// the harness organically discovers that server's tools (see that method's remarks).
 /// </para>
 /// <para>
 /// Registered as <see cref="IHostedService"/>, matching <c>ToolAuthorizationConfigValidator</c>'s
@@ -27,12 +31,25 @@ namespace Infrastructure.AI.Plugins;
 /// registered <em>after</em> <c>PluginStartupLoader</c> (see the DI registration) so
 /// <see cref="IPluginRegistry"/> is already populated when <see cref="StartAsync"/> runs.
 /// </para>
+/// <para>
+/// <strong>The MCP server list is read from <see cref="IOptionsMonitor{TOptions}"/> inside
+/// <see cref="StartAsync"/>, never captured at construction time.</strong> The .NET Generic Host
+/// resolves — and so constructs — every <see cref="IHostedService"/> up front, before calling
+/// <c>StartAsync</c> on any of them; <c>PluginStartupLoader</c> only merges a plugin's own MCP
+/// servers into the shared <see cref="AIConfig.McpServers"/> instance from inside its own
+/// <c>StartAsync</c>. Reading the server list at construction (e.g. captured once by the DI factory)
+/// would therefore see the config from BEFORE that merge — missing every plugin-declared server —
+/// regardless of registration order. Reading it fresh inside this type's own <c>StartAsync</c>,
+/// which the Host guarantees runs after <c>PluginStartupLoader.StartAsync</c> completes, is what
+/// actually sees the merged list.
+/// </para>
 /// </remarks>
 public sealed class PluginToolBoundaryStartupValidator : IHostedService
 {
     private readonly IPluginRegistry _registry;
     private readonly IPluginToolBoundaryTracker _tracker;
     private readonly Func<string, bool> _isKnownFirstPartyToolName;
+    private readonly IOptionsMonitor<AIConfig> _aiConfig;
     private readonly ILogger<PluginToolBoundaryStartupValidator> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryStartupValidator"/> class.</summary>
@@ -42,21 +59,28 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
     /// Case-insensitive first-party (keyed-DI) tool-name membership check — see
     /// <see cref="IPluginToolBoundaryTracker.Seed"/>'s remarks for why case-insensitivity matters.
     /// </param>
+    /// <param name="aiConfig">
+    /// Supplies the enabled MCP server names configured anywhere on the host, read fresh inside
+    /// <see cref="StartAsync"/> — see this type's remarks for why it cannot be resolved any earlier.
+    /// </param>
     /// <param name="logger">Records the validated boundary shape.</param>
     public PluginToolBoundaryStartupValidator(
         IPluginRegistry registry,
         IPluginToolBoundaryTracker tracker,
         Func<string, bool> isKnownFirstPartyToolName,
+        IOptionsMonitor<AIConfig> aiConfig,
         ILogger<PluginToolBoundaryStartupValidator> logger)
     {
         ArgumentNullException.ThrowIfNull(registry);
         ArgumentNullException.ThrowIfNull(tracker);
         ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
+        ArgumentNullException.ThrowIfNull(aiConfig);
         ArgumentNullException.ThrowIfNull(logger);
 
         _registry = registry;
         _tracker = tracker;
         _isKnownFirstPartyToolName = isKnownFirstPartyToolName;
+        _aiConfig = aiConfig;
         _logger = logger;
     }
 
@@ -67,7 +91,15 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
             .Where(p => p.Status == PluginLoadStatus.Loaded)
             .ToList();
 
-        var immediateViolations = _tracker.Seed(loadedPlugins, _isKnownFirstPartyToolName);
+        // Read fresh here, not captured earlier — see this type's remarks for why. By this point
+        // PluginStartupLoader.StartAsync has already merged every plugin's own MCP servers into the
+        // SAME McpServersConfig.Servers instance (registration order = StartAsync order).
+        var allConfiguredMcpServerNames = _aiConfig.CurrentValue.McpServers.Servers
+            .Where(kvp => kvp.Value.Enabled)
+            .Select(kvp => kvp.Key)
+            .ToList();
+
+        var immediateViolations = _tracker.Seed(loadedPlugins, _isKnownFirstPartyToolName, allConfiguredMcpServerNames);
         if (immediateViolations.Count == 0)
         {
             _logger.LogInformation(

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -1,3 +1,4 @@
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Domain.Common.Config.AI;
 using Microsoft.Extensions.Hosting;
@@ -17,12 +18,18 @@ namespace Infrastructure.AI.Plugins;
 /// configured on the host, an entry might be a real MCP tool name — a plugin skill's tool
 /// declaration can resolve against ANY host-configured server, not just ones the plugin itself
 /// declares (see <c>ToolChainBuilder.ResolveEffectiveMcpServerName</c>) — only knowable once the
-/// harness actually talks to that server. This validator does not connect to any server itself
-/// (that would make host startup depend on every configured third-party server being reachable,
-/// which the existing lazy MCP connection design deliberately avoids). Those entries are seeded
-/// into <see cref="IPluginToolBoundaryTracker"/> here and resolved or fail-closed-faulted later,
-/// lazily, by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/> the first time
-/// the harness organically discovers that server's tools (see that method's remarks).
+/// harness actually talks to that server. Those entries are seeded into
+/// <see cref="IPluginToolBoundaryTracker"/> as <see cref="PluginBoundaryStatus.Pending"/> here, and
+/// resolved or fail-closed-faulted by <see cref="IPluginToolBoundaryTracker.ReportServerToolsDiscovered"/>
+/// whenever the harness discovers that server's tools — including a proactive, fire-and-forget
+/// query this validator itself kicks off for every <see cref="IPluginToolBoundaryTracker.PendingServerNames"/>
+/// server right after <see cref="StartAsync"/> seeds them, not only when the running session
+/// organically needs that server. <strong>Host boot itself still never blocks on this</strong> — the
+/// proactive query is started, never awaited, so a slow or unreachable third-party server delays how
+/// quickly its dependent plugins leave <see cref="PluginBoundaryStatus.Pending"/>, never delays
+/// <see cref="StartAsync"/> returning. A plugin whose boundary is still resolving when a request
+/// arrives is denied, not trusted — see <see cref="PluginBoundaryStatus"/>'s remarks for why that is
+/// the deliberate fail-closed default, not a race condition to route around.
 /// </para>
 /// <para>
 /// Registered as <see cref="IHostedService"/>, matching <c>ToolAuthorizationConfigValidator</c>'s
@@ -50,6 +57,7 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
     private readonly IPluginToolBoundaryTracker _tracker;
     private readonly Func<string, bool> _isKnownFirstPartyToolName;
     private readonly IOptionsMonitor<AIConfig> _aiConfig;
+    private readonly IMcpToolProvider _toolProvider;
     private readonly ILogger<PluginToolBoundaryStartupValidator> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="PluginToolBoundaryStartupValidator"/> class.</summary>
@@ -63,24 +71,35 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
     /// Supplies the enabled MCP server names configured anywhere on the host, read fresh inside
     /// <see cref="StartAsync"/> — see this type's remarks for why it cannot be resolved any earlier.
     /// </param>
+    /// <param name="toolProvider">
+    /// Used to proactively resolve every <see cref="IPluginToolBoundaryTracker.PendingServerNames"/>
+    /// server right after <see cref="IPluginToolBoundaryTracker.Seed"/> — fire-and-forget, in the
+    /// background, never awaited before <see cref="StartAsync"/> returns — so a plugin boundary
+    /// doesn't stay <see cref="PluginBoundaryStatus.Pending"/> (and therefore denied) for the rest of
+    /// the process lifetime just because nothing else happens to query that server. See this type's
+    /// remarks for why boot itself must still never block on live third-party connectivity.
+    /// </param>
     /// <param name="logger">Records the validated boundary shape.</param>
     public PluginToolBoundaryStartupValidator(
         IPluginRegistry registry,
         IPluginToolBoundaryTracker tracker,
         Func<string, bool> isKnownFirstPartyToolName,
         IOptionsMonitor<AIConfig> aiConfig,
+        IMcpToolProvider toolProvider,
         ILogger<PluginToolBoundaryStartupValidator> logger)
     {
         ArgumentNullException.ThrowIfNull(registry);
         ArgumentNullException.ThrowIfNull(tracker);
         ArgumentNullException.ThrowIfNull(isKnownFirstPartyToolName);
         ArgumentNullException.ThrowIfNull(aiConfig);
+        ArgumentNullException.ThrowIfNull(toolProvider);
         ArgumentNullException.ThrowIfNull(logger);
 
         _registry = registry;
         _tracker = tracker;
         _isKnownFirstPartyToolName = isKnownFirstPartyToolName;
         _aiConfig = aiConfig;
+        _toolProvider = toolProvider;
         _logger = logger;
     }
 
@@ -106,6 +125,8 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
                 "Plugin tool boundaries validated: {PluginCount} loaded plugin(s), no immediately " +
                 "unresolvable AllowedTools/DeniedTools entries.",
                 loadedPlugins.Count);
+
+            ResolvePendingServersInBackground();
             return Task.CompletedTask;
         }
 
@@ -118,6 +139,44 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
             + "the host refuses to boot (#524 — an unrecognized DeniedTools entry silently denies "
             + "nothing, which is worse than an error). Fix the following then restart:\n - "
             + string.Join("\n - ", lines));
+    }
+
+    /// <summary>
+    /// Fire-and-forget: queries every <see cref="IPluginToolBoundaryTracker.PendingServerNames"/>
+    /// server once, in the background, so a plugin boundary depending on it resolves promptly instead
+    /// of only when the running session organically needs that server — see this type's remarks.
+    /// Never awaited by <see cref="StartAsync"/>; each server's task owns its own exception handling
+    /// so a connection failure here can neither propagate to an unobserved-task-exception handler nor
+    /// block any other server's resolution.
+    /// </summary>
+    private void ResolvePendingServersInBackground()
+    {
+        foreach (var serverName in _tracker.PendingServerNames)
+        {
+            _ = ResolveOneServerAsync(serverName);
+        }
+    }
+
+    private async Task ResolveOneServerAsync(string serverName)
+    {
+        try
+        {
+            // The result itself is discarded — GetToolsAsync's own success/failure path already
+            // reports to the boundary tracker (McpToolProvider.DiscoverToolsAsync and its
+            // connection-failure branch); this call exists purely to trigger that reporting sooner
+            // than "whenever a skill happens to need this server" would.
+            await _toolProvider.GetToolsAsync(serverName);
+        }
+        catch (Exception ex)
+        {
+            // GetToolsAsync's own contract is "skipped rather than throwing" for every caller it
+            // documents (see its remarks) — this catch exists as a last-resort backstop against that
+            // contract changing under this call site in the future, not because it is expected to
+            // fire today.
+            _logger.LogWarning(ex,
+                "Proactive plugin-boundary resolution for MCP server '{ServerName}' failed unexpectedly",
+                serverName);
+        }
     }
 
     /// <inheritdoc />

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -130,9 +130,13 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
             return Task.CompletedTask;
         }
 
+        // #524 round-2 code-review: this branch fires when NO MCP server is configured anywhere on
+        // the host (see Seed's own remarks) — not when this specific plugin declares none of its own.
+        // A plugin can legitimately declare a server that is merely disabled right now; the fix in
+        // that case is re-enabling a server, not touching this plugin's declaration at all.
         var lines = immediateViolations.Select(v =>
             $"Plugin '{v.PluginName}': {v.ListKind} entry '{v.ToolName}' matches no first-party tool, " +
-            "and this plugin declares no MCP server that could ever supply it either.");
+            "and no MCP server is configured anywhere on this host that could ever supply it either.");
 
         throw new InvalidOperationException(
             "One or more plugin AllowedTools/DeniedTools entries name a tool that does not exist, so "
@@ -157,10 +161,31 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
         }
     }
 
+    // A Stdio/spawned-process MCP server (npx, a container) can genuinely take a few seconds to
+    // become reachable — this is not a failure, just a cold start still in progress.
+    private const int MaxAvailabilityAttempts = 5;
+    private static readonly TimeSpan AvailabilityRetryDelay = TimeSpan.FromSeconds(1);
+
     private async Task ResolveOneServerAsync(string serverName)
     {
         try
         {
+            // #524 round-2 code-review: GetToolsAsync's failure path reports to the boundary tracker,
+            // and ReportServerToolsDiscovered only honors the FIRST report per server — so a proactive
+            // probe that races a still-starting server and loses would itself permanently fault the
+            // plugin, with no way back short of a process restart. IsServerAvailableAsync has no such
+            // side effect (confirmed: it never calls the tracker), so it's safe to retry here — only
+            // the ONE real, reporting attempt below happens after the server is confirmed reachable or
+            // this budget is exhausted, matching organic usage's own single-attempt behavior rather
+            // than manufacturing a second, artificially-lenient reporting path.
+            for (var attempt = 0; attempt < MaxAvailabilityAttempts; attempt++)
+            {
+                if (await _toolProvider.IsServerAvailableAsync(serverName))
+                    break;
+                if (attempt < MaxAvailabilityAttempts - 1)
+                    await Task.Delay(AvailabilityRetryDelay);
+            }
+
             // The result itself is discarded — GetToolsAsync's own success/failure path already
             // reports to the boundary tracker (McpToolProvider.DiscoverToolsAsync and its
             // connection-failure branch); this call exists purely to trigger that reporting sooner

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -1,0 +1,155 @@
+using Application.AI.Common.Interfaces.Plugins;
+using Application.AI.Common.Services.Plugins;
+using Domain.Common.Config.AI.Plugins;
+using FluentAssertions;
+using Moq;
+
+namespace Application.AI.Common.Tests.Plugins;
+
+/// <summary>
+/// #524: <see cref="PluginToolBoundaryTracker"/> is what turns a plugin
+/// <c>AllowedTools</c>/<c>DeniedTools</c> entry that matches no real tool from a silent no-op into
+/// a loud, fail-closed fault — either immediately at startup (a plugin with no MCP servers has no
+/// other source an entry could resolve from) or lazily, once every MCP server the plugin depends on
+/// has reported its tool list at least once.
+/// </summary>
+public sealed class PluginToolBoundaryTrackerTests
+{
+    private readonly Mock<IPluginRegistry> _registry = new();
+    private readonly PluginToolBoundaryTracker _sut;
+
+    public PluginToolBoundaryTrackerTests()
+    {
+        _sut = new PluginToolBoundaryTracker(_registry.Object);
+    }
+
+    private static LoadedPlugin MakePlugin(
+        string name, IReadOnlyList<string>? mcpServerNames = null,
+        IReadOnlyList<string>? allowedTools = null, IReadOnlyList<string>? deniedTools = null) =>
+        new(name, "1.0.0", $"/plugins/{name}", new PluginManifest { Name = name, Version = "1.0.0" },
+            PluginLoadStatus.Loaded, [], mcpServerNames ?? [],
+            new PluginDeclaration { Name = name, AllowedTools = allowedTools, DeniedTools = deniedTools });
+
+    private static bool NoFirstPartyToolsKnown(string _) => false;
+
+    [Fact]
+    public void Seed_PluginWithNoMcpServersAndUnknownDeniedEntry_ReturnsImmediateViolation()
+    {
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        violations.Should().ContainSingle(v =>
+            v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
+    }
+
+    [Fact]
+    public void Seed_PluginWithNoMcpServersAndEveryEntryKnownFirstParty_ReturnsNoViolations()
+    {
+        var plugin = MakePlugin("azure", deniedTools: ["file_write"]);
+
+        var violations = _sut.Seed([plugin], name => name == "file_write");
+
+        violations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Seed_PluginWithMcpServerAndUnknownEntry_DoesNotReturnImmediateViolation()
+    {
+        // Not yet decidable — the entry might be a real MCP tool name, only knowable once that
+        // server's tool list has actually been discovered (ReportServerToolsDiscovered).
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["maybe_mcp_tool"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ServerListContainsThePendingEntry_ResolvesWithoutFault()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool", "other_tool"]);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ServerListMissingThePendingEntry_FaultsAndReturnsViolation()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["some_other_tool"]);
+
+        violations.Should().ContainSingle(v =>
+            v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_TwoServers_OnlyFaultsAfterTheLastOneReports()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var afterFirst = _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]);
+        afterFirst.Should().BeEmpty("s2 hasn't reported yet — not provably fake");
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["also_unrelated"]);
+        afterSecond.Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_TwoServersOneResolvesTheEntry_NeverFaults()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]).Should().BeEmpty();
+        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["real_tool"]);
+
+        afterSecond.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ConcurrentReportsForBothServers_FaultsExactlyOnce()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
+        Parallel.Invoke(
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated1"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s2", ["unrelated2"])));
+
+        results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ServerNothingIsPendingFor_ReturnsEmpty()
+    {
+        var violations = _sut.ReportServerToolsDiscovered("unrelated:server", ["tool1"]);
+
+        violations.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_MatchIsCaseInsensitive_ResolvesWithoutFault()
+    {
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["Real_Tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool"]);
+
+        violations.Should().BeEmpty();
+    }
+}

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -54,6 +54,44 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
+    public void Seed_NoMcpServerAndSameUnknownNameInBothLists_ReturnsOneImmediateViolationInsteadOfThrowing()
+    {
+        var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        violations.Should().ContainSingle(v => v.PluginName == "azure" && v.ToolName == "file_wrte");
+    }
+
+    [Fact]
+    public void Seed_HasMcpServerAndSameUnknownNameInBothLists_DoesNotThrow()
+    {
+        // Regression: a name appearing in both AllowedTools and DeniedTools (or twice in one list)
+        // used to throw ArgumentException out of the pending-entries dictionary build the moment a
+        // plugin declares at least one MCP server, crashing host startup on a legally shaped — if
+        // pointless — plugin config, instead of the clean diagnostic this feature exists to produce.
+        var plugin = MakePlugin(
+            "azure", mcpServerNames: ["azure:server1"], allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+
+        var act = () => _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Seed_HasMcpServerAndSameUnknownNameTwiceInOneList_ThenReportServerToolsDiscovered_FaultsOnce()
+    {
+        var plugin = MakePlugin(
+            "azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte", "file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["unrelated"]);
+
+        violations.Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
     public void Seed_PluginWithMcpServerAndUnknownEntry_DoesNotReturnImmediateViolation()
     {
         // Not yet decidable — the entry might be a real MCP tool name, only knowable once that
@@ -129,6 +167,25 @@ public sealed class PluginToolBoundaryTrackerTests
         Parallel.Invoke(
             () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated1"])),
             () => results.Add(_sut.ReportServerToolsDiscovered("azure:s2", ["unrelated2"])));
+
+        results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_ConcurrentReportsForTheSameSingleServer_FaultsExactlyOnce()
+    {
+        // Regression (code-review finding on #524): two overlapping discovery calls for the SAME
+        // server can both pass the initial lookup before either removes the plugin from tracking,
+        // so both would reach the "last pending server just reported" branch and double-fault
+        // without the Resolved guard.
+        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1"], deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+
+        var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
+        Parallel.Invoke(
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -9,9 +9,12 @@ namespace Application.AI.Common.Tests.Plugins;
 /// <summary>
 /// #524: <see cref="PluginToolBoundaryTracker"/> is what turns a plugin
 /// <c>AllowedTools</c>/<c>DeniedTools</c> entry that matches no real tool from a silent no-op into
-/// a loud, fail-closed fault — either immediately at startup (a plugin with no MCP servers has no
-/// other source an entry could resolve from) or lazily, once every MCP server the plugin depends on
-/// has reported its tool list at least once.
+/// a loud, fail-closed fault — either immediately at startup (no MCP server is configured anywhere
+/// on the host) or lazily, once every host-configured MCP server has reported its tool list at
+/// least once. Deliberately keyed on the HOST'S full server list, not any one plugin's own declared
+/// servers — a review-round finding confirmed a plugin skill's tool declaration can resolve against
+/// ANY host-configured server (<c>ToolChainBuilder.ResolveEffectiveMcpServerName</c>), so a plugin
+/// with zero MCP servers of its own can still legitimately reference a host-level server's tool.
 /// </summary>
 public sealed class PluginToolBoundaryTrackerTests
 {
@@ -32,73 +35,103 @@ public sealed class PluginToolBoundaryTrackerTests
 
     private static bool NoFirstPartyToolsKnown(string _) => false;
 
+    private static readonly IReadOnlyCollection<string> NoServersConfigured = [];
+
     [Fact]
-    public void Seed_PluginWithNoMcpServersAndUnknownDeniedEntry_ReturnsImmediateViolation()
+    public void Seed_NoServersConfiguredAnywhereAndUnknownDeniedEntry_ReturnsImmediateViolation()
     {
         var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
 
-        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
         violations.Should().ContainSingle(v =>
             v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
     }
 
     [Fact]
-    public void Seed_PluginWithNoMcpServersAndEveryEntryKnownFirstParty_ReturnsNoViolations()
+    public void Seed_NoServersConfiguredAndEveryEntryKnownFirstParty_ReturnsNoViolations()
     {
         var plugin = MakePlugin("azure", deniedTools: ["file_write"]);
 
-        var violations = _sut.Seed([plugin], name => name == "file_write");
+        var violations = _sut.Seed([plugin], name => name == "file_write", NoServersConfigured);
 
         violations.Should().BeEmpty();
     }
 
     [Fact]
-    public void Seed_NoMcpServerAndSameUnknownNameInBothLists_ReturnsOneImmediateViolationInsteadOfThrowing()
+    public void Seed_PluginDeclaresNoOwnServerButHostHasOneConfigured_DoesNotFaultImmediately()
+    {
+        // The regression this test guards: a plugin with zero MCP servers of its OWN can still
+        // legitimately reference a tool from a host-level MCP server it doesn't declare (a plugin
+        // skill's ToolDeclaration resolves against any configured server when unrestricted). Faulting
+        // this immediately — as an earlier version did, scoped only to the plugin's own servers —
+        // crashed boot on a valid, pre-existing configuration.
+        var plugin = MakePlugin("azure", deniedTools: ["maybe_host_level_tool"]); // no own MCP servers
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_HostServerResolvesAPluginsEntry_NeverFaults()
+    {
+        // Same scenario, carried through to resolution: the host-level server (not the plugin's own)
+        // reports a list containing the entry — it resolves, exactly as a valid config should.
+        var plugin = MakePlugin("azure", deniedTools: ["delete_repository"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
+
+        var violations = _sut.ReportServerToolsDiscovered("host:github", ["delete_repository", "create_issue"]);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void Seed_NoServersConfiguredAndSameUnknownNameInBothLists_ReturnsOneImmediateViolationInsteadOfThrowing()
     {
         var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
 
-        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
         violations.Should().ContainSingle(v => v.PluginName == "azure" && v.ToolName == "file_wrte");
     }
 
     [Fact]
-    public void Seed_HasMcpServerAndSameUnknownNameInBothLists_DoesNotThrow()
+    public void Seed_HasConfiguredServerAndSameUnknownNameInBothLists_DoesNotThrow()
     {
         // Regression: a name appearing in both AllowedTools and DeniedTools (or twice in one list)
-        // used to throw ArgumentException out of the pending-entries dictionary build the moment a
-        // plugin declares at least one MCP server, crashing host startup on a legally shaped — if
-        // pointless — plugin config, instead of the clean diagnostic this feature exists to produce.
-        var plugin = MakePlugin(
-            "azure", mcpServerNames: ["azure:server1"], allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+        // used to throw ArgumentException out of the pending-entries dictionary build the moment at
+        // least one MCP server exists, crashing host startup on a legally shaped — if pointless —
+        // plugin config, instead of the clean diagnostic this feature exists to produce.
+        var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
 
-        var act = () => _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var act = () => _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
         act.Should().NotThrow();
     }
 
     [Fact]
-    public void Seed_HasMcpServerAndSameUnknownNameTwiceInOneList_ThenReportServerToolsDiscovered_FaultsOnce()
+    public void Seed_HasConfiguredServerAndSameUnknownNameTwiceInOneList_ThenReportServerToolsDiscovered_FaultsOnce()
     {
-        var plugin = MakePlugin(
-            "azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte", "file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte", "file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["unrelated"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["unrelated"]);
 
         violations.Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
-    public void Seed_PluginWithMcpServerAndUnknownEntry_DoesNotReturnImmediateViolation()
+    public void Seed_AtLeastOneServerConfiguredAndUnknownEntry_DoesNotReturnImmediateViolation()
     {
         // Not yet decidable — the entry might be a real MCP tool name, only knowable once that
         // server's tool list has actually been discovered (ReportServerToolsDiscovered).
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["maybe_mcp_tool"]);
+        var plugin = MakePlugin("azure", deniedTools: ["maybe_mcp_tool"]);
 
-        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
         violations.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -107,10 +140,10 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_ServerListContainsThePendingEntry_ResolvesWithoutFault()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["real_tool"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool", "other_tool"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["real_tool", "other_tool"]);
 
         violations.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -119,10 +152,10 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_ServerListMissingThePendingEntry_FaultsAndReturnsViolation()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["some_other_tool"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["some_other_tool"]);
 
         violations.Should().ContainSingle(v =>
             v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
@@ -130,28 +163,28 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
-    public void ReportServerToolsDiscovered_TwoServers_OnlyFaultsAfterTheLastOneReports()
+    public void ReportServerToolsDiscovered_TwoConfiguredServers_OnlyFaultsAfterTheLastOneReports()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1", "s2"]);
 
-        var afterFirst = _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]);
+        var afterFirst = _sut.ReportServerToolsDiscovered("s1", ["unrelated"]);
         afterFirst.Should().BeEmpty("s2 hasn't reported yet — not provably fake");
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
-        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["also_unrelated"]);
+        var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["also_unrelated"]);
         afterSecond.Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
     }
 
     [Fact]
-    public void ReportServerToolsDiscovered_TwoServersOneResolvesTheEntry_NeverFaults()
+    public void ReportServerToolsDiscovered_TwoConfiguredServersOneResolvesTheEntry_NeverFaults()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["real_tool"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["real_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1", "s2"]);
 
-        _sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"]).Should().BeEmpty();
-        var afterSecond = _sut.ReportServerToolsDiscovered("azure:s2", ["real_tool"]);
+        _sut.ReportServerToolsDiscovered("s1", ["unrelated"]).Should().BeEmpty();
+        var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["real_tool"]);
 
         afterSecond.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
@@ -160,13 +193,13 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_ConcurrentReportsForBothServers_FaultsExactlyOnce()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1", "azure:s2"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1", "s2"]);
 
         var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
         Parallel.Invoke(
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated1"])),
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s2", ["unrelated2"])));
+            () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated1"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("s2", ["unrelated2"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
@@ -179,13 +212,13 @@ public sealed class PluginToolBoundaryTrackerTests
         // server can both pass the initial lookup before either removes the plugin from tracking,
         // so both would reach the "last pending server just reported" branch and double-fault
         // without the Resolved guard.
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:s1"], deniedTools: ["file_wrte"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["s1"]);
 
         var results = new System.Collections.Concurrent.ConcurrentBag<IReadOnlyList<PluginToolBoundaryViolation>>();
         Parallel.Invoke(
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])),
-            () => results.Add(_sut.ReportServerToolsDiscovered("azure:s1", ["unrelated"])));
+            () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated"])),
+            () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
@@ -202,10 +235,10 @@ public sealed class PluginToolBoundaryTrackerTests
     [Fact]
     public void ReportServerToolsDiscovered_MatchIsCaseInsensitive_ResolvesWithoutFault()
     {
-        var plugin = MakePlugin("azure", mcpServerNames: ["azure:server1"], deniedTools: ["Real_Tool"]);
-        _sut.Seed([plugin], NoFirstPartyToolsKnown);
+        var plugin = MakePlugin("azure", deniedTools: ["Real_Tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
-        var violations = _sut.ReportServerToolsDiscovered("azure:server1", ["real_tool"]);
+        var violations = _sut.ReportServerToolsDiscovered("server1", ["real_tool"]);
 
         violations.Should().BeEmpty();
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -49,6 +49,19 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
+    public void Seed_ImmediateViolation_AlsoMarksTheRegistryFaulted()
+    {
+        // Defense in depth (review-round finding): the immediate branch's enforcement otherwise
+        // relies entirely on the caller (PluginToolBoundaryStartupValidator) rethrowing — marking
+        // the registry here too means IPluginRegistry.IsBoundaryFaulted is authoritative regardless.
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
+
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+    }
+
+    [Fact]
     public void Seed_NoServersConfiguredAndEveryEntryKnownFirstParty_ReturnsNoViolations()
     {
         var plugin = MakePlugin("azure", deniedTools: ["file_write"]);
@@ -96,6 +109,19 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
         violations.Should().ContainSingle(v => v.PluginName == "azure" && v.ToolName == "file_wrte");
+    }
+
+    [Fact]
+    public void Seed_SameUnknownNameInBothLists_ReportsDeniedToolsNotAllowedTools()
+    {
+        // The bypass-immune guarantee lives in DeniedTools, so a duplicate-list typo must surface
+        // under that label, not silently as an AllowedTools violation an operator might "fix" by
+        // only touching the AllowedTools entry and leaving the DeniedTools occurrence unaddressed.
+        var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);
+
+        var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
+
+        violations.Should().ContainSingle(v => v.ListKind == "DeniedTools");
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -154,6 +154,28 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
+    public void ReportServerToolsDiscovered_EveryEntryResolvesFromTheFirstOfTwoServers_VerifiesWithoutWaitingForTheSecond()
+    {
+        // #524 round-2 code-review: waiting for every configured server to report before verifying a
+        // plugin whose entries already fully resolved from an EARLIER server needlessly stretches how
+        // long ToolChainBuilder denies its tools (Pending) — a later, unrelated server's report can
+        // never un-match something already proven to exist.
+        var plugin = MakePlugin("azure", deniedTools: ["delete_repository"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github", "host:jira"]);
+
+        var violations = _sut.ReportServerToolsDiscovered("host:github", ["delete_repository"]);
+
+        violations.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryVerified("azure"), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+
+        // The still-unreported "host:jira" server must have nothing left to do for this plugin.
+        var laterReport = _sut.ReportServerToolsDiscovered("host:jira", []);
+        laterReport.Should().BeEmpty();
+        _registry.Verify(r => r.MarkBoundaryVerified("azure"), Times.Once, "must not be called a second time for the same resolution");
+    }
+
+    [Fact]
     public void Seed_NoServersConfiguredAndSameUnknownNameInBothLists_ReturnsOneImmediateViolationInsteadOfThrowing()
     {
         var plugin = MakePlugin("azure", allowedTools: ["file_wrte"], deniedTools: ["file_wrte"]);

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -88,6 +88,20 @@ public sealed class PluginToolBoundaryTrackerTests
     }
 
     [Fact]
+    public void Seed_EntryDeferredToLazyResolution_MarksTheRegistryPending()
+    {
+        // #524 redesign: an entry that can't be resolved immediately must be recorded as Pending
+        // (untrusted) — not left implicitly "not yet faulted, so trusted" the way a bare fault flag
+        // would leave it. This is what lets ToolChainBuilder deny the plugin's tools while it waits,
+        // instead of a server nothing organically queries leaving it silently trusted forever.
+        var plugin = MakePlugin("azure", deniedTools: ["maybe_host_level_tool"]);
+
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
+
+        _registry.Verify(r => r.MarkBoundaryPending("azure"), Times.Once);
+    }
+
+    [Fact]
     public void ReportServerToolsDiscovered_HostServerResolvesAPluginsEntry_NeverFaults()
     {
         // Same scenario, carried through to resolution: the host-level server (not the plugin's own)
@@ -99,6 +113,44 @@ public sealed class PluginToolBoundaryTrackerTests
 
         violations.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_EveryPendingEntryResolves_MarksTheRegistryVerified()
+    {
+        // The other half of the Pending -> {Verified, Faulted} transition (#524 redesign): resolving
+        // clean must explicitly clear Pending, not just leave it implicitly "not faulted" — that
+        // implicit gap is exactly what let a resolved plugin's boundary stay ambiguous with one that
+        // was never checked at all.
+        var plugin = MakePlugin("azure", deniedTools: ["delete_repository"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
+
+        _sut.ReportServerToolsDiscovered("host:github", ["delete_repository", "create_issue"]);
+
+        _registry.Verify(r => r.MarkBoundaryVerified("azure"), Times.Once);
+    }
+
+    [Fact]
+    public void PendingServerNames_AfterSeed_ContainsEveryConfiguredServer()
+    {
+        // Matches Seed's own deliberate design (see class remarks): an entry can resolve against ANY
+        // host-configured server, not just the plugin's own, so every configured server counts as
+        // "pending" for PluginToolBoundaryStartupValidator's proactive-resolution purposes.
+        var plugin = MakePlugin("azure", deniedTools: ["maybe_host_level_tool"]);
+
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github", "host:jira"]);
+
+        _sut.PendingServerNames.Should().BeEquivalentTo(["host:github", "host:jira"]);
+    }
+
+    [Fact]
+    public void PendingServerNames_NoPluginHasUnresolvedEntries_IsEmpty()
+    {
+        var plugin = MakePlugin("azure", deniedTools: ["file_write"]);
+
+        _sut.Seed([plugin], name => name == "file_write", ["host:github"]);
+
+        _sut.PendingServerNames.Should().BeEmpty();
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -264,6 +264,36 @@ public class ToolChainBuilderTests
         tools.Should().ContainSingle(t => t.Name == "safe");
     }
 
+    [Fact]
+    public async Task BuildToolsAsync_PluginBoundaryFaulted_DeniesAllToolsRegardlessOfDeclaredList()
+    {
+        // #524: once PluginToolBoundaryTracker has proven a plugin's AllowedTools/DeniedTools
+        // boundary can't be trusted (an entry matches no real tool), the boundary itself is no
+        // longer safe to apply — even a tool the (otherwise fine) DeniedTools list would have let
+        // through must be denied too, since the boundary might be missing an intended denial.
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", DeniedTools = ["dangerous"] }));
+        pluginRegistry.Setup(r => r.IsBoundaryFaulted("p")).Returns(true);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            Tools = [AIFunctionFactory.Create(() => "r", "safe")]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty();
+    }
+
     // --- Managed mode: pre-created tools ---
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -276,7 +276,37 @@ public class ToolChainBuilderTests
             new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
                 PluginLoadStatus.Loaded, [], ["p:server"],
                 new PluginDeclaration { Name = "p", DeniedTools = ["dangerous"] }));
-        pluginRegistry.Setup(r => r.IsBoundaryFaulted("p")).Returns(true);
+        pluginRegistry.Setup(r => r.GetBoundaryStatus("p")).Returns(PluginBoundaryStatus.Faulted);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            Tools = [AIFunctionFactory.Create(() => "r", "safe")]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildToolsAsync_PluginBoundaryPending_DeniesAllToolsSameAsFaulted()
+    {
+        // #524 redesign: an entry still awaiting an MCP server's tool list is exactly as unproven as
+        // one already confirmed fake — trusting it in the meantime is the gap that let a plugin
+        // boundary stay silently trusted forever when a dependent server was never organically
+        // queried. Pending must deny, not pass through to ApplyPluginToolBoundary.
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", DeniedTools = ["dangerous"] }));
+        pluginRegistry.Setup(r => r.GetBoundaryStatus("p")).Returns(PluginBoundaryStatus.Pending);
 
         var services = new ServiceCollection();
         services.AddSingleton(pluginRegistry.Object);

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -265,6 +265,49 @@ public class ToolChainBuilderTests
     }
 
     [Fact]
+    public async Task BuildToolsAsync_DeniedToolNamesTheDiKeyButItsAitoolNameDisagrees_StillRemovesIt()
+    {
+        // Code-review finding on #524: a keyed ITool can legitimately report a converted AITool.Name
+        // that disagrees with its own DI registration key (ToolCatalogTests.
+        // Catalog_ToolWhoseNameDisagreesWithItsKey_... proves this is a real, supported shape). A
+        // plugin author writes DeniedTools against the DI key — the same identifier
+        // PluginToolBoundaryTracker's existence check validates against — because that's the name a
+        // skill's ToolDeclaration resolves by. Before the fix, ApplyPluginToolBoundary matched only
+        // against AITool.Name, so a DeniedTools entry naming the key was "verified" as real by the
+        // existence check but silently never matched anything here — the exact no-op #524 exists to
+        // close, just reopened one layer down.
+        var toolMock = new Mock<ITool>();
+        toolMock.Setup(t => t.Name).Returns("self_reported_name");
+
+        var converter = new Mock<IToolConverter>();
+        converter.Setup(c => c.Convert(toolMock.Object, null))
+            .Returns(AIFunctionFactory.Create(() => "converted", "self_reported_name"));
+
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", DeniedTools = ["registered_key"] }));
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("registered_key", toolMock.Object);
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(toolConverter: converter.Object, serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            ToolDeclarations = [new ToolDeclaration { Name = "registered_key" }]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty("the plugin's DeniedTools entry names the DI key, which must still " +
+            "match even though the converted tool's own Name disagrees with it");
+    }
+
+    [Fact]
     public async Task BuildToolsAsync_PluginBoundaryFaulted_DeniesAllToolsRegardlessOfDeclaredList()
     {
         // #524: once PluginToolBoundaryTracker has proven a plugin's AllowedTools/DeniedTools

--- a/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/PluginPermissionRuleProviderTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
+using Application.AI.Common.Services.Tools;
 using Application.Core.Permissions;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
@@ -33,13 +34,19 @@ public sealed class PluginPermissionRuleProviderTests : IDisposable
     private void GivenGlobalKeyedTool(string toolName) =>
         _services.AddKeyedSingleton<ITool>(toolName, (_, _) => Mock.Of<ITool>());
 
-    private PluginPermissionRuleProvider CreateProvider()
+    private PluginPermissionRuleProvider CreateProvider(params string[] knownFirstPartyToolNames)
     {
         _serviceProvider = _services.BuildServiceProvider();
+        // #524 round-2: an empty key set is fine for every pre-existing test here — none configures
+        // GetBoundaryStatus to return anything but the Moq default (PluginBoundaryStatus.Verified,
+        // the enum's zero value), so the blanket-deny path this lookup feeds never fires for them.
+        var firstPartyToolLookup = new FirstPartyToolLookup(
+            _serviceProvider, new HashSet<string>(knownFirstPartyToolNames));
         return new PluginPermissionRuleProvider(
             _registryMock.Object,
             _skillRegistryMock.Object,
             _serviceProvider,
+            firstPartyToolLookup,
             NullLogger<PluginPermissionRuleProvider>.Instance);
     }
 
@@ -283,5 +290,62 @@ public sealed class PluginPermissionRuleProviderTests : IDisposable
         var rules = await CreateProvider().GetRulesAsync("any-agent");
 
         rules.Should().BeEmpty();
+    }
+
+    // --- #524 round-2 code-review: unverified boundary must not leave a global tool unprotected ---
+
+    [Theory]
+    [InlineData(PluginBoundaryStatus.Pending)]
+    [InlineData(PluginBoundaryStatus.Faulted)]
+    public async Task GetRulesAsync_PluginBoundaryUnverified_EmitsBypassImmuneDenyForEveryFirstPartyTool(
+        PluginBoundaryStatus status)
+    {
+        // This is the SECOND enforcement path #524's original fix never touched: ToolChainBuilder
+        // only filters the tool SET sourced from the faulted plugin's own skill, but DeniedTools
+        // exists specifically to let a plugin block a GLOBAL tool it does not own — reachable through
+        // any OTHER skill in the agent, regardless of this plugin's own boundary state. An unresolved
+        // entry gives no way to know which specific global tool it was meant to protect, so the
+        // fail-closed response is broad: deny every known first-party tool, not scoped to this plugin.
+        var declaration = new PluginDeclaration { Name = "azure", DeniedTools = ["file_wrte"] };
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        _registryMock.Setup(r => r.GetBoundaryStatus("azure")).Returns(status);
+
+        var rules = await CreateProvider("file_system", "shell").GetRulesAsync("any-agent");
+
+        rules.Should().Contain(r => r.ToolPattern == "file_system"
+            && r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
+        rules.Should().Contain(r => r.ToolPattern == "shell"
+            && r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_PluginBoundaryVerified_DoesNotEmitBlanketDeny()
+    {
+        var declaration = new PluginDeclaration { Name = "azure", DeniedTools = ["file_write"] };
+        _registryMock.Setup(r => r.GetLoadedPlugins()).Returns(new List<LoadedPlugin> { Loaded(declaration) });
+        _registryMock.Setup(r => r.GetBoundaryStatus("azure")).Returns(PluginBoundaryStatus.Verified);
+
+        var rules = await CreateProvider("file_system", "shell").GetRulesAsync("any-agent");
+
+        rules.Should().NotContain(r => r.ToolPattern == "file_system");
+        rules.Should().NotContain(r => r.ToolPattern == "shell");
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_OnlyOneOfMultiplePluginsUnverified_StillEmitsBlanketDenyAgentWide()
+    {
+        // The blanket deny is not scoped to the specific unverified plugin — it can't be, since which
+        // global tool a corrupted entry was meant to protect is unknowable — so even a fully healthy
+        // second plugin doesn't limit its reach.
+        var healthy = new PluginDeclaration { Name = "healthy" };
+        var broken = new PluginDeclaration { Name = "broken", DeniedTools = ["file_wrte"] };
+        _registryMock.Setup(r => r.GetLoadedPlugins())
+            .Returns(new List<LoadedPlugin> { Loaded(healthy), Loaded(broken) });
+        _registryMock.Setup(r => r.GetBoundaryStatus("healthy")).Returns(PluginBoundaryStatus.Verified);
+        _registryMock.Setup(r => r.GetBoundaryStatus("broken")).Returns(PluginBoundaryStatus.Faulted);
+
+        var rules = await CreateProvider("file_system").GetRulesAsync("any-agent");
+
+        rules.Should().Contain(r => r.ToolPattern == "file_system" && r.Behavior == PermissionBehaviorType.Deny);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Infrastructure.AI.MCP.Tests.csproj
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Infrastructure.AI.MCP.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI.MCP/Infrastructure.AI.MCP.csproj" />
     <ProjectReference Include="../../Infrastructure/Infrastructure.AI/Infrastructure.AI.csproj" />
     <ProjectReference Include="../../Application/Application.AI.Common/Application.AI.Common.csproj" />
+    <ProjectReference Include="../Tests.Common/Tests.Common.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
@@ -1,0 +1,107 @@
+using Application.AI.Common.Interfaces.Plugins;
+using FluentAssertions;
+using Infrastructure.AI.MCP.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Tests.Common;
+using Xunit;
+
+namespace Infrastructure.AI.MCP.Tests.Services;
+
+/// <summary>
+/// #524: <see cref="McpToolProvider"/> reports every successfully-discovered MCP server's tool
+/// names to <see cref="IPluginToolBoundaryTracker"/> — the untrusted-input half of the plugin
+/// tool-boundary existence check (the other half, first-party names at startup, is covered by
+/// <c>PluginToolBoundaryStartupValidator</c>'s own tests).
+/// </summary>
+/// <remarks>
+/// No fixture in this test project drives <c>McpToolProvider.DiscoverToolsAsync</c>'s
+/// success path end to end — it requires a live <c>McpClient</c> connection, which nothing here
+/// fakes (every existing <c>McpToolProvider*Tests</c> file exercises only failure/unavailable-server
+/// paths). These tests instead call
+/// <see cref="McpToolProvider.ReportDiscoveryToBoundaryTracker(string, IEnumerable{string})"/>
+/// directly — the exact reporting step <c>DiscoverToolsAsync</c> calls immediately after a
+/// successful <c>ListToolsAsync</c>, extracted to take bare tool names specifically so it can be
+/// exercised without a real connection. A correctness-review finding on #524 flagged this call site
+/// as having zero coverage: deleting it would silently re-open the exact "unrecognized DeniedTools
+/// entry is a silent no-op" hole the feature exists to close, with every other test in the suite
+/// staying green.
+/// </remarks>
+public sealed class McpToolProviderBoundaryTrackerTests
+{
+    private static (McpToolProvider Provider, McpConnectionManager Manager) CreateSut(
+        IPluginToolBoundaryTracker? boundaryTracker)
+    {
+        var manager = McpConnectionManagerBundleEgressSupport.CreateManager(
+            Mock.Of<ILogger<McpConnectionManager>>(),
+            new Mock<ILoggerFactory>().Object,
+            TestSsrf.HandlerFactory(),
+            new Domain.Common.Config.AI.MCP.McpServersConfig(),
+            new Infrastructure.AI.Bundles.BundleOwnedMcpServerRegistry());
+
+        var provider = new McpToolProvider(Mock.Of<ILogger<McpToolProvider>>(), manager, boundaryTracker);
+        return (provider, manager);
+    }
+
+    [Fact]
+    public void ReportDiscoveryToBoundaryTracker_TrackerWired_CallsReportServerToolsDiscoveredWithTheDiscoveredNames()
+    {
+        var tracker = new Mock<IPluginToolBoundaryTracker>();
+        tracker.Setup(t => t.ReportServerToolsDiscovered(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns([]);
+        var (sut, _) = CreateSut(tracker.Object);
+
+        var expectedNames = new[] { "tool_a", "tool_b" };
+        sut.ReportDiscoveryToBoundaryTracker("azure:server1", expectedNames);
+
+        tracker.Verify(t => t.ReportServerToolsDiscovered(
+            "azure:server1",
+            It.Is<IReadOnlyCollection<string>>(names => names.SequenceEqual(expectedNames))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ReportDiscoveryToBoundaryTracker_NoTrackerWired_DoesNotThrow()
+    {
+        var (sut, _) = CreateSut(boundaryTracker: null);
+
+        var act = () => sut.ReportDiscoveryToBoundaryTracker("azure:server1", ["tool_a"]);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ReportDiscoveryToBoundaryTracker_TrackerReturnsAViolation_DoesNotThrow()
+    {
+        // The violation is logged (LogCritical), never rethrown — a boundary fault must not turn an
+        // otherwise-successful discovery call into a failure. Enforcement is separate, via
+        // IPluginRegistry.IsBoundaryFaulted on the plugin's next tool resolution.
+        var tracker = new Mock<IPluginToolBoundaryTracker>();
+        tracker.Setup(t => t.ReportServerToolsDiscovered(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
+        var (sut, _) = CreateSut(tracker.Object);
+
+        var act = () => sut.ReportDiscoveryToBoundaryTracker("azure:server1", ["unrelated"]);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void DiscoverToolsAsync_SourceStillCallsReportDiscoveryToBoundaryTracker()
+    {
+        // The three tests above prove ReportDiscoveryToBoundaryTracker itself works — none of them
+        // prove DiscoverToolsAsync (private, reachable only via a live MCP connection nothing in
+        // this project fakes) still CALLS it after a successful ListToolsAsync. A source-level check
+        // is the only thing that can catch that call site being silently removed, matching this
+        // repo's established pattern for exactly this class of risk (see SecurityControlHasACallerTests).
+        var path = RepoRoot.Combine(
+            "src", "Content", "Infrastructure", "Infrastructure.AI.MCP", "Services", "McpToolProvider.cs");
+        var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(path));
+
+        var discoverToolsAsyncStart = code.IndexOf("private async Task<IList<AITool>> DiscoverToolsAsync", StringComparison.Ordinal);
+        discoverToolsAsyncStart.Should().BeGreaterThan(-1, "DiscoverToolsAsync should still exist under this name");
+        var methodBody = code[discoverToolsAsyncStart..(discoverToolsAsyncStart + 1500)];
+
+        methodBody.Should().Contain("ReportDiscoveryToBoundaryTracker(serverName");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
@@ -104,4 +104,42 @@ public sealed class McpToolProviderBoundaryTrackerTests
 
         methodBody.Should().Contain("ReportDiscoveryToBoundaryTracker(serverName");
     }
+
+    [Fact]
+    public void DiscoverToolsAsync_SourceReportsEmptyDiscoveryOnFailure()
+    {
+        // #524 redesign: a plugin boundary entry pending on a server whose discovery FAILS (the
+        // server connected but ListToolsAsync itself then failed) must not wait forever — this proves
+        // the catch(Exception) block still reports an empty discovery so ReportServerToolsDiscovered
+        // can resolve or fault the entry instead of leaving it stuck Pending indefinitely.
+        var path = RepoRoot.Combine(
+            "src", "Content", "Infrastructure", "Infrastructure.AI.MCP", "Services", "McpToolProvider.cs");
+        var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(path));
+
+        var discoverToolsAsyncStart = code.IndexOf("private async Task<IList<AITool>> DiscoverToolsAsync", StringComparison.Ordinal);
+        discoverToolsAsyncStart.Should().BeGreaterThan(-1, "DiscoverToolsAsync should still exist under this name");
+        var methodBody = code[discoverToolsAsyncStart..(discoverToolsAsyncStart + 2500)];
+
+        methodBody.Should().Contain("RecordOutcome(start, serverName, McpConventions.StatusValues.Error)");
+        methodBody.Should().Contain("ReportDiscoveryToBoundaryTracker(serverName, [])");
+    }
+
+    [Fact]
+    public void GetToolsAsync_SourceReportsEmptyDiscoveryWhenConnectionFails()
+    {
+        // The other, more common failure shape: the server can't even be CONNECTED to (genuinely
+        // down, misconfigured). That never reaches DiscoverToolsAsync at all — GetToolsAsync's own
+        // "client is null" branch is the only place that can report it, so a pending plugin boundary
+        // entry doesn't wait forever for a connection that will never succeed.
+        var path = RepoRoot.Combine(
+            "src", "Content", "Infrastructure", "Infrastructure.AI.MCP", "Services", "McpToolProvider.cs");
+        var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(path));
+
+        var getToolsAsyncStart = code.IndexOf("public async Task<IList<AITool>> GetToolsAsync", StringComparison.Ordinal);
+        getToolsAsyncStart.Should().BeGreaterThan(-1, "GetToolsAsync should still exist under this name");
+        var methodBody = code[getToolsAsyncStart..(getToolsAsyncStart + 1500)];
+
+        methodBody.Should().Contain("if (client is null)");
+        methodBody.Should().Contain("ReportDiscoveryToBoundaryTracker(serverName, [])");
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
@@ -124,8 +124,17 @@ public sealed class McpToolProviderBoundaryTrackerTests
         // catch(Exception) block, where the round-1 report-on-failure bug lived, must be checked.
         var catchStart = code.IndexOf("catch (Exception)", start, StringComparison.Ordinal);
         catchStart.Should().BeGreaterThan(start, "DiscoverToolsAsync should still have a catch(Exception) block");
-        var nextMethod = code.IndexOf("private ", catchStart + 1, StringComparison.Ordinal);
-        var catchBody = nextMethod > catchStart ? code[catchStart..nextMethod] : code[catchStart..(catchStart + 800)];
+        // #524 round-2 code-review: searching only for "private " skipped straight past
+        // ReportDiscoveryToBoundaryTracker (internal), silently widening the checked region to
+        // whatever comes after it too — today's pass was luck, not a guarantee. Take whichever of
+        // "private "/"internal "/"public " comes first after the catch block starts.
+        var candidates = new[] { "private ", "internal ", "public " }
+            .Select(modifier => code.IndexOf(modifier, catchStart + 1, StringComparison.Ordinal))
+            .Where(i => i > catchStart)
+            .ToList();
+        candidates.Should().NotBeEmpty("some member must follow DiscoverToolsAsync's catch block");
+        var nextMember = candidates.Min();
+        var catchBody = code[catchStart..nextMember];
 
         catchBody.Should().NotContain("SafeReportDiscoveryToBoundaryTracker",
             "reporting on failure must happen only at the operation's genuinely terminal exits, not on this method's own (possibly first-attempt, possibly-recoverable) failure");

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
@@ -106,22 +106,72 @@ public sealed class McpToolProviderBoundaryTrackerTests
     }
 
     [Fact]
-    public void DiscoverToolsAsync_SourceReportsEmptyDiscoveryOnFailure()
+    public void DiscoverToolsAsync_SourceDoesNotReportToBoundaryTrackerOnItsOwnFailure()
     {
-        // #524 redesign: a plugin boundary entry pending on a server whose discovery FAILS (the
-        // server connected but ListToolsAsync itself then failed) must not wait forever — this proves
-        // the catch(Exception) block still reports an empty discovery so ReportServerToolsDiscovered
-        // can resolve or fault the entry instead of leaving it stuck Pending indefinitely.
+        // #524 round-2 code-review: DiscoverToolsAsync is called for BOTH the first attempt and the
+        // post-reconnect retry. Reporting from its own catch(Exception) block fired on the first,
+        // possibly-transient failure — before RetryAfterReconnectAsync ever got a chance to recover —
+        // and ReportServerToolsDiscovered only honors the FIRST report per server, silently dropping
+        // the correct, later one. A one-off network blip could then permanently fault a healthy
+        // plugin. This proves the report call was removed from this method's own failure path.
         var path = RepoRoot.Combine(
             "src", "Content", "Infrastructure", "Infrastructure.AI.MCP", "Services", "McpToolProvider.cs");
         var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(path));
 
-        var discoverToolsAsyncStart = code.IndexOf("private async Task<IList<AITool>> DiscoverToolsAsync", StringComparison.Ordinal);
-        discoverToolsAsyncStart.Should().BeGreaterThan(-1, "DiscoverToolsAsync should still exist under this name");
-        var methodBody = code[discoverToolsAsyncStart..(discoverToolsAsyncStart + 2500)];
+        var start = code.IndexOf("private async Task<IList<AITool>> DiscoverToolsAsync", StringComparison.Ordinal);
+        start.Should().BeGreaterThan(-1, "DiscoverToolsAsync should still exist under this name");
+        // Success path legitimately still reports (with the real discovered names) — only the
+        // catch(Exception) block, where the round-1 report-on-failure bug lived, must be checked.
+        var catchStart = code.IndexOf("catch (Exception)", start, StringComparison.Ordinal);
+        catchStart.Should().BeGreaterThan(start, "DiscoverToolsAsync should still have a catch(Exception) block");
+        var nextMethod = code.IndexOf("private ", catchStart + 1, StringComparison.Ordinal);
+        var catchBody = nextMethod > catchStart ? code[catchStart..nextMethod] : code[catchStart..(catchStart + 800)];
 
-        methodBody.Should().Contain("RecordOutcome(start, serverName, McpConventions.StatusValues.Error)");
-        methodBody.Should().Contain("ReportDiscoveryToBoundaryTracker(serverName, [])");
+        catchBody.Should().NotContain("SafeReportDiscoveryToBoundaryTracker",
+            "reporting on failure must happen only at the operation's genuinely terminal exits, not on this method's own (possibly first-attempt, possibly-recoverable) failure");
+    }
+
+    [Fact]
+    public void RetryAfterReconnectAsync_SourceReportsEmptyDiscoveryAtBothTerminalFailureExits()
+    {
+        // The other half of the fix: reporting must happen exactly once, at the genuinely terminal
+        // points — after a failed reconnect, and after a retried discovery also fails — not before.
+        var path = RepoRoot.Combine(
+            "src", "Content", "Infrastructure", "Infrastructure.AI.MCP", "Services", "McpToolProvider.cs");
+        var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(path));
+
+        var start = code.IndexOf("private async Task<IList<AITool>> RetryAfterReconnectAsync", StringComparison.Ordinal);
+        start.Should().BeGreaterThan(-1, "RetryAfterReconnectAsync should still exist under this name");
+        // Bounded at the helper's own declaration, not the next Task-returning method — that
+        // declaration line itself contains "SafeReportDiscoveryToBoundaryTracker" as its method name,
+        // which would inflate the occurrence count by one if included in the slice.
+        var nextMethod = code.IndexOf("private void SafeReportDiscoveryToBoundaryTracker", start + 1, StringComparison.Ordinal);
+        nextMethod.Should().BeGreaterThan(start);
+        var methodBody = code[start..nextMethod];
+
+        var occurrences = System.Text.RegularExpressions.Regex.Matches(methodBody, "SafeReportDiscoveryToBoundaryTracker").Count;
+        occurrences.Should().Be(2,
+            "one for the failed-reconnect exit (freshClient is null) and one for the retried-discovery-also-failed exit");
+    }
+
+    [Fact]
+    public void GetToolsAsync_SourceSkipsReportingWhenNullClientCameFromCancellation()
+    {
+        // TryConnectAsync collapses a genuine connection failure and a caller cancellation to the same
+        // null return — reporting unconditionally there would let an unrelated caller hitting cancel
+        // wrongly fault a plugin's boundary. This proves the cancellation guard is in place.
+        var path = RepoRoot.Combine(
+            "src", "Content", "Infrastructure", "Infrastructure.AI.MCP", "Services", "McpToolProvider.cs");
+        var code = SourceScan.StripCommentsAndStrings(File.ReadAllText(path));
+
+        var start = code.IndexOf("public async Task<IList<AITool>> GetToolsAsync", StringComparison.Ordinal);
+        start.Should().BeGreaterThan(-1, "GetToolsAsync should still exist under this name");
+        var clientIsNullIndex = code.IndexOf("if (client is null)", start, StringComparison.Ordinal);
+        clientIsNullIndex.Should().BeGreaterThan(start);
+        var branchBody = code[clientIsNullIndex..(clientIsNullIndex + 800)];
+
+        branchBody.Should().Contain("if (!cancellationToken.IsCancellationRequested)");
+        branchBody.Should().Contain("SafeReportDiscoveryToBoundaryTracker");
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Agent;
 using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Escalation;
+using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Resilience;
 using Domain.Common.Config;
 using Domain.Common.Config.AI.MCP;
@@ -10,6 +11,7 @@ using FluentAssertions;
 using Infrastructure.AI.Escalation;
 using Infrastructure.AI.KnowledgeGraph;
 using Infrastructure.AI.MCP;
+using Infrastructure.AI.Plugins;
 using Infrastructure.AI.Resilience;
 using Infrastructure.AI.Tests.Planner.StepExecutors;
 using MediatR;
@@ -272,6 +274,33 @@ public sealed class DependencyInjectionTests
         var hostedServices = provider.GetServices<IHostedService>().ToList();
 
         hostedServices.Should().NotContain(s => s is LlmRetryQueue);
+    }
+
+    [Fact]
+    public void AddInfrastructureAIDependencies_RegistersPluginToolBoundaryStartupValidatorHostedService()
+    {
+        // #524: this is the ONLY thing standing between the startup validator and becoming a
+        // ninth instance of the "control nothing invokes" family (CLAUDE.md Common Mistakes) — a
+        // hosted service that is never registered runs never, however correct its own logic is.
+        var services = CreateBaseServices();
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
+        using var provider = services.BuildServiceProvider();
+
+        var hostedServices = provider.GetServices<IHostedService>().ToList();
+
+        hostedServices.Should().Contain(s => s is PluginToolBoundaryStartupValidator);
+    }
+
+    [Fact]
+    public void AddInfrastructureAIDependencies_RegistersIPluginToolBoundaryTracker()
+    {
+        var services = CreateBaseServices();
+        services.AddInfrastructureAIDependencies(IsolatedAppConfig.Create());
+        using var provider = services.BuildServiceProvider();
+
+        var tracker = provider.GetService<IPluginToolBoundaryTracker>();
+
+        tracker.Should().NotBeNull();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -67,6 +67,14 @@ public sealed class DependencyInjectionTests
         // PR added, or that pre-existing guard throws for every hosted-service enumeration test.
         services.AddSingleton(Mock.Of<IMcpToolProvider>());
         services.AddSingleton(Mock.Of<IBundleMcpServerRegistrar>());
+        // PluginToolBoundaryStartupValidator's firstPartyToolNames set (/simplify: reuses
+        // FirstPartyToolLookup instead of re-scanning `services` independently) resolves it eagerly
+        // during hosted-service construction. The real composition root registers it via
+        // Application.AI.Common's own DI module, called separately from AddInfrastructureAIDependencies
+        // — mirror that here so hosted-service enumeration can resolve. Sealed class, so a real instance
+        // rather than a Mock.Of<T>; the empty key set is fine since these tests don't exercise its content.
+        services.AddSingleton(sp => new Application.AI.Common.Services.Tools.FirstPartyToolLookup(
+            sp, new HashSet<string>()));
 
         return services;
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DependencyInjectionTests.cs
@@ -58,6 +58,15 @@ public sealed class DependencyInjectionTests
         services.AddMemoryCache();
         services.AddSingleton<ISender>(new Mock<ISender>().Object);
         services.AddKnowledgeGraphDependencies(config);
+        // PluginToolBoundaryStartupValidator (#524 redesign) depends on IMcpToolProvider, to
+        // proactively resolve pending plugin-boundary entries right after boot. The real composition
+        // root registers it via Infrastructure.AI.MCP's own DI module, called separately from
+        // AddInfrastructureAIDependencies — mirror that here so hosted-service enumeration can resolve.
+        // BundleRunExecutor's own constructor enforces "IMcpToolProvider and IBundleMcpServerRegistrar
+        // register together, never one without the other" — both mocked here, not just the one this
+        // PR added, or that pre-existing guard throws for every hosted-service enumeration test.
+        services.AddSingleton(Mock.Of<IMcpToolProvider>());
+        services.AddSingleton(Mock.Of<IBundleMcpServerRegistrar>());
 
         return services;
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
@@ -1,3 +1,5 @@
+using Application.AI.Common.Interfaces;
+using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.DriftDetection;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Learnings;
@@ -222,6 +224,16 @@ public sealed class DriftLearningsDiTests
         // the real composition root registers this via Application.AI.Common's own DI module,
         // called separately from AddInfrastructureAIDependencies — mirror that here too.
         services.AddMemoryCache();
+
+        // PluginToolBoundaryStartupValidator (#524 redesign) depends on IMcpToolProvider, to
+        // proactively resolve pending plugin-boundary entries right after boot. The real composition
+        // root registers it via Infrastructure.AI.MCP's own DI module, called separately from
+        // AddInfrastructureAIDependencies — mirror that here so hosted-service enumeration can resolve.
+        // BundleRunExecutor's own constructor enforces "IMcpToolProvider and IBundleMcpServerRegistrar
+        // register together, never one without the other" — both mocked here, not just the one this
+        // PR added, or that pre-existing guard throws for every hosted-service enumeration test.
+        services.AddSingleton(Mock.Of<IMcpToolProvider>());
+        services.AddSingleton(Mock.Of<IBundleMcpServerRegistrar>());
 
         // Register knowledge graph (provides IKnowledgeGraphStore for graph-backed stores)
         services.AddKnowledgeGraphDependencies(appConfig);

--- a/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/DriftLearningsDiTests.cs
@@ -234,6 +234,14 @@ public sealed class DriftLearningsDiTests
         // PR added, or that pre-existing guard throws for every hosted-service enumeration test.
         services.AddSingleton(Mock.Of<IMcpToolProvider>());
         services.AddSingleton(Mock.Of<IBundleMcpServerRegistrar>());
+        // PluginToolBoundaryStartupValidator's firstPartyToolNames set (/simplify: reuses
+        // FirstPartyToolLookup instead of re-scanning `services` independently) resolves it eagerly
+        // during hosted-service construction. The real composition root registers it via
+        // Application.AI.Common's own DI module, called separately from AddInfrastructureAIDependencies
+        // — mirror that here so hosted-service enumeration can resolve. Sealed class, so a real instance
+        // rather than a Mock.Of<T>; the empty key set is fine since these tests don't exercise its content.
+        services.AddSingleton(sp => new Application.AI.Common.Services.Tools.FirstPartyToolLookup(
+            sp, new HashSet<string>()));
 
         // Register knowledge graph (provides IKnowledgeGraphStore for graph-backed stores)
         services.AddKnowledgeGraphDependencies(appConfig);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Application.Core.Permissions;
 using Domain.AI.Agents;
 using Domain.AI.Bundles;
@@ -135,6 +136,10 @@ public sealed class EnvelopeEnforcementIntegrationTests
                 tierResolver.Object, options, NullLogger<AutonomyTierRuleProvider>.Instance),
             new PluginPermissionRuleProvider(
                 pluginRegistry.Object, skillRegistry.Object, new ServiceCollection().BuildServiceProvider(),
+                // #524 round-2: empty key set is fine — pluginRegistry never configures
+                // GetBoundaryStatus, so Moq's default (PluginBoundaryStatus.Verified) means the
+                // blanket-deny path this lookup feeds never fires here.
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
                 NullLogger<PluginPermissionRuleProvider>.Instance),
             new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance),
             new ConfigBasedRuleProvider(options)

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/PlannerDiRegistrationTests.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Attestation;
+using Application.AI.Common.Interfaces.Bundles;
 using Application.AI.Common.Interfaces.Escalation;
 using Application.AI.Common.Interfaces.Governance;
 using Application.AI.Common.Interfaces.Planner;
@@ -310,6 +311,16 @@ public sealed class PlannerDiRegistrationTests : IDisposable
         services.AddSingleton<IPromptRegistry>(new Mock<IPromptRegistry>().Object);
         services.AddSingleton<IPromptRenderer>(new Mock<IPromptRenderer>().Object);
         services.AddSingleton<IPromptUsageRecorder>(new Mock<IPromptUsageRecorder>().Object);
+
+        // PluginToolBoundaryStartupValidator (#524 redesign) depends on IMcpToolProvider, to
+        // proactively resolve pending plugin-boundary entries right after boot. The real composition
+        // root registers it via Infrastructure.AI.MCP's own DI module, called separately from
+        // AddInfrastructureAIDependencies — mirror that here so hosted-service enumeration can resolve.
+        // BundleRunExecutor's own constructor enforces "IMcpToolProvider and IBundleMcpServerRegistrar
+        // register together, never one without the other" — both mocked here, not just the one this
+        // PR added, or that pre-existing guard throws for every hosted-service enumeration test.
+        services.AddSingleton(Mock.Of<IMcpToolProvider>());
+        services.AddSingleton(Mock.Of<IBundleMcpServerRegistrar>());
 
         // Knowledge graph (required by drift/learnings already in AddInfrastructureAIDependencies)
         services.AddKnowledgeGraphDependencies(appConfig);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -69,4 +69,27 @@ public class PluginRegistryTests
 
         _sut.IsLoaded("broken").Should().BeFalse();
     }
+
+    [Fact]
+    public void IsBoundaryFaulted_UnmarkedPlugin_ReturnsFalse()
+    {
+        _sut.IsBoundaryFaulted("azure").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MarkBoundaryFaulted_ThenIsBoundaryFaulted_ReturnsTrue()
+    {
+        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
+
+        _sut.IsBoundaryFaulted("azure").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsBoundaryFaulted_CaseInsensitive_ReturnsTrue()
+    {
+        _sut.MarkBoundaryFaulted("Azure", "reason");
+
+        _sut.IsBoundaryFaulted("azure").Should().BeTrue();
+        _sut.IsBoundaryFaulted("AZURE").Should().BeTrue();
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -71,25 +71,54 @@ public class PluginRegistryTests
     }
 
     [Fact]
-    public void IsBoundaryFaulted_UnmarkedPlugin_ReturnsFalse()
+    public void GetBoundaryStatus_UnmarkedPlugin_ReturnsVerified()
     {
-        _sut.IsBoundaryFaulted("azure").Should().BeFalse();
+        _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Verified);
     }
 
     [Fact]
-    public void MarkBoundaryFaulted_ThenIsBoundaryFaulted_ReturnsTrue()
+    public void MarkBoundaryFaulted_ThenGetBoundaryStatus_ReturnsFaulted()
     {
         _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
 
-        _sut.IsBoundaryFaulted("azure").Should().BeTrue();
+        _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
     }
 
     [Fact]
-    public void IsBoundaryFaulted_CaseInsensitive_ReturnsTrue()
+    public void GetBoundaryStatus_CaseInsensitive_ReturnsFaulted()
     {
         _sut.MarkBoundaryFaulted("Azure", "reason");
 
-        _sut.IsBoundaryFaulted("azure").Should().BeTrue();
-        _sut.IsBoundaryFaulted("AZURE").Should().BeTrue();
+        _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
+        _sut.GetBoundaryStatus("AZURE").Should().Be(PluginBoundaryStatus.Faulted);
+    }
+
+    [Fact]
+    public void MarkBoundaryPending_ThenGetBoundaryStatus_ReturnsPending()
+    {
+        _sut.MarkBoundaryPending("azure");
+
+        _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Pending);
+    }
+
+    [Fact]
+    public void MarkBoundaryPending_ThenMarkBoundaryVerified_ReturnsVerified()
+    {
+        _sut.MarkBoundaryPending("azure");
+        _sut.MarkBoundaryVerified("azure");
+
+        _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Verified);
+    }
+
+    [Fact]
+    public void MarkBoundaryFaulted_ThenMarkBoundaryVerified_StaysFaulted()
+    {
+        // Faulted is terminal (#524 redesign) — a caller resolving one pending entry has no way to
+        // know whether some OTHER entry already faulted this same plugin through a different call,
+        // so MarkBoundaryVerified must never be able to downgrade it.
+        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
+        _sut.MarkBoundaryVerified("azure");
+
+        _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -121,4 +121,18 @@ public class PluginRegistryTests
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
     }
+
+    [Fact]
+    public void MarkBoundaryFaulted_ThenMarkBoundaryPending_StaysFaulted()
+    {
+        // Same terminal guarantee as MarkBoundaryVerified above (#524 round-2 code-review): the two
+        // methods had this guard asymmetrically — only Verified refused to downgrade Faulted. Not
+        // reachable via any caller today (Seed calls MarkBoundaryPending at most once per plugin, and
+        // never after a fault), but the registry is the shared trust boundary, not any one caller's
+        // discipline, so it must hold regardless of how many callers exist in the future.
+        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
+        _sut.MarkBoundaryPending("azure");
+
+        _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
+    }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
@@ -1,8 +1,12 @@
+using System.Collections.Concurrent;
 using Application.AI.Common.Interfaces.Plugins;
+using Domain.Common.Config.AI;
+using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
 using Infrastructure.AI.Plugins;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -10,8 +14,9 @@ namespace Infrastructure.AI.Tests.Plugins;
 
 /// <summary>
 /// #524: <see cref="PluginToolBoundaryStartupValidator"/> refuses to boot when
-/// <see cref="IPluginToolBoundaryTracker.Seed"/> reports an immediately-provable violation (a
-/// plugin with no MCP servers whose AllowedTools/DeniedTools entry matches no first-party tool).
+/// <see cref="IPluginToolBoundaryTracker.Seed"/> reports an immediately-provable violation (no MCP
+/// server configured anywhere on the host, and an AllowedTools/DeniedTools entry matches no
+/// first-party tool).
 /// </summary>
 public sealed class PluginToolBoundaryStartupValidatorTests
 {
@@ -22,15 +27,27 @@ public sealed class PluginToolBoundaryStartupValidatorTests
         new(name, "1.0.0", $"/plugins/{name}", new PluginManifest { Name = name, Version = "1.0.0" },
             PluginLoadStatus.Loaded, [], [], new PluginDeclaration { Name = name, DeniedTools = ["file_wrte"] });
 
-    private PluginToolBoundaryStartupValidator MakeSut(Func<string, bool> isKnownFirstPartyToolName) =>
+    private static IOptionsMonitor<AIConfig> MakeAiConfig(params string[] enabledServerNames)
+    {
+        var servers = new ConcurrentDictionary<string, McpServerDefinition>(
+            enabledServerNames.ToDictionary(n => n, _ => new McpServerDefinition { Enabled = true }));
+        var config = new AIConfig { McpServers = new McpServersConfig { Servers = servers } };
+        var monitor = new Mock<IOptionsMonitor<AIConfig>>();
+        monitor.Setup(m => m.CurrentValue).Returns(config);
+        return monitor.Object;
+    }
+
+    private PluginToolBoundaryStartupValidator MakeSut(
+        Func<string, bool> isKnownFirstPartyToolName, IOptionsMonitor<AIConfig>? aiConfig = null) =>
         new(_registry.Object, _tracker.Object, isKnownFirstPartyToolName,
-            NullLogger<PluginToolBoundaryStartupValidator>.Instance);
+            aiConfig ?? MakeAiConfig(), NullLogger<PluginToolBoundaryStartupValidator>.Instance);
 
     [Fact]
     public async Task StartAsync_SeedReturnsNoViolations_DoesNotThrow()
     {
         _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
-        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
             .Returns([]);
         var sut = MakeSut(_ => true);
 
@@ -43,7 +60,8 @@ public sealed class PluginToolBoundaryStartupValidatorTests
     public async Task StartAsync_SeedReturnsAnImmediateViolation_ThrowsNamingPluginAndTool()
     {
         _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
-        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
             .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
         var sut = MakeSut(_ => false);
 
@@ -62,13 +80,39 @@ public sealed class PluginToolBoundaryStartupValidatorTests
             new PluginDeclaration { Name = "disabled-plugin" });
         _registry.Setup(r => r.GetLoadedPlugins()).Returns([loaded, disabled]);
         IReadOnlyList<LoadedPlugin>? captured = null;
-        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
-            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>>((plugins, _) => captured = plugins)
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>, IReadOnlyCollection<string>>(
+                (plugins, _, _) => captured = plugins)
             .Returns([]);
         var sut = MakeSut(_ => true);
 
         await sut.StartAsync(CancellationToken.None);
 
         captured.Should().ContainSingle().Which.Name.Should().Be("azure");
+    }
+
+    [Fact]
+    public async Task StartAsync_PassesOnlyEnabledConfiguredServerNamesToSeed()
+    {
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        IReadOnlyCollection<string>? captured = null;
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>, IReadOnlyCollection<string>>(
+                (_, _, servers) => captured = servers)
+            .Returns([]);
+        var servers = new ConcurrentDictionary<string, McpServerDefinition>
+        {
+            ["enabled-server"] = new() { Enabled = true },
+            ["disabled-server"] = new() { Enabled = false },
+        };
+        var aiConfig = new Mock<IOptionsMonitor<AIConfig>>();
+        aiConfig.Setup(m => m.CurrentValue).Returns(new AIConfig { McpServers = new McpServersConfig { Servers = servers } });
+        var sut = MakeSut(_ => true, aiConfig.Object);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        captured.Should().ContainSingle().Which.Should().Be("enabled-server");
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
@@ -1,0 +1,74 @@
+using Application.AI.Common.Interfaces.Plugins;
+using Domain.Common.Config.AI.Plugins;
+using FluentAssertions;
+using Infrastructure.AI.Plugins;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Plugins;
+
+/// <summary>
+/// #524: <see cref="PluginToolBoundaryStartupValidator"/> refuses to boot when
+/// <see cref="IPluginToolBoundaryTracker.Seed"/> reports an immediately-provable violation (a
+/// plugin with no MCP servers whose AllowedTools/DeniedTools entry matches no first-party tool).
+/// </summary>
+public sealed class PluginToolBoundaryStartupValidatorTests
+{
+    private readonly Mock<IPluginRegistry> _registry = new();
+    private readonly Mock<IPluginToolBoundaryTracker> _tracker = new();
+
+    private static LoadedPlugin MakePlugin(string name) =>
+        new(name, "1.0.0", $"/plugins/{name}", new PluginManifest { Name = name, Version = "1.0.0" },
+            PluginLoadStatus.Loaded, [], [], new PluginDeclaration { Name = name, DeniedTools = ["file_wrte"] });
+
+    private PluginToolBoundaryStartupValidator MakeSut(Func<string, bool> isKnownFirstPartyToolName) =>
+        new(_registry.Object, _tracker.Object, isKnownFirstPartyToolName,
+            NullLogger<PluginToolBoundaryStartupValidator>.Instance);
+
+    [Fact]
+    public async Task StartAsync_SeedReturnsNoViolations_DoesNotThrow()
+    {
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+            .Returns([]);
+        var sut = MakeSut(_ => true);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_SeedReturnsAnImmediateViolation_ThrowsNamingPluginAndTool()
+    {
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+            .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
+        var sut = MakeSut(_ => false);
+
+        var act = async () => await sut.StartAsync(CancellationToken.None);
+
+        (await act.Should().ThrowAsync<InvalidOperationException>())
+            .WithMessage("*azure*").WithMessage("*DeniedTools*").WithMessage("*file_wrte*");
+    }
+
+    [Fact]
+    public async Task StartAsync_OnlyPassesLoadedPluginsToSeed_ExcludingDisabledAndFailed()
+    {
+        var loaded = MakePlugin("azure");
+        var disabled = new LoadedPlugin("disabled-plugin", "", "/plugins/disabled",
+            new PluginManifest { Name = "disabled-plugin" }, PluginLoadStatus.Disabled, [], [],
+            new PluginDeclaration { Name = "disabled-plugin" });
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([loaded, disabled]);
+        IReadOnlyList<LoadedPlugin>? captured = null;
+        _tracker.Setup(t => t.Seed(It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>()))
+            .Callback<IReadOnlyList<LoadedPlugin>, Func<string, bool>>((plugins, _) => captured = plugins)
+            .Returns([]);
+        var sut = MakeSut(_ => true);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        captured.Should().ContainSingle().Which.Name.Should().Be("azure");
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
@@ -141,6 +141,14 @@ public sealed class PluginToolBoundaryStartupValidatorTests
             .Returns([]);
         _tracker.Setup(t => t.PendingServerNames).Returns(["server-a", "server-b"]);
 
+        // #524 round-3: the availability-poll grace period this test doesn't itself exercise needs
+        // IsServerAvailableAsync mocked too — an unconfigured Mock<T> method returns null for a
+        // Task<bool>, and awaiting null throws, which ResolveOneServerAsync's own catch swallows
+        // before ever reaching GetToolsAsync.
+        _toolProvider
+            .Setup(p => p.IsServerAvailableAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
         var queried = new ConcurrentBag<string>();
         var bothQueried = new TaskCompletionSource();
         _toolProvider
@@ -162,6 +170,42 @@ public sealed class PluginToolBoundaryStartupValidatorTests
     }
 
     [Fact]
+    public async Task StartAsync_SeedSucceeds_ServerNotYetAvailable_RetriesBeforeGivingUp()
+    {
+        // #524 round-3 code-review: a Stdio/spawned-process MCP server can genuinely take a few
+        // seconds to become reachable. Without this retry, the very first proactive probe racing a
+        // still-starting server would report failure and permanently fault a healthy plugin — the
+        // exact regression this fix closes. Proves GetToolsAsync isn't even attempted until
+        // IsServerAvailableAsync reports true.
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns([]);
+        _tracker.Setup(t => t.PendingServerNames).Returns(["server-a"]);
+
+        var availabilityCalls = 0;
+        var getToolsCalled = new TaskCompletionSource();
+        _toolProvider
+            .Setup(p => p.IsServerAvailableAsync("server-a", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => Interlocked.Increment(ref availabilityCalls) >= 3); // "Available" on the 3rd poll.
+        _toolProvider
+            .Setup(p => p.GetToolsAsync("server-a", It.IsAny<CancellationToken>()))
+            .Returns((string _, CancellationToken _) =>
+            {
+                getToolsCalled.TrySetResult();
+                return Task.FromResult<IList<AITool>>([]);
+            });
+        var sut = MakeSut(_ => true);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        await Task.WhenAny(getToolsCalled.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+        getToolsCalled.Task.IsCompletedSuccessfully.Should().BeTrue(
+            "GetToolsAsync must still be attempted once the server becomes available, not abandoned after the first failed poll");
+        availabilityCalls.Should().BeGreaterThanOrEqualTo(3);
+    }
+
+    [Fact]
     public async Task StartAsync_SeedSucceeds_DoesNotAwaitPendingServerResolutionBeforeReturning()
     {
         // The proactive query must be fire-and-forget — StartAsync blocking on live third-party MCP
@@ -172,6 +216,9 @@ public sealed class PluginToolBoundaryStartupValidatorTests
                 It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
             .Returns([]);
         _tracker.Setup(t => t.PendingServerNames).Returns(["server-a"]);
+        _toolProvider
+            .Setup(p => p.IsServerAvailableAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
         _toolProvider
             .Setup(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(new TaskCompletionSource<IList<AITool>>().Task); // Never completes.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
@@ -1,10 +1,12 @@
 using System.Collections.Concurrent;
+using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.Plugins;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.MCP;
 using Domain.Common.Config.AI.Plugins;
 using FluentAssertions;
 using Infrastructure.AI.Plugins;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -22,6 +24,17 @@ public sealed class PluginToolBoundaryStartupValidatorTests
 {
     private readonly Mock<IPluginRegistry> _registry = new();
     private readonly Mock<IPluginToolBoundaryTracker> _tracker = new();
+    private readonly Mock<IMcpToolProvider> _toolProvider = new();
+
+    public PluginToolBoundaryStartupValidatorTests()
+    {
+        // Every existing test cares only about Seed's own behavior, not proactive resolution — an
+        // unconfigured IReadOnlyCollection<string> property mock returns null, and this type's
+        // background-resolution foreach over it would NRE. Set here (constructor runs before every
+        // test method body) so a test that itself calls Setup(t => t.PendingServerNames) still wins —
+        // Moq's last-Setup-wins semantics means that must run AFTER this default, not before.
+        _tracker.Setup(t => t.PendingServerNames).Returns([]);
+    }
 
     private static LoadedPlugin MakePlugin(string name) =>
         new(name, "1.0.0", $"/plugins/{name}", new PluginManifest { Name = name, Version = "1.0.0" },
@@ -40,7 +53,7 @@ public sealed class PluginToolBoundaryStartupValidatorTests
     private PluginToolBoundaryStartupValidator MakeSut(
         Func<string, bool> isKnownFirstPartyToolName, IOptionsMonitor<AIConfig>? aiConfig = null) =>
         new(_registry.Object, _tracker.Object, isKnownFirstPartyToolName,
-            aiConfig ?? MakeAiConfig(), NullLogger<PluginToolBoundaryStartupValidator>.Instance);
+            aiConfig ?? MakeAiConfig(), _toolProvider.Object, NullLogger<PluginToolBoundaryStartupValidator>.Instance);
 
     [Fact]
     public async Task StartAsync_SeedReturnsNoViolations_DoesNotThrow()
@@ -114,5 +127,59 @@ public sealed class PluginToolBoundaryStartupValidatorTests
         await sut.StartAsync(CancellationToken.None);
 
         captured.Should().ContainSingle().Which.Should().Be("enabled-server");
+    }
+
+    [Fact]
+    public async Task StartAsync_SeedSucceeds_ProactivelyQueriesEveryPendingServerInBackground()
+    {
+        // #524 redesign: a plugin boundary entry left Pending after Seed must not wait for the
+        // running session to organically need that server — this validator queries it itself, right
+        // after boot, so the entry resolves promptly instead of staying denied indefinitely.
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns([]);
+        _tracker.Setup(t => t.PendingServerNames).Returns(["server-a", "server-b"]);
+
+        var queried = new ConcurrentBag<string>();
+        var bothQueried = new TaskCompletionSource();
+        _toolProvider
+            .Setup(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns((string serverName, CancellationToken _) =>
+            {
+                queried.Add(serverName);
+                if (queried.Count == 2)
+                    bothQueried.TrySetResult();
+                return Task.FromResult<IList<AITool>>([]);
+            });
+        var sut = MakeSut(_ => true);
+
+        await sut.StartAsync(CancellationToken.None);
+
+        // Fire-and-forget: bounded wait for the background tasks to actually run, not a blind sleep.
+        await Task.WhenAny(bothQueried.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+        queried.Should().BeEquivalentTo(["server-a", "server-b"]);
+    }
+
+    [Fact]
+    public async Task StartAsync_SeedSucceeds_DoesNotAwaitPendingServerResolutionBeforeReturning()
+    {
+        // The proactive query must be fire-and-forget — StartAsync blocking on live third-party MCP
+        // connectivity is exactly the boot-time coupling this type's own remarks say must never
+        // happen. A GetToolsAsync that never completes on its own must not stop StartAsync returning.
+        _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
+        _tracker.Setup(t => t.Seed(
+                It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
+            .Returns([]);
+        _tracker.Setup(t => t.PendingServerNames).Returns(["server-a"]);
+        _toolProvider
+            .Setup(p => p.GetToolsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(new TaskCompletionSource<IList<AITool>>().Task); // Never completes.
+        var sut = MakeSut(_ => true);
+
+        var startTask = sut.StartAsync(CancellationToken.None);
+
+        var completed = await Task.WhenAny(startTask, Task.Delay(TimeSpan.FromSeconds(2)));
+        completed.Should().Be(startTask, "StartAsync must not block on a proactive resolution that never completes");
     }
 }


### PR DESCRIPTION
## Summary

Closes #524. Supersedes the stale, unmerged #586 (Part A shipped in this same shape via that earlier PR; this PR is the full redesign following code-review's discovery of a real gap in that design).

A plugin's `AllowedTools`/`DeniedTools` declaration can name a tool that doesn't actually exist — a typo, most dangerously in `DeniedTools`, which is documented as bypass-immune. Before this PR, an unresolvable entry was a silent no-op. This PR:

- Adds a real three-state `PluginBoundaryStatus` (`Verified` / `Pending` / `Faulted`) instead of a boolean, so "still resolving" is never silently trusted the way it briefly could be — a plugin boundary that depends on an MCP server nothing organically queries no longer stays trusted forever.
- Verifies first-party entries at boot (cheap, no live connectivity needed) and resolves MCP-sourced entries lazily as servers are discovered, plus proactively at boot (bounded, fire-and-forget, never blocks host startup).
- Denies for `Pending` exactly like `Faulted` at the point tools are assembled (`ToolChainBuilder`), closing the trust window a review round found.
- Adds a second, independent enforcement path (`PluginPermissionRuleProvider`): when any plugin's boundary isn't `Verified`, every first-party tool is denied agent-wide, closing a gap where a corrupted `DeniedTools` entry meant to protect a *global* tool reachable through another skill was never checked by the tool-set filter alone.
- Fixes a second, independent identity-mismatch bug code-review found in the same area: the existence check and `ApplyPluginToolBoundary` were checking a plugin boundary entry against two different names for the same tool (its DI registration key vs. its self-reported published name) — a real, tested-elsewhere shape in this codebase where the two can legitimately disagree. Both now agree on the DI key.

This branch went through many review rounds (each round found and fixed a real issue — full history in the commit log). Follow-up issues filed for everything confirmed non-blocking or out of this PR's scope: #608, #610, #611, #612, #613, #614.

## Test plan

- [x] Full solution build + test suite, clean (`dotnet build && dotnet test` on `src/AgenticHarness.slnx`)
- [x] New regression tests added and mutation-tested (confirmed failing without each fix, passing with it) for every new guard condition
- [x] `run-gates.sh` (full gate set: build, test, owasp, docs-links, grader, correctness, security, docs-drift) — all passed
- [x] `/code-review` and `/simplify` — findings triaged, real ones fixed, rest filed as follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVKDxbkyu6kqeZd6qCLJM6