### PR TITLE
feat: wire real-time text + tool-call events onto AG-UI (M1 Section B0.4)

### DIFF
--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiEvents.cs
@@ -29,10 +29,12 @@ namespace Presentation.AgentHub.AgUi;
 [JsonDerivedType(typeof(TextMessageStartEvent), AgUiEventType.TextMessageStart)]
 [JsonDerivedType(typeof(TextMessageContentEvent), AgUiEventType.TextMessageContent)]
 [JsonDerivedType(typeof(TextMessageEndEvent), AgUiEventType.TextMessageEnd)]
-// Client round-trip tool calls (mid-run blocking proxy)
+// Client round-trip tool calls (mid-run blocking proxy) and server-executed tool call announcements
+// (both share the same Start/Args/End shape; only server-executed calls also emit a Result)
 [JsonDerivedType(typeof(ToolCallStartEvent), AgUiEventType.ToolCallStart)]
 [JsonDerivedType(typeof(ToolCallArgsEvent), AgUiEventType.ToolCallArgs)]
 [JsonDerivedType(typeof(ToolCallEndEvent), AgUiEventType.ToolCallEnd)]
+[JsonDerivedType(typeof(ToolCallResultEvent), AgUiEventType.ToolCallResult)]
 // Escalation
 [JsonDerivedType(typeof(EscalationRequestedEvent), AgUiEventType.EscalationRequested)]
 [JsonDerivedType(typeof(EscalationResolvedEvent), AgUiEventType.EscalationResolved)]

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiRunHandler.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using Application.AI.Common.Interfaces;
 using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.OpenTelemetry.Metrics;
+using Application.AI.Common.Services;
 using Application.Common.Exceptions.ExceptionTypes;
 using Application.Core.CQRS.Agents.ExecuteAgentTurn;
 using Domain.AI.Telemetry.Conventions;
@@ -25,8 +26,6 @@ namespace Presentation.AgentHub.AgUi;
 /// </remarks>
 public sealed class AgUiRunHandler
 {
-    private const int ChunkSize = 50;
-
     private readonly IMediator _mediator;
     private readonly IConversationStore _conversationStore;
     private readonly IObservabilityStore _observabilityStore;
@@ -338,6 +337,26 @@ public sealed class AgUiRunHandler
             ObservabilitySessionId = telemetry.SessionId,
         };
 
+        // Stream and persist the assistant response under a single stable id, generated before
+        // dispatch (not after, as this used to be) because the attached sink below needs it to tag
+        // TEXT_MESSAGE_CONTENT frames as they arrive mid-turn. The client references this id (via
+        // TEXT_MESSAGE_START) for retry-from-message, so the streamed id and the persisted id MUST
+        // match. TEXT_MESSAGE_START is NOT emitted here, deliberately: a turn that fails before any
+        // generation happens must produce only RUN_ERROR, never an empty, orphaned message frame —
+        // see AgUiTurnStreamSink.Started for how the message gets framed lazily instead.
+        var assistantId = Guid.NewGuid();
+        var messageId = assistantId.ToString();
+
+        // Attach a real streaming sink for the duration of this dispatch so
+        // ExecuteAgentTurnCommandHandler takes its streaming branch instead of the blocking one —
+        // this is what actually delivers on AG-UI's reason for existing (tool-call visibility, real
+        // token streaming), which nothing wired up before this. Restored in finally exactly like
+        // ConversationOrchestrator's own SignalR attach/restore, so a nested or subsequent dispatch
+        // on this async flow is unaffected.
+        var sink = new AgUiTurnStreamSink(writer, messageId);
+        var previousSink = AgentTurnStreamSink.Current;
+        AgentTurnStreamSink.Current = sink;
+
         AgentTurnResult result;
         try
         {
@@ -350,8 +369,14 @@ public sealed class AgUiRunHandler
         catch (Exception ex)
         {
             _logger.LogError(ex, "AG-UI run {RunId}: MediatR dispatch failed.", input.RunId);
+            if (sink.Started)
+                await writer.WriteAsync(new TextMessageEndEvent(messageId), ct);
             await writer.WriteAsync(new RunErrorEvent("An error occurred during agent execution."), ct);
             return;
+        }
+        finally
+        {
+            AgentTurnStreamSink.Current = previousSink;
         }
 
         if (!result.Success)
@@ -373,6 +398,8 @@ public sealed class AgUiRunHandler
                     ? result.Error!
                     : "The agent was unable to process your request.";
 
+            if (sink.Started)
+                await writer.WriteAsync(new TextMessageEndEvent(messageId), ct);
             await writer.WriteAsync(new RunErrorEvent(message), ct);
             return;
         }
@@ -400,23 +427,22 @@ public sealed class AgUiRunHandler
                 result.CostUsd, result.ToolsInvoked.Count, result.Model),
             ct);
 
-        // Stream and persist the assistant response under a single stable id. The client
-        // references this id (via TEXT_MESSAGE_START) for retry-from-message, so the streamed
-        // id and the persisted id MUST match. All TEXT_MESSAGE_* events for this message share it.
-        var assistantId = Guid.NewGuid();
-        var messageId = assistantId.ToString();
-        await writer.WriteAsync(new TextMessageStartEvent(messageId, "assistant"), ct);
-
         var response = result.Response;
-        for (var i = 0; i < response.Length; i += ChunkSize)
-        {
-            var chunk = response.Substring(i, Math.Min(ChunkSize, response.Length - i));
-            await writer.WriteAsync(new TextMessageContentEvent(messageId, chunk), ct);
-        }
 
+        // The common case: text already streamed to the client in real time via the sink attached
+        // above, so this just closes the message frame. The fallback covers a caller that never
+        // drove the sink in real time — a provider without streaming support, or a test double that
+        // returns a canned AgentTurnResult directly — by emitting the complete response as one frame,
+        // identical to this method's behavior before real streaming existed. Either way the client
+        // sees exactly one well-formed START/CONTENT*/END sequence for this messageId.
+        if (!sink.Started)
+        {
+            await writer.WriteAsync(new TextMessageStartEvent(messageId, "assistant"), ct);
+            if (!string.IsNullOrEmpty(response))
+                await writer.WriteAsync(new TextMessageContentEvent(messageId, response), ct);
+        }
         await writer.WriteAsync(new TextMessageEndEvent(messageId), ct);
 
-        // Persist the assistant response under the same id that was streamed to the client.
         var assistantMsg = new ConversationMessage(
             assistantId,
             MessageRole.Assistant,

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiToolCallEvents.cs
@@ -51,3 +51,22 @@ public sealed record ToolCallEndEvent(
     /// <summary>The tool call that has finished streaming arguments.</summary>
     [property: JsonPropertyName("toolCallId")] string ToolCallId
 ) : AgUiEvent;
+
+/// <summary>
+/// The result of a tool call the server executed itself (a normal MCP or local tool, as opposed to
+/// the mid-run client-round-trip flow the three events above exist for — that case's result arrives
+/// via the browser's own <c>POST /ag-ui/tool-result</c>, never as an event). Emitted once, after the
+/// matching <see cref="ToolCallEndEvent"/>, by a turn's attached streaming sink.
+/// </summary>
+public sealed record ToolCallResultEvent(
+    /// <summary>The tool call this result belongs to.</summary>
+    [property: JsonPropertyName("toolCallId")] string ToolCallId,
+    /// <summary>The tool's redacted output text, or empty when <see cref="Withheld"/> is true.</summary>
+    [property: JsonPropertyName("result")] string Result,
+    /// <summary>
+    /// <see langword="true"/> when the real result was withheld (oversized or unredactable) — see
+    /// <c>StreamedToolCallResult.Withheld</c> for the full contract. Never <see langword="false"/>,
+    /// so omitted from the wire on every normal frame.
+    /// </summary>
+    [property: JsonPropertyName("withheld")] bool? Withheld = null
+) : AgUiEvent;

--- a/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiTurnStreamSink.cs
+++ b/src/Content/Presentation/Presentation.AgentHub/AgUi/AgUiTurnStreamSink.cs
@@ -1,0 +1,87 @@
+using Application.AI.Common.Interfaces;
+
+namespace Presentation.AgentHub.AgUi;
+
+/// <summary>
+/// The <see cref="IAgentTurnStreamSink"/> an AG-UI run attaches for the duration of its dispatch,
+/// translating real text deltas and server-executed tool-call activity into AG-UI SSE events on
+/// that run's own <see cref="IAgUiEventWriter"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the piece that was missing for AG-UI to deliver on the reason it was chosen over the
+/// SignalR hub: <c>ConversationOrchestrator</c> (SignalR) already attaches an
+/// <c>AgentTurnStreamSink</c> for text but passes <c>null</c> for the tool-call callbacks, so it has
+/// always dropped tool visibility — the capability was never missing, only unused there. This type
+/// is the AG-UI transport's equivalent attachment, populating all three callbacks.
+/// </para>
+/// <para>
+/// Tool-call announcements reuse the same <see cref="ToolCallStartEvent"/>/<see cref="ToolCallArgsEvent"/>/
+/// <see cref="ToolCallEndEvent"/> sequence <c>AgUiClientToolBridge</c> uses for its own, unrelated
+/// mid-run client-round-trip case — the wire shape is identical; only the follow-up differs (a
+/// server-executed tool's actual output arrives here as <see cref="ToolCallResultEvent"/>, whereas a
+/// client-round-trip tool's result arrives out-of-band via <c>POST /ag-ui/tool-result</c>).
+/// </para>
+/// <para>
+/// <strong><see cref="Started"/> exists because TEXT_MESSAGE_START must never be sent for a turn
+/// that never produces a message.</strong> A turn that fails before any generation happens (a
+/// configuration error, a MediatR exception) must emit only RUN_ERROR — no orphaned, empty text
+/// message frame. This sink therefore starts the message lazily, on its first real delta, rather
+/// than the caller starting it unconditionally before dispatch; <see cref="Started"/> tells
+/// <c>AgUiRunHandler</c> whether that ever happened, so it knows whether to fall back to emitting
+/// the complete response as one frame (the pre-streaming behavior, still correct for any caller —
+/// including tests — that never drives this sink in real time) or whether the message was already
+/// framed as it streamed.
+/// </para>
+/// </remarks>
+internal sealed class AgUiTurnStreamSink : IAgentTurnStreamSink
+{
+    private readonly IAgUiEventWriter _writer;
+    private readonly string _messageId;
+    private bool _started;
+
+    /// <summary>Creates a sink writing events for the message <paramref name="messageId"/> onto <paramref name="writer"/>.</summary>
+    public AgUiTurnStreamSink(IAgUiEventWriter writer, string messageId)
+    {
+        _writer = writer;
+        _messageId = messageId;
+    }
+
+    /// <summary>
+    /// Whether this sink has emitted TEXT_MESSAGE_START — i.e. whether at least one real delta
+    /// streamed through it. The caller must emit TEXT_MESSAGE_END if and only if this is true by the
+    /// time it decides how to close out the message.
+    /// </summary>
+    public bool Started => _started;
+
+    /// <inheritdoc />
+    public async Task EmitAsync(string delta, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(delta))
+            return;
+
+        if (!_started)
+        {
+            _started = true;
+            await _writer.WriteAsync(new TextMessageStartEvent(_messageId, "assistant"), cancellationToken);
+        }
+
+        await _writer.WriteAsync(new TextMessageContentEvent(_messageId, delta), cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task EmitToolCallAsync(
+        string toolCallId, string toolCallName, StreamedToolCallArguments args, CancellationToken cancellationToken)
+    {
+        await _writer.WriteAsync(new ToolCallStartEvent(toolCallId, toolCallName), cancellationToken);
+        await _writer.WriteAsync(
+            new ToolCallArgsEvent(toolCallId, args.Json, args.Withheld ? true : null), cancellationToken);
+        await _writer.WriteAsync(new ToolCallEndEvent(toolCallId), cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task EmitToolCallResultAsync(
+        string toolCallId, StreamedToolCallResult result, CancellationToken cancellationToken) =>
+        _writer.WriteAsync(
+            new ToolCallResultEvent(toolCallId, result.Text, result.Withheld ? true : null), cancellationToken);
+}

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiRunHandlerTests.cs
@@ -759,6 +759,98 @@ public sealed class AgUiRunHandlerTests
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    /// <summary>
+    /// Proves the actual wiring this handler exists to provide, not just each piece in isolation:
+    /// <see cref="AgUiRunHandler"/> must attach a sink to <c>AgentTurnStreamSink.Current</c> *before*
+    /// dispatching, so that whatever runs inside the MediatR call — here, a mediator stand-in
+    /// driving the ambient sink directly, standing in for what
+    /// <c>ExecuteAgentTurnCommandHandler.RunStreamingTurnAsync</c> does for a real turn — reaches the
+    /// live SSE stream as real per-delta content and real tool-call events, not the finished
+    /// response chunked up after the fact. This is the specific capability the AG-UI protocol choice
+    /// was made for; a regression here silently turns AG-UI back into a thin text-only transport
+    /// indistinguishable from the SignalR hub it replaced.
+    /// </summary>
+    [Fact]
+    public async Task HandleRunAsync_MediatorDrivesAmbientSink_RealDeltasAndToolCallsReachTheStream()
+    {
+        const string threadId = "conv-streaming";
+        const string userId = "user-streaming";
+
+        var mediator = new Mock<IMediator>();
+        var store = new Mock<IConversationStore>();
+        var record = MakeRecord(threadId, userId);
+
+        store.Setup(s => s.GetAsync(threadId, userId, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(record);
+        store.Setup(s => s.GetHistoryForDispatch(threadId, userId, It.IsAny<int>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync([]);
+        store.Setup(s => s.AppendMessageAsync(threadId, userId, It.IsAny<ConversationMessage>(), It.IsAny<CancellationToken>()))
+             .Returns(Task.CompletedTask);
+
+        mediator
+            .Setup(m => m.Send(It.IsAny<ExecuteAgentTurnCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(async (ExecuteAgentTurnCommand _, CancellationToken ct) =>
+            {
+                // Stands in for RunStreamingTurnAsync: drives whatever sink the handler attached
+                // ambiently before calling Send, exactly as the real streaming loop would.
+                var sink = Application.AI.Common.Services.AgentTurnStreamSink.Current;
+                sink.Should().NotBeNull(
+                    "AgUiRunHandler must attach a sink before dispatch, or a real turn silently falls back to the blocking, tool-invisible path");
+
+                await sink!.EmitAsync("Let me check. ", ct);
+                await sink.EmitToolCallAsync(
+                    "call-1", "search_memory", new StreamedToolCallArguments("{\"q\":\"eyes\"}", false), ct);
+                await sink.EmitToolCallResultAsync(
+                    "call-1", new StreamedToolCallResult("green", false), ct);
+                await sink.EmitAsync("Green.", ct);
+
+                return MakeSuccessResult("Let me check. Green.");
+            });
+
+        var budget = new Mock<IConversationBudgetTracker>();
+        budget.Setup(b => b.GetStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ConversationBudgetStatus.Disabled);
+
+        var handler = BuildHandler(mediator, store, budget: budget);
+        var input = MakeInput(threadId, "Do you remember my eyes?");
+        var user = MakeUser(userId);
+
+        using var ms = new MemoryStream();
+        var writer = new AgUiEventWriter(ms);
+
+        await handler.HandleRunAsync(input, writer, user);
+
+        var frames = ParseSseFrames(ms);
+        var types = frames.Select(EventType).ToList();
+
+        types.Should().Equal(
+            AgUiEventType.RunStarted,
+            AgUiEventType.TextMessageStart,
+            AgUiEventType.TextMessageContent,
+            AgUiEventType.ToolCallStart,
+            AgUiEventType.ToolCallArgs,
+            AgUiEventType.ToolCallEnd,
+            AgUiEventType.ToolCallResult,
+            AgUiEventType.TextMessageContent,
+            AgUiEventType.TextMessageEnd,
+            AgUiEventType.RunFinished);
+
+        // The two content deltas arrived separately, not as one post-hoc chunk of the final response —
+        // this is the difference between real streaming and the artificial chunking it replaced.
+        var deltas = frames.Where(f => EventType(f) == AgUiEventType.TextMessageContent)
+            .Select(f => f.RootElement.GetProperty("delta").GetString())
+            .ToList();
+        deltas.Should().Equal("Let me check. ", "Green.");
+
+        var toolResult = frames.Single(f => EventType(f) == AgUiEventType.ToolCallResult);
+        toolResult.RootElement.GetProperty("toolCallId").GetString().Should().Be("call-1");
+        toolResult.RootElement.GetProperty("result").GetString().Should().Be("green");
+
+        // The ambient sink must be detached again once dispatch finishes, or a later turn on the same
+        // async flow would silently inherit this one's writer.
+        Application.AI.Common.Services.AgentTurnStreamSink.Current.Should().BeNull();
+    }
+
     [Fact]
     public async Task HandleRunAsync_ClientSuppliesUserMessageId_PersistsUserMessageUnderThatId()
     {

--- a/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiTurnStreamSinkTests.cs
+++ b/src/Content/Tests/Presentation.AgentHub.Tests/AgUi/AgUiTurnStreamSinkTests.cs
@@ -1,0 +1,154 @@
+using Application.AI.Common.Interfaces;
+using FluentAssertions;
+using Moq;
+using Presentation.AgentHub.AgUi;
+using Xunit;
+
+namespace Presentation.AgentHub.Tests.AgUi;
+
+/// <summary>
+/// Tests for <see cref="AgUiTurnStreamSink"/> — the translation from
+/// <see cref="IAgentTurnStreamSink"/> callbacks (real text deltas, tool calls, tool results) into
+/// AG-UI SSE events, and the lazy-start contract <see cref="AgUiRunHandler"/> depends on to avoid
+/// emitting an orphaned message frame for a turn that never generates anything.
+/// </summary>
+public sealed class AgUiTurnStreamSinkTests
+{
+    private const string MessageId = "msg-1";
+
+    private static (AgUiTurnStreamSink Sink, List<AgUiEvent> Written) Create()
+    {
+        var written = new List<AgUiEvent>();
+        var writer = new Mock<IAgUiEventWriter>();
+        writer.Setup(w => w.WriteAsync(It.IsAny<AgUiEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<AgUiEvent, CancellationToken>((evt, _) => written.Add(evt))
+            .Returns(Task.CompletedTask);
+        return (new AgUiTurnStreamSink(writer.Object, MessageId), written);
+    }
+
+    [Fact]
+    public void NoDeltaEmitted_StartedIsFalse()
+    {
+        var (sink, written) = Create();
+
+        sink.Started.Should().BeFalse();
+        written.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FirstDelta_EmitsStartThenContent_InThatOrder()
+    {
+        var (sink, written) = Create();
+
+        await sink.EmitAsync("Hello", CancellationToken.None);
+
+        sink.Started.Should().BeTrue();
+        written.Should().HaveCount(2);
+        written[0].Should().BeOfType<TextMessageStartEvent>()
+            .Which.Should().BeEquivalentTo(new TextMessageStartEvent(MessageId, "assistant"));
+        written[1].Should().BeOfType<TextMessageContentEvent>()
+            .Which.Should().BeEquivalentTo(new TextMessageContentEvent(MessageId, "Hello"));
+    }
+
+    [Fact]
+    public async Task SecondDelta_DoesNotRepeatStart()
+    {
+        var (sink, written) = Create();
+
+        await sink.EmitAsync("Hello", CancellationToken.None);
+        await sink.EmitAsync(" there", CancellationToken.None);
+
+        written.OfType<TextMessageStartEvent>().Should().HaveCount(1,
+            "TEXT_MESSAGE_START must appear exactly once per message, no matter how many deltas follow");
+        written.OfType<TextMessageContentEvent>().Select(e => e.Delta)
+            .Should().Equal("Hello", " there");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public async Task BlankDelta_ContributesNothing(string? delta)
+    {
+        var (sink, written) = Create();
+
+        await sink.EmitAsync(delta!, CancellationToken.None);
+
+        sink.Started.Should().BeFalse("an empty delta must not itself start the message");
+        written.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ToolCall_EmitsStartArgsEnd_InOrder_WithoutTouchingTextFraming()
+    {
+        var (sink, written) = Create();
+
+        await sink.EmitToolCallAsync(
+            "call-1", "search_memory", new StreamedToolCallArguments("{\"q\":\"green eyes\"}", false),
+            CancellationToken.None);
+
+        sink.Started.Should().BeFalse("a tool call alone must not start the text message frame");
+        written.Should().HaveCount(3);
+        written[0].Should().BeEquivalentTo(new ToolCallStartEvent("call-1", "search_memory"));
+        written[1].Should().BeEquivalentTo(new ToolCallArgsEvent("call-1", "{\"q\":\"green eyes\"}", null));
+        written[2].Should().BeEquivalentTo(new ToolCallEndEvent("call-1"));
+    }
+
+    [Fact]
+    public async Task ToolCall_WithheldArguments_ArgsEventCarriesWithheldTrue()
+    {
+        var (sink, written) = Create();
+
+        await sink.EmitToolCallAsync(
+            "call-1", "big_tool", new StreamedToolCallArguments("{}", true), CancellationToken.None);
+
+        written.OfType<ToolCallArgsEvent>().Single().Withheld.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ToolCallResult_EmitsToolCallResultEvent()
+    {
+        var (sink, written) = Create();
+
+        await sink.EmitToolCallResultAsync(
+            "call-1", new StreamedToolCallResult("42 memories found", false), CancellationToken.None);
+
+        written.Should().ContainSingle().Which.Should().BeEquivalentTo(
+            new ToolCallResultEvent("call-1", "42 memories found", null));
+    }
+
+    [Fact]
+    public async Task ToolCallResult_Withheld_CarriesEmptyTextAndWithheldTrue()
+    {
+        var (sink, written) = Create();
+
+        await sink.EmitToolCallResultAsync(
+            "call-1", new StreamedToolCallResult("", true), CancellationToken.None);
+
+        var evt = written.OfType<ToolCallResultEvent>().Single();
+        evt.Result.Should().BeEmpty();
+        evt.Withheld.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TextAndToolCallsInterleave_InCallOrder()
+    {
+        // A realistic turn: some text, then a tool call and its result, then more text.
+        var (sink, written) = Create();
+
+        await sink.EmitAsync("Let me check. ", CancellationToken.None);
+        await sink.EmitToolCallAsync(
+            "call-1", "search_memory", new StreamedToolCallArguments("{}", false), CancellationToken.None);
+        await sink.EmitToolCallResultAsync(
+            "call-1", new StreamedToolCallResult("found it", false), CancellationToken.None);
+        await sink.EmitAsync("Found it.", CancellationToken.None);
+
+        written.Select(e => e.GetType().Name).Should().Equal(
+            nameof(TextMessageStartEvent),
+            nameof(TextMessageContentEvent),
+            nameof(ToolCallStartEvent),
+            nameof(ToolCallArgsEvent),
+            nameof(ToolCallEndEvent),
+            nameof(ToolCallResultEvent),
+            nameof(TextMessageContentEvent));
+    }
+}


### PR DESCRIPTION
## Summary

AG-UI was chosen over the SignalR hub specifically because it can carry tool-call and
approval events, not just text — the audit-trail value the whole M1 migration is
justified on. Reading `AgUiRunHandler` closely showed that wiring was never actually
connected: it never attached a streaming sink before dispatch, so the handler always
took its blocking branch and the "streaming" text the client saw was the finished
response artificially cut into fixed-size chunks after the fact. Zero `TOOL_CALL_*`
events were ever emitted for a normal server-executed tool call — the one place they
do fire (`AgUiClientToolBridge`) is an unrelated mechanism for tools a *browser*
executes mid-run, not a server's own MCP/local tools.

## What changed

Pure wiring, not new machinery — everything needed already existed and is already
exercised by the SignalR path today (which attaches a sink for text but passes `null`
for the tool callbacks, which is why *it* drops tool events too; the capability was
never missing there either):

- New `AgUiTurnStreamSink` implements `IAgentTurnStreamSink`, translating real deltas
  into `TextMessageContentEvent` and tool-call activity into the same Start/Args/End
  sequence `AgUiClientToolBridge` already uses for its own case, plus a new
  `ToolCallResultEvent` (the `AgUiEventType.ToolCallResult` constant already existed,
  unused — the record was never written) for a server-executed tool's actual output.
- The message frame starts lazily, on the sink's first real delta, so a turn that
  fails before any generation happens still emits only `RUN_ERROR` — never an
  orphaned, empty `TEXT_MESSAGE_START`/`END` pair. `AgUiRunHandler` falls back to the
  old single-frame behavior only when nothing streamed in real time (a provider
  without streaming support, or a test double bypassing the real handler), so every
  caller still sees a well-formed message either way.
- `AgUiRunHandler` attaches the sink to `AgentTurnStreamSink.Current` before dispatch
  and restores it in `finally`, identical in shape to `ConversationOrchestrator`'s own
  SignalR attach/restore.

## Test plan

- [x] Full `Presentation.AgentHub.Tests` suite green (498 tests, 11 new).
- [x] New integration test drives the ambient sink from inside a mocked MediatR call
      — standing in for what `ExecuteAgentTurnCommandHandler`'s real streaming loop
      does — and asserts the resulting SSE stream shows real interleaved text and
      `TOOL_CALL_START`/`ARGS`/`END`/`RESULT` events, not one blob at the end.
- [x] Two pre-existing tests needed updating: the failure-path test's contract
      (`RUN_ERROR` must never come with an orphaned text message) is preserved
      exactly, and the happy-path test now exercises the fallback single-frame path
      since its mock doesn't drive real-time streaming — both still pass unchanged in
      what they assert, only in how the handler gets there.
- [ ] Not yet re-confirmed against a real, live Claude turn with a real tool call
      (the previous PR's live check covered per-turn context, not this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)