### PR TITLE
fix: close per-skill egress-scope gaps left by #531 (#589)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
+++ b/src/Content/Application/Application.AI.Common/Factories/AgentExecutionContextFactory.ContextProviders.cs
@@ -154,7 +154,9 @@ public partial class AgentExecutionContextFactory
         // rides along with.
         providers.Add(new Services.Agent.GoverningToolContextProvider(
             _loggerFactory.CreateLogger<Services.Agent.GoverningToolContextProvider>(),
-            _sanitizer));
+            _sanitizer,
+            disclosableSkills,
+            _serviceProvider.GetService<Interfaces.Skills.ICurrentSkillAccessor>()));
 
         AppendPerTurnBudgetProvider(providers, baseline);
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Skills/ICurrentSkillAccessor.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Skills/ICurrentSkillAccessor.cs
@@ -1,7 +1,7 @@
 namespace Application.AI.Common.Interfaces.Skills;
 
 /// <summary>
-/// Ambient accessor that exposes the identifier of the skill currently driving
+/// Ambient accessor that exposes the identifiers of the skill(s) currently driving
 /// the agent turn. Set by the skill-execution path when a skill activates,
 /// cleared when it deactivates. Consumed by per-skill policy resolvers (e.g.
 /// the egress allowlist resolver) that need to vary behavior by skill without
@@ -15,26 +15,34 @@ namespace Application.AI.Common.Interfaces.Skills;
 /// scope.
 /// </para>
 /// <para>
-/// A null value means "no skill active" — resolvers fall back to the
-/// harness-wide default policy. Implementations are thread-safe; concurrent
-/// agent turns running on different async contexts each see their own value.
+/// An empty list means "no skill active" — resolvers fall back to the
+/// harness-wide default policy. More than one id means the current tool call is
+/// shared by multiple skills (#589) — a policy resolver that varies by skill must
+/// union each named skill's own contribution rather than picking one. Implementations
+/// are thread-safe; concurrent agent turns running on different async contexts each
+/// see their own value.
 /// </para>
 /// </remarks>
 public interface ICurrentSkillAccessor
 {
     /// <summary>
-    /// Gets the identifier of the skill currently active on this async context,
-    /// or null when no skill scope has been established.
+    /// Gets the identifiers of the skill(s) currently active on this async context,
+    /// or an empty list when no skill scope has been established.
     /// </summary>
-    string? CurrentSkillId { get; }
+    IReadOnlyList<string> CurrentSkillIds { get; }
 
     /// <summary>
-    /// Establishes the supplied <paramref name="skillId"/> as the current skill
+    /// Establishes the supplied <paramref name="skillIds"/> as the current skill(s)
     /// for this async context until the returned token is disposed. Restores
     /// the previous value on disposal so nested skill activations compose.
     /// </summary>
-    /// <param name="skillId">The identifier of the skill to make current. Must not be null or whitespace.</param>
+    /// <param name="skillIds">
+    /// The identifier(s) of the skill(s) to make current. Must not be null or empty, and no entry
+    /// may be null or whitespace.
+    /// </param>
     /// <returns>A token that restores the previous current-skill value when disposed.</returns>
-    /// <exception cref="ArgumentException">The supplied <paramref name="skillId"/> is null, empty, or whitespace.</exception>
-    IDisposable BeginScope(string skillId);
+    /// <exception cref="ArgumentException">
+    /// <paramref name="skillIds"/> is null, empty, or contains a null/whitespace entry.
+    /// </exception>
+    IDisposable BeginScope(IReadOnlyList<string> skillIds);
 }

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -1,4 +1,6 @@
+using Application.AI.Common.Helpers;
 using Application.AI.Common.Interfaces.Governance;
+using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
 using Microsoft.Agents.AI;
@@ -91,6 +93,8 @@ public sealed class GoverningToolContextProvider : AIContextProvider
 
     private readonly ILogger<GoverningToolContextProvider> _logger;
     private readonly ICompositeResponseSanitizer _sanitizer;
+    private readonly ICurrentSkillAccessor? _currentSkillAccessor;
+    private readonly IReadOnlyDictionary<string, string>? _skillIdByFrameworkName;
 
     /// <summary>Initializes a new <see cref="GoverningToolContextProvider"/>.</summary>
     /// <param name="logger">Logger that receives reserved plan-capability collision reports.</param>
@@ -99,8 +103,22 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     /// provider exempts from <see cref="GovernedAIFunction"/> wrapping, and so also from #469's
     /// unconditional sanitize, since that guarantee is carried by the wrapper these two never receive.
     /// </param>
+    /// <param name="disclosableSkills">
+    /// The agent's own framework skills (#589), for attributing a <c>run_skill_script</c> call to the
+    /// harness skill it names — see <see cref="Govern"/>'s remarks. Null (or empty) means the agent
+    /// has no disclosable skills, or the caller does not have this list (e.g. tests); either way
+    /// <c>run_skill_script</c> falls back to no scope, unchanged from before this parameter existed.
+    /// </param>
+    /// <param name="currentSkillAccessor">
+    /// Establishes the ambient current skill for a <c>run_skill_script</c> call, resolved per call
+    /// from <paramref name="disclosableSkills"/> (#589) — see <see cref="Govern"/>'s remarks. Null has
+    /// the same "no scope to establish" effect as a null/empty <paramref name="disclosableSkills"/>.
+    /// </param>
     public GoverningToolContextProvider(
-        ILogger<GoverningToolContextProvider> logger, ICompositeResponseSanitizer sanitizer)
+        ILogger<GoverningToolContextProvider> logger,
+        ICompositeResponseSanitizer sanitizer,
+        IReadOnlyList<DisclosableSkill>? disclosableSkills = null,
+        ICurrentSkillAccessor? currentSkillAccessor = null)
         : base(
             provideInputMessageFilter: messages => messages,
             storeInputRequestMessageFilter: messages => messages,
@@ -108,6 +126,11 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     {
         _logger = logger;
         _sanitizer = sanitizer;
+        _currentSkillAccessor = currentSkillAccessor;
+        _skillIdByFrameworkName = disclosableSkills is { Count: > 0 }
+            ? disclosableSkills.ToDictionary(
+                s => s.Skill.Frontmatter.Name, s => s.SkillId, StringComparer.Ordinal)
+            : null;
     }
 
     /// <inheritdoc />
@@ -125,7 +148,7 @@ public sealed class GoverningToolContextProvider : AIContextProvider
         // every provider ahead of this one — then filter and wrap what it produced.
         var merged = await base.InvokingCoreAsync(context, cancellationToken).ConfigureAwait(false);
 
-        var tools = FilterAndGovern(merged.Tools, _logger, _sanitizer);
+        var tools = FilterAndGovern(merged.Tools, _logger, _sanitizer, _currentSkillAccessor, _skillIdByFrameworkName);
 
         // Nothing was dropped or needed wrapping — avoid allocating a new AIContext.
         if (tools is null)
@@ -148,8 +171,14 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     /// <param name="tools">The tools accumulated on the context, possibly null or empty.</param>
     /// <param name="logger">Logger that receives reserved plan-capability collision reports.</param>
     /// <param name="sanitizer">Passed through to <see cref="Govern"/> — see its remarks.</param>
+    /// <param name="currentSkillAccessor">Passed through to <see cref="Govern"/> — see its remarks.</param>
+    /// <param name="skillIdByFrameworkName">Passed through to <see cref="Govern"/> — see its remarks.</param>
     internal static List<AITool>? FilterAndGovern(
-        IEnumerable<AITool>? tools, ILogger logger, ICompositeResponseSanitizer sanitizer)
+        IEnumerable<AITool>? tools,
+        ILogger logger,
+        ICompositeResponseSanitizer sanitizer,
+        ICurrentSkillAccessor? currentSkillAccessor = null,
+        IReadOnlyDictionary<string, string>? skillIdByFrameworkName = null)
     {
         var original = tools?.ToList();
         if (original is null or { Count: 0 })
@@ -161,7 +190,7 @@ public sealed class GoverningToolContextProvider : AIContextProvider
 
         for (var i = 0; i < permitted.Count; i++)
         {
-            var governed = Govern(permitted[i], sanitizer);
+            var governed = Govern(permitted[i], sanitizer, currentSkillAccessor, skillIdByFrameworkName);
             if (!ReferenceEquals(governed, permitted[i]))
             {
                 permitted[i] = governed;
@@ -207,15 +236,64 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     /// deliberately <em>not</em> in that set and is fully governed here: executing a skill's script is a
     /// capability, and on a bundle run it is one the caller's envelope must grant.
     /// </para>
+    /// <para>
+    /// <strong><c>run_skill_script</c> resolves its skill scope per call, not at construction (#589).</strong>
+    /// The framework's <c>AgentSkillsProvider</c> publishes exactly one instance of this tool, shared by
+    /// every skill on the agent — the model tells it which skill's script to run via a <c>skillName</c>
+    /// argument (the framework's own kebab-case skill name, confirmed against the installed
+    /// <c>Microsoft.Agents.AI</c> package's <c>AgentSkillsProvider.RunSkillScriptAsync</c> signature),
+    /// not by which instance was invoked. There is no per-tool skill id to bake in the way
+    /// <see cref="ToolChainBuilder.WrapGoverned"/> does for a skill's own first-party/MCP tools, so this
+    /// wraps the tool with <see cref="GovernedAIFunction"/>'s <c>skillIdFromArguments</c> resolver
+    /// instead of a fixed id — it reads the actual call's <c>skillName</c> argument and maps it back to
+    /// the harness skill id via <paramref name="skillIdByFrameworkName"/>. Fails closed: a missing
+    /// argument or a name outside the map establishes no scope, the same as before this parameter
+    /// existed, never a wrong or stale skill's scope.
+    /// </para>
     /// </remarks>
-    internal static AITool Govern(AITool tool, ICompositeResponseSanitizer sanitizer)
+    internal static AITool Govern(
+        AITool tool,
+        ICompositeResponseSanitizer sanitizer,
+        ICurrentSkillAccessor? currentSkillAccessor = null,
+        IReadOnlyDictionary<string, string>? skillIdByFrameworkName = null)
     {
         if (tool is not AIFunction fn || tool is GovernedAIFunction || tool is SanitizingAIFunction)
             return tool;
 
-        return ToolPermissionFilter.SkillDisclosureToolNames.Contains(fn.Name)
-            ? new SanitizingAIFunction(fn, sanitizer)
-            : new GovernedAIFunction(fn);
+        if (ToolPermissionFilter.SkillDisclosureToolNames.Contains(fn.Name))
+            return new SanitizingAIFunction(fn, sanitizer);
+
+        if (fn.Name == AgentSkillsProvider.RunSkillScriptToolName && skillIdByFrameworkName is { Count: > 0 })
+        {
+            return new GovernedAIFunction(
+                fn,
+                currentSkillAccessor: currentSkillAccessor,
+                skillIdFromArguments: arguments => ResolveSkillIdFromArguments(arguments, skillIdByFrameworkName));
+        }
+
+        return new GovernedAIFunction(fn);
+    }
+
+    /// <summary>
+    /// Reads <c>run_skill_script</c>'s own <c>skillName</c> argument (the framework's parameter name)
+    /// and maps it back to the harness <see cref="Domain.AI.Skills.SkillDefinition.Id"/> that
+    /// contributed it, or <see langword="null"/> when the argument is missing or names a skill outside
+    /// <paramref name="skillIdByFrameworkName"/> — either way, no scope is established (#589's
+    /// fail-closed contract), never a guess.
+    /// </summary>
+    private static string? ResolveSkillIdFromArguments(
+        AIFunctionArguments arguments, IReadOnlyDictionary<string, string> skillIdByFrameworkName)
+    {
+        if (!arguments.TryGetValue("skillName", out var value))
+            return null;
+
+        // Mirrors GovernedAIFunction.ReadOperation: the framework's own pipeline supplies a
+        // JsonElement, but read defensively since arguments is a plain object? dictionary with no
+        // compile-time guarantee of that shape.
+        return ToolParameters.NormalizeScalar(value) is string frameworkName &&
+            skillIdByFrameworkName.TryGetValue(frameworkName, out var skillId)
+                ? skillId
+                : null;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -315,16 +315,10 @@ public sealed class GoverningToolContextProvider : AIContextProvider
     private static string? ResolveSkillIdFromArguments(
         AIFunctionArguments arguments, IReadOnlyDictionary<string, string> skillIdByFrameworkName)
     {
-        if (!arguments.TryGetValue("skillName", out var value))
-            return null;
-
-        // Mirrors GovernedAIFunction.ReadOperation: the framework's own pipeline supplies a
-        // JsonElement, but read defensively since arguments is a plain object? dictionary with no
-        // compile-time guarantee of that shape.
-        return ToolParameters.NormalizeScalar(value) is string frameworkName &&
-            skillIdByFrameworkName.TryGetValue(frameworkName, out var skillId)
-                ? skillId
-                : null;
+        var frameworkName = ToolParameters.ReadStringArgument(arguments, "skillName");
+        return frameworkName is not null && skillIdByFrameworkName.TryGetValue(frameworkName, out var skillId)
+            ? skillId
+            : null;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -32,16 +32,15 @@ namespace Application.AI.Common.Services.Agent;
 /// template other consumers extend, so it is written down rather than left implicit.
 /// </para>
 /// <para>
-/// <strong>Known limitation: no per-skill egress scope on this channel either (#531, tracked as #589).</strong> The
-/// same missing provenance that blocks MCP-failure normalization above also blocks
-/// <see cref="GovernedAIFunction"/>'s skill-scoped egress wiring: <see cref="Govern"/>'s
-/// <c>new GovernedAIFunction(fn)</c> call always passes a null skill id, so a tool reaching the model
-/// through this channel — <c>run_skill_script</c> notably, the one tool here that IS fully governed —
-/// runs with whatever skill scope (if any) happens to already be ambient from an outer call, never one
-/// attributed to the skill that actually contributed it. Fails closed (the egress resolver falls back
-/// to the harness-wide default allowlist), never open. Giving this channel real per-tool skill
-/// attribution is the same larger, separate change the MCP-provenance gap above already calls for —
-/// not something to bolt onto one tool here without doing it for the whole channel.
+/// <strong><c>run_skill_script</c> now resolves its skill scope per call (#531, #589).</strong> The
+/// same missing per-tool provenance that still blocks MCP-failure normalization above does NOT block
+/// this tool's egress scope any more: <see cref="Govern"/> wraps it with
+/// <see cref="GovernedAIFunction"/>'s <c>skillIdFromArguments</c> resolver, which reads the model's own
+/// <c>skillName</c> call argument and maps it back to the harness skill that contributed it — see
+/// <see cref="Govern"/>'s remarks for the mechanics. A missing or unrecognized <c>skillName</c> still
+/// fails closed to the harness-wide default allowlist, never a guess. The two other skill-disclosure
+/// tools (<c>load_skill</c>/<c>read_skill_resource</c>) are exempt from <see cref="GovernedAIFunction"/>
+/// entirely, so this does not apply to them — see the exemption rationale below.
 /// </para>
 /// <para>
 /// Register this provider <em>last</em> in the <c>AIContextProviders</c> list (after the skills
@@ -128,9 +127,38 @@ public sealed class GoverningToolContextProvider : AIContextProvider
         _sanitizer = sanitizer;
         _currentSkillAccessor = currentSkillAccessor;
         _skillIdByFrameworkName = disclosableSkills is { Count: > 0 }
-            ? disclosableSkills.ToDictionary(
-                s => s.Skill.Frontmatter.Name, s => s.SkillId, StringComparer.Ordinal)
+            ? BuildSkillIdByFrameworkName(disclosableSkills, logger)
             : null;
+    }
+
+    /// <summary>
+    /// First-wins map from a framework skill's <c>Frontmatter.Name</c> to the harness
+    /// <see cref="Domain.AI.Skills.SkillDefinition.Id"/> that built it. A plain
+    /// <c>ToDictionary</c> would throw on a duplicate name (code-review finding): today's only
+    /// caller, <c>DisclosableSkillFactory.Create</c>, already de-dupes with this exact comparer, so a
+    /// duplicate can't reach here in production — but this constructor is public on a template repo
+    /// other consumers clone and extend, and this diff's own contract everywhere else is fail-closed
+    /// (deny/no-scope), never an unhandled exception. A skipped duplicate keeps its own tool's scope
+    /// resolution behaving exactly as it would with an empty map — no scope, not a crash.
+    /// </summary>
+    private static Dictionary<string, string> BuildSkillIdByFrameworkName(
+        IReadOnlyList<DisclosableSkill> disclosableSkills, ILogger logger)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var skill in disclosableSkills)
+        {
+            var frameworkName = skill.Skill.Frontmatter.Name;
+            if (!map.TryAdd(frameworkName, skill.SkillId))
+            {
+                logger.LogWarning(
+                    "Skill {SkillId}: framework name '{FrameworkName}' already claimed by another " +
+                    "skill — run_skill_script calls naming it will resolve to whichever skill claimed " +
+                    "it first, not this one.",
+                    skill.SkillId, frameworkName);
+            }
+        }
+
+        return map;
     }
 
     /// <inheritdoc />

--- a/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Agent/GoverningToolContextProvider.cs
@@ -37,8 +37,11 @@ namespace Application.AI.Common.Services.Agent;
 /// this tool's egress scope any more: <see cref="Govern"/> wraps it with
 /// <see cref="GovernedAIFunction"/>'s <c>skillIdFromArguments</c> resolver, which reads the model's own
 /// <c>skillName</c> call argument and maps it back to the harness skill that contributed it — see
-/// <see cref="Govern"/>'s remarks for the mechanics. A missing or unrecognized <c>skillName</c> still
-/// fails closed to the harness-wide default allowlist, never a guess. The two other skill-disclosure
+/// <see cref="Govern"/>'s remarks for the mechanics. A missing or unrecognized <c>skillName</c>
+/// establishes no NEW scope — never a guess — which on this channel's actual call position means the
+/// harness-wide default allowlist applies, since nothing establishes an outer scope ahead of it here.
+/// That is a fact about where this tool sits on the rail today, not a guarantee this code itself makes;
+/// see <see cref="Govern"/>'s remarks for what "no scope" precisely means. The two other skill-disclosure
 /// tools (<c>load_skill</c>/<c>read_skill_resource</c>) are exempt from <see cref="GovernedAIFunction"/>
 /// entirely, so this does not apply to them — see the exemption rationale below.
 /// </para>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -58,7 +58,8 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
 
     private readonly ToolCompositionTaint? _compositionTaint;
     private readonly ICurrentSkillAccessor? _currentSkillAccessor;
-    private readonly string? _skillId;
+    private readonly IReadOnlyList<string>? _skillIds;
+    private readonly Func<AIFunctionArguments, string?>? _skillIdFromArguments;
 
     /// <param name="innerFunction">The tool function this wrapper governs.</param>
     /// <param name="compositionTaint">
@@ -66,26 +67,42 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     /// <see cref="ToolChainBuilder.ApplyCompositionTaint"/>.
     /// </param>
     /// <param name="currentSkillAccessor">
-    /// Establishes <paramref name="skillId"/> as the ambient current skill (#531) for the duration of
-    /// this call, so a per-skill policy resolver (the egress allowlist resolver) sees the right skill
-    /// without the caller threading it through every method. Null when this tool was not built from a
-    /// skill context (e.g. <c>ToolChainBuilder.BuildToolsByName</c>, used for delegated subagents) —
-    /// the call then runs with whatever skill scope, if any, is already ambient.
+    /// Establishes <paramref name="skillIds"/> (or <paramref name="skillIdFromArguments"/>'s result)
+    /// as the ambient current skill(s) (#531) for the duration of this call, so a per-skill policy
+    /// resolver (the egress allowlist resolver) sees the right skill(s) without the caller threading
+    /// it through every method. Null when this tool was not built from a skill context (e.g.
+    /// <c>ToolChainBuilder.BuildToolsByName</c>, used for delegated subagents) — the call then runs
+    /// with whatever skill scope, if any, is already ambient.
     /// </param>
-    /// <param name="skillId">
-    /// The id of the skill this tool was resolved for. Null has the same "no scope to establish"
-    /// effect as a null <paramref name="currentSkillAccessor"/>.
+    /// <param name="skillIds">
+    /// The id(s) of the skill(s) this tool was resolved for — more than one when two skills in a
+    /// merged agent share this tool's name (#589, the union case: see
+    /// <see cref="ToolChainBuilder.ProjectSurvivors"/>). Null or empty has the same "no scope to
+    /// establish" effect as a null <paramref name="currentSkillAccessor"/>. Mutually exclusive with
+    /// <paramref name="skillIdFromArguments"/> in practice — a tool either has a scope fixed at build
+    /// time or resolves one per call, never both; when both are supplied,
+    /// <paramref name="skillIdFromArguments"/> wins.
+    /// </param>
+    /// <param name="skillIdFromArguments">
+    /// Resolves the active skill from this call's own arguments instead of a scope fixed at build
+    /// time — needed when one tool instance is shared by every skill and the caller names which
+    /// skill it means as an argument (#589's <c>run_skill_script</c> case: the framework's
+    /// <c>AgentSkillsProvider</c> is a single agent-wide instance, not one per skill). A null or
+    /// blank result establishes no scope (fail-closed to the harness-wide default), never a wrong
+    /// or stale one.
     /// </param>
     public GovernedAIFunction(
         AIFunction innerFunction,
         ToolCompositionTaint? compositionTaint = null,
         ICurrentSkillAccessor? currentSkillAccessor = null,
-        string? skillId = null)
+        IReadOnlyList<string>? skillIds = null,
+        Func<AIFunctionArguments, string?>? skillIdFromArguments = null)
         : base(innerFunction)
     {
         _compositionTaint = compositionTaint;
         _currentSkillAccessor = currentSkillAccessor;
-        _skillId = skillId;
+        _skillIds = skillIds;
+        _skillIdFromArguments = skillIdFromArguments;
     }
 
     /// <summary>
@@ -99,14 +116,14 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     internal AIFunction Inner => InnerFunction;
 
     /// <summary>
-    /// The skill this tool was resolved for (#531), so <c>ToolChainBuilder.ApplyCompositionTaint</c>'s
+    /// The skill(s) this tool was resolved for (#531), so <c>ToolChainBuilder.ApplyCompositionTaint</c>'s
     /// re-wrap can carry it forward onto the new instance instead of silently losing the scope.
     /// </summary>
-    internal string? SkillId => _skillId;
+    internal IReadOnlyList<string>? SkillIds => _skillIds;
 
     /// <summary>
     /// The accessor supplied at construction, for the same re-wrap-forwarding reason as
-    /// <see cref="SkillId"/>.
+    /// <see cref="SkillIds"/>.
     /// </summary>
     internal ICurrentSkillAccessor? CurrentSkillAccessor => _currentSkillAccessor;
 
@@ -114,7 +131,7 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
         AIFunctionArguments arguments,
         CancellationToken cancellationToken)
     {
-        using var skillScope = BeginSkillScope();
+        using var skillScope = BeginSkillScope(arguments);
 
         var admissionPipeline = ToolAdmissionAccessor.Current;
         if (admissionPipeline is null)
@@ -183,13 +200,27 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     }
 
     /// <summary>
-    /// Establishes <see cref="_skillId"/> as the ambient current skill for this call's duration
-    /// (#531), or returns null (no-op scope) when either half is missing. Called once, wrapping the
-    /// whole method body, so both the early-return-no-admission-pipeline branch and the main path get
-    /// the same scope without duplicating the check.
+    /// Establishes the active skill(s) as the ambient current skill(s) for this call's duration
+    /// (#531), or returns null (no-op scope) when there is none to establish. Called once, wrapping
+    /// the whole method body, so both the early-return-no-admission-pipeline branch and the main path
+    /// get the same scope without duplicating the check.
     /// </summary>
-    private IDisposable? BeginSkillScope() =>
-        !string.IsNullOrWhiteSpace(_skillId) ? _currentSkillAccessor?.BeginScope(_skillId) : null;
+    /// <remarks>
+    /// <paramref name="arguments"/>-based resolution (<see cref="_skillIdFromArguments"/>) takes
+    /// priority when both it and <see cref="_skillIds"/> are supplied (#589): a tool that resolves its
+    /// skill per call is telling this wrapper it does not have one fixed scope to fall back to, so a
+    /// stale build-time id would be strictly worse than the per-call answer, never a useful fallback.
+    /// </remarks>
+    private IDisposable? BeginSkillScope(AIFunctionArguments arguments)
+    {
+        if (_skillIdFromArguments is not null)
+        {
+            var resolved = _skillIdFromArguments(arguments);
+            return !string.IsNullOrWhiteSpace(resolved) ? _currentSkillAccessor?.BeginScope([resolved]) : null;
+        }
+
+        return _skillIds is { Count: > 0 } ? _currentSkillAccessor?.BeginScope(_skillIds) : null;
+    }
 
     /// <summary>
     /// Extracts this call's requested paths/hosts (#418), when the wrapped function is a

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -88,8 +88,9 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     /// time — needed when one tool instance is shared by every skill and the caller names which
     /// skill it means as an argument (#589's <c>run_skill_script</c> case: the framework's
     /// <c>AgentSkillsProvider</c> is a single agent-wide instance, not one per skill). A null or
-    /// blank result establishes no scope (fail-closed to the harness-wide default), never a wrong
-    /// or stale one.
+    /// blank result establishes NO scope — this call runs with whatever scope, if any, is already
+    /// ambient from an outer call — never a wrong or stale one. Not the same claim as "falls back to
+    /// the harness-wide default": that only follows when nothing established an outer scope either.
     /// </param>
     public GovernedAIFunction(
         AIFunction innerFunction,

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -101,7 +101,10 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     {
         _compositionTaint = compositionTaint;
         _currentSkillAccessor = currentSkillAccessor;
-        _skillIds = skillIds;
+        // Filtered once here, not per call (#589 perf finding): _skillIds never changes after
+        // construction, so re-deriving "the non-blank ones" from scratch on every governed
+        // invocation — this class's hottest path — repeated work with a result fixed at build time.
+        _skillIds = skillIds?.Where(id => !string.IsNullOrWhiteSpace(id)).ToList();
         _skillIdFromArguments = skillIdFromArguments;
     }
 
@@ -219,15 +222,11 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
             return !string.IsNullOrWhiteSpace(resolved) ? _currentSkillAccessor?.BeginScope([resolved]) : null;
         }
 
-        if (_skillIds is not { Count: > 0 })
-            return null;
-
-        // The single-id predecessor of this method silently skipped a blank _skillId rather than
-        // handing it to BeginScope (which throws on one) — preserve that "a blank id means no scope
-        // for it" leniency here rather than letting Count > 0 alone wave a list containing one
-        // through to a throw (#589 correctness-review finding).
-        var nonBlankIds = _skillIds.Where(id => !string.IsNullOrWhiteSpace(id)).ToList();
-        return nonBlankIds.Count > 0 ? _currentSkillAccessor?.BeginScope(nonBlankIds) : null;
+        // _skillIds was already filtered to non-blank entries in the constructor (the single-id
+        // predecessor of this method silently skipped a blank id rather than handing it to
+        // BeginScope, which throws on one — the constructor-time filter preserves that leniency
+        // without re-deriving it here on every call).
+        return _skillIds is { Count: > 0 } ? _currentSkillAccessor?.BeginScope(_skillIds) : null;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -80,8 +80,9 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     /// <see cref="ToolChainBuilder.ProjectSurvivors"/>). Null or empty has the same "no scope to
     /// establish" effect as a null <paramref name="currentSkillAccessor"/>. Mutually exclusive with
     /// <paramref name="skillIdFromArguments"/> in practice — a tool either has a scope fixed at build
-    /// time or resolves one per call, never both; when both are supplied,
-    /// <paramref name="skillIdFromArguments"/> wins.
+    /// time or resolves one per call, never both. No production call site supplies both today; if one
+    /// ever did, <paramref name="skillIdFromArguments"/> is consulted first and this parameter is
+    /// never read — not a fallback contest where this list is tried second when the resolver misses.
     /// </param>
     /// <param name="skillIdFromArguments">
     /// Resolves the active skill from this call's own arguments instead of a scope fixed at build
@@ -257,16 +258,8 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
         return ResourceParameterExtractor.Extract(operation, parameters, resourceDeclaring.ResourceParametersByOperation);
     }
 
-    private static string? ReadOperation(AIFunctionArguments arguments)
-    {
-        if (!arguments.TryGetValue(AIToolConverter.OperationArgumentName, out var value))
-            return null;
-
-        // ToolParameters.NormalizeScalar unwraps a string-valued JsonElement; anything it doesn't
-        // return as a string (a CLR non-string, or a non-string JsonElement) falls out here as null,
-        // preserving this method's original three-arm behavior (#595).
-        return ToolParameters.NormalizeScalar(value) as string;
-    }
+    private static string? ReadOperation(AIFunctionArguments arguments) =>
+        ToolParameters.ReadStringArgument(arguments, AIToolConverter.OperationArgumentName);
 
     /// <summary>
     /// Reads the raw <c>parametersJson</c> argument, accepting both shapes <see cref="ReadOperation"/>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -219,7 +219,15 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
             return !string.IsNullOrWhiteSpace(resolved) ? _currentSkillAccessor?.BeginScope([resolved]) : null;
         }
 
-        return _skillIds is { Count: > 0 } ? _currentSkillAccessor?.BeginScope(_skillIds) : null;
+        if (_skillIds is not { Count: > 0 })
+            return null;
+
+        // The single-id predecessor of this method silently skipped a blank _skillId rather than
+        // handing it to BeginScope (which throws on one) — preserve that "a blank id means no scope
+        // for it" leniency here rather than letting Count > 0 alone wave a list containing one
+        // through to a throw (#589 correctness-review finding).
+        var nonBlankIds = _skillIds.Where(id => !string.IsNullOrWhiteSpace(id)).ToList();
+        return nonBlankIds.Count > 0 ? _currentSkillAccessor?.BeginScope(nonBlankIds) : null;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
@@ -204,6 +204,16 @@ public partial class ToolChainBuilder
     private static AITool UnionSkillScopeIfNeeded(
         AITool published, AITool candidate, ConcurrentDictionary<AITool, byte> callOnceCandidates)
     {
+        // Checked before the union-needed early return below, not only inside it (code-review
+        // finding: a skill that names the same tool via two of its own ToolDeclarations - same skill
+        // id on both, so the union branch never fires at all - could still have the DISCARDED
+        // candidate be the one call-once-tagged. Since `published` is what survives to
+        // RegisterSurvivingCallOnceTools either way, tag IT the moment either side was a candidate,
+        // independent of whether a union rewrap also happens.
+        var eitherWasCallOnceCandidate = callOnceCandidates.ContainsKey(published) || callOnceCandidates.ContainsKey(candidate);
+        if (eitherWasCallOnceCandidate)
+            callOnceCandidates.TryAdd(published, 0);
+
         if (published is not GovernedAIFunction publishedGoverned || candidate is not GovernedAIFunction candidateGoverned)
             return published;
 
@@ -220,7 +230,7 @@ public partial class ToolChainBuilder
         var rewrapped = new GovernedAIFunction(
             publishedGoverned.Inner, compositionTaint: null, publishedGoverned.CurrentSkillAccessor, union);
 
-        if (callOnceCandidates.ContainsKey(published) || callOnceCandidates.ContainsKey(candidate))
+        if (eitherWasCallOnceCandidate)
             callOnceCandidates.TryAdd(rewrapped, 0);
 
         return rewrapped;

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
@@ -117,21 +117,15 @@ public partial class ToolChainBuilder
     /// the same pass rather than re-derived by the caller.
     /// </summary>
     /// <remarks>
-    /// <strong>Known limitation: two skills sharing a first-party tool name pin the published
-    /// instance's per-skill egress scope (#531, tracked as #589) to whichever skill enumerated
-    /// first.</strong> Each
-    /// skill's tools are already wrapped as <see cref="GovernedAIFunction"/> — one <c>SkillId</c>
-    /// baked in per instance — before <paramref name="allProvisioned"/> reaches this method
-    /// (<c>BuildProvisionedToolsAsync</c>/<c>FinalizeChain</c> runs per skill, upstream). The
-    /// first-party dedup loop below (<c>seen.Add(p.Tool.Name)</c>) keeps only the first-enumerated
-    /// skill's instance, so a call to that shared tool always resolves the first skill's egress
-    /// allowlist, even during a turn the model is conceptually driving from the second skill. Not a
-    /// security hole — the resolved policy is still a real, valid skill's policy, never the harness
-    /// default's absence of one — but it can silently withhold a second skill's declared allowlist
-    /// addition for a tool the two skills happen to share by name. Fixing this precisely needs a
-    /// design decision this PR doesn't make: whether a shared tool name should union every
-    /// contributing skill's allowlist, or something else. Tracked for follow-up rather than guessed at
-    /// here.
+    /// <strong>Two skills sharing a first-party tool name union both skills' egress scope (#531,
+    /// #589).</strong> Each skill's tools are already wrapped as <see cref="GovernedAIFunction"/> —
+    /// one instance's <c>SkillIds</c> baked in per skill — before <paramref name="allProvisioned"/>
+    /// reaches this method (<c>BuildProvisionedToolsAsync</c>/<c>FinalizeChain</c> runs per skill,
+    /// upstream). The first-party dedup loop below detects a second skill sharing an already-published
+    /// name and re-wraps the published instance to carry the union of both skills' ids, rather than
+    /// silently keeping only whichever skill enumerated first — so a call to the shared tool resolves
+    /// an egress policy covering both skills' declared allowlists, regardless of which one the model
+    /// is conceptually driving the turn from.
     /// </remarks>
     private static (List<AITool> Tools, HashSet<string> McpAttributedNames) ProjectSurvivors(
         List<ProvisionedTool> allProvisioned,
@@ -139,7 +133,7 @@ public partial class ToolChainBuilder
         HashSet<string> survivingNames,
         HashSet<string> firstPartyNames)
     {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var indexByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var result = new List<AITool>();
 
         foreach (var p in allProvisioned)
@@ -148,8 +142,15 @@ public partial class ToolChainBuilder
                 continue;
             if (!survivingNames.Contains(p.Tool.Name))
                 continue;
-            if (seen.Add(p.Tool.Name))
+
+            if (!indexByName.TryGetValue(p.Tool.Name, out var existingIndex))
+            {
+                indexByName[p.Tool.Name] = result.Count;
                 result.Add(p.Tool);
+                continue;
+            }
+
+            result[existingIndex] = UnionSkillScopeIfNeeded(result[existingIndex], p.Tool);
         }
 
         var mcpAttributedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -160,7 +161,7 @@ public partial class ToolChainBuilder
             // first-party claim, and the first-party-wins policy above is already fully applied.
             if (!survivingNames.Contains(candidate.Tool.Name))
                 continue;
-            if (seen.Add(candidate.Tool.Name))
+            if (indexByName.TryAdd(candidate.Tool.Name, result.Count))
             {
                 result.Add(candidate.Tool);
                 mcpAttributedNames.Add(candidate.Tool.Name);
@@ -168,6 +169,39 @@ public partial class ToolChainBuilder
         }
 
         return (result, mcpAttributedNames);
+    }
+
+    /// <summary>
+    /// When two skills share a first-party tool name, unions the second skill's <see cref="GovernedAIFunction.SkillIds"/>
+    /// into the already-published instance instead of silently dropping them (#589). Re-wraps the same
+    /// way <see cref="ApplyCompositionTaint"/> does — unwrap to <see cref="GovernedAIFunction.Inner"/>,
+    /// rewrap with the combined scope — since this runs before that method, on tools with no
+    /// composition taint yet, so there is nothing else to preserve across the rewrap.
+    /// </summary>
+    /// <param name="published">The instance already added to the result list for this name.</param>
+    /// <param name="candidate">A later-enumerated skill's own instance of the same-named tool.</param>
+    /// <returns>
+    /// <paramref name="published"/> unchanged when either side isn't a <see cref="GovernedAIFunction"/>
+    /// or the candidate's skill ids are already fully covered by the published instance; otherwise a
+    /// new instance wrapping the same inner function with the union of both sides' skill ids.
+    /// </returns>
+    private static AITool UnionSkillScopeIfNeeded(AITool published, AITool candidate)
+    {
+        if (published is not GovernedAIFunction publishedGoverned || candidate is not GovernedAIFunction candidateGoverned)
+            return published;
+
+        var publishedIds = publishedGoverned.SkillIds ?? [];
+        var candidateIds = candidateGoverned.SkillIds ?? [];
+        if (candidateIds.Count == 0 || candidateIds.All(id => publishedIds.Contains(id, StringComparer.OrdinalIgnoreCase)))
+            return published;
+
+        var union = publishedIds
+            .Concat(candidateIds)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new GovernedAIFunction(
+            publishedGoverned.Inner, compositionTaint: null, publishedGoverned.CurrentSkillAccessor, union);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using Application.AI.Common.Helpers;
 using Application.AI.Common.OpenTelemetry.Metrics;
@@ -33,7 +34,8 @@ public partial class ToolChainBuilder
     /// make the two indistinguishable, because origin was recorded at resolution time, not
     /// reconstructed from what the tools say about themselves.
     /// </remarks>
-    private (List<AITool> Tools, HashSet<string> McpAttributedNames) ResolveSurvivingTools(List<ProvisionedTool> allProvisioned)
+    private (List<AITool> Tools, HashSet<string> McpAttributedNames) ResolveSurvivingTools(
+        List<ProvisionedTool> allProvisioned, ConcurrentDictionary<AITool, byte> callOnceCandidates)
     {
         var firstPartyNames = CollectFirstPartyNames(allProvisioned);
 
@@ -53,7 +55,7 @@ public partial class ToolChainBuilder
         else
             AddScannedMcpNames(mcpCandidates, survivingNames);
 
-        return ProjectSurvivors(allProvisioned, mcpCandidates, survivingNames, firstPartyNames);
+        return ProjectSurvivors(allProvisioned, mcpCandidates, survivingNames, firstPartyNames, callOnceCandidates);
     }
 
     private static HashSet<string> CollectFirstPartyNames(List<ProvisionedTool> allProvisioned)
@@ -125,13 +127,20 @@ public partial class ToolChainBuilder
     /// name and re-wraps the published instance to carry the union of both skills' ids, rather than
     /// silently keeping only whichever skill enumerated first — so a call to the shared tool resolves
     /// an egress policy covering both skills' declared allowlists, regardless of which one the model
-    /// is conceptually driving the turn from.
+    /// is conceptually driving the turn from. The re-wrap also carries <paramref name="callOnceCandidates"/>
+    /// forward onto the new instance — the same alias-preservation <see cref="WrapGoverned"/> already
+    /// does — because that set is keyed by reference identity
+    /// (<see cref="ReferenceEqualityComparer.Instance"/>): a re-wrap that produced a new,
+    /// never-tagged instance without this would silently drop a shared tool's
+    /// <c>CallOncePerConversation</c> restriction the moment two skills happened to share its name
+    /// (correctness/security review finding on this PR's own first draft).
     /// </remarks>
     private static (List<AITool> Tools, HashSet<string> McpAttributedNames) ProjectSurvivors(
         List<ProvisionedTool> allProvisioned,
         List<ProvisionedTool> mcpCandidates,
         HashSet<string> survivingNames,
-        HashSet<string> firstPartyNames)
+        HashSet<string> firstPartyNames,
+        ConcurrentDictionary<AITool, byte> callOnceCandidates)
     {
         var indexByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         var result = new List<AITool>();
@@ -150,7 +159,7 @@ public partial class ToolChainBuilder
                 continue;
             }
 
-            result[existingIndex] = UnionSkillScopeIfNeeded(result[existingIndex], p.Tool);
+            result[existingIndex] = UnionSkillScopeIfNeeded(result[existingIndex], p.Tool, callOnceCandidates);
         }
 
         var mcpAttributedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -180,12 +189,20 @@ public partial class ToolChainBuilder
     /// </summary>
     /// <param name="published">The instance already added to the result list for this name.</param>
     /// <param name="candidate">A later-enumerated skill's own instance of the same-named tool.</param>
+    /// <param name="callOnceCandidates">
+    /// The whole-agent-set call-once candidate tracker (#589 correctness/security review finding):
+    /// keyed by reference identity, so a re-wrap here that produced a new, untagged instance would
+    /// silently fall out of it, dropping a shared tool's <c>CallOncePerConversation</c> restriction
+    /// exactly the way <see cref="WrapGoverned"/>'s own alias-carry-forward comment already warns
+    /// about for its own re-wrap. If either side was tagged, the new instance is tagged too.
+    /// </param>
     /// <returns>
     /// <paramref name="published"/> unchanged when either side isn't a <see cref="GovernedAIFunction"/>
     /// or the candidate's skill ids are already fully covered by the published instance; otherwise a
     /// new instance wrapping the same inner function with the union of both sides' skill ids.
     /// </returns>
-    private static AITool UnionSkillScopeIfNeeded(AITool published, AITool candidate)
+    private static AITool UnionSkillScopeIfNeeded(
+        AITool published, AITool candidate, ConcurrentDictionary<AITool, byte> callOnceCandidates)
     {
         if (published is not GovernedAIFunction publishedGoverned || candidate is not GovernedAIFunction candidateGoverned)
             return published;
@@ -200,8 +217,13 @@ public partial class ToolChainBuilder
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        return new GovernedAIFunction(
+        var rewrapped = new GovernedAIFunction(
             publishedGoverned.Inner, compositionTaint: null, publishedGoverned.CurrentSkillAccessor, union);
+
+        if (callOnceCandidates.ContainsKey(published) || callOnceCandidates.ContainsKey(candidate))
+            callOnceCandidates.TryAdd(rewrapped, 0);
+
+        return rewrapped;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
@@ -45,7 +45,7 @@ public partial class ToolChainBuilder
         // independent first-occurrence picks (one for scanning, one for publishing) could otherwise
         // disagree if the same server was contacted twice within one build and returned a changed
         // definition in between the two calls.
-        var mcpCandidates = DeduplicateMcpCandidates(allProvisioned, firstPartyNames);
+        var mcpCandidates = DeduplicateMcpCandidates(allProvisioned, firstPartyNames, callOnceCandidates);
 
         var survivingNames = new HashSet<string>(firstPartyNames, StringComparer.OrdinalIgnoreCase);
 
@@ -74,6 +74,7 @@ public partial class ToolChainBuilder
     /// scanner or the published surface as an MCP entry).
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Grouped by (server, name) together — NOT by name alone, and NOT by a concatenated string key.
     /// Grouping by name alone would collapse two genuinely different servers' same-named tools down to a
     /// single candidate before the surface scanner ever saw more than one of them, silently discarding
@@ -81,14 +82,48 @@ public partial class ToolChainBuilder
     /// the same bug: server "trusted" + tool "reader" and server "trustedread" + tool "er" would hash
     /// identically. A tuple key compares both components independently, so no such collision is
     /// possible. Grouping still only removes true duplicates: the same server's tool recorded twice
-    /// because two different resolution paths reached it.
+    /// because two different resolution paths reached it — including two different skills each
+    /// declaring the SAME server/tool pair, which is exactly the case a bare "keep the first" pick
+    /// would have silently mishandled.
+    /// </para>
+    /// <para>
+    /// #589 code-review finding (second round): a bare <c>g.First()</c> here has the identical bug
+    /// the first-party dedup loop in <see cref="ProjectSurvivors"/> was fixed to avoid — each skill's
+    /// own <c>GovernedAIFunction</c> wrapper (with that skill's own <see cref="GovernedAIFunction.SkillIds"/>)
+    /// is already built by the time tools from multiple skills are pooled into <paramref name="allProvisioned"/>
+    /// here (<c>WrapGoverned</c>, via <c>FinalizeChain</c>, runs per skill upstream of this method), so
+    /// two skills naming the same MCP server/tool each produce their own independently-scoped instance.
+    /// Folding the group through <see cref="UnionSkillScopeIfNeeded"/> — the same primitive the
+    /// first-party loop uses — closes this the same way, rather than leaving the MCP source exempt from
+    /// a fix its own tool-source counterpart already received.
+    /// </para>
     /// </remarks>
-    private static List<ProvisionedTool> DeduplicateMcpCandidates(List<ProvisionedTool> allProvisioned, HashSet<string> firstPartyNames)
+    private static List<ProvisionedTool> DeduplicateMcpCandidates(
+        List<ProvisionedTool> allProvisioned, HashSet<string> firstPartyNames, ConcurrentDictionary<AITool, byte> callOnceCandidates)
         => allProvisioned
             .Where(p => p.McpServerName is not null && !firstPartyNames.Contains(p.Tool.Name))
             .GroupBy(p => (Server: p.McpServerName!.ToUpperInvariant(), Name: p.Tool.Name.ToUpperInvariant()))
-            .Select(g => g.First())
+            .Select(g => UnionMcpGroup(g, callOnceCandidates))
             .ToList();
+
+    /// <summary>
+    /// Folds every skill's independently-wrapped instance of the same (server, name) MCP tool into one
+    /// published <see cref="ProvisionedTool"/>, carrying the union of every instance's skill scope —
+    /// the MCP-source counterpart to <see cref="ProjectSurvivors"/>'s first-party dedup loop.
+    /// </summary>
+    private static ProvisionedTool UnionMcpGroup(
+        IEnumerable<ProvisionedTool> group, ConcurrentDictionary<AITool, byte> callOnceCandidates)
+    {
+        using var enumerator = group.GetEnumerator();
+        enumerator.MoveNext();
+        var canonical = enumerator.Current;
+        var unionedTool = canonical.Tool;
+
+        while (enumerator.MoveNext())
+            unionedTool = UnionSkillScopeIfNeeded(unionedTool, enumerator.Current.Tool, callOnceCandidates);
+
+        return canonical with { Tool = unionedTool };
+    }
 
     /// <summary>
     /// Runs the surface scanner over the canonical MCP candidate set and admits whatever the withhold
@@ -204,47 +239,46 @@ public partial class ToolChainBuilder
     private static AITool UnionSkillScopeIfNeeded(
         AITool published, AITool candidate, ConcurrentDictionary<AITool, byte> callOnceCandidates)
     {
-        // Computed once up front, but the actual TryAdd is deferred to whichever instance this
-        // method actually returns (code-simplifier: tagging `published` unconditionally here, then
-        // tagging `rewrapped` again below when a rewrap happens, left a stale-but-harmless entry for
-        // the discarded `published` instance — RegisterSurvivingCallOnceTools only reads tags for
-        // tools that make it into the final surface, so it was never a bug, just a wasted write).
-        // Still evaluated before the union-needed check below, not only inside it (code-review
-        // finding: a skill that names the same tool via two of its own ToolDeclarations - same skill
-        // id on both, so the union branch never fires at all - could still have the DISCARDED
-        // candidate be the one call-once-tagged. Since `published` is what survives to
-        // RegisterSurvivingCallOnceTools either way, tag whichever instance is actually returned the
-        // moment either side was a candidate, independent of whether a union rewrap also happens.
+        // Evaluated up front, on the two ORIGINAL instances, not on whatever ResolveUnion returns —
+        // a skill that names the same tool via two of its own ToolDeclarations (same skill id on
+        // both) never triggers a rewrap at all, so the DISCARDED candidate could still have been the
+        // one call-once-tagged. Since `published` is what survives to RegisterSurvivingCallOnceTools
+        // either way (a rewrap or not), tag whichever instance ResolveUnion actually returns, exactly
+        // once, right here — not once per return branch inside it (code-simplifier: an earlier version
+        // repeated the identical tag-then-return pair in all three of ResolveUnion's branches instead
+        // of tagging the one result this method actually produces).
         var eitherWasCallOnceCandidate = callOnceCandidates.ContainsKey(published) || callOnceCandidates.ContainsKey(candidate);
+        var result = ResolveUnion(published, candidate);
 
+        if (eitherWasCallOnceCandidate)
+            callOnceCandidates.TryAdd(result, 0);
+
+        return result;
+    }
+
+    /// <summary>
+    /// The pure "what tool should this name now publish as" decision behind
+    /// <see cref="UnionSkillScopeIfNeeded"/>, with no side effects of its own — <em>every</em> return
+    /// here is a candidate for <see cref="UnionSkillScopeIfNeeded"/>'s single call-once tag, so this
+    /// method must never tag anything itself.
+    /// </summary>
+    private static AITool ResolveUnion(AITool published, AITool candidate)
+    {
         if (published is not GovernedAIFunction publishedGoverned || candidate is not GovernedAIFunction candidateGoverned)
-        {
-            if (eitherWasCallOnceCandidate)
-                callOnceCandidates.TryAdd(published, 0);
             return published;
-        }
 
         var publishedIds = publishedGoverned.SkillIds ?? [];
         var candidateIds = candidateGoverned.SkillIds ?? [];
         if (candidateIds.Count == 0 || candidateIds.All(id => publishedIds.Contains(id, StringComparer.OrdinalIgnoreCase)))
-        {
-            if (eitherWasCallOnceCandidate)
-                callOnceCandidates.TryAdd(published, 0);
             return published;
-        }
 
         var union = publishedIds
             .Concat(candidateIds)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        var rewrapped = new GovernedAIFunction(
+        return new GovernedAIFunction(
             publishedGoverned.Inner, compositionTaint: null, publishedGoverned.CurrentSkillAccessor, union);
-
-        if (eitherWasCallOnceCandidate)
-            callOnceCandidates.TryAdd(rewrapped, 0);
-
-        return rewrapped;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
@@ -204,23 +204,34 @@ public partial class ToolChainBuilder
     private static AITool UnionSkillScopeIfNeeded(
         AITool published, AITool candidate, ConcurrentDictionary<AITool, byte> callOnceCandidates)
     {
-        // Checked before the union-needed early return below, not only inside it (code-review
+        // Computed once up front, but the actual TryAdd is deferred to whichever instance this
+        // method actually returns (code-simplifier: tagging `published` unconditionally here, then
+        // tagging `rewrapped` again below when a rewrap happens, left a stale-but-harmless entry for
+        // the discarded `published` instance — RegisterSurvivingCallOnceTools only reads tags for
+        // tools that make it into the final surface, so it was never a bug, just a wasted write).
+        // Still evaluated before the union-needed check below, not only inside it (code-review
         // finding: a skill that names the same tool via two of its own ToolDeclarations - same skill
         // id on both, so the union branch never fires at all - could still have the DISCARDED
         // candidate be the one call-once-tagged. Since `published` is what survives to
-        // RegisterSurvivingCallOnceTools either way, tag IT the moment either side was a candidate,
-        // independent of whether a union rewrap also happens.
+        // RegisterSurvivingCallOnceTools either way, tag whichever instance is actually returned the
+        // moment either side was a candidate, independent of whether a union rewrap also happens.
         var eitherWasCallOnceCandidate = callOnceCandidates.ContainsKey(published) || callOnceCandidates.ContainsKey(candidate);
-        if (eitherWasCallOnceCandidate)
-            callOnceCandidates.TryAdd(published, 0);
 
         if (published is not GovernedAIFunction publishedGoverned || candidate is not GovernedAIFunction candidateGoverned)
+        {
+            if (eitherWasCallOnceCandidate)
+                callOnceCandidates.TryAdd(published, 0);
             return published;
+        }
 
         var publishedIds = publishedGoverned.SkillIds ?? [];
         var candidateIds = candidateGoverned.SkillIds ?? [];
         if (candidateIds.Count == 0 || candidateIds.All(id => publishedIds.Contains(id, StringComparer.OrdinalIgnoreCase)))
+        {
+            if (eitherWasCallOnceCandidate)
+                callOnceCandidates.TryAdd(published, 0);
             return published;
+        }
 
         var union = publishedIds
             .Concat(candidateIds)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -105,7 +105,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
     {
         var callOnceCandidates = new ConcurrentDictionary<AITool, byte>(ReferenceEqualityComparer.Instance);
         var provisioned = await BuildProvisionedToolsAsync(skill, options, callOnceCandidates, cancellationToken);
-        var (tools, _) = ResolveSurvivingTools(provisioned);
+        var (tools, _) = ResolveSurvivingTools(provisioned, callOnceCandidates);
 
         // Registration happens here, against the truly final published surface — the point at which
         // every filter (plugin boundary, reserved-capability, first-party/cross-server precedence,
@@ -447,7 +447,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
             allProvisioned.AddRange(skillTools);
         }
 
-        var (deduplicated, attributedMcp) = ResolveSurvivingTools(allProvisioned);
+        var (deduplicated, attributedMcp) = ResolveSurvivingTools(allProvisioned, callOnceCandidates);
 
         // A null allowlist means no restriction; a non-null one is an active restriction that keeps
         // only the listed tools — an empty (but non-null) list therefore denies every tool, which is

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -387,7 +387,8 @@ public partial class ToolChainBuilder : IToolChainBuilder
             var wrapped = p.Tool is AIFunction fn and not GovernedAIFunction
                 ? new GovernedAIFunction(
                     p.McpServerName is not null ? new McpFailureNormalizingAIFunction(fn) : fn,
-                    currentSkillAccessor: currentSkillAccessor, skillId: p.SkillId)
+                    currentSkillAccessor: currentSkillAccessor,
+                    skillIds: p.SkillId is not null ? [p.SkillId] : null)
                 : p.Tool;
 
             if (callOnceCandidates is not null && callOnceCandidates.ContainsKey(p.Tool))
@@ -541,12 +542,12 @@ public partial class ToolChainBuilder : IToolChainBuilder
             // rewrapping — never double-governing, since InnerFunction always points at the real tool.
             // governed.Inner already carries any McpFailureNormalizingAIFunction wrapping intact —
             // there is no separate provenance flag left to forward. governed.CurrentSkillAccessor/
-            // SkillId (#531) DO need forwarding explicitly — unlike Inner, they are not implicit in
-            // the wrapped function, so a re-wrap that forgot them would silently drop the tool's skill
-            // scope the moment a composition finding implicates it.
+            // SkillIds (#531/#589) DO need forwarding explicitly — unlike Inner, they are not implicit
+            // in the wrapped function, so a re-wrap that forgot them would silently drop the tool's
+            // skill scope the moment a composition finding implicates it.
             return (AITool)new GovernedAIFunction(
                 governed.Inner, new ToolCompositionTaint(findings),
-                governed.CurrentSkillAccessor, governed.SkillId);
+                governed.CurrentSkillAccessor, governed.SkillIds);
         }).ToList();
     }
 

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolParameters.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.Extensions.AI;
 
 namespace Application.AI.Common.Services.Tools;
 
@@ -199,6 +200,26 @@ public static class ToolParameters
         var normalized = NormalizeScalar(value);
         return normalized is JsonElement je ? je.GetRawText() : normalized;
     }
+
+    /// <summary>
+    /// Reads one string-valued argument from a tool's <see cref="AIFunctionArguments"/>, applying the
+    /// same string-unwrap rule as <see cref="NormalizeScalar"/>.
+    /// </summary>
+    /// <remarks>
+    /// Extracted (#589 code-review) from two independent copies of the identical "TryGetValue then
+    /// unwrap" sequence — <c>GovernedAIFunction.ReadOperation</c> and
+    /// <c>GoverningToolContextProvider.ResolveSkillIdFromArguments</c> — each reading a
+    /// differently-named argument but otherwise doing the same two steps.
+    /// </remarks>
+    /// <param name="arguments">The tool call's arguments.</param>
+    /// <param name="key">The argument name to look up.</param>
+    /// <returns>
+    /// The unwrapped string when <paramref name="key"/> is present and resolves to one via
+    /// <see cref="NormalizeScalar"/>; otherwise <see langword="null"/> — the key is absent, or its
+    /// value is a CLR non-string or a non-string <see cref="JsonElement"/>.
+    /// </returns>
+    public static string? ReadStringArgument(AIFunctionArguments arguments, string key) =>
+        arguments.TryGetValue(key, out var value) ? NormalizeScalar(value) as string : null;
 
     /// <summary>
     /// The shared answer for "no parameters". A fresh dictionary per call would allocate on the

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
@@ -91,14 +91,33 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         _noSkillPolicy = new Lazy<IEgressPolicy>(BuildDefaultOnlyPolicy);
     }
 
+    // Separator between skill ids in a composite multi-skill cache key. A skill id is validated
+    // kebab-case elsewhere in this harness, so U+0001 (a control character no legitimate skill id
+    // can contain) cannot collide with a real id the way a printable separator like ',' could if a
+    // skill id ever legitimately contained one.
+    private const char CompositeKeySeparator = '';
+
     /// <inheritdoc />
     public IEgressPolicy ResolveFor(AgentIdentity identity)
     {
         ArgumentNullException.ThrowIfNull(identity);
 
-        var skillId = _currentSkill.CurrentSkillId;
-        return skillId is null ? _noSkillPolicy.Value : _skillCache.GetOrAdd(skillId, BuildPolicyForSkill);
+        var skillIds = _currentSkill.CurrentSkillIds;
+        return skillIds.Count switch
+        {
+            0 => _noSkillPolicy.Value,
+            1 => _skillCache.GetOrAdd(skillIds[0], BuildPolicyForSkill),
+            _ => _skillCache.GetOrAdd(CompositeKey(skillIds), _ => BuildPolicyForSkills(skillIds)),
+        };
     }
+
+    /// <summary>
+    /// A cache key for a multi-skill scope (#589) that cannot collide with any single skill id —
+    /// every single-id key is a bare skill id with no <see cref="CompositeKeySeparator"/> in it, so a
+    /// key containing that separator can never equal one.
+    /// </summary>
+    private static string CompositeKey(IReadOnlyList<string> skillIds) =>
+        string.Join(CompositeKeySeparator, skillIds.OrderBy(id => id, StringComparer.OrdinalIgnoreCase));
 
     private IEgressPolicy BuildDefaultOnlyPolicy()
     {
@@ -109,17 +128,7 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     private IEgressPolicy BuildPolicyForSkill(string key)
     {
         var defaultEntries = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
-
-        var skill = _skillRegistry.TryGet(key);
-        if (skill is null)
-        {
-            _logger.LogWarning(
-                "Egress policy lookup for unknown skill '{SkillId}' — falling back to harness-wide default.",
-                key);
-            return new DefaultEgressPolicy(defaultEntries, _policyLogger, _timeProvider);
-        }
-
-        var perSkill = skill.Egress?.Allowlist ?? [];
+        var perSkill = SkillAllowlistEntries(key);
         if (perSkill.Count == 0)
         {
             // Skill has no additions — reuse the default-only policy shape.
@@ -137,5 +146,50 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
             key, defaultEntries.Count, perSkill.Count);
 
         return new DefaultEgressPolicy(merged, _policyLogger, _timeProvider);
+    }
+
+    /// <summary>
+    /// The multi-skill counterpart of <see cref="BuildPolicyForSkill"/> (#589): default entries plus
+    /// EVERY named skill's own allowlist additions, unioned. A tool name shared by two skills must
+    /// resolve at least as broad an allowlist as either skill would grant it alone — this is the same
+    /// additive contract <see cref="BuildPolicyForSkill"/> already applies to a single skill, extended
+    /// to more than one active at once.
+    /// </summary>
+    private IEgressPolicy BuildPolicyForSkills(IReadOnlyList<string> skillIds)
+    {
+        var defaultEntries = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
+
+        var merged = new List<EgressAllowlistEntry>(defaultEntries);
+        foreach (var skillId in skillIds)
+            merged.AddRange(SkillAllowlistEntries(skillId));
+
+        if (merged.Count == defaultEntries.Count)
+            return new DefaultEgressPolicy(defaultEntries, _policyLogger, _timeProvider);
+
+        _logger.LogDebug(
+            "Built union egress policy for skills '{SkillIds}': {DefaultCount} default + {MergedCount} " +
+            "combined per-skill entries.",
+            string.Join(", ", skillIds), defaultEntries.Count, merged.Count - defaultEntries.Count);
+
+        return new DefaultEgressPolicy(merged, _policyLogger, _timeProvider);
+    }
+
+    /// <summary>
+    /// One skill's own manifest allowlist entries — empty when the skill is unknown (logged) or
+    /// declares none. Shared by the single- and multi-skill resolve paths so the lookup and the
+    /// unknown-skill warning are written once.
+    /// </summary>
+    private IReadOnlyList<EgressAllowlistEntry> SkillAllowlistEntries(string skillId)
+    {
+        var skill = _skillRegistry.TryGet(skillId);
+        if (skill is null)
+        {
+            _logger.LogWarning(
+                "Egress policy lookup for unknown skill '{SkillId}' — no per-skill entries contributed.",
+                skillId);
+            return [];
+        }
+
+        return skill.Egress?.Allowlist ?? [];
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
@@ -113,6 +113,13 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     /// Order-independent, case-insensitive structural equality over a skill-id list — what makes
     /// <see cref="_skillCache"/> safe to key directly on the list rather than on an encoded string.
     /// </summary>
+    /// <remarks>
+    /// Single-element lists get a dedicated O(1) path in both members (#589 code-review, second
+    /// round): a single active skill is the overwhelming common case — <see cref="ResolveFor"/> runs
+    /// on every governed outbound HTTP request — and the general path's <c>OrderBy</c> sort is pure
+    /// overhead when there is nothing to order. This restores, for that case, the same cost the old
+    /// design's separate bare-string single-skill cache had before the two caches were merged.
+    /// </remarks>
     private sealed class SkillIdListComparer : IEqualityComparer<IReadOnlyList<string>>
     {
         public static readonly SkillIdListComparer Instance = new();
@@ -123,6 +130,8 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
                 return true;
             if (x is null || y is null || x.Count != y.Count)
                 return false;
+            if (x.Count == 1)
+                return string.Equals(x[0], y[0], StringComparison.OrdinalIgnoreCase);
 
             return x.OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
                 .SequenceEqual(y.OrderBy(id => id, StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
@@ -130,6 +139,9 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
 
         public int GetHashCode(IReadOnlyList<string> obj)
         {
+            if (obj.Count == 1)
+                return StringComparer.OrdinalIgnoreCase.GetHashCode(obj[0]);
+
             var hash = new HashCode();
             foreach (var id in obj.OrderBy(id => id, StringComparer.OrdinalIgnoreCase))
                 hash.Add(id, StringComparer.OrdinalIgnoreCase);

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
@@ -66,6 +66,14 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     private readonly Lazy<IEgressPolicy> _noSkillPolicy;
     private readonly ConcurrentDictionary<string, IEgressPolicy> _skillCache = new(StringComparer.OrdinalIgnoreCase);
 
+    // A separate cache, not a composite key sharing _skillCache's key space (#589 security-review
+    // finding): the composite key's own U+0001-cannot-collide argument rests on an unverified claim
+    // ("a skill id is validated kebab-case elsewhere") that no validator in this codebase actually
+    // enforces — the same class of mistake the two-cache split above was already introduced to
+    // eliminate for the no-skill/single-skill boundary. A separate dictionary removes the whole
+    // collision class rather than resting on an id-shape assumption a future caller could violate.
+    private readonly ConcurrentDictionary<string, IEgressPolicy> _multiSkillCache = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>Initializes a new <see cref="SkillManifestEgressPolicyResolver"/>.</summary>
     public SkillManifestEgressPolicyResolver(
         ICurrentSkillAccessor currentSkill,
@@ -91,10 +99,10 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         _noSkillPolicy = new Lazy<IEgressPolicy>(BuildDefaultOnlyPolicy);
     }
 
-    // Separator between skill ids in a composite multi-skill cache key. A skill id is validated
-    // kebab-case elsewhere in this harness, so U+0001 (a control character no legitimate skill id
-    // can contain) cannot collide with a real id the way a printable separator like ',' could if a
-    // skill id ever legitimately contained one.
+    // Separator joining skill ids into a multi-skill cache key. Only has to be deterministic within
+    // _multiSkillCache's own key space — unlike a composite key sharing _skillCache with bare
+    // single-skill ids, there is no cross-cache collision to defend against, so no claim about what
+    // characters a skill id can or can't contain is load-bearing here.
     private const char CompositeKeySeparator = '';
 
     /// <inheritdoc />
@@ -107,14 +115,13 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         {
             0 => _noSkillPolicy.Value,
             1 => _skillCache.GetOrAdd(skillIds[0], BuildPolicyForSkill),
-            _ => _skillCache.GetOrAdd(CompositeKey(skillIds), _ => BuildPolicyForSkills(skillIds)),
+            _ => _multiSkillCache.GetOrAdd(CompositeKey(skillIds), _ => BuildPolicyForSkills(skillIds)),
         };
     }
 
     /// <summary>
-    /// A cache key for a multi-skill scope (#589) that cannot collide with any single skill id —
-    /// every single-id key is a bare skill id with no <see cref="CompositeKeySeparator"/> in it, so a
-    /// key containing that separator can never equal one.
+    /// A deterministic cache key for a multi-skill scope (#589), for <see cref="_multiSkillCache"/>'s
+    /// own key space only.
     /// </summary>
     private static string CompositeKey(IReadOnlyList<string> skillIds) =>
         string.Join(CompositeKeySeparator, skillIds.OrderBy(id => id, StringComparer.OrdinalIgnoreCase));

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
@@ -67,11 +67,10 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     private readonly ConcurrentDictionary<string, IEgressPolicy> _skillCache = new(StringComparer.OrdinalIgnoreCase);
 
     // A separate cache, not a composite key sharing _skillCache's key space (#589 security-review
-    // finding): the composite key's own U+0001-cannot-collide argument rests on an unverified claim
-    // ("a skill id is validated kebab-case elsewhere") that no validator in this codebase actually
-    // enforces — the same class of mistake the two-cache split above was already introduced to
-    // eliminate for the no-skill/single-skill boundary. A separate dictionary removes the whole
-    // collision class rather than resting on an id-shape assumption a future caller could violate.
+    // finding): a composite key sharing the single-skill cache's own key space would need an
+    // unenforced assumption about what characters a skill id can contain to stay collision-free
+    // against a bare id. A separate dictionary removes that collision class entirely — the same
+    // pattern the no-skill/single-skill split above already uses for the identical reason.
     private readonly ConcurrentDictionary<string, IEgressPolicy> _multiSkillCache = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Initializes a new <see cref="SkillManifestEgressPolicyResolver"/>.</summary>
@@ -99,12 +98,6 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         _noSkillPolicy = new Lazy<IEgressPolicy>(BuildDefaultOnlyPolicy);
     }
 
-    // Separator joining skill ids into a multi-skill cache key. Only has to be deterministic within
-    // _multiSkillCache's own key space — unlike a composite key sharing _skillCache with bare
-    // single-skill ids, there is no cross-cache collision to defend against, so no claim about what
-    // characters a skill id can or can't contain is load-bearing here.
-    private const char CompositeKeySeparator = '';
-
     /// <inheritdoc />
     public IEgressPolicy ResolveFor(AgentIdentity identity)
     {
@@ -114,17 +107,30 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         return skillIds.Count switch
         {
             0 => _noSkillPolicy.Value,
-            1 => _skillCache.GetOrAdd(skillIds[0], BuildPolicyForSkill),
+            1 => _skillCache.GetOrAdd(skillIds[0], key => BuildPolicyForSkills([key])),
             _ => _multiSkillCache.GetOrAdd(CompositeKey(skillIds), _ => BuildPolicyForSkills(skillIds)),
         };
     }
 
     /// <summary>
-    /// A deterministic cache key for a multi-skill scope (#589), for <see cref="_multiSkillCache"/>'s
-    /// own key space only.
+    /// A deterministic, collision-free cache key for a multi-skill scope (#589), for
+    /// <see cref="_multiSkillCache"/>'s own key space only.
     /// </summary>
+    /// <remarks>
+    /// Length-prefixes each sorted id (<c>"{length}{id}"</c>) rather than joining with a bare
+    /// separator (code-review finding: no validator in this codebase restricts what characters a
+    /// skill id can contain — <c>SkillMetadataParser</c> takes it straight from manifest YAML — so a
+    /// bare-separator join could ambiguously collide, e.g. ids <c>["a", "bc"]</c> and
+    /// <c>["ab", "c"]</c> would sort and join to the identical string with no separator, or the same
+    /// collision recurs one level up if the separator itself can appear inside an id). Length-prefixing
+    /// makes every segment's boundary a function of a number the join itself writes, not of what the
+    /// id contains, so two different sorted id lists can never produce the same key regardless of
+    /// content.
+    /// </remarks>
     private static string CompositeKey(IReadOnlyList<string> skillIds) =>
-        string.Join(CompositeKeySeparator, skillIds.OrderBy(id => id, StringComparer.OrdinalIgnoreCase));
+        string.Concat(skillIds
+            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+            .Select(id => $"{id.Length}{id}"));
 
     private IEgressPolicy BuildDefaultOnlyPolicy()
     {
@@ -132,35 +138,13 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         return new DefaultEgressPolicy(defaultEntries, _policyLogger, _timeProvider);
     }
 
-    private IEgressPolicy BuildPolicyForSkill(string key)
-    {
-        var defaultEntries = EgressAllowlistMapper.Map(_appConfig.CurrentValue.AI.Egress.DefaultAllowlist);
-        var perSkill = SkillAllowlistEntries(key);
-        if (perSkill.Count == 0)
-        {
-            // Skill has no additions — reuse the default-only policy shape.
-            return new DefaultEgressPolicy(defaultEntries, _policyLogger, _timeProvider);
-        }
-
-        // Merge default + per-skill (ADDITIVE union). Duplicates are harmless;
-        // the policy's match algorithm short-circuits on the first match.
-        var merged = new List<EgressAllowlistEntry>(defaultEntries.Count + perSkill.Count);
-        merged.AddRange(defaultEntries);
-        merged.AddRange(perSkill);
-
-        _logger.LogDebug(
-            "Built egress policy for skill '{SkillId}': {DefaultCount} default + {PerSkillCount} per-skill entries.",
-            key, defaultEntries.Count, perSkill.Count);
-
-        return new DefaultEgressPolicy(merged, _policyLogger, _timeProvider);
-    }
-
     /// <summary>
-    /// The multi-skill counterpart of <see cref="BuildPolicyForSkill"/> (#589): default entries plus
-    /// EVERY named skill's own allowlist additions, unioned. A tool name shared by two skills must
-    /// resolve at least as broad an allowlist as either skill would grant it alone — this is the same
-    /// additive contract <see cref="BuildPolicyForSkill"/> already applies to a single skill, extended
-    /// to more than one active at once.
+    /// Default entries plus every named skill's own allowlist additions, unioned — the single
+    /// implementation for both the single- and multi-skill resolve paths (#589 code-review finding:
+    /// these were two near-identical hand-written copies of the same merge; the one-skill case is
+    /// just this with a one-element list, so there is no reason for a second implementation to drift
+    /// from). A tool name shared by two skills must resolve at least as broad an allowlist as either
+    /// skill would grant it alone.
     /// </summary>
     private IEgressPolicy BuildPolicyForSkills(IReadOnlyList<string> skillIds)
     {
@@ -174,7 +158,7 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
             return new DefaultEgressPolicy(defaultEntries, _policyLogger, _timeProvider);
 
         _logger.LogDebug(
-            "Built union egress policy for skills '{SkillIds}': {DefaultCount} default + {MergedCount} " +
+            "Built egress policy for skill(s) '{SkillIds}': {DefaultCount} default + {AddedCount} " +
             "combined per-skill entries.",
             string.Join(", ", skillIds), defaultEntries.Count, merged.Count - defaultEntries.Count);
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
@@ -117,20 +117,25 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     /// <see cref="_multiSkillCache"/>'s own key space only.
     /// </summary>
     /// <remarks>
-    /// Length-prefixes each sorted id (<c>"{length}{id}"</c>) rather than joining with a bare
-    /// separator (code-review finding: no validator in this codebase restricts what characters a
-    /// skill id can contain — <c>SkillMetadataParser</c> takes it straight from manifest YAML — so a
-    /// bare-separator join could ambiguously collide, e.g. ids <c>["a", "bc"]</c> and
-    /// <c>["ab", "c"]</c> would sort and join to the identical string with no separator, or the same
-    /// collision recurs one level up if the separator itself can appear inside an id). Length-prefixing
-    /// makes every segment's boundary a function of a number the join itself writes, not of what the
-    /// id contains, so two different sorted id lists can never produce the same key regardless of
-    /// content.
+    /// Length-prefixes each sorted id as <c>"{length}:{id}"</c> — not a bare separator join
+    /// (code-review finding: no validator in this codebase restricts what characters a skill id can
+    /// contain, so a bare-separator join could ambiguously collide, e.g. ids <c>["a", "bc"]</c> and
+    /// <c>["ab", "c"]</c> sort and join to the identical string with no separator, or the same
+    /// collision recurs one level up if the separator itself can appear inside an id) — and not a bare
+    /// length prefix with no delimiter either (a SECOND round of review caught this same fix's own
+    /// first version: <c>"{length}{id}"</c> is not actually unambiguous, because the decimal length
+    /// digits are not delimited from the content that follows — a digit-leading id can extend what
+    /// looks like the length of the PRECEDING segment, e.g. ids <c>["2", "abcdefghij"]</c> (lengths 1,
+    /// 10) and a single id <c>["10abcdefghij"]</c> (length 12) both produce <c>"1210abcdefghij"</c>).
+    /// The <c>:</c> delimiter is what actually closes the gap: it can never be a decimal digit, so the
+    /// length-digit run for each segment always terminates at the first <c>:</c> regardless of what the
+    /// id itself contains, and exactly that many characters are then consumed as the segment's content
+    /// before the next length-digit run begins.
     /// </remarks>
     private static string CompositeKey(IReadOnlyList<string> skillIds) =>
         string.Concat(skillIds
             .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
-            .Select(id => $"{id.Length}{id}"));
+            .Select(id => $"{id.Length}:{id}"));
 
     private IEgressPolicy BuildDefaultOnlyPolicy()
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Egress/SkillManifestEgressPolicyResolver.cs
@@ -53,25 +53,25 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
     private readonly ILogger<DefaultEgressPolicy> _policyLogger;
     private readonly TimeProvider _timeProvider;
 
-    // Two separate caches rather than one keyed by skill id plus a reserved sentinel string (#531
-    // security-review finding): the prior design's sentinel ("<no-skill>") relied on no real skill
-    // ever being named that, case-insensitively, in a case-insensitive cache — a property nothing
-    // enforced, and one the sentinel's own doc comment misstated (it claimed the safety came from
-    // skill ids never containing spaces, which the sentinel itself doesn't contain and so proves
-    // nothing about). A skill an operator names any case variant of the sentinel would collide in
-    // the shared dictionary with the reserved "no skill" entry, in whichever direction lost the
-    // race to populate the cache first — leaking that skill's widened allowlist onto every
-    // unscoped call, or vice versa. Splitting the "no skill" case onto its own field makes the
-    // collision structurally impossible rather than relying on a string never being reused.
+    // No-skill policy stays on its own field rather than a reserved sentinel key sharing the skill
+    // cache's key space (#531 security-review finding): the prior design's sentinel ("<no-skill>")
+    // relied on no real skill ever being named that, case-insensitively, in a case-insensitive
+    // cache — a property nothing enforced, and one the sentinel's own doc comment misstated (it
+    // claimed the safety came from skill ids never containing spaces, which the sentinel itself
+    // doesn't contain and so proves nothing about). Splitting the "no skill" case onto its own
+    // field makes the collision structurally impossible rather than relying on a string never
+    // being reused.
     private readonly Lazy<IEgressPolicy> _noSkillPolicy;
-    private readonly ConcurrentDictionary<string, IEgressPolicy> _skillCache = new(StringComparer.OrdinalIgnoreCase);
 
-    // A separate cache, not a composite key sharing _skillCache's key space (#589 security-review
-    // finding): a composite key sharing the single-skill cache's own key space would need an
-    // unenforced assumption about what characters a skill id can contain to stay collision-free
-    // against a bare id. A separate dictionary removes that collision class entirely — the same
-    // pattern the no-skill/single-skill split above already uses for the identical reason.
-    private readonly ConcurrentDictionary<string, IEgressPolicy> _multiSkillCache = new(StringComparer.OrdinalIgnoreCase);
+    // One cache for every non-empty skill scope, single- or multi-skill alike, keyed by structural
+    // (order-independent, case-insensitive) list equality rather than a string encoding of the list
+    // (#589 simplification: an earlier version kept a separate string-keyed cache per arity, with a
+    // hand-proved collision-free length-prefix encoding for the multi-skill key — see git history —
+    // that took two review rounds to actually get right. A comparer keyed directly on the list
+    // sidesteps that whole class of encoding-collision reasoning: two lists are the same cache slot
+    // exactly when SkillIdListComparer says they're equal, by construction, for any arity).
+    private readonly ConcurrentDictionary<IReadOnlyList<string>, IEgressPolicy> _skillCache =
+        new(SkillIdListComparer.Instance);
 
     /// <summary>Initializes a new <see cref="SkillManifestEgressPolicyResolver"/>.</summary>
     public SkillManifestEgressPolicyResolver(
@@ -104,38 +104,38 @@ public sealed class SkillManifestEgressPolicyResolver : IEgressPolicyResolver
         ArgumentNullException.ThrowIfNull(identity);
 
         var skillIds = _currentSkill.CurrentSkillIds;
-        return skillIds.Count switch
-        {
-            0 => _noSkillPolicy.Value,
-            1 => _skillCache.GetOrAdd(skillIds[0], key => BuildPolicyForSkills([key])),
-            _ => _multiSkillCache.GetOrAdd(CompositeKey(skillIds), _ => BuildPolicyForSkills(skillIds)),
-        };
+        return skillIds.Count == 0
+            ? _noSkillPolicy.Value
+            : _skillCache.GetOrAdd(skillIds, static (ids, self) => self.BuildPolicyForSkills(ids), this);
     }
 
     /// <summary>
-    /// A deterministic, collision-free cache key for a multi-skill scope (#589), for
-    /// <see cref="_multiSkillCache"/>'s own key space only.
+    /// Order-independent, case-insensitive structural equality over a skill-id list — what makes
+    /// <see cref="_skillCache"/> safe to key directly on the list rather than on an encoded string.
     /// </summary>
-    /// <remarks>
-    /// Length-prefixes each sorted id as <c>"{length}:{id}"</c> — not a bare separator join
-    /// (code-review finding: no validator in this codebase restricts what characters a skill id can
-    /// contain, so a bare-separator join could ambiguously collide, e.g. ids <c>["a", "bc"]</c> and
-    /// <c>["ab", "c"]</c> sort and join to the identical string with no separator, or the same
-    /// collision recurs one level up if the separator itself can appear inside an id) — and not a bare
-    /// length prefix with no delimiter either (a SECOND round of review caught this same fix's own
-    /// first version: <c>"{length}{id}"</c> is not actually unambiguous, because the decimal length
-    /// digits are not delimited from the content that follows — a digit-leading id can extend what
-    /// looks like the length of the PRECEDING segment, e.g. ids <c>["2", "abcdefghij"]</c> (lengths 1,
-    /// 10) and a single id <c>["10abcdefghij"]</c> (length 12) both produce <c>"1210abcdefghij"</c>).
-    /// The <c>:</c> delimiter is what actually closes the gap: it can never be a decimal digit, so the
-    /// length-digit run for each segment always terminates at the first <c>:</c> regardless of what the
-    /// id itself contains, and exactly that many characters are then consumed as the segment's content
-    /// before the next length-digit run begins.
-    /// </remarks>
-    private static string CompositeKey(IReadOnlyList<string> skillIds) =>
-        string.Concat(skillIds
-            .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
-            .Select(id => $"{id.Length}:{id}"));
+    private sealed class SkillIdListComparer : IEqualityComparer<IReadOnlyList<string>>
+    {
+        public static readonly SkillIdListComparer Instance = new();
+
+        public bool Equals(IReadOnlyList<string>? x, IReadOnlyList<string>? y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (x is null || y is null || x.Count != y.Count)
+                return false;
+
+            return x.OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .SequenceEqual(y.OrderBy(id => id, StringComparer.OrdinalIgnoreCase), StringComparer.OrdinalIgnoreCase);
+        }
+
+        public int GetHashCode(IReadOnlyList<string> obj)
+        {
+            var hash = new HashCode();
+            foreach (var id in obj.OrderBy(id => id, StringComparer.OrdinalIgnoreCase))
+                hash.Add(id, StringComparer.OrdinalIgnoreCase);
+            return hash.ToHashCode();
+        }
+    }
 
     private IEgressPolicy BuildDefaultOnlyPolicy()
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/MetaHarness/AgentEvaluationService.cs
@@ -269,14 +269,32 @@ public sealed class AgentEvaluationService : IEvaluationService
     /// <summary>
     /// Builds the eval context's <see cref="AIContextProvider"/> rail: the progressive-disclosure skills
     /// provider over <paramref name="skillDirectory"/> (when present) followed unconditionally by
-    /// <see cref="Application.AI.Common.Services.Agent.GoverningToolContextProvider"/>, mirroring the production wiring in
-    /// <c>AgentExecutionContextFactory.BuildMergedAIContextProviders</c>.
+    /// <see cref="Application.AI.Common.Services.Agent.GoverningToolContextProvider"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// #482: the governance wrapper is attached unconditionally, same as the production factory —
     /// without it, <c>load_skill</c>/<c>read_skill_resource</c> carry no sanitize coverage on this path
     /// at all, since <c>ToolChainBuilder</c> (the other place governance gets wired in) is never
     /// consulted for an eval context built directly from a materialized skill snapshot.
+    /// </para>
+    /// <para>
+    /// This does NOT fully mirror <c>AgentExecutionContextFactory.BuildMergedAIContextProviders</c>'s
+    /// wiring (#589): production passes <c>disclosableSkills</c> and an <see
+    /// cref="Application.AI.Common.Interfaces.Skills.ICurrentSkillAccessor"/> so <c>run_skill_script</c>
+    /// can resolve which skill's egress scope a call belongs to. Neither is available here — this method
+    /// loads the candidate's skill straight from a materialized directory via <c>UseFileSkill</c> rather
+    /// than through <c>DisclosableSkillFactory</c>, so there is no harness <c>SkillId</c> for a candidate
+    /// under evaluation to hand the resolver in the first place; a candidate is a proposed skill mutation,
+    /// never a registered entry in <see cref="Application.AI.Common.Interfaces.ISkillMetadataRegistry"/>.
+    /// Closing this gap for real needs eval to parse the materialized directory into a
+    /// <see cref="Domain.AI.Skills.SkillDefinition"/> and read it through a sandboxed
+    /// <see cref="Application.AI.Common.Interfaces.Skills.ISkillFileReader"/>, the same as the production
+    /// path — tracked as a follow-up rather than folded into #589, since #589 is scoped to the production
+    /// wiring. In practice this path is no worse than production today: both wire
+    /// <c>UseFileScriptRunner(NoOpScriptRunner)</c>, so <c>run_skill_script</c> has nothing to run either
+    /// way.
+    /// </para>
     /// </remarks>
     private IList<AIContextProvider> BuildContextProviders(string? skillDirectory)
     {

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/CurrentSkillAccessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/CurrentSkillAccessor.cs
@@ -34,7 +34,11 @@ public sealed class CurrentSkillAccessor : ICurrentSkillAccessor
             ArgumentException.ThrowIfNullOrWhiteSpace(skillId, nameof(skillIds));
 
         var previous = Slot.Value;
-        Slot.Value = skillIds;
+        // Copies rather than stores the caller's reference (#589 security-review finding): every
+        // in-repo caller happens to pass a freshly-built list today, but ICurrentSkillAccessor is a
+        // public interface a template consumer implements against, and a caller who mutated its list
+        // after this call returned would otherwise mutate the live ambient scope past validation.
+        Slot.Value = [.. skillIds];
         return new Restorer(previous);
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Skills/CurrentSkillAccessor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Skills/CurrentSkillAccessor.cs
@@ -18,27 +18,32 @@ namespace Infrastructure.AI.Skills;
 /// </remarks>
 public sealed class CurrentSkillAccessor : ICurrentSkillAccessor
 {
-    private static readonly AsyncLocal<string?> Slot = new();
+    private static readonly IReadOnlyList<string> NoSkills = [];
+    private static readonly AsyncLocal<IReadOnlyList<string>?> Slot = new();
 
     /// <inheritdoc />
-    public string? CurrentSkillId => Slot.Value;
+    public IReadOnlyList<string> CurrentSkillIds => Slot.Value ?? NoSkills;
 
     /// <inheritdoc />
-    public IDisposable BeginScope(string skillId)
+    public IDisposable BeginScope(IReadOnlyList<string> skillIds)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(skillId);
+        ArgumentNullException.ThrowIfNull(skillIds);
+        if (skillIds.Count == 0)
+            throw new ArgumentException("At least one skill id is required.", nameof(skillIds));
+        foreach (var skillId in skillIds)
+            ArgumentException.ThrowIfNullOrWhiteSpace(skillId, nameof(skillIds));
 
         var previous = Slot.Value;
-        Slot.Value = skillId;
+        Slot.Value = skillIds;
         return new Restorer(previous);
     }
 
     private sealed class Restorer : IDisposable
     {
-        private readonly string? _previous;
+        private readonly IReadOnlyList<string>? _previous;
         private bool _disposed;
 
-        public Restorer(string? previous)
+        public Restorer(IReadOnlyList<string>? previous)
         {
             _previous = previous;
         }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/GoverningToolContextProviderTests.cs
@@ -1,8 +1,12 @@
 using System.Text.Json;
+using Application.AI.Common.Interfaces.Skills;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Planner;
+using FluentAssertions;
+using Infrastructure.AI.Skills;
+using Microsoft.Agents.AI;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -171,6 +175,79 @@ public sealed class GoverningToolContextProviderTests
             tools, NullLogger<GoverningToolContextProviderTests>.Instance, AdmissionHarness.PermissiveSanitizer());
 
         Assert.Null(result);
+    }
+
+    /// <summary>A tool function that records <see cref="CurrentSkillAccessor.CurrentSkillIds"/> at the
+    /// moment it executes — the only way to observe an ambient scope actually established for THIS
+    /// call, since <see cref="MakeFunction"/>'s plain <c>() =&gt; "ok"</c> body has no such hook.</summary>
+    private static AIFunction MakeScopeObservingFunction(string name, CurrentSkillAccessor accessor, Action<IReadOnlyList<string>> observe) =>
+        AIFunctionFactory.Create(
+            () =>
+            {
+                observe(accessor.CurrentSkillIds);
+                return "ok";
+            },
+            new AIFunctionFactoryOptions { Name = name, Description = "t" });
+
+    [Fact]
+    public async Task Govern_RunSkillScriptWithKnownSkillName_EstablishesThatSkillsScopeForTheCall()
+    {
+        // #589: the framework publishes one run_skill_script instance shared by every skill on the
+        // agent — the model names which skill's script to run via the skillName argument, not by
+        // which instance it invoked. Govern must resolve THAT argument at call time, not bake a
+        // fixed skill id in at construction like it does for a skill's own first-party/MCP tools.
+        var accessor = new CurrentSkillAccessor();
+        IReadOnlyList<string>? observedDuringCall = null;
+        var inner = MakeScopeObservingFunction(
+            AgentSkillsProvider.RunSkillScriptToolName, accessor, ids => observedDuringCall = ids);
+        var nameMap = new Dictionary<string, string> { ["reader-skill"] = "reader-skill-harness-id" };
+
+        var wrapped = (AIFunction)GoverningToolContextProvider.Govern(
+            inner, AdmissionHarness.PermissiveSanitizer(), accessor, nameMap);
+
+        var args = new AIFunctionArguments { ["skillName"] = "reader-skill" };
+        await wrapped.InvokeAsync(args, CancellationToken.None);
+
+        observedDuringCall.Should().Equal(["reader-skill-harness-id"], "the model's skillName argument must map to the harness's own skill id");
+        accessor.CurrentSkillIds.Should().BeEmpty("the scope must be restored once the call returns");
+    }
+
+    [Theory]
+    [InlineData("unmapped-skill")]
+    [InlineData(null)]
+    public async Task Govern_RunSkillScriptWithUnmappedOrMissingSkillName_EstablishesNoScope(string? skillName)
+    {
+        // Fail-closed contract (#589): a skillName the map doesn't recognize, or no skillName at all,
+        // must never fall back to a guess or a stale scope — only no scope, same as before this
+        // parameter existed.
+        var accessor = new CurrentSkillAccessor();
+        IReadOnlyList<string>? observedDuringCall = null;
+        var inner = MakeScopeObservingFunction(
+            AgentSkillsProvider.RunSkillScriptToolName, accessor, ids => observedDuringCall = ids);
+        var nameMap = new Dictionary<string, string> { ["reader-skill"] = "reader-skill-harness-id" };
+
+        var wrapped = (AIFunction)GoverningToolContextProvider.Govern(
+            inner, AdmissionHarness.PermissiveSanitizer(), accessor, nameMap);
+
+        var args = skillName is null
+            ? new AIFunctionArguments()
+            : new AIFunctionArguments { ["skillName"] = skillName };
+        await wrapped.InvokeAsync(args, CancellationToken.None);
+
+        observedDuringCall.Should().BeEmpty("an unrecognized or missing skillName must establish no scope, never a guess");
+    }
+
+    [Fact]
+    public void Govern_RunSkillScriptWithNoSkillMapSupplied_WrapsWithoutASkillResolver()
+    {
+        // The default (no disclosableSkills passed to the constructor, e.g. an agent with none, or a
+        // caller that doesn't have this context) must behave exactly as before this parameter existed:
+        // a plain GovernedAIFunction with no skill scope to establish.
+        var inner = MakeFunction(AgentSkillsProvider.RunSkillScriptToolName);
+
+        var result = GoverningToolContextProvider.Govern(inner, AdmissionHarness.PermissiveSanitizer());
+
+        Assert.IsType<GovernedAIFunction>(result);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/SkillEgressScopeActivationTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/SkillEgressScopeActivationTests.cs
@@ -17,7 +17,7 @@ namespace Application.AI.Common.Tests.Governance;
 
 /// <summary>
 /// #531: proves the missing wire — <see cref="ToolChainBuilder"/> and <see cref="GovernedAIFunction"/>
-/// actually establish <see cref="ICurrentSkillAccessor.CurrentSkillId"/> for the duration of a tool
+/// actually establish <see cref="ICurrentSkillAccessor.CurrentSkillIds"/> for the duration of a tool
 /// call built from a skill, which is the one thing standing between
 /// <c>SkillManifestEgressPolicyResolver</c>'s already-correct merge logic and it ever running in
 /// production. Uses the real <see cref="CurrentSkillAccessor"/> (Infrastructure), not a mock — the
@@ -49,7 +49,7 @@ public sealed class SkillEgressScopeActivationTests
             .Setup(fs => fs.ReadFileAsync("notes.txt", It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
-                observedDuringCall = accessor.CurrentSkillId;
+                observedDuringCall = accessor.CurrentSkillIds.FirstOrDefault();
                 return "hello world";
             });
 
@@ -60,7 +60,7 @@ public sealed class SkillEgressScopeActivationTests
         var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
         var aiFunction = (AIFunction)tools.Single();
 
-        accessor.CurrentSkillId.Should().BeNull("no skill scope should be active before the call");
+        accessor.CurrentSkillIds.Should().BeEmpty("no skill scope should be active before the call");
 
         var args = new AIFunctionArguments
         {
@@ -70,7 +70,46 @@ public sealed class SkillEgressScopeActivationTests
         await aiFunction.InvokeAsync(args);
 
         observedDuringCall.Should().Be("reader-skill", "the resolver reads CurrentSkillId from inside the tool's own execution");
-        accessor.CurrentSkillId.Should().BeNull("the scope must be restored once the call returns, not leaked to the next call");
+        accessor.CurrentSkillIds.Should().BeEmpty("the scope must be restored once the call returns, not leaked to the next call");
+    }
+
+    [Fact]
+    public async Task TwoSkillsShareAFirstPartyToolName_InvokingItEstablishesBothSkillsScope()
+    {
+        // #589: before this fix, ToolChainBuilder.ProjectSurvivors' cross-skill dedup kept only the
+        // first-enumerated skill's already-wrapped GovernedAIFunction instance for a shared name,
+        // silently dropping the second skill's SkillIds — a call to the shared tool would only ever
+        // establish "reader-skill-a", never "reader-skill-b" too, no matter which skill the model was
+        // conceptually driving the turn from.
+        var (_, fileSystem, accessor, provider) = BuildFixture();
+
+        IReadOnlyList<string>? observedDuringCall = null;
+        fileSystem
+            .Setup(fs => fs.ReadFileAsync("notes.txt", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                observedDuringCall = accessor.CurrentSkillIds;
+                return "hello world";
+            });
+
+        var builder = new ToolChainBuilder(
+            NullLogger<ToolChainBuilder>.Instance, provider, new AIToolConverter(NullLogger<AIToolConverter>.Instance));
+
+        var skillA = new SkillDefinition { Id = "reader-skill-a", Name = "reader-skill-a", AllowedTools = ["file_system"] };
+        var skillB = new SkillDefinition { Id = "reader-skill-b", Name = "reader-skill-b", AllowedTools = ["file_system"] };
+        var tools = await builder.BuildMergedToolsAsync([skillA, skillB], new SkillAgentOptions());
+        var aiFunction = (AIFunction)tools.Should().ContainSingle("both skills share one first-party tool name").Which;
+
+        var args = new AIFunctionArguments
+        {
+            ["operation"] = "read",
+            ["parametersJson"] = System.Text.Json.JsonSerializer.SerializeToElement(new { path = "notes.txt" })
+        };
+        await aiFunction.InvokeAsync(args);
+
+        observedDuringCall.Should().BeEquivalentTo(["reader-skill-a", "reader-skill-b"],
+            "the published instance must carry both skills' ids, not just whichever enumerated first");
+        accessor.CurrentSkillIds.Should().BeEmpty("the scope must be restored once the call returns");
     }
 
     [Fact]
@@ -85,7 +124,7 @@ public sealed class SkillEgressScopeActivationTests
             .Setup(fs => fs.ReadFileAsync("notes.txt", It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
-                observedDuringCall = accessor.CurrentSkillId;
+                observedDuringCall = accessor.CurrentSkillIds.FirstOrDefault();
                 return "hello world";
             });
 
@@ -131,7 +170,7 @@ public sealed class SkillEgressScopeActivationTests
             .Setup(fs => fs.ReadFileAsync("notes.txt", It.IsAny<CancellationToken>()))
             .ReturnsAsync(() =>
             {
-                observedDuringCall = accessor.CurrentSkillId;
+                observedDuringCall = accessor.CurrentSkillIds.FirstOrDefault();
                 return "hello world";
             });
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -569,6 +569,36 @@ public class ToolChainBuilderTests
     }
 
     [Fact]
+    public async Task BuildMergedToolsAsync_TwoSkillsShareAnMcpToolName_UnionsBothSkillsEgressScope()
+    {
+        // #589 code-review finding (second round): DeduplicateMcpCandidates picked g.First() for a
+        // (server, name) group, silently dropping every later skill's independently-scoped instance -
+        // the exact bug ProjectSurvivors' first-party dedup loop was fixed to avoid, left open for the
+        // MCP tool source. Each skill's own GovernedAIFunction wrapper (with that skill's own SkillIds)
+        // is already built before tools from multiple skills are pooled here, so two plugin skills
+        // naming the same MCP server/tool must union rather than first-win.
+        var mcpProvider = new Mock<IMcpToolProvider>();
+        mcpProvider
+            .Setup(p => p.GetAllToolsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, IList<AITool>>
+            {
+                ["shared-server"] = [AIFunctionFactory.Create(() => "r", "shared_mcp_tool")]
+            });
+
+        var builder = CreateBuilder(mcpToolProvider: mcpProvider.Object);
+
+        var skillA = new SkillDefinition { Id = "skill-a", Name = "skill-a", Instructions = "Test", PluginSource = "plugin" };
+        var skillB = new SkillDefinition { Id = "skill-b", Name = "skill-b", Instructions = "Test", PluginSource = "plugin" };
+
+        var tools = await builder.BuildMergedToolsAsync([skillA, skillB], new SkillAgentOptions());
+
+        var governed = tools.Should().ContainSingle(t => t.Name == "shared_mcp_tool")
+            .Which.Should().BeOfType<GovernedAIFunction>().Subject;
+        governed.SkillIds.Should().BeEquivalentTo(["skill-a", "skill-b"],
+            "both skills declared this MCP tool, so the published instance must carry both skills' scope");
+    }
+
+    [Fact]
     public async Task BuildToolsAsync_ToolNotDeclaredCallOnce_PolicyNeverConsulted()
     {
         var toolMock = new Mock<ITool>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -521,6 +521,54 @@ public class ToolChainBuilderTests
     }
 
     [Fact]
+    public async Task BuildMergedToolsAsync_OneSkillDeclaresTheSameToolTwiceOnlyOneCallOnce_StillRegistersIt()
+    {
+        // #589 round-2 code-review finding: UnionSkillScopeIfNeeded's early return (candidate's skill
+        // ids already fully covered by the published instance's) fires for a SINGLE skill that names
+        // the same tool via two of its own ToolDeclarations - same skill id on both, so no union
+        // rewrap happens at all. The call-once carry-forward used to live only inside the union-rewrap
+        // branch, so it never ran on this path, silently dropping the restriction whenever the
+        // discarded (not the published) declaration was the call-once one.
+        var toolMock = new Mock<ITool>();
+        toolMock.Setup(t => t.Name).Returns("twice_declared_tool");
+
+        var converter = new Mock<IToolConverter>();
+        // A factory delegate, not a fixed value: each ToolDeclaration resolves independently in
+        // production (IToolConverter.Convert is called once per resolution), so each of the two
+        // declarations here must get its OWN AIFunction instance too - a fixed .Returns(value) would
+        // hand both the identical object, aliasing them through WrapGoverned's own callOnceCandidates
+        // tagging (same raw reference tagged once = both wrapped instances tagged) and silently
+        // testing nothing about this method's OWN early-return carry-forward fix.
+        converter.Setup(c => c.Convert(toolMock.Object, null))
+            .Returns(() => AIFunctionFactory.Create(() => "converted", "twice_declared_tool"));
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("twice_declared_tool", toolMock.Object);
+
+        var policy = new ToolCallOncePolicy(NullLogger<ToolCallOncePolicy>.Instance);
+        var builder = CreateBuilder(
+            toolConverter: converter.Object,
+            serviceProvider: services.BuildServiceProvider(),
+            callOncePolicy: policy);
+
+        var skill = new SkillDefinition
+        {
+            Id = "skill-a", Name = "skill-a", Instructions = "Test",
+            ToolDeclarations =
+            [
+                new ToolDeclaration { Name = "twice_declared_tool", CallOncePerConversation = false },
+                new ToolDeclaration { Name = "twice_declared_tool", CallOncePerConversation = true }
+            ]
+        };
+
+        var tools = await builder.BuildMergedToolsAsync([skill], new SkillAgentOptions());
+
+        tools.Should().ContainSingle();
+        policy.IsCallOnce("twice_declared_tool").Should().BeTrue(
+            "the second declaration's call-once flag must survive even though the dedup discarded its instance");
+    }
+
+    [Fact]
     public async Task BuildToolsAsync_ToolNotDeclaredCallOnce_PolicyNeverConsulted()
     {
         var toolMock = new Mock<ITool>();

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -479,6 +479,48 @@ public class ToolChainBuilderTests
     }
 
     [Fact]
+    public async Task BuildMergedToolsAsync_TwoSkillsShareACallOnceFirstPartyToolName_StillRegistersIt()
+    {
+        // #589 correctness/security review finding on this PR's own first draft: the union re-wrap
+        // ProjectSurvivors performs when two skills share a first-party tool name replaced the
+        // published instance with a brand-new one, never tagged in callOnceCandidates (a
+        // reference-identity-keyed set) — silently dropping a declared CallOncePerConversation
+        // restriction the moment two skills happened to share a call-once tool's name.
+        var toolMock = new Mock<ITool>();
+        toolMock.Setup(t => t.Name).Returns("shared_once_tool");
+
+        var converter = new Mock<IToolConverter>();
+        converter.Setup(c => c.Convert(toolMock.Object, null))
+            .Returns(AIFunctionFactory.Create(() => "converted", "shared_once_tool"));
+
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("shared_once_tool", toolMock.Object);
+
+        var policy = new ToolCallOncePolicy(NullLogger<ToolCallOncePolicy>.Instance);
+        var builder = CreateBuilder(
+            toolConverter: converter.Object,
+            serviceProvider: services.BuildServiceProvider(),
+            callOncePolicy: policy);
+
+        var skillA = new SkillDefinition
+        {
+            Id = "skill-a", Name = "skill-a", Instructions = "Test",
+            ToolDeclarations = [new ToolDeclaration { Name = "shared_once_tool", CallOncePerConversation = true }]
+        };
+        var skillB = new SkillDefinition
+        {
+            Id = "skill-b", Name = "skill-b", Instructions = "Test",
+            ToolDeclarations = [new ToolDeclaration { Name = "shared_once_tool", CallOncePerConversation = true }]
+        };
+
+        var tools = await builder.BuildMergedToolsAsync([skillA, skillB], new SkillAgentOptions());
+
+        tools.Should().ContainSingle("both skills share one first-party tool name");
+        policy.IsCallOnce("shared_once_tool").Should().BeTrue(
+            "the union re-wrap must carry the call-once candidacy forward onto the new instance");
+    }
+
+    [Fact]
     public async Task BuildToolsAsync_ToolNotDeclaredCallOnce_PolicyNeverConsulted()
     {
         var toolMock = new Mock<ITool>();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/SkillManifestEgressPolicyResolverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/SkillManifestEgressPolicyResolverTests.cs
@@ -140,6 +140,56 @@ public sealed class SkillManifestEgressPolicyResolverTests
     }
 
     /// <summary>
+    /// #589 correctness/security review finding on this PR's own first draft: the multi-skill cache
+    /// key's original length-prefix scheme (<c>"{length}{id}"</c>, no delimiter between the length
+    /// digits and the id content) was not actually collision-free — a digit-leading id can extend what
+    /// looks like the length of the preceding segment. Concretely, sorted-and-joined ids
+    /// <c>["2", "abcdefghij", "zzz"]</c> and <c>["10abcdefghij", "zzz"]</c> both produced the identical
+    /// key <c>"1210abcdefghij3zzz"</c> under that scheme, even though they name two entirely different
+    /// skill combinations. This test resolves both sets (with distinct, mutually exclusive allowlist
+    /// entries) and proves neither one's policy leaks into the other's cache slot.
+    /// </summary>
+    [Fact]
+    public async Task ResolveFor_TwoDifferentMultiSkillSetsWithColliderShapedIds_NeverShareACacheEntry()
+    {
+        var accessor = new CurrentSkillAccessor();
+
+        var skillTwo = SkillWithAllowlist("2", new EgressAllowlistEntry
+        { Host = "set-a-only.example.com", Schemes = ["https"], Ports = [443] });
+        var skillAbc = SkillWithAllowlist("abcdefghij");
+        var skillZzz = SkillWithAllowlist("zzz");
+        var skillTenAbc = SkillWithAllowlist("10abcdefghij", new EgressAllowlistEntry
+        { Host = "set-b-only.example.com", Schemes = ["https"], Ports = [443] });
+
+        var registry = new Mock<ISkillMetadataRegistry>(MockBehavior.Strict);
+        registry.Setup(r => r.TryGet("2")).Returns(skillTwo);
+        registry.Setup(r => r.TryGet("abcdefghij")).Returns(skillAbc);
+        registry.Setup(r => r.TryGet("zzz")).Returns(skillZzz);
+        registry.Setup(r => r.TryGet("10abcdefghij")).Returns(skillTenAbc);
+
+        var resolver = NewResolver(accessor, registry.Object);
+
+        using (accessor.BeginScope(["2", "abcdefghij", "zzz"]))
+        {
+            var setAPolicy = resolver.ResolveFor(TestIdentity.Default);
+            var allowed = await setAPolicy.AllowAsync(new Uri("https://set-a-only.example.com/"), TestIdentity.Default, CancellationToken.None);
+            allowed.Allowed.Should().BeTrue("set A's own skill '2' declared this host");
+        }
+
+        using (accessor.BeginScope(["10abcdefghij", "zzz"]))
+        {
+            var setBPolicy = resolver.ResolveFor(TestIdentity.Default);
+
+            var setBHost = await setBPolicy.AllowAsync(new Uri("https://set-b-only.example.com/"), TestIdentity.Default, CancellationToken.None);
+            setBHost.Allowed.Should().BeTrue("set B's own skill '10abcdefghij' declared this host");
+
+            var setAHost = await setBPolicy.AllowAsync(new Uri("https://set-a-only.example.com/"), TestIdentity.Default, CancellationToken.None);
+            setAHost.Allowed.Should().BeFalse(
+                "set B never declared this host - a colliding cache key would have returned set A's cached policy instead");
+        }
+    }
+
+    /// <summary>
     /// Test 6 (brief): the resolver caches by skill key. Two lookups with the
     /// same active skill return the SAME policy instance. Per-skill cache keeps
     /// the merge cost amortized over the lifetime of the process.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Egress/SkillManifestEgressPolicyResolverTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Egress/SkillManifestEgressPolicyResolverTests.cs
@@ -57,7 +57,7 @@ public sealed class SkillManifestEgressPolicyResolverTests
     public async Task ResolveFor_SkillWithAllowlist_MergesDefaultAndPerSkill()
     {
         var accessor = new CurrentSkillAccessor();
-        using var _ = accessor.BeginScope("github-reader");
+        using var _ = accessor.BeginScope(["github-reader"]);
 
         var skill = SkillWithAllowlist("github-reader", new EgressAllowlistEntry
         {
@@ -97,6 +97,49 @@ public sealed class SkillManifestEgressPolicyResolverTests
     }
 
     /// <summary>
+    /// #589: two skills active at once (the shared-tool-name union case) resolve a policy carrying
+    /// BOTH skills' own allowlist additions, not just the first or the default. Proves the resolver's
+    /// own multi-id path, independent of how <c>ToolChainBuilder</c>/<c>GovernedAIFunction</c> come to
+    /// establish more than one id at a time.
+    /// </summary>
+    [Fact]
+    public async Task ResolveFor_TwoSkillsActive_UnionsBothSkillsOwnAllowlists()
+    {
+        var accessor = new CurrentSkillAccessor();
+        using var _ = accessor.BeginScope(["skill-a", "skill-b"]);
+
+        var skillA = SkillWithAllowlist("skill-a", new EgressAllowlistEntry
+        {
+            Host = "a.example.com", Schemes = ["https"], Ports = [443]
+        });
+        var skillB = SkillWithAllowlist("skill-b", new EgressAllowlistEntry
+        {
+            Host = "b.example.com", Schemes = ["https"], Ports = [443]
+        });
+
+        var registry = new Mock<ISkillMetadataRegistry>(MockBehavior.Strict);
+        registry.Setup(r => r.TryGet("skill-a")).Returns(skillA);
+        registry.Setup(r => r.TryGet("skill-b")).Returns(skillB);
+
+        var resolver = NewResolver(accessor, registry.Object,
+            new EgressAllowlistConfigEntry { Host = "default.example.com", Schemes = ["https"], Ports = [443] });
+
+        var policy = resolver.ResolveFor(TestIdentity.Default);
+
+        var aVerdict = await policy.AllowAsync(new Uri("https://a.example.com/"), TestIdentity.Default, CancellationToken.None);
+        aVerdict.Allowed.Should().BeTrue("skill-a's own allowlist addition must apply even though skill-b is also active");
+
+        var bVerdict = await policy.AllowAsync(new Uri("https://b.example.com/"), TestIdentity.Default, CancellationToken.None);
+        bVerdict.Allowed.Should().BeTrue("skill-b's own allowlist addition must apply even though skill-a is also active");
+
+        var defaultVerdict = await policy.AllowAsync(new Uri("https://default.example.com/"), TestIdentity.Default, CancellationToken.None);
+        defaultVerdict.Allowed.Should().BeTrue("the harness-wide default must still apply under a multi-skill scope");
+
+        var deniedVerdict = await policy.AllowAsync(new Uri("https://attacker.example.org/"), TestIdentity.Default, CancellationToken.None);
+        deniedVerdict.Allowed.Should().BeFalse("a host neither skill nor the default names must still be refused");
+    }
+
+    /// <summary>
     /// Test 6 (brief): the resolver caches by skill key. Two lookups with the
     /// same active skill return the SAME policy instance. Per-skill cache keeps
     /// the merge cost amortized over the lifetime of the process.
@@ -105,7 +148,7 @@ public sealed class SkillManifestEgressPolicyResolverTests
     public void ResolveFor_SameSkillTwice_ReturnsSamePolicyInstance()
     {
         var accessor = new CurrentSkillAccessor();
-        using var _ = accessor.BeginScope("cached-skill");
+        using var _ = accessor.BeginScope(["cached-skill"]);
 
         var skill = SkillWithAllowlist("cached-skill", new EgressAllowlistEntry
         {
@@ -129,8 +172,8 @@ public sealed class SkillManifestEgressPolicyResolverTests
     }
 
     /// <summary>
-    /// No skill in scope (<see cref="ICurrentSkillAccessor.CurrentSkillId"/> is
-    /// null) falls back to a default-only policy. The resolver does not touch
+    /// No skill in scope (<see cref="ICurrentSkillAccessor.CurrentSkillIds"/> is
+    /// empty) falls back to a default-only policy. The resolver does not touch
     /// the registry on the no-skill path.
     /// </summary>
     [Fact]
@@ -168,7 +211,7 @@ public sealed class SkillManifestEgressPolicyResolverTests
     public async Task ResolveFor_UnknownSkill_FallsBackToDefaultOnlyPolicy()
     {
         var accessor = new CurrentSkillAccessor();
-        using var _ = accessor.BeginScope("unknown-skill");
+        using var _ = accessor.BeginScope(["unknown-skill"]);
 
         var registry = new Mock<ISkillMetadataRegistry>(MockBehavior.Strict);
         registry.Setup(r => r.TryGet("unknown-skill")).Returns((SkillDefinition?)null);
@@ -199,7 +242,7 @@ public sealed class SkillManifestEgressPolicyResolverTests
     public async Task ResolveFor_SkillWithEmptyAllowlist_ReturnsDefaultOnly()
     {
         var accessor = new CurrentSkillAccessor();
-        using var _ = accessor.BeginScope("empty-allowlist");
+        using var _ = accessor.BeginScope(["empty-allowlist"]);
 
         var registry = new Mock<ISkillMetadataRegistry>(MockBehavior.Strict);
         registry.Setup(r => r.TryGet("empty-allowlist"))
@@ -258,7 +301,7 @@ public sealed class SkillManifestEgressPolicyResolverTests
             new Uri("https://widened.example.com/"), TestIdentity.Default, CancellationToken.None);
         noSkillVerdict.Allowed.Should().BeFalse("the no-skill policy must never carry a skill's widened allowlist");
 
-        using var _ = accessor.BeginScope("<NO-SKILL>");
+        using var _ = accessor.BeginScope(["<NO-SKILL>"]);
         var skillPolicy = resolver.ResolveFor(TestIdentity.Default);
         var skillVerdict = await skillPolicy.AllowAsync(
             new Uri("https://widened.example.com/"), TestIdentity.Default, CancellationToken.None);
@@ -274,20 +317,20 @@ public sealed class SkillManifestEgressPolicyResolverTests
     public void CurrentSkillAccessor_NestedScopes_RestorePreviousOnDispose()
     {
         var accessor = new CurrentSkillAccessor();
-        accessor.CurrentSkillId.Should().BeNull();
+        accessor.CurrentSkillIds.Should().BeEmpty();
 
-        using (var outer = accessor.BeginScope("outer"))
+        using (var outer = accessor.BeginScope(["outer"]))
         {
-            accessor.CurrentSkillId.Should().Be("outer");
+            accessor.CurrentSkillIds.Should().Equal("outer");
 
-            using (var inner = accessor.BeginScope("inner"))
+            using (var inner = accessor.BeginScope(["inner"]))
             {
-                accessor.CurrentSkillId.Should().Be("inner");
+                accessor.CurrentSkillIds.Should().Equal("inner");
             }
 
-            accessor.CurrentSkillId.Should().Be("outer");
+            accessor.CurrentSkillIds.Should().Equal("outer");
         }
 
-        accessor.CurrentSkillId.Should().BeNull();
+        accessor.CurrentSkillIds.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
## Summary

Closes #589 — two per-skill egress-scope gaps left open by #531's review, plus a third gap of the same shape found by this PR's own review process.

- **Two skills sharing a first-party tool name** now union both skills' egress allowlist additions onto the shared instance, instead of silently keeping only whichever skill was enumerated first (`ToolChainBuilder.Surface.cs`'s `UnionSkillScopeIfNeeded`).
- **Two skills sharing an MCP-sourced tool name** get the identical fix — found by this PR's own second `/code-review` round: `DeduplicateMcpCandidates` was still doing a bare "keep the first" pick, the exact bug the first-party fix above was created to close, just left open for the MCP tool source.
- **`run_skill_script`** (the framework's single, agent-wide skill-script tool) now resolves which skill's egress scope applies from the call's own `skillName` argument, rather than establishing no scope at all — currently inert in production (no scripts are registered yet) but wired correctly for when a real script runner exists.
- **`ICurrentSkillAccessor`** widened from a single skill id to a list, so more than one skill's scope can be ambient at once.

## Review history (honest accounting)

This PR self-caught and fixed several regressions in its own earlier drafts, each confirmed by an independent review pass and closed with a mutation-tested regression test:
- Call-once (`CallOncePerConversation`) candidacy dropped across the skill-scope union re-wrap (twice — once in the union branch, once in an early-return edge case).
- A multi-skill egress cache key collision (a length-prefix encoding that wasn't actually unambiguous until a `:` delimiter was added).
- A false "mirrors production wiring" doc claim on the eval harness's skill-scope wiring (real gap tracked as #620, not fixed here — the eval path has no harness `SkillId` for a training candidate to resolve scope from in the first place).
- A performance regression this PR's own `/simplify` pass introduced (merging two egress caches into one lost the O(1) single-skill fast path) — caught and fixed in the same PR by a second review round.

## Follow-ups filed (deliberately deferred, not blocking)

- #620 — eval harness's `run_skill_script` skill-scope doesn't mirror production wiring (needs eval to parse a `SkillDefinition` instead of loading from a raw directory).
- #621 — call-once tool tracking is still an out-of-band reference-identity side channel, unlike skill scope which this PR promoted to a first-class field (the exact carry-forward-on-rewrap bug shape recurred twice within this PR's own history).

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] `dotnet test src/AgenticHarness.slnx` — full suite green
- [x] `scripts/rails/run-gates.sh` — clean (build, test, owasp, grader, correctness, security, docs-drift)
- [x] `/code-review` — 2 full passes, all findings addressed, fixed, or deferred as follow-up issues
- [x] `/simplify` — applied, with one of its own fixes catching and re-fixing a real regression on a second pass
- [x] New regression tests for both union cases (first-party and MCP), mutation-tested against the pre-fix code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBmRJhoKkkmdiEdR6eXBfy