### PR TITLE
fix: validate TrainSkillCommand in SkillTrainingExample before dispatch

### DIFF
--- a/src/AgenticHarness.slnx
+++ b/src/AgenticHarness.slnx
@@ -291,5 +291,10 @@
       <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
       <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
     </Project>
+    <Project Path="Content/Tests/Presentation.ConsoleUI.Tests/Presentation.ConsoleUI.Tests.csproj">
+      <BuildType Solution="Debug-AgentHub-All|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-Dashboard|*" Project="Debug" />
+      <BuildType Solution="Debug-AgentHub-WebUI|*" Project="Debug" />
+    </Project>
   </Folder>
 </Solution>

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -89,27 +89,26 @@ public sealed class SkillTrainingExample
     /// Validates <paramref name="cmd"/> and dispatches to <paramref name="handler"/> on success.
     /// </summary>
     /// <remarks>
-    /// This demo bypasses IMediator.Send and calls the handler directly, so
-    /// RequestValidationBehavior never runs for TrainSkillCommand here. That's deliberate:
-    /// the demo's whole point is running the state machine against deterministic,
-    /// LLM-free stubs (DeterministicRolloutRunner/DeterministicProposer); dispatching
-    /// through the app's real DI-registered IMediator would resolve the real (or
-    /// NotConfigured*, fail-fast) IRolloutRunner/IPatchProposer instead of these stubs.
-    /// The validator itself has no dependencies, so it's constructed by hand — same
-    /// style as everything else in BuildHandler() — to restore the coverage the pipeline
-    /// would otherwise provide, rather than silently skipping it. On failure this produces
-    /// the exact same Result&lt;T&gt;.ValidationFailure shape TrainSkillCommandHandler's own inline
-    /// guards already return for this exact "no pipeline" scenario, so the demo has one
-    /// consistent failure-reporting path in <see cref="RunAsync"/> instead of two. See #533.
+    /// This demo calls the handler directly instead of dispatching through IMediator.Send, so
+    /// RequestValidationBehavior never runs — deliberately, since a real DI-resolved IMediator
+    /// would replace this demo's deterministic stubs with the real (or NotConfigured*,
+    /// fail-fast) IRolloutRunner/IPatchProposer. Validating by hand here restores that coverage
+    /// and returns the same <see cref="Result{T}"/>.ValidationFailure shape
+    /// TrainSkillCommandHandler's own inline guards use for this exact "no pipeline" scenario.
+    /// Internal (not private) so <c>Presentation.ConsoleUI.Tests</c> can assert the short-circuit
+    /// directly. See #533.
     /// </remarks>
-    private static async Task<Result<SkillTrainingRunResult>> ValidateAndDispatchAsync(
+    internal static async Task<Result<SkillTrainingRunResult>> ValidateAndDispatchAsync(
         TrainSkillCommandHandler handler, TrainSkillCommand cmd, CancellationToken cancellationToken)
     {
         var validation = await new TrainSkillCommandValidator().ValidateAsync(cmd, cancellationToken);
-        return validation.IsValid
-            ? await handler.Handle(cmd, cancellationToken)
-            : Result<SkillTrainingRunResult>.ValidationFailure(
+        if (!validation.IsValid)
+        {
+            return Result<SkillTrainingRunResult>.ValidationFailure(
                 validation.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}").ToList());
+        }
+
+        return await handler.Handle(cmd, cancellationToken);
     }
 
     private static TrainSkillCommandHandler BuildHandler()

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -57,6 +57,23 @@ public sealed class SkillTrainingExample
             }
         };
 
+        // This demo bypasses IMediator.Send and calls the handler directly, so
+        // RequestValidationBehavior never runs for TrainSkillCommand here. That's deliberate:
+        // the demo's whole point is running the state machine against deterministic,
+        // LLM-free stubs (DeterministicRolloutRunner/DeterministicProposer); dispatching
+        // through the app's real DI-registered IMediator would resolve the real (or
+        // NotConfigured*, fail-fast) IRolloutRunner/IPatchProposer instead of these stubs.
+        // The validator itself has no dependencies, so it's constructed by hand — same
+        // style as everything else in BuildHandler() — to restore the coverage the pipeline
+        // would otherwise provide, rather than silently skipping it. See #533.
+        var validationResult = await new TrainSkillCommandValidator().ValidateAsync(cmd, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var errors = validationResult.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}");
+            AnsiConsole.MarkupLineInterpolated($"[red]Validation failed:[/] {string.Join("; ", errors)}");
+            return;
+        }
+
         var result = await handler.Handle(cmd, cancellationToken);
         if (!result.IsSuccess)
         {

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.SkillTraining;
 using Application.AI.Common.Services.ClaimVerification;
 using Application.AI.Common.Services.SkillTraining;
 using Domain.AI.SkillTraining;
+using Domain.Common;
 using Domain.Common.Config;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -65,16 +66,16 @@ public sealed class SkillTrainingExample
         // NotConfigured*, fail-fast) IRolloutRunner/IPatchProposer instead of these stubs.
         // The validator itself has no dependencies, so it's constructed by hand — same
         // style as everything else in BuildHandler() — to restore the coverage the pipeline
-        // would otherwise provide, rather than silently skipping it. See #533.
-        var validationResult = await new TrainSkillCommandValidator().ValidateAsync(cmd, cancellationToken);
-        if (!validationResult.IsValid)
-        {
-            var errors = validationResult.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}");
-            AnsiConsole.MarkupLineInterpolated($"[red]Validation failed:[/] {string.Join("; ", errors)}");
-            return;
-        }
+        // would otherwise provide, rather than silently skipping it. On failure this produces
+        // the exact same Result<T>.ValidationFailure shape TrainSkillCommandHandler's own inline
+        // guards already return for this exact "no pipeline" scenario, so the demo has one
+        // consistent failure-reporting path below instead of two. See #533.
+        var validation = await new TrainSkillCommandValidator().ValidateAsync(cmd, cancellationToken);
+        var result = validation.IsValid
+            ? await handler.Handle(cmd, cancellationToken)
+            : Result<SkillTrainingRunResult>.ValidationFailure(
+                validation.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}").ToList());
 
-        var result = await handler.Handle(cmd, cancellationToken);
         if (!result.IsSuccess)
         {
             AnsiConsole.MarkupLineInterpolated($"[red]Training failed:[/] {string.Join("; ", result.Errors)}");

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -58,24 +58,7 @@ public sealed class SkillTrainingExample
             }
         };
 
-        // This demo bypasses IMediator.Send and calls the handler directly, so
-        // RequestValidationBehavior never runs for TrainSkillCommand here. That's deliberate:
-        // the demo's whole point is running the state machine against deterministic,
-        // LLM-free stubs (DeterministicRolloutRunner/DeterministicProposer); dispatching
-        // through the app's real DI-registered IMediator would resolve the real (or
-        // NotConfigured*, fail-fast) IRolloutRunner/IPatchProposer instead of these stubs.
-        // The validator itself has no dependencies, so it's constructed by hand — same
-        // style as everything else in BuildHandler() — to restore the coverage the pipeline
-        // would otherwise provide, rather than silently skipping it. On failure this produces
-        // the exact same Result<T>.ValidationFailure shape TrainSkillCommandHandler's own inline
-        // guards already return for this exact "no pipeline" scenario, so the demo has one
-        // consistent failure-reporting path below instead of two. See #533.
-        var validation = await new TrainSkillCommandValidator().ValidateAsync(cmd, cancellationToken);
-        var result = validation.IsValid
-            ? await handler.Handle(cmd, cancellationToken)
-            : Result<SkillTrainingRunResult>.ValidationFailure(
-                validation.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}").ToList());
-
+        var result = await ValidateAndDispatchAsync(handler, cmd, cancellationToken);
         if (!result.IsSuccess)
         {
             AnsiConsole.MarkupLineInterpolated($"[red]Training failed:[/] {string.Join("; ", result.Errors)}");
@@ -100,6 +83,33 @@ public sealed class SkillTrainingExample
             $"[bold]Best:[/] step {run.BestStep}, score {run.BestScore:F2}, accepted any: {run.HasAcceptedAny}");
         AnsiConsole.MarkupLineInterpolated(
             $"[grey]Steps executed: {run.StepsExecuted}, consecutive rejects on exit: {run.ConsecutiveRejects}[/]");
+    }
+
+    /// <summary>
+    /// Validates <paramref name="cmd"/> and dispatches to <paramref name="handler"/> on success.
+    /// </summary>
+    /// <remarks>
+    /// This demo bypasses IMediator.Send and calls the handler directly, so
+    /// RequestValidationBehavior never runs for TrainSkillCommand here. That's deliberate:
+    /// the demo's whole point is running the state machine against deterministic,
+    /// LLM-free stubs (DeterministicRolloutRunner/DeterministicProposer); dispatching
+    /// through the app's real DI-registered IMediator would resolve the real (or
+    /// NotConfigured*, fail-fast) IRolloutRunner/IPatchProposer instead of these stubs.
+    /// The validator itself has no dependencies, so it's constructed by hand — same
+    /// style as everything else in BuildHandler() — to restore the coverage the pipeline
+    /// would otherwise provide, rather than silently skipping it. On failure this produces
+    /// the exact same Result&lt;T&gt;.ValidationFailure shape TrainSkillCommandHandler's own inline
+    /// guards already return for this exact "no pipeline" scenario, so the demo has one
+    /// consistent failure-reporting path in <see cref="RunAsync"/> instead of two. See #533.
+    /// </remarks>
+    private static async Task<Result<SkillTrainingRunResult>> ValidateAndDispatchAsync(
+        TrainSkillCommandHandler handler, TrainSkillCommand cmd, CancellationToken cancellationToken)
+    {
+        var validation = await new TrainSkillCommandValidator().ValidateAsync(cmd, cancellationToken);
+        return validation.IsValid
+            ? await handler.Handle(cmd, cancellationToken)
+            : Result<SkillTrainingRunResult>.ValidationFailure(
+                validation.Errors.Select(e => $"{e.PropertyName}: {e.ErrorMessage}").ToList());
     }
 
     private static TrainSkillCommandHandler BuildHandler()

--- a/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Examples/SkillTrainingExample.cs
@@ -37,26 +37,7 @@ public sealed class SkillTrainingExample
         ConsoleHelper.DisplayModeInfo(isLive: false, "Deterministic stubs — no LLM calls.");
 
         var handler = BuildHandler();
-
-        var cmd = new TrainSkillCommand
-        {
-            RunId = "demo-run-1",
-            SkillId = "demo-skill",
-            InitialSkill = "# Demo Skill\n\n## Approach\n- Start simple.",
-            Config = new TrainSkillConfig
-            {
-                Epochs = 2,
-                StepsPerEpoch = 3,
-                LrStart = 4,
-                LrMin = 1,
-                LrScheduler = "cosine",
-                GateMetric = GateMetric.Hard,
-                Patience = 3,
-                UseSlowUpdate = false,
-                UseMetaSkill = false,
-                Seed = 42
-            }
-        };
+        var cmd = BuildDemoCommand();
 
         var result = await ValidateAndDispatchAsync(handler, cmd, cancellationToken);
         if (!result.IsSuccess)
@@ -111,7 +92,37 @@ public sealed class SkillTrainingExample
         return await handler.Handle(cmd, cancellationToken);
     }
 
-    private static TrainSkillCommandHandler BuildHandler()
+    /// <summary>
+    /// The demo's command. Internal (not private) so <c>Presentation.ConsoleUI.Tests</c> can
+    /// assert against the exact same literal <see cref="RunAsync"/> dispatches, instead of a
+    /// separately-typed copy that could drift from it.
+    /// </summary>
+    internal static TrainSkillCommand BuildDemoCommand() => new()
+    {
+        RunId = "demo-run-1",
+        SkillId = "demo-skill",
+        InitialSkill = "# Demo Skill\n\n## Approach\n- Start simple.",
+        Config = new TrainSkillConfig
+        {
+            Epochs = 2,
+            StepsPerEpoch = 3,
+            LrStart = 4,
+            LrMin = 1,
+            LrScheduler = "cosine",
+            GateMetric = GateMetric.Hard,
+            Patience = 3,
+            UseSlowUpdate = false,
+            UseMetaSkill = false,
+            Seed = 42
+        }
+    };
+
+    /// <summary>
+    /// Builds the handler with deterministic, LLM-free stubs. Internal (not private) so
+    /// <c>Presentation.ConsoleUI.Tests</c> can exercise <see cref="ValidateAndDispatchAsync"/>'s
+    /// success path end-to-end against a real handler, not just its validation short-circuit.
+    /// </summary>
+    internal static TrainSkillCommandHandler BuildHandler()
     {
         var aggregator = new PatchAggregator();
         var selector = new TopKEditSelector();

--- a/src/Content/Presentation/Presentation.ConsoleUI/Presentation.ConsoleUI.csproj
+++ b/src/Content/Presentation/Presentation.ConsoleUI/Presentation.ConsoleUI.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Presentation.ConsoleUI.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
     <PackageReference Include="Spectre.Console" />
   </ItemGroup>

--- a/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
+++ b/src/Content/Tests/Presentation.Common.Tests/Composition/SecurityControlHasACallerTests.cs
@@ -617,13 +617,14 @@ public sealed class SecurityControlHasACallerTests
     /// <strong>What this exemption does NOT prove.</strong> It says the type is <em>dispatchable</em>
     /// through MediatR, so a <c>Send</c> would run its validator. It does not prove every caller uses
     /// <c>Send</c>. A caller that constructs a handler and invokes <c>Handle</c> directly bypasses the
-    /// pipeline entirely, and that is not hypothetical — <c>SkillTrainingExample</c> does exactly this
-    /// with <c>TrainSkillCommand</c>, so <c>TrainSkillCommandValidator</c> is certified here while
-    /// that particular path runs none of its rules. Harmless there (the example's config is
-    /// hardcoded valid) but a pattern a template consumer could copy. Detecting it needs call-graph
-    /// analysis rather than a source scan, so it is stated rather than checked — the same honesty this
-    /// file demands of the consumer-resolved exemption, which likewise proves a consumer <em>would</em>
-    /// call each validator, not that one exists to be called.
+    /// pipeline entirely — this was not hypothetical: <c>SkillTrainingExample</c> did exactly this
+    /// with <c>TrainSkillCommand</c> until #533, which restored <c>TrainSkillCommandValidator</c>'s
+    /// coverage on that path by invoking it explicitly (the demo can't dispatch through the real
+    /// <c>IMediator</c> without losing its deterministic, LLM-free stubs — see the call site's own
+    /// comment). The general risk remains real for any future direct-<c>Handle</c> caller. Detecting
+    /// it needs call-graph analysis rather than a source scan, so it is stated rather than checked —
+    /// the same honesty this file demands of the consumer-resolved exemption, which likewise proves a
+    /// consumer <em>would</em> call each validator, not that one exists to be called.
     /// </para>
     /// <para>
     /// The base list is cut at <c>where</c> before matching. The capture runs to the end of the line,

--- a/src/Content/Tests/Presentation.ConsoleUI.Tests/Examples/SkillTrainingExampleTests.cs
+++ b/src/Content/Tests/Presentation.ConsoleUI.Tests/Examples/SkillTrainingExampleTests.cs
@@ -1,0 +1,83 @@
+using Application.AI.Common.CQRS.SkillTraining.TrainSkill;
+using Domain.AI.SkillTraining;
+using FluentAssertions;
+using Presentation.ConsoleUI.Examples;
+using Xunit;
+
+namespace Presentation.ConsoleUI.Tests.Examples;
+
+/// <summary>
+/// Regression coverage for #533: <see cref="SkillTrainingExample"/> calls
+/// <see cref="TrainSkillCommandHandler"/> directly instead of through <c>IMediator.Send</c>, so it
+/// must validate <see cref="TrainSkillCommand"/> itself before dispatching.
+/// </summary>
+public sealed class SkillTrainingExampleTests
+{
+    /// <summary>
+    /// A null handler proves the short-circuit: if an invalid command ever reached
+    /// <c>handler.Handle</c>, this would throw <see cref="NullReferenceException"/> instead of
+    /// returning a validation failure.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAndDispatchAsync_InvalidCommand_ReturnsValidationFailureWithoutInvokingHandler()
+    {
+        var invalid = new TrainSkillCommand
+        {
+            RunId = "",
+            SkillId = "demo-skill",
+            InitialSkill = "# Demo",
+            Config = new TrainSkillConfig
+            {
+                Epochs = 2,
+                StepsPerEpoch = 3,
+                LrStart = 1,
+                LrMin = 4,
+                LrScheduler = "bogus",
+                GateMetric = GateMetric.Hard,
+                Patience = 3,
+                Seed = 42
+            }
+        };
+
+        var result = await SkillTrainingExample.ValidateAndDispatchAsync(
+            handler: null!, invalid, CancellationToken.None);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.Contains("RunId"));
+        result.Errors.Should().Contain(e => e.Contains("LrScheduler"));
+        result.Errors.Should().Contain(e => e.Contains("LrMin"));
+    }
+
+    /// <summary>
+    /// The demo's own hardcoded command must keep passing validation, or the demo would silently
+    /// stop running.
+    /// </summary>
+    [Fact]
+    public async Task ValidateAndDispatchAsync_DemoCommand_PassesValidation()
+    {
+        var demoCommand = new TrainSkillCommand
+        {
+            RunId = "demo-run-1",
+            SkillId = "demo-skill",
+            InitialSkill = "# Demo Skill\n\n## Approach\n- Start simple.",
+            Config = new TrainSkillConfig
+            {
+                Epochs = 2,
+                StepsPerEpoch = 3,
+                LrStart = 4,
+                LrMin = 1,
+                LrScheduler = "cosine",
+                GateMetric = GateMetric.Hard,
+                Patience = 3,
+                UseSlowUpdate = false,
+                UseMetaSkill = false,
+                Seed = 42
+            }
+        };
+
+        var validator = new TrainSkillCommandValidator();
+        var validationResult = await validator.ValidateAsync(demoCommand);
+
+        validationResult.IsValid.Should().BeTrue();
+    }
+}

--- a/src/Content/Tests/Presentation.ConsoleUI.Tests/Examples/SkillTrainingExampleTests.cs
+++ b/src/Content/Tests/Presentation.ConsoleUI.Tests/Examples/SkillTrainingExampleTests.cs
@@ -49,35 +49,21 @@ public sealed class SkillTrainingExampleTests
     }
 
     /// <summary>
-    /// The demo's own hardcoded command must keep passing validation, or the demo would silently
-    /// stop running.
+    /// Exercises ValidateAndDispatchAsync's success path end-to-end: the demo's own command
+    /// (via <see cref="SkillTrainingExample.BuildDemoCommand"/>, not a separately-typed copy)
+    /// against a real handler (via <see cref="SkillTrainingExample.BuildHandler"/>) must pass
+    /// validation and reach handler.Handle, or the demo would silently stop running.
     /// </summary>
     [Fact]
-    public async Task ValidateAndDispatchAsync_DemoCommand_PassesValidation()
+    public async Task ValidateAndDispatchAsync_DemoCommand_PassesValidationAndDispatchesToHandler()
     {
-        var demoCommand = new TrainSkillCommand
-        {
-            RunId = "demo-run-1",
-            SkillId = "demo-skill",
-            InitialSkill = "# Demo Skill\n\n## Approach\n- Start simple.",
-            Config = new TrainSkillConfig
-            {
-                Epochs = 2,
-                StepsPerEpoch = 3,
-                LrStart = 4,
-                LrMin = 1,
-                LrScheduler = "cosine",
-                GateMetric = GateMetric.Hard,
-                Patience = 3,
-                UseSlowUpdate = false,
-                UseMetaSkill = false,
-                Seed = 42
-            }
-        };
+        var handler = SkillTrainingExample.BuildHandler();
+        var demoCommand = SkillTrainingExample.BuildDemoCommand();
 
-        var validator = new TrainSkillCommandValidator();
-        var validationResult = await validator.ValidateAsync(demoCommand);
+        var result = await SkillTrainingExample.ValidateAndDispatchAsync(
+            handler, demoCommand, CancellationToken.None);
 
-        validationResult.IsValid.Should().BeTrue();
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
     }
 }

--- a/src/Content/Tests/Presentation.ConsoleUI.Tests/Presentation.ConsoleUI.Tests.csproj
+++ b/src/Content/Tests/Presentation.ConsoleUI.Tests/Presentation.ConsoleUI.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>Presentation.ConsoleUI.Tests</RootNamespace>
+    <Configurations>Debug;Release;Debug-AgentHub-All;Debug-AgentHub-WebUI;Debug-AgentHub-Dashboard</Configurations>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../Presentation/Presentation.ConsoleUI/Presentation.ConsoleUI.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- `SkillTrainingExample` calls `TrainSkillCommandHandler.Handle` directly instead of through `IMediator.Send`, so `RequestValidationBehavior` never runs — the demo needs deterministic, LLM-free stubs for `IRolloutRunner`/`IPatchProposer` that a real DI-resolved `IMediator` would replace with the real (or `NotConfigured*`, fail-fast) implementations. That left `TrainSkillCommandValidator`'s rules unenforced on this path — harmless today (the demo's hardcoded command is always valid) but a template consumer copying this pattern with real user-supplied config would get zero validation and no error saying so.
- Extracted the validate-then-dispatch logic into `ValidateAndDispatchAsync`, which runs `TrainSkillCommandValidator` by hand and, on failure, returns the exact same `Result<T>.ValidationFailure` shape `TrainSkillCommandHandler`'s own inline guards already use for this exact "no pipeline" scenario — so the demo has one consistent failure-reporting path instead of two.
- Added `Presentation.ConsoleUI.Tests` (new project — none existed for this layer) with regression coverage: an invalid-command test proves the guard short-circuits before `handler.Handle` (passes `handler: null!` so a broken guard fails loudly), and a demo-command test exercises the success path end-to-end against a real handler. Both mutation-tested by temporarily breaking the code under test and confirming the test fails, then reverting.
- Updated a now-stale doc comment in `SecurityControlHasACallerTests.cs` that cited this exact file as a live example of the gap.

Closes #533.

## Review notes

Went through 3 local review rounds (each found something real and got fixed):
1. Initial fix — clean on correctness/grader, one advisory (stale doc comment, fixed).
2. `/simplify` (4 parallel angles) converged on routing the failure through `Result<T>.ValidationFailure` instead of a hand-rolled print branch; `/code-review` separately flagged the resulting function exceeding the 50-line guideline — both fixed.
3. `/code-review` found the new tests didn't actually exercise the method under test (one test called the validator directly instead of `ValidateAndDispatchAsync`, the other never ran at all) — fixed by extracting `BuildDemoCommand`/making `BuildHandler` internal so tests drive the real methods end-to-end.

**Deliberately not fixed:** the validation-error format string (`$"{PropertyName}: {ErrorMessage}"`) duplicates the identical line in `RequestValidationBehavior.cs` — flagged twice, independently, by different review passes. Low severity (pure formatting, no functional impact), and extracting a shared helper for a 2-site duplication is more abstraction than the fix warrants. Noted here rather than fixed.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 errors
- [x] New `Presentation.ConsoleUI.Tests` project: 2/2 pass, both mutation-tested
- [x] `dotnet test` locally: only failures are 9 pre-existing `Presentation.AgentHub.Tests.Telemetry.MetricsE2ETests` — confirmed environmental (Docker Desktop unavailable on this machine, so Testcontainers can't start the Prometheus fixture), unrelated to this change (different layer entirely). CI has Docker and will run these for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu