### PR TITLE
fix: don't deny everything for an AllowedTools-only boundary fault

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
@@ -66,14 +66,44 @@ public interface IPluginRegistry
     /// <summary>
     /// Marks <paramref name="pluginName"/>'s tool boundary <see cref="PluginBoundaryStatus.Faulted"/>:
     /// at least one of its <c>AllowedTools</c>/<c>DeniedTools</c> entries has been proven to match no
-    /// real tool (#524). A boundary that can't be trusted is treated fail-closed — <c>ToolChainBuilder</c>
-    /// denies every tool for a faulted plugin rather than run with a partially-broken policy, since a
-    /// typo in <c>DeniedTools</c> (documented as bypass-immune) silently defeats that guarantee
-    /// otherwise. Terminal: once faulted, always faulted for the process lifetime.
+    /// real tool (#524). A boundary that can't be trusted is treated fail-closed by default —
+    /// <c>ToolChainBuilder</c> denies every tool for a faulted plugin rather than run with a
+    /// partially-broken policy, since a typo in <c>DeniedTools</c> (documented as bypass-immune)
+    /// silently defeats that guarantee otherwise. Terminal: once faulted, always faulted for the
+    /// process lifetime.
     /// </summary>
     /// <param name="pluginName">The plugin whose boundary is faulted.</param>
     /// <param name="reason">Human-readable reason, for logging/diagnostics.</param>
-    void MarkBoundaryFaulted(string pluginName, string reason);
+    /// <param name="violations">
+    /// The specific entries that proved fake (#608). Callers that need to distinguish a
+    /// <c>DeniedTools</c> fault (still must fail closed everywhere — the bypass-immune guarantee is at
+    /// risk) from an <c>AllowedTools</c>-only fault (can never widen access, so the narrower
+    /// consequence of just excluding that one name is safe) read this back via
+    /// <see cref="GetBoundaryViolations"/>. Required, not optional: the only production caller
+    /// (<c>PluginToolBoundaryTracker</c>) already computes this list at both places it calls this
+    /// method, so there is no case where passing it is a real burden — and an optional parameter would
+    /// let a future call site silently keep the registry violations-blind for that plugin, defeating
+    /// the whole point of storing this.
+    /// </param>
+    void MarkBoundaryFaulted(
+        string pluginName, string reason, IReadOnlyList<PluginToolBoundaryViolation> violations);
+
+    /// <summary>
+    /// The specific boundary entries that proved <paramref name="pluginName"/>'s tool boundary
+    /// <see cref="PluginBoundaryStatus.Faulted"/> (#608) — empty when the plugin isn't
+    /// <see cref="PluginBoundaryStatus.Faulted"/>, or when it is but no violation detail was recorded
+    /// for it.
+    /// </summary>
+    /// <remarks>
+    /// A caller deciding how broadly to fail closed on a Faulted plugin should treat an empty result
+    /// here the same as "at least one violation is <c>DeniedTools</c>" — i.e. fail closed on
+    /// uncertainty, not just on a confirmed hit. The only way this comes back empty for a genuinely
+    /// Faulted plugin is a registry implementation (or a test double) that never recorded violations at
+    /// all, and that absence of information is exactly the case #524's own reasoning treats as
+    /// dangerous-until-proven-otherwise.
+    /// </remarks>
+    /// <param name="pluginName">The plugin to query.</param>
+    IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName);
 
     /// <summary>
     /// Monotonically increasing counter, bumped by every mutation (<see cref="Register"/>,

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
@@ -79,7 +79,6 @@ public interface IPluginRegistry
     /// process lifetime.
     /// </summary>
     /// <param name="pluginName">The plugin whose boundary is faulted.</param>
-    /// <param name="reason">Human-readable reason, for logging/diagnostics.</param>
     /// <param name="violations">
     /// The specific entries that proved fake (#608). Callers that need to distinguish a
     /// <c>DeniedTools</c> fault (still must fail closed everywhere — the bypass-immune guarantee is at
@@ -89,10 +88,12 @@ public interface IPluginRegistry
     /// (<c>PluginToolBoundaryTracker</c>) already computes this list at both places it calls this
     /// method, so there is no case where passing it is a real burden — and an optional parameter would
     /// let a future call site silently keep the registry violations-blind for that plugin, defeating
-    /// the whole point of storing this.
+    /// the whole point of storing this. (An earlier revision also took a human-readable <c>reason</c>
+    /// string here — dropped in a /simplify pass: the implementation never used it (every real caller
+    /// already logs/throws its own formatted detail at the point of fault), and it carried no
+    /// information <paramref name="violations"/> doesn't already carry structurally.)
     /// </param>
-    void MarkBoundaryFaulted(
-        string pluginName, string reason, IReadOnlyList<PluginToolBoundaryViolation> violations);
+    void MarkBoundaryFaulted(string pluginName, IReadOnlyList<PluginToolBoundaryViolation> violations);
 
     /// <summary>
     /// The specific boundary entries that proved <paramref name="pluginName"/>'s tool boundary

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginRegistry.cs
@@ -36,9 +36,15 @@ public interface IPluginRegistry
     /// window defaulted to Verified, meaning a genuinely never-checked <c>DeniedTools</c> entry (which
     /// is a silent no-op until proven to match a real tool — see <see cref="MarkBoundaryFaulted"/>)
     /// would be trusted and applied as if already proven safe. Defaulting to Pending closes that by
-    /// construction: the caller denies all tools for a plugin in this state exactly as it does for one
-    /// already proven <see cref="PluginBoundaryStatus.Faulted"/>, regardless of whether the race is
-    /// even reachable in a given host's actual startup ordering.
+    /// construction: the caller denies all tools for a plugin in this state, regardless of whether the
+    /// race is even reachable in a given host's actual startup ordering — the same fail-closed
+    /// treatment a <see cref="PluginBoundaryStatus.Faulted"/> boundary gets when its violations aren't
+    /// (or can't be) proven confined to <c>AllowedTools</c>. Since #608, that "exactly as Faulted"
+    /// equivalence is no longer literal in every case: a Faulted boundary whose violations ARE proven
+    /// confined to <c>AllowedTools</c> runs the caller's normal filter instead of denying everything,
+    /// while Pending still denies everything unconditionally — Pending was deliberately left out of
+    /// that narrowing (see <c>PluginPermissionRuleProvider.BoundaryDemandsAgentWideFailClosed</c>'s
+    /// remarks for why: it's transient by nature, not a #608 scope decision).
     /// </remarks>
     PluginBoundaryStatus GetBoundaryStatus(string pluginName);
 

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -12,6 +12,21 @@ namespace Application.AI.Common.Interfaces.Plugins;
 public sealed record PluginToolBoundaryViolation(string PluginName, string ListKind, string ToolName);
 
 /// <summary>
+/// The two values <see cref="PluginToolBoundaryViolation.ListKind"/> can hold. Shared so
+/// <c>PluginToolBoundaryTracker</c> (which produces violations) and every consumer that reads them
+/// back via <see cref="IPluginRegistry.GetBoundaryViolations"/> (#608) compare against the same
+/// symbols rather than each hardcoding the literal strings.
+/// </summary>
+public static class PluginToolBoundaryListKind
+{
+    /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.AllowedTools"/> entry.</summary>
+    public const string AllowedTools = "AllowedTools";
+
+    /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.DeniedTools"/> entry.</summary>
+    public const string DeniedTools = "DeniedTools";
+}
+
+/// <summary>
 /// Tracks whether every <c>AllowedTools</c>/<c>DeniedTools</c> entry a loaded plugin declares
 /// actually matches a real tool — first-party (keyed-DI, known at startup) or MCP-provided (known
 /// only once the owning server's tool list has been discovered at least once).

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -43,13 +43,41 @@ public static class PluginToolBoundaryViolationExtensions
     /// certainty.
     /// </summary>
     /// <remarks>
-    /// The single shared decision both <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> and
-    /// <c>PluginPermissionRuleProvider.BoundaryDemandsAgentWideFailClosed</c> must agree on (#608
-    /// code-review) — two independent reimplementations of the same predicate risk silently
-    /// diverging if this shape is ever revisited (e.g. a third list kind).
+    /// The leaf check <see cref="RequiresFailClosed"/> is built from — kept separate because it's a
+    /// pure fact about a violation list, independent of what a caller does with it.
     /// </remarks>
     public static bool IsConfinedToAllowedTools(this IReadOnlyList<PluginToolBoundaryViolation>? violations) =>
         violations is { Count: > 0 } && violations.All(v => v.ListKind == PluginToolBoundaryListKind.AllowedTools);
+
+    /// <summary>
+    /// Whether a plugin's boundary <paramref name="status"/> demands the caller's fail-closed
+    /// response (#608) — deny everything, rather than run the normal boundary filter.
+    /// <see langword="true"/> for <see cref="PluginBoundaryStatus.Pending"/> unconditionally (it's
+    /// transient — resolves to <see cref="PluginBoundaryStatus.Verified"/> or
+    /// <see cref="PluginBoundaryStatus.Faulted"/> once every configured MCP server reports, so
+    /// narrowing it isn't part of what #608 addressed), and for
+    /// <see cref="PluginBoundaryStatus.Faulted"/> unless <paramref name="violations"/> is
+    /// <see cref="IsConfinedToAllowedTools">confined to AllowedTools</see>.
+    /// </summary>
+    /// <remarks>
+    /// The single shared decision both <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> and
+    /// <c>PluginPermissionRuleProvider.BoundaryDemandsAgentWideFailClosed</c> call, instead of each
+    /// independently re-deriving the same Verified/Pending/Faulted branch (#608 code-review /
+    /// /simplify — flagged across two review rounds as a divergence risk: only the leaf
+    /// <see cref="IsConfinedToAllowedTools"/> check was originally shared, not the branch around it).
+    /// <paramref name="violations"/> is only consulted when <paramref name="status"/> is
+    /// <see cref="PluginBoundaryStatus.Faulted"/> — callers should pass <see langword="null"/> (or
+    /// skip fetching it) otherwise, since <see cref="IPluginRegistry.GetBoundaryViolations"/> is
+    /// meaningless for any other status.
+    /// </remarks>
+    public static bool RequiresFailClosed(
+        this PluginBoundaryStatus status, IReadOnlyList<PluginToolBoundaryViolation>? violations) =>
+        status switch
+        {
+            PluginBoundaryStatus.Verified => false,
+            PluginBoundaryStatus.Faulted => !violations.IsConfinedToAllowedTools(),
+            _ => true, // Pending, or any future status — fail closed on uncertainty.
+        };
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -24,6 +24,24 @@ public static class PluginToolBoundaryListKind
 
     /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.DeniedTools"/> entry.</summary>
     public const string DeniedTools = "DeniedTools";
+
+    /// <summary>
+    /// Whether a Faulted boundary's <paramref name="violations"/> are provably confined to
+    /// <see cref="AllowedTools"/> — the one shape (#608) that can never widen a plugin's access and
+    /// can never defeat the <see cref="DeniedTools"/> bypass-immune guarantee, so it's safe for a
+    /// consumer to run its normal boundary filter instead of denying everything. <see langword="null"/>
+    /// or an empty list is NOT confined — a registry that recorded nothing gives no way to rule out a
+    /// <see cref="DeniedTools"/> hit, so it must be treated the same as a confirmed one: fail closed
+    /// on uncertainty, not just on certainty.
+    /// </summary>
+    /// <remarks>
+    /// The single shared decision both <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> and
+    /// <c>PluginPermissionRuleProvider.BoundaryDemandsAgentWideFailClosed</c> must agree on (#608
+    /// code-review) — two independent reimplementations of the same predicate risk silently
+    /// diverging if this shape is ever revisited (e.g. a third list kind).
+    /// </remarks>
+    public static bool IsFaultConfinedToAllowedTools(IReadOnlyList<PluginToolBoundaryViolation>? violations) =>
+        violations is { Count: > 0 } && violations.All(v => v.ListKind == AllowedTools);
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -3,28 +3,30 @@ using Domain.Common.Config.AI.Plugins;
 namespace Application.AI.Common.Interfaces.Plugins;
 
 /// <summary>
+/// Which declared list a <see cref="PluginToolBoundaryViolation"/> came from. An enum, not a
+/// string (#608 code-review/security-reviewer) — since #608, this field is the SOLE discriminator
+/// between "deny everything" and "run the normal boundary filter," so a typo'd or mislabeled string
+/// would have been a silent security decision with no compiler protection. Both producers already
+/// compare against these two symbols rather than hardcoding literals; the enum makes that the only
+/// possible comparison instead of a convention.
+/// </summary>
+public enum PluginToolBoundaryListKind
+{
+    /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.AllowedTools"/> entry.</summary>
+    AllowedTools,
+
+    /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.DeniedTools"/> entry.</summary>
+    DeniedTools,
+}
+
+/// <summary>
 /// One <see cref="PluginDeclaration.AllowedTools"/>/<see cref="PluginDeclaration.DeniedTools"/>
 /// entry that has been confirmed to not match any known tool — first-party or MCP-provided.
 /// </summary>
 /// <param name="PluginName">The plugin whose boundary declared the entry.</param>
-/// <param name="ListKind">Either <c>"AllowedTools"</c> or <c>"DeniedTools"</c>, for the error message.</param>
+/// <param name="ListKind">Which list the offending entry came from.</param>
 /// <param name="ToolName">The offending entry itself.</param>
-public sealed record PluginToolBoundaryViolation(string PluginName, string ListKind, string ToolName);
-
-/// <summary>
-/// The two values <see cref="PluginToolBoundaryViolation.ListKind"/> can hold. Shared so
-/// <c>PluginToolBoundaryTracker</c> (which produces violations) and every consumer that reads them
-/// back via <see cref="IPluginRegistry.GetBoundaryViolations"/> (#608) compare against the same
-/// symbols rather than each hardcoding the literal strings.
-/// </summary>
-public static class PluginToolBoundaryListKind
-{
-    /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.AllowedTools"/> entry.</summary>
-    public const string AllowedTools = "AllowedTools";
-
-    /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.DeniedTools"/> entry.</summary>
-    public const string DeniedTools = "DeniedTools";
-}
+public sealed record PluginToolBoundaryViolation(string PluginName, PluginToolBoundaryListKind ListKind, string ToolName);
 
 /// <summary>
 /// Extension helpers over a <see cref="PluginToolBoundaryViolation"/> list, used to classify a
@@ -78,6 +80,24 @@ public static class PluginToolBoundaryViolationExtensions
             PluginBoundaryStatus.Faulted => !violations.IsConfinedToAllowedTools(),
             _ => true, // Pending, or any future status — fail closed on uncertainty.
         };
+
+    /// <summary>
+    /// Whether <paramref name="pluginName"/>'s CURRENT boundary state (read fresh from
+    /// <paramref name="registry"/>) demands the fail-closed response (#608) — the fetch-and-pair
+    /// both consumers need, not just the leaf decision. Only fetches
+    /// <see cref="IPluginRegistry.GetBoundaryViolations"/> when the status is actually
+    /// <see cref="PluginBoundaryStatus.Faulted"/> (security-reviewer finding: consolidates the
+    /// "only fetch violations when Faulted" rule both call sites previously re-derived by hand).
+    /// </summary>
+    public static bool BoundaryRequiresFailClosed(this IPluginRegistry registry, string pluginName)
+    {
+        var status = registry.GetBoundaryStatus(pluginName);
+        var violations = status == PluginBoundaryStatus.Faulted
+            ? registry.GetBoundaryViolations(pluginName)
+            : null;
+
+        return status.RequiresFailClosed(violations);
+    }
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -24,15 +24,23 @@ public static class PluginToolBoundaryListKind
 
     /// <summary>A <see cref="Domain.Common.Config.AI.Plugins.PluginDeclaration.DeniedTools"/> entry.</summary>
     public const string DeniedTools = "DeniedTools";
+}
 
+/// <summary>
+/// Extension helpers over a <see cref="PluginToolBoundaryViolation"/> list, used to classify a
+/// <c>Faulted</c> boundary's fault shape (#608).
+/// </summary>
+public static class PluginToolBoundaryViolationExtensions
+{
     /// <summary>
     /// Whether a Faulted boundary's <paramref name="violations"/> are provably confined to
-    /// <see cref="AllowedTools"/> — the one shape (#608) that can never widen a plugin's access and
-    /// can never defeat the <see cref="DeniedTools"/> bypass-immune guarantee, so it's safe for a
-    /// consumer to run its normal boundary filter instead of denying everything. <see langword="null"/>
-    /// or an empty list is NOT confined — a registry that recorded nothing gives no way to rule out a
-    /// <see cref="DeniedTools"/> hit, so it must be treated the same as a confirmed one: fail closed
-    /// on uncertainty, not just on certainty.
+    /// <see cref="PluginToolBoundaryListKind.AllowedTools"/> — the one shape (#608) that can never
+    /// widen a plugin's access and can never defeat the <see cref="PluginToolBoundaryListKind.DeniedTools"/>
+    /// bypass-immune guarantee, so it's safe for a consumer to run its normal boundary filter instead
+    /// of denying everything. <see langword="null"/> or an empty list is NOT confined — a registry
+    /// that recorded nothing gives no way to rule out a <see cref="PluginToolBoundaryListKind.DeniedTools"/>
+    /// hit, so it must be treated the same as a confirmed one: fail closed on uncertainty, not just on
+    /// certainty.
     /// </summary>
     /// <remarks>
     /// The single shared decision both <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> and
@@ -40,8 +48,8 @@ public static class PluginToolBoundaryListKind
     /// code-review) — two independent reimplementations of the same predicate risk silently
     /// diverging if this shape is ever revisited (e.g. a third list kind).
     /// </remarks>
-    public static bool IsFaultConfinedToAllowedTools(IReadOnlyList<PluginToolBoundaryViolation>? violations) =>
-        violations is { Count: > 0 } && violations.All(v => v.ListKind == AllowedTools);
+    public static bool IsConfinedToAllowedTools(this IReadOnlyList<PluginToolBoundaryViolation>? violations) =>
+        violations is { Count: > 0 } && violations.All(v => v.ListKind == PluginToolBoundaryListKind.AllowedTools);
 }
 
 /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -10,7 +10,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
     // call site) is safe and needs no dedicated lock object.
     private sealed class PendingPlugin
     {
-        public required Dictionary<string, string> PendingEntries { get; init; } // name -> list kind
+        public required Dictionary<string, PluginToolBoundaryListKind> PendingEntries { get; init; } // name -> list kind
         public required HashSet<string> PendingServers { get; init; }
 
         // Guards against firing twice for one plugin: a caller can still hold this same instance
@@ -201,9 +201,9 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
         return violations;
     }
 
-    private static IReadOnlyList<(string Name, string ListKind)> BoundaryEntries(LoadedPlugin plugin)
+    private static IReadOnlyList<(string Name, PluginToolBoundaryListKind ListKind)> BoundaryEntries(LoadedPlugin plugin)
     {
-        var entries = new List<(string, string)>();
+        var entries = new List<(string, PluginToolBoundaryListKind)>();
         if (plugin.Declaration.AllowedTools is { Count: > 0 } allowed)
             entries.AddRange(allowed.Select(name => (name, PluginToolBoundaryListKind.AllowedTools)));
         if (plugin.Declaration.DeniedTools is { Count: > 0 } denied)

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -6,9 +6,6 @@ namespace Application.AI.Common.Services.Plugins;
 /// <inheritdoc cref="IPluginToolBoundaryTracker" />
 public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
 {
-    private const string AllowedToolsListKind = "AllowedTools";
-    private const string DeniedToolsListKind = "DeniedTools";
-
     // Never exposed outside this file, so locking on the instance itself (lock (pending) at each
     // call site) is safe and needs no dedicated lock object.
     private sealed class PendingPlugin
@@ -70,7 +67,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 // A name duplicated across both lists reports as DeniedTools — the list the
                 // bypass-immune security guarantee actually depends on — rather than whichever
                 // list happened to be enumerated first.
-                .Select(g => g.FirstOrDefault(e => e.ListKind == DeniedToolsListKind, g.First()))
+                .Select(g => g.FirstOrDefault(e => e.ListKind == PluginToolBoundaryListKind.DeniedTools, g.First()))
                 .ToList();
             if (unresolved.Count == 0)
             {
@@ -104,7 +101,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 // the registry here too means the fault is recorded independently of whether that
                 // caller rethrows — the same defense-in-depth ReportServerToolsDiscovered already
                 // gives the lazy branch.
-                _registry.MarkBoundaryFaulted(plugin.Name, FaultReason(immediateForPlugin));
+                _registry.MarkBoundaryFaulted(plugin.Name, FaultReason(immediateForPlugin), immediateForPlugin);
                 continue;
             }
 
@@ -196,7 +193,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             }
             else if (faulted is { Count: > 0 })
             {
-                _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted));
+                _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted), faulted);
                 violations.AddRange(faulted);
             }
         }
@@ -211,9 +208,9 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
     {
         var entries = new List<(string, string)>();
         if (plugin.Declaration.AllowedTools is { Count: > 0 } allowed)
-            entries.AddRange(allowed.Select(name => (name, AllowedToolsListKind)));
+            entries.AddRange(allowed.Select(name => (name, PluginToolBoundaryListKind.AllowedTools)));
         if (plugin.Declaration.DeniedTools is { Count: > 0 } denied)
-            entries.AddRange(denied.Select(name => (name, DeniedToolsListKind)));
+            entries.AddRange(denied.Select(name => (name, PluginToolBoundaryListKind.DeniedTools)));
         return entries;
     }
 }

--- a/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Plugins/PluginToolBoundaryTracker.cs
@@ -101,7 +101,7 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
                 // the registry here too means the fault is recorded independently of whether that
                 // caller rethrows — the same defense-in-depth ReportServerToolsDiscovered already
                 // gives the lazy branch.
-                _registry.MarkBoundaryFaulted(plugin.Name, FaultReason(immediateForPlugin), immediateForPlugin);
+                _registry.MarkBoundaryFaulted(plugin.Name, immediateForPlugin);
                 continue;
             }
 
@@ -193,16 +193,13 @@ public sealed class PluginToolBoundaryTracker : IPluginToolBoundaryTracker
             }
             else if (faulted is { Count: > 0 })
             {
-                _registry.MarkBoundaryFaulted(pluginName, FaultReason(faulted), faulted);
+                _registry.MarkBoundaryFaulted(pluginName, faulted);
                 violations.AddRange(faulted);
             }
         }
 
         return violations;
     }
-
-    private static string FaultReason(IReadOnlyList<PluginToolBoundaryViolation> violations) =>
-        $"Tool boundary entries match no known tool: {string.Join(", ", violations.Select(v => $"{v.ListKind}:{v.ToolName}"))}";
 
     private static IReadOnlyList<(string Name, string ListKind)> BoundaryEntries(LoadedPlugin plugin)
     {

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -258,18 +258,11 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // entry there means the tool the plugin author meant to block never gets excluded, which is
         // the actual hazard #524 exists to prevent — so that case (and Pending, and an empty/unknown
         // violation set) still denies everything, fail-closed on uncertainty exactly as before.
-        if (status == PluginBoundaryStatus.Faulted)
+        if (status == PluginBoundaryStatus.Faulted
+            && PluginToolBoundaryListKind.IsFaultConfinedToAllowedTools(
+                pluginRegistry.GetBoundaryViolations(skill.PluginSource)))
         {
-            // Null-tolerant: IPluginRegistry.GetBoundaryViolations documents "empty ... when no
-            // violation detail was recorded" — a registry implementation that genuinely recorded
-            // nothing (including a test double with no explicit setup) is exactly that case, and
-            // must be treated identically to an explicit empty list: fail closed on uncertainty.
-            var violations = pluginRegistry.GetBoundaryViolations(skill.PluginSource);
-            if (violations is { Count: > 0 }
-                && violations.All(v => v.ListKind == PluginToolBoundaryListKind.AllowedTools))
-            {
-                return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
-            }
+            return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
         }
 
         _logger.LogWarning(

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -240,26 +240,21 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // #524: a boundary entry that matches no real tool is provably broken, not just
         // permissive — most dangerously for DeniedTools, documented as bypass-immune. Once
         // PluginToolBoundaryTracker has proven that (see its remarks), the boundary can no longer
-        // be fully trusted. Pending is treated identically to a DeniedTools-involving Faulted, not
-        // to Verified — an entry still awaiting an MCP server's tool list is exactly as unproven as
-        // one already confirmed fake, and trusting it in the meantime is the specific gap a review
-        // round found: a server nothing else happens to query left a plugin's boundary silently
-        // trusted forever.
-        // #608: a Faulted boundary whose violations are ALL AllowedTools entries can never widen
-        // this plugin's access — AllowedTools is a positive allow-set match
-        // (ApplyPluginToolBoundary's own `tools.Where(t => allowSet.Contains(...))`), so a name that
-        // matches no real tool is already an inert no-op there; running the filter normally already
-        // produces the narrower "just lose that one tool" outcome the corrupted entry implies,
-        // without any special-casing. A DeniedTools-involving fault is the opposite shape: a bogus
-        // entry there means the tool the plugin author meant to block never gets excluded, which is
-        // the actual hazard #524 exists to prevent — so that case (and Pending, and an empty/unknown
-        // violation set) still denies everything, fail-closed on uncertainty exactly as before.
+        // be fully trusted. #608 narrowed this: a Faulted boundary whose violations are ALL
+        // AllowedTools entries can never widen this plugin's access — AllowedTools is a positive
+        // allow-set match (ApplyPluginToolBoundary's own `tools.Where(t => allowSet.Contains(...))`),
+        // so a name that matches no real tool is already an inert no-op there; running the filter
+        // normally already produces the narrower "just lose that one tool" outcome the corrupted
+        // entry implies, without any special-casing. Every other case (a DeniedTools-involving
+        // Faulted, Pending, or an empty/unknown violation set) still denies everything, fail-closed
+        // on uncertainty — see PluginBoundaryStatus.RequiresFailClosed's remarks, the single shared
+        // decision this and PluginPermissionRuleProvider.BoundaryDemandsAgentWideFailClosed both call.
         var status = pluginRegistry!.GetBoundaryStatus(skill.PluginSource);
-        var trustedEnoughToApplyNormally = status == PluginBoundaryStatus.Verified
-            || (status == PluginBoundaryStatus.Faulted
-                && pluginRegistry.GetBoundaryViolations(skill.PluginSource).IsConfinedToAllowedTools());
+        var violations = status == PluginBoundaryStatus.Faulted
+            ? pluginRegistry.GetBoundaryViolations(skill.PluginSource)
+            : null;
 
-        if (trustedEnoughToApplyNormally)
+        if (!status.RequiresFailClosed(violations))
             return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
 
         _logger.LogWarning(

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -247,15 +247,32 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // normally already produces the narrower "just lose that one tool" outcome the corrupted
         // entry implies, without any special-casing. Every other case (a DeniedTools-involving
         // Faulted, Pending, or an empty/unknown violation set) still denies everything, fail-closed
-        // on uncertainty — see PluginBoundaryStatus.RequiresFailClosed's remarks, the single shared
-        // decision this and PluginPermissionRuleProvider.BoundaryDemandsAgentWideFailClosed both call.
+        // on uncertainty — see PluginToolBoundaryViolationExtensions.RequiresFailClosed's remarks,
+        // the single shared decision this and PluginPermissionRuleProvider.BoundaryDemandsAgentWideFailClosed
+        // both call. Fetched here rather than through the BoundaryRequiresFailClosed(registry, name)
+        // convenience overload next to it, since this method needs `status` again below for the log
+        // message — calling that overload would mean fetching status twice, not once.
         var status = pluginRegistry!.GetBoundaryStatus(skill.PluginSource);
         var violations = status == PluginBoundaryStatus.Faulted
             ? pluginRegistry.GetBoundaryViolations(skill.PluginSource)
             : null;
 
         if (!status.RequiresFailClosed(violations))
+        {
+            if (status == PluginBoundaryStatus.Faulted)
+            {
+                // security-reviewer finding: the run-normally-on-a-Faulted-boundary case is silent
+                // otherwise — visible only by NOT seeing the deny warning below. Log it explicitly at
+                // the enforcement point, not just at the point the fault was first recorded.
+                _logger.LogWarning(
+                    "Plugin '{Plugin}' tool boundary is Faulted, but every violation is confined to " +
+                    "AllowedTools (#608) — running the normal boundary filter for skill '{Skill}' " +
+                    "instead of denying everything.",
+                    skill.PluginSource, skill.Id);
+            }
+
             return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
+        }
 
         _logger.LogWarning(
             "Plugin '{Plugin}' tool boundary is {Status} (an AllowedTools/DeniedTools entry " +

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -259,8 +259,7 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // the actual hazard #524 exists to prevent — so that case (and Pending, and an empty/unknown
         // violation set) still denies everything, fail-closed on uncertainty exactly as before.
         if (status == PluginBoundaryStatus.Faulted
-            && PluginToolBoundaryListKind.IsFaultConfinedToAllowedTools(
-                pluginRegistry.GetBoundaryViolations(skill.PluginSource)))
+            && pluginRegistry.GetBoundaryViolations(skill.PluginSource).IsConfinedToAllowedTools())
         {
             return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
         }

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -240,22 +240,43 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // #524: a boundary entry that matches no real tool is provably broken, not just
         // permissive — most dangerously for DeniedTools, documented as bypass-immune. Once
         // PluginToolBoundaryTracker has proven that (see its remarks), the boundary can no longer
-        // be trusted, so this denies every tool from the plugin rather than run with a
-        // partially-broken policy. Pending is treated identically to Faulted, not to Verified — an
-        // entry still awaiting an MCP server's tool list is exactly as unproven as one already
-        // confirmed fake, and trusting it in the meantime is the specific gap a review round found:
-        // a server nothing else happens to query left a plugin's boundary silently trusted forever.
+        // be fully trusted. Pending is treated identically to a DeniedTools-involving Faulted, not
+        // to Verified — an entry still awaiting an MCP server's tool list is exactly as unproven as
+        // one already confirmed fake, and trusting it in the meantime is the specific gap a review
+        // round found: a server nothing else happens to query left a plugin's boundary silently
+        // trusted forever.
         var status = pluginRegistry!.GetBoundaryStatus(skill.PluginSource);
-        if (status != PluginBoundaryStatus.Verified)
+        if (status == PluginBoundaryStatus.Verified)
+            return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
+
+        // #608: a Faulted boundary whose violations are ALL AllowedTools entries can never widen
+        // this plugin's access — AllowedTools is a positive allow-set match
+        // (ApplyPluginToolBoundary's own `tools.Where(t => allowSet.Contains(...))`), so a name that
+        // matches no real tool is already an inert no-op there; running the filter normally already
+        // produces the narrower "just lose that one tool" outcome the corrupted entry implies,
+        // without any special-casing. A DeniedTools-involving fault is the opposite shape: a bogus
+        // entry there means the tool the plugin author meant to block never gets excluded, which is
+        // the actual hazard #524 exists to prevent — so that case (and Pending, and an empty/unknown
+        // violation set) still denies everything, fail-closed on uncertainty exactly as before.
+        if (status == PluginBoundaryStatus.Faulted)
         {
-            _logger.LogWarning(
-                "Plugin '{Plugin}' tool boundary is {Status} (an AllowedTools/DeniedTools entry " +
-                "matches no known tool, or still awaits one) — denying all tools for skill '{Skill}'",
-                skill.PluginSource, status, skill.Id);
-            return [];
+            // Null-tolerant: IPluginRegistry.GetBoundaryViolations documents "empty ... when no
+            // violation detail was recorded" — a registry implementation that genuinely recorded
+            // nothing (including a test double with no explicit setup) is exactly that case, and
+            // must be treated identically to an explicit empty list: fail closed on uncertainty.
+            var violations = pluginRegistry.GetBoundaryViolations(skill.PluginSource);
+            if (violations is { Count: > 0 }
+                && violations.All(v => v.ListKind == PluginToolBoundaryListKind.AllowedTools))
+            {
+                return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
+            }
         }
 
-        return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
+        _logger.LogWarning(
+            "Plugin '{Plugin}' tool boundary is {Status} (an AllowedTools/DeniedTools entry " +
+            "matches no known tool, or still awaits one) — denying all tools for skill '{Skill}'",
+            skill.PluginSource, status, skill.Id);
+        return [];
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -245,10 +245,6 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // one already confirmed fake, and trusting it in the meantime is the specific gap a review
         // round found: a server nothing else happens to query left a plugin's boundary silently
         // trusted forever.
-        var status = pluginRegistry!.GetBoundaryStatus(skill.PluginSource);
-        if (status == PluginBoundaryStatus.Verified)
-            return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
-
         // #608: a Faulted boundary whose violations are ALL AllowedTools entries can never widen
         // this plugin's access — AllowedTools is a positive allow-set match
         // (ApplyPluginToolBoundary's own `tools.Where(t => allowSet.Contains(...))`), so a name that
@@ -258,11 +254,13 @@ public partial class ToolChainBuilder : IToolChainBuilder
         // entry there means the tool the plugin author meant to block never gets excluded, which is
         // the actual hazard #524 exists to prevent — so that case (and Pending, and an empty/unknown
         // violation set) still denies everything, fail-closed on uncertainty exactly as before.
-        if (status == PluginBoundaryStatus.Faulted
-            && pluginRegistry.GetBoundaryViolations(skill.PluginSource).IsConfinedToAllowedTools())
-        {
+        var status = pluginRegistry!.GetBoundaryStatus(skill.PluginSource);
+        var trustedEnoughToApplyNormally = status == PluginBoundaryStatus.Verified
+            || (status == PluginBoundaryStatus.Faulted
+                && pluginRegistry.GetBoundaryViolations(skill.PluginSource).IsConfinedToAllowedTools());
+
+        if (trustedEnoughToApplyNormally)
             return ApplyPluginToolBoundary(provisioned, loadedPlugin.Declaration);
-        }
 
         _logger.LogWarning(
             "Plugin '{Plugin}' tool boundary is {Status} (an AllowedTools/DeniedTools entry " +

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -225,21 +225,17 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
     /// <see cref="ComputeRules"/>'s agent-wide fail-closed fallback (#608).
     /// </summary>
     /// <remarks>
-    /// Delegates to <see cref="PluginToolBoundaryViolationExtensions.RequiresFailClosed"/> — the single shared
-    /// decision this and <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> both call, instead
-    /// of each independently re-deriving the same Verified/Pending/Faulted branch (see that method's
-    /// remarks for the full reasoning, including why <c>Pending</c> keeps the original
-    /// list-kind-agnostic treatment).
+    /// Delegates to <see cref="PluginToolBoundaryViolationExtensions.BoundaryRequiresFailClosed"/> —
+    /// the single shared fetch-and-decide both this and
+    /// <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> need, instead of each independently
+    /// re-deriving the same "only fetch violations when Faulted" rule around the same
+    /// Verified/Pending/Faulted branch (see that method's remarks for the full reasoning, including
+    /// why <c>Pending</c> keeps the original list-kind-agnostic treatment, and why it uses the
+    /// lower-level <see cref="PluginToolBoundaryViolationExtensions.RequiresFailClosed"/> overload
+    /// directly rather than this convenience one — it needs the boundary status again afterward).
     /// </remarks>
-    private bool BoundaryDemandsAgentWideFailClosed(string pluginName)
-    {
-        var status = _registry.GetBoundaryStatus(pluginName);
-        var violations = status == PluginBoundaryStatus.Faulted
-            ? _registry.GetBoundaryViolations(pluginName)
-            : null;
-
-        return status.RequiresFailClosed(violations);
-    }
+    private bool BoundaryDemandsAgentWideFailClosed(string pluginName) =>
+        _registry.BoundaryRequiresFailClosed(pluginName);
 
     /// <summary>
     /// DeniedTools are bypass-immune and enforced independently of any AutonomyLevel: a plugin that

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -243,8 +243,7 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
         // Shared with ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill's identical decision (#608
         // code-review) — one predicate both consumers agree on, rather than two independent
         // reimplementations that could silently diverge.
-        return !PluginToolBoundaryListKind.IsFaultConfinedToAllowedTools(
-            _registry.GetBoundaryViolations(pluginName));
+        return !_registry.GetBoundaryViolations(pluginName).IsConfinedToAllowedTools();
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -61,17 +61,19 @@ namespace Application.Core.Permissions;
 /// tool it does not own (the doc above's "backstop for sensitive global tools"), and
 /// <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> only ever filters the tool SET sourced from
 /// the plugin's OWN skill — a global tool reachable through any OTHER skill in the same agent is never
-/// touched by that filter regardless of this plugin's boundary state. When
-/// <see cref="IPluginRegistry.GetBoundaryStatus"/> is not <see cref="PluginBoundaryStatus.Verified"/>
-/// for a plugin, this provider therefore ALSO emits a bypass-immune Deny rule for every first-party
-/// tool name known to the host (<see cref="FirstPartyToolLookup.RegisteredFirstPartyToolKeys"/>) — not
-/// scoped to this plugin, because a corrupted/unresolved entry gives no way to know which specific
-/// global tool it was meant to protect. This is agent-wide and deliberately broad: Matt's explicit call
-/// (this PR's own review) was that the collateral cost of over-blocking shared tools is acceptable
-/// against the alternative of leaving a sensitive tool's only declared protection silently absent. The
-/// existing, correctly-scoped DeniedTools and autonomy-baseline rules below are still emitted
-/// unconditionally alongside this — harmless overlap for first-party names, and still the only
-/// coverage for any additional, validly-named non-first-party (MCP) entry in the same list.
+/// touched by that filter regardless of this plugin's boundary state. When a plugin's boundary
+/// <see cref="BoundaryDemandsAgentWideFailClosed"/> (Pending, or Faulted with a <c>DeniedTools</c>
+/// violation — see that method's remarks for the #608 narrowing that excludes a fault provably
+/// confined to <c>AllowedTools</c>), this provider therefore ALSO emits a bypass-immune Deny rule for
+/// every first-party tool name known to the host
+/// (<see cref="FirstPartyToolLookup.RegisteredFirstPartyToolKeys"/>) — not scoped to this plugin,
+/// because a corrupted/unresolved entry gives no way to know which specific global tool it was meant
+/// to protect. This is agent-wide and deliberately broad: Matt's explicit call (this PR's own review)
+/// was that the collateral cost of over-blocking shared tools is acceptable against the alternative
+/// of leaving a sensitive tool's only declared protection silently absent. The existing,
+/// correctly-scoped DeniedTools and autonomy-baseline rules below are still emitted unconditionally
+/// alongside this — harmless overlap for first-party names, and still the only coverage for any
+/// additional, validly-named non-first-party (MCP) entry in the same list.
 /// </para>
 /// </remarks>
 public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
@@ -194,8 +196,8 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 
     /// <summary>
     /// Emits <paramref name="plugin"/>'s own Deny and autonomy-baseline rules into
-    /// <paramref name="rules"/>, and reports whether its boundary is unverified (contributing to
-    /// <see cref="ComputeRules"/>'s agent-wide fail-closed decision).
+    /// <paramref name="rules"/>, and reports whether its boundary contributes to
+    /// <see cref="ComputeRules"/>'s agent-wide fail-closed decision.
     /// </summary>
     private bool EmitPluginRules(LoadedPlugin plugin, List<ToolPermissionRule> rules)
     {
@@ -209,13 +211,41 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
         // registering any disabled or failed plugin — a normal operational state — would flip
         // the agent-wide fail-closed response and silently deny every first-party tool for the
         // process lifetime.
-        var boundaryUnverified = plugin.Status == PluginLoadStatus.Loaded
-            && _registry.GetBoundaryStatus(plugin.Name) != PluginBoundaryStatus.Verified;
+        var boundaryContributesToFailClosed = plugin.Status == PluginLoadStatus.Loaded
+            && BoundaryDemandsAgentWideFailClosed(plugin.Name);
 
         EmitDeniedToolsRules(plugin, rules);
         EmitAutonomyBaselineRules(plugin, rules);
 
-        return boundaryUnverified;
+        return boundaryContributesToFailClosed;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="pluginName"/>'s boundary state should contribute to
+    /// <see cref="ComputeRules"/>'s agent-wide fail-closed fallback (#608). <c>Pending</c> always
+    /// does — it's transient by nature (resolves to Verified or Faulted once every configured MCP
+    /// server reports), so it keeps the original list-kind-agnostic treatment. A <c>Faulted</c>
+    /// boundary contributes UNLESS every recorded violation is <c>AllowedTools</c>: that list can
+    /// only ever narrow a plugin's own grant, never widen it, and can never defeat the
+    /// <c>DeniedTools</c> bypass-immune guarantee this fallback exists to protect — so a fault
+    /// provably confined to it doesn't warrant denying every first-party tool agent-wide. An empty
+    /// or unrecorded violation set is treated the same as a <c>DeniedTools</c> hit: fail closed on
+    /// uncertainty, not just on a confirmed one.
+    /// </summary>
+    private bool BoundaryDemandsAgentWideFailClosed(string pluginName)
+    {
+        var status = _registry.GetBoundaryStatus(pluginName);
+        if (status == PluginBoundaryStatus.Verified)
+            return false;
+        if (status == PluginBoundaryStatus.Pending)
+            return true;
+
+        // Null-tolerant: see ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill's identical guard —
+        // "no violation detail was recorded" (including a test double with no explicit setup) is
+        // exactly the documented empty case, not an error.
+        var violations = _registry.GetBoundaryViolations(pluginName);
+        return violations is not { Count: > 0 }
+            || violations.Any(v => v.ListKind == PluginToolBoundaryListKind.DeniedTools);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -222,28 +222,23 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
 
     /// <summary>
     /// Whether <paramref name="pluginName"/>'s boundary state should contribute to
-    /// <see cref="ComputeRules"/>'s agent-wide fail-closed fallback (#608). <c>Pending</c> always
-    /// does — it's transient by nature (resolves to Verified or Faulted once every configured MCP
-    /// server reports), so it keeps the original list-kind-agnostic treatment. A <c>Faulted</c>
-    /// boundary contributes UNLESS every recorded violation is <c>AllowedTools</c>: that list can
-    /// only ever narrow a plugin's own grant, never widen it, and can never defeat the
-    /// <c>DeniedTools</c> bypass-immune guarantee this fallback exists to protect — so a fault
-    /// provably confined to it doesn't warrant denying every first-party tool agent-wide. An empty
-    /// or unrecorded violation set is treated the same as a <c>DeniedTools</c> hit: fail closed on
-    /// uncertainty, not just on a confirmed one.
+    /// <see cref="ComputeRules"/>'s agent-wide fail-closed fallback (#608).
     /// </summary>
+    /// <remarks>
+    /// Delegates to <see cref="PluginToolBoundaryViolationExtensions.RequiresFailClosed"/> — the single shared
+    /// decision this and <c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c> both call, instead
+    /// of each independently re-deriving the same Verified/Pending/Faulted branch (see that method's
+    /// remarks for the full reasoning, including why <c>Pending</c> keeps the original
+    /// list-kind-agnostic treatment).
+    /// </remarks>
     private bool BoundaryDemandsAgentWideFailClosed(string pluginName)
     {
         var status = _registry.GetBoundaryStatus(pluginName);
-        if (status == PluginBoundaryStatus.Verified)
-            return false;
-        if (status == PluginBoundaryStatus.Pending)
-            return true;
+        var violations = status == PluginBoundaryStatus.Faulted
+            ? _registry.GetBoundaryViolations(pluginName)
+            : null;
 
-        // Shared with ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill's identical decision (#608
-        // code-review) — one predicate both consumers agree on, rather than two independent
-        // reimplementations that could silently diverge.
-        return !_registry.GetBoundaryViolations(pluginName).IsConfinedToAllowedTools();
+        return status.RequiresFailClosed(violations);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -240,12 +240,11 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
         if (status == PluginBoundaryStatus.Pending)
             return true;
 
-        // Null-tolerant: see ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill's identical guard —
-        // "no violation detail was recorded" (including a test double with no explicit setup) is
-        // exactly the documented empty case, not an error.
-        var violations = _registry.GetBoundaryViolations(pluginName);
-        return violations is not { Count: > 0 }
-            || violations.Any(v => v.ListKind == PluginToolBoundaryListKind.DeniedTools);
+        // Shared with ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill's identical decision (#608
+        // code-review) — one predicate both consumers agree on, rather than two independent
+        // reimplementations that could silently diverge.
+        return !PluginToolBoundaryListKind.IsFaultConfinedToAllowedTools(
+            _registry.GetBoundaryViolations(pluginName));
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -325,13 +325,25 @@ public sealed class McpToolProvider : IMcpToolProvider
             return;
 
         var violations = _boundaryTracker.ReportServerToolsDiscovered(serverName, discoveredToolNames.ToList());
-        foreach (var violation in violations)
+
+        // security-reviewer finding: the old message unconditionally claimed "all tools from this
+        // plugin are now denied," which is false since #608 for a fault confined to AllowedTools.
+        // Group by plugin (every violation for one plugin's fault is reported together — see
+        // ReportServerToolsDiscovered's remarks) so the logged consequence matches what actually
+        // happens, not just what used to always happen.
+        foreach (var group in violations.GroupBy(v => v.PluginName))
         {
+            var entries = string.Join(", ", group.Select(v => $"{v.ListKind}:'{v.ToolName}'"));
+            var confined = group.ToList().IsConfinedToAllowedTools();
             _logger.LogCritical(
-                "Plugin '{Plugin}': {ListKind} entry '{ToolName}' matches no known tool (first-party " +
-                "or MCP) — this entry is a no-op, and the plugin's tool boundary can no longer be " +
-                "trusted, so all tools from this plugin are now denied.",
-                violation.PluginName, violation.ListKind, violation.ToolName);
+                "Plugin '{Plugin}': boundary entries match no known tool (first-party or MCP) and are " +
+                "no-ops: {Entries}. {Consequence}",
+                group.Key, entries,
+                confined
+                    ? "Confined to AllowedTools (#608) — can only narrow this plugin's own grant, " +
+                      "never widen it, so the boundary still runs normally; fix the manifest entry."
+                    : "Includes a DeniedTools entry — the boundary can no longer be trusted, so all " +
+                      "tools from this plugin are now denied.");
         }
     }
 

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -304,9 +304,13 @@ public sealed class McpToolProvider : IMcpToolProvider
     /// AllowedTools/DeniedTools entries against them. A no-op when no tracker is wired (most tests)
     /// or nothing is pending for this server (the overwhelmingly common case). Logged at Critical,
     /// not thrown — the tracker never throws, and a boundary violation must not disturb this
-    /// otherwise-successful discovery call's own return value; enforcement happens separately, via
-    /// <c>IPluginRegistry.GetBoundaryStatus</c> denying the plugin's tools on its next resolution
-    /// whenever the status isn't <see cref="Application.AI.Common.Interfaces.Plugins.PluginBoundaryStatus.Verified"/>.
+    /// otherwise-successful discovery call's own return value; enforcement happens separately, on the
+    /// plugin's next resolution, via <c>IPluginRegistry.GetBoundaryStatus</c>/<c>GetBoundaryViolations</c>
+    /// — denying the plugin's tools whenever the status is
+    /// <see cref="Application.AI.Common.Interfaces.Plugins.PluginBoundaryStatus.Pending"/>, or
+    /// <see cref="Application.AI.Common.Interfaces.Plugins.PluginBoundaryStatus.Faulted"/> with
+    /// violations that aren't provably confined to <c>AllowedTools</c> (#608) — not unconditionally
+    /// on any non-Verified status.
     /// </summary>
     /// <remarks>
     /// Takes bare tool names rather than <see cref="McpClientTool"/> instances specifically so this

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -20,7 +20,12 @@ public sealed class PluginRegistry : IPluginRegistry
     // inside the same _stateLock critical section as _boundaryStatus and _stateVersion below, for the
     // same reason documented on that lock: a reader must never observe the status flip to Faulted
     // without also observing the violation list that explains it.
-    private readonly ConcurrentDictionary<string, IReadOnlyList<PluginToolBoundaryViolation>> _boundaryViolations =
+    //
+    // Stored as List<T>, not IReadOnlyList<T> — MarkBoundaryFaulted always replaces the dictionary
+    // entry wholesale (never mutates a published list in place), so GetBoundaryViolations can wrap
+    // the stored instance in .AsReadOnly() (O(1), and a caller downcasting to List<T> gets an
+    // InvalidCastException rather than a mutable handle) instead of copying it on every read.
+    private readonly ConcurrentDictionary<string, List<PluginToolBoundaryViolation>> _boundaryViolations =
         new(StringComparer.OrdinalIgnoreCase);
 
     // #612 grader finding, round 1: writing the dictionary and bumping _stateVersion as two separate
@@ -134,36 +139,34 @@ public sealed class PluginRegistry : IPluginRegistry
     }
 
     /// <inheritdoc />
-    public void MarkBoundaryFaulted(
-        string pluginName, string reason, IReadOnlyList<PluginToolBoundaryViolation> violations)
+    public void MarkBoundaryFaulted(string pluginName, IReadOnlyList<PluginToolBoundaryViolation> violations)
     {
         lock (_stateLock)
         {
-            // reason is a human-readable summary of facts (plugin/list-kind/tool-name) the caller
-            // already surfaces separately at the point of fault — McpToolProvider logs the
-            // violation list at Critical, PluginToolBoundaryStartupValidator throws with the same
-            // details — so nothing here needs reason back. violations IS stored (#608 — unlike
-            // reason, this now has real readers: GetBoundaryViolations lets a consumer distinguish
-            // a DeniedTools fault from an AllowedTools-only one).
-            //
-            // #608 code-review: two hardening fixes on the same field.
-            // 1. Defensive copy (.ToList()) rather than storing the caller's list by reference — a
-            //    different threat model than PluginPermissionRuleProvider's .AsReadOnly() cache in
-            //    this same PR (that one wraps a freshly-built List<T> this class already owns; this
-            //    one copies a foreign, caller-supplied list before taking custody of it), same goal:
-            //    a future caller downcasting and mutating the stored instance would otherwise
-            //    permanently corrupt the registry's record for every later reader.
+            // #608 code-review, /simplify pass: two fixes on the same field.
+            // 1. AddOrUpdate, not a manual GetValueOrDefault-then-indexer-write — matches the idiom
+            //    MarkBoundaryPending/MarkBoundaryVerified above already established for exactly this
+            //    "merge into a concurrent dictionary" shape, rather than reintroducing the
+            //    check-then-set pattern that caused #612's own bug (this lock makes it safe either
+            //    way today, but AddOrUpdate's atomicity doesn't *depend* on the lock staying exactly
+            //    this shape, and consistency with the sibling mutators is worth keeping on its own).
             // 2. Merge with any already-recorded violations for this plugin instead of overwriting.
             //    MarkBoundaryFaulted has no guard against being called twice for the same plugin
-            //    (its siblings MarkBoundaryPending/MarkBoundaryVerified explicitly refuse to
-            //    downgrade an already-Faulted status, but that guard was never extended to this
-            //    field). Not reachable via today's two callers in PluginToolBoundaryTracker (its
-            //    Resolved flag makes the immediate and lazy paths mutually exclusive per plugin),
-            //    but the registry is documented as the shared trust boundary regardless of caller
-            //    discipline — a second call must only ever be able to ADD to the recorded danger,
-            //    never silently narrow away an already-recorded DeniedTools violation.
-            var existing = _boundaryViolations.GetValueOrDefault(pluginName);
-            _boundaryViolations[pluginName] = (existing ?? []).Concat(violations).ToList();
+            //    (its siblings explicitly refuse to downgrade an already-Faulted status, but that
+            //    guard was never extended to this field). Not reachable via today's two callers in
+            //    PluginToolBoundaryTracker (its Resolved flag makes the immediate and lazy paths
+            //    mutually exclusive per plugin), but the registry is documented as the shared trust
+            //    boundary regardless of caller discipline — a second call must only ever be able to
+            //    ADD to the recorded danger, never silently narrow away an already-recorded
+            //    DeniedTools violation. (A /simplify pass suggested dropping this for an
+            //    unreachable-today guard instead, matching the siblings' shape — rejected: for
+            //    THIS field a guard would mean "first call wins," which could permanently lock in an
+            //    incomplete violation set if a later call would have added a DeniedTools entry the
+            //    first one missed. Merge is the only shape that can't get less safe over time.)
+            _boundaryViolations.AddOrUpdate(
+                pluginName,
+                _ => violations.ToList(),
+                (_, existing) => existing.Concat(violations).ToList());
             _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
             _stateVersion++;
         }
@@ -171,10 +174,11 @@ public sealed class PluginRegistry : IPluginRegistry
 
     /// <inheritdoc />
     public IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName) =>
-        // #608 code-review round 3: lock-free for the same reason as GetBoundaryStatus above. Returns
-        // a fresh copy (.ToList()), not the stored instance — MarkBoundaryFaulted defensively copies
-        // on write (round 2), but a caller mutating the exact instance handed back by a bare
-        // GetValueOrDefault would still corrupt the registry's own record; this closes the same
-        // hazard on the read side.
-        _boundaryViolations.GetValueOrDefault(pluginName, []).ToList();
+        // #608 code-review round 3 / /simplify: lock-free for the same reason as GetBoundaryStatus
+        // above. .AsReadOnly(), not .ToList() — O(1) instead of a full copy, and a caller downcasting
+        // the result to List<T> (the exact mutation hazard a prior round closed with a copy) now gets
+        // an InvalidCastException instead of a mutable handle, since ReadOnlyCollection<T> is a
+        // distinct type. Safe because MarkBoundaryFaulted above never mutates a published list in
+        // place — every write replaces the dictionary entry with a brand-new list.
+        _boundaryViolations.TryGetValue(pluginName, out var violations) ? violations.AsReadOnly() : [];
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -88,14 +88,19 @@ public sealed class PluginRegistry : IPluginRegistry
         // verify, Pending/Faulted otherwise), so an absent entry here means genuinely unseeded, not
         // "seeded with an empty boundary" — the two used to be indistinguishable.
         //
-        // #608 code-review: reads this dictionary AND _boundaryViolations under the same _stateLock
-        // every writer already uses, not lock-free. This method's own status and GetBoundaryViolations'
-        // violation list are two SEPARATE ConcurrentDictionary entries written together inside
-        // MarkBoundaryFaulted's lock — reading either one lock-free reopens the exact
-        // write-locked/read-unlocked race this file's _stateVersion comment already exists to warn
-        // against (PR #628): a caller could observe Faulted here but a stale (or not-yet-written)
-        // violation list from GetBoundaryViolations, since nothing pairs the two reads together
-        // without the lock.
+        // #608 code-review round 2: reads this dictionary under the same _stateLock every writer
+        // uses (each individual read is torn-write-free), not lock-free.
+        //
+        // What this does NOT guarantee: a caller that calls this method and GetBoundaryViolations as
+        // two SEPARATE calls does not get an atomic combined snapshot — a concurrent MarkBoundaryFaulted
+        // can land between the two. Today this is provably safe rather than merely "usually fine":
+        // MarkBoundaryFaulted MERGES violations (never overwrites/narrows, see its own remarks), so the
+        // worst a racing reader can observe is a violations list from a LATER point in time than the
+        // status it read — which can only ADD violations, never drop the one that made a fault
+        // dangerous. If MarkBoundaryFaulted's merge-only guarantee is ever relaxed, this reasoning
+        // breaks and the two calls would need a single atomic combined accessor instead — do not treat
+        // "each read is individually locked" as equivalent to "the pair is atomic" without re-deriving
+        // this argument.
         lock (_stateLock)
         {
             return _boundaryStatus.GetValueOrDefault(pluginName, PluginBoundaryStatus.Pending);
@@ -176,8 +181,10 @@ public sealed class PluginRegistry : IPluginRegistry
     /// <inheritdoc />
     public IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName)
     {
-        // #608 code-review: see GetBoundaryStatus's remarks — read under the same lock every writer
-        // uses, so a caller pairing this with GetBoundaryStatus never observes a torn write.
+        // #608 code-review round 2: see GetBoundaryStatus's remarks — each individual read here is
+        // torn-write-free, but pairing this with a separate GetBoundaryStatus call is NOT an atomic
+        // combined snapshot. Safe today only because MarkBoundaryFaulted's violations are merge-only
+        // (never narrowed) — re-read that reasoning before relying on this pairing for anything new.
         lock (_stateLock)
         {
             return _boundaryViolations.GetValueOrDefault(pluginName, []);

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -81,12 +81,26 @@ public sealed class PluginRegistry : IPluginRegistry
     }
 
     /// <inheritdoc />
-    public PluginBoundaryStatus GetBoundaryStatus(string pluginName) =>
+    public PluginBoundaryStatus GetBoundaryStatus(string pluginName)
+    {
         // #613: Pending, not Verified — see the interface doc for why. PluginToolBoundaryTracker.Seed
         // now explicitly marks every loaded plugin it processes (Verified when it has nothing to
         // verify, Pending/Faulted otherwise), so an absent entry here means genuinely unseeded, not
         // "seeded with an empty boundary" — the two used to be indistinguishable.
-        _boundaryStatus.GetValueOrDefault(pluginName, PluginBoundaryStatus.Pending);
+        //
+        // #608 code-review: reads this dictionary AND _boundaryViolations under the same _stateLock
+        // every writer already uses, not lock-free. This method's own status and GetBoundaryViolations'
+        // violation list are two SEPARATE ConcurrentDictionary entries written together inside
+        // MarkBoundaryFaulted's lock — reading either one lock-free reopens the exact
+        // write-locked/read-unlocked race this file's _stateVersion comment already exists to warn
+        // against (PR #628): a caller could observe Faulted here but a stale (or not-yet-written)
+        // violation list from GetBoundaryViolations, since nothing pairs the two reads together
+        // without the lock.
+        lock (_stateLock)
+        {
+            return _boundaryStatus.GetValueOrDefault(pluginName, PluginBoundaryStatus.Pending);
+        }
+    }
 
     /// <inheritdoc />
     public void MarkBoundaryPending(string pluginName)
@@ -135,13 +149,38 @@ public sealed class PluginRegistry : IPluginRegistry
             // details — so nothing here needs reason back. violations IS stored (#608 — unlike
             // reason, this now has real readers: GetBoundaryViolations lets a consumer distinguish
             // a DeniedTools fault from an AllowedTools-only one).
+            //
+            // #608 code-review: two hardening fixes on the same field.
+            // 1. Defensive copy (.ToList()) rather than storing the caller's list by reference —
+            //    mirrors PluginPermissionRuleProvider's own .AsReadOnly() cache from this same PR:
+            //    a future caller downcasting and mutating the stored instance would otherwise
+            //    permanently corrupt the registry's record for every later reader.
+            // 2. Merge with any already-recorded violations for this plugin instead of overwriting.
+            //    MarkBoundaryFaulted has no guard against being called twice for the same plugin
+            //    (its siblings MarkBoundaryPending/MarkBoundaryVerified explicitly refuse to
+            //    downgrade an already-Faulted status, but that guard was never extended to this
+            //    field). Not reachable via today's two callers in PluginToolBoundaryTracker (its
+            //    Resolved flag makes the immediate and lazy paths mutually exclusive per plugin),
+            //    but the registry is documented as the shared trust boundary regardless of caller
+            //    discipline — a second call must only ever be able to ADD to the recorded danger,
+            //    never silently narrow away an already-recorded DeniedTools violation.
+            var existing = _boundaryViolations.GetValueOrDefault(pluginName);
+            _boundaryViolations[pluginName] = existing is null or { Count: 0 }
+                ? violations.ToList()
+                : existing.Concat(violations).ToList();
             _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
-            _boundaryViolations[pluginName] = violations;
             _stateVersion++;
         }
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName) =>
-        _boundaryViolations.GetValueOrDefault(pluginName, []);
+    public IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName)
+    {
+        // #608 code-review: see GetBoundaryStatus's remarks — read under the same lock every writer
+        // uses, so a caller pairing this with GetBoundaryStatus never observes a torn write.
+        lock (_stateLock)
+        {
+            return _boundaryViolations.GetValueOrDefault(pluginName, []);
+        }
+    }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -81,31 +81,22 @@ public sealed class PluginRegistry : IPluginRegistry
     }
 
     /// <inheritdoc />
-    public PluginBoundaryStatus GetBoundaryStatus(string pluginName)
-    {
+    public PluginBoundaryStatus GetBoundaryStatus(string pluginName) =>
         // #613: Pending, not Verified — see the interface doc for why. PluginToolBoundaryTracker.Seed
         // now explicitly marks every loaded plugin it processes (Verified when it has nothing to
         // verify, Pending/Faulted otherwise), so an absent entry here means genuinely unseeded, not
         // "seeded with an empty boundary" — the two used to be indistinguishable.
         //
-        // #608 code-review round 2: reads this dictionary under the same _stateLock every writer
-        // uses (each individual read is torn-write-free), not lock-free.
-        //
-        // What this does NOT guarantee: a caller that calls this method and GetBoundaryViolations as
-        // two SEPARATE calls does not get an atomic combined snapshot — a concurrent MarkBoundaryFaulted
-        // can land between the two. Today this is provably safe rather than merely "usually fine":
-        // MarkBoundaryFaulted MERGES violations (never overwrites/narrows, see its own remarks), so the
-        // worst a racing reader can observe is a violations list from a LATER point in time than the
-        // status it read — which can only ADD violations, never drop the one that made a fault
-        // dangerous. If MarkBoundaryFaulted's merge-only guarantee is ever relaxed, this reasoning
-        // breaks and the two calls would need a single atomic combined accessor instead — do not treat
-        // "each read is individually locked" as equivalent to "the pair is atomic" without re-deriving
-        // this argument.
-        lock (_stateLock)
-        {
-            return _boundaryStatus.GetValueOrDefault(pluginName, PluginBoundaryStatus.Pending);
-        }
-    }
+        // #608 code-review round 3: deliberately lock-free. ConcurrentDictionary already guarantees a
+        // single-key read is never torn, with or without an external lock — a round-2 pass wrapped
+        // this in _stateLock reacting to a finding about atomicity, but that added contention against
+        // every writer for zero real benefit, since it does not (and cannot, as a single-method call)
+        // provide the one guarantee that would actually matter: a JOINT atomic snapshot of status AND
+        // GetBoundaryViolations together. A caller that calls both as two separate calls never gets
+        // that regardless of whether either individual read takes the lock — see GetBoundaryViolations'
+        // remarks for why that gap is safe today anyway (MarkBoundaryFaulted's violations are
+        // merge-only, never narrowed).
+        _boundaryStatus.GetValueOrDefault(pluginName, PluginBoundaryStatus.Pending);
 
     /// <inheritdoc />
     public void MarkBoundaryPending(string pluginName)
@@ -156,8 +147,10 @@ public sealed class PluginRegistry : IPluginRegistry
             // a DeniedTools fault from an AllowedTools-only one).
             //
             // #608 code-review: two hardening fixes on the same field.
-            // 1. Defensive copy (.ToList()) rather than storing the caller's list by reference —
-            //    mirrors PluginPermissionRuleProvider's own .AsReadOnly() cache from this same PR:
+            // 1. Defensive copy (.ToList()) rather than storing the caller's list by reference — a
+            //    different threat model than PluginPermissionRuleProvider's .AsReadOnly() cache in
+            //    this same PR (that one wraps a freshly-built List<T> this class already owns; this
+            //    one copies a foreign, caller-supplied list before taking custody of it), same goal:
             //    a future caller downcasting and mutating the stored instance would otherwise
             //    permanently corrupt the registry's record for every later reader.
             // 2. Merge with any already-recorded violations for this plugin instead of overwriting.
@@ -170,24 +163,18 @@ public sealed class PluginRegistry : IPluginRegistry
             //    discipline — a second call must only ever be able to ADD to the recorded danger,
             //    never silently narrow away an already-recorded DeniedTools violation.
             var existing = _boundaryViolations.GetValueOrDefault(pluginName);
-            _boundaryViolations[pluginName] = existing is null or { Count: 0 }
-                ? violations.ToList()
-                : existing.Concat(violations).ToList();
+            _boundaryViolations[pluginName] = (existing ?? []).Concat(violations).ToList();
             _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
             _stateVersion++;
         }
     }
 
     /// <inheritdoc />
-    public IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName)
-    {
-        // #608 code-review round 2: see GetBoundaryStatus's remarks — each individual read here is
-        // torn-write-free, but pairing this with a separate GetBoundaryStatus call is NOT an atomic
-        // combined snapshot. Safe today only because MarkBoundaryFaulted's violations are merge-only
-        // (never narrowed) — re-read that reasoning before relying on this pairing for anything new.
-        lock (_stateLock)
-        {
-            return _boundaryViolations.GetValueOrDefault(pluginName, []);
-        }
-    }
+    public IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName) =>
+        // #608 code-review round 3: lock-free for the same reason as GetBoundaryStatus above. Returns
+        // a fresh copy (.ToList()), not the stored instance — MarkBoundaryFaulted defensively copies
+        // on write (round 2), but a caller mutating the exact instance handed back by a bare
+        // GetValueOrDefault would still corrupt the registry's own record; this closes the same
+        // hazard on the read side.
+        _boundaryViolations.GetValueOrDefault(pluginName, []).ToList();
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -141,8 +141,18 @@ public sealed class PluginRegistry : IPluginRegistry
     /// <inheritdoc />
     public void MarkBoundaryFaulted(string pluginName, IReadOnlyList<PluginToolBoundaryViolation> violations)
     {
+        ArgumentNullException.ThrowIfNull(violations);
+
         lock (_stateLock)
         {
+            // security-reviewer finding: set the fail-closed status FIRST, before touching
+            // _boundaryViolations — Faulted-with-no-recorded-violations is itself fail closed (see
+            // RequiresFailClosed), so if anything below this line throws, the plugin lands in a safe
+            // state by construction rather than by coincidence of what its prior status happened to
+            // be. (The null guard above already prevents the one way this could throw today, but the
+            // ordering itself is a general invariant worth holding regardless.)
+            _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
+
             // #608 code-review, /simplify pass: two fixes on the same field.
             // 1. AddOrUpdate, not a manual GetValueOrDefault-then-indexer-write — matches the idiom
             //    MarkBoundaryPending/MarkBoundaryVerified above already established for exactly this
@@ -167,7 +177,6 @@ public sealed class PluginRegistry : IPluginRegistry
                 pluginName,
                 _ => violations.ToList(),
                 (_, existing) => existing.Concat(violations).ToList());
-            _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
             _stateVersion++;
         }
     }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginRegistry.cs
@@ -14,6 +14,15 @@ public sealed class PluginRegistry : IPluginRegistry
     private readonly ConcurrentDictionary<string, PluginBoundaryStatus> _boundaryStatus =
         new(StringComparer.OrdinalIgnoreCase);
 
+    // #608: which specific entries proved a Faulted plugin's boundary broken, so a consumer can
+    // distinguish a DeniedTools fault (must still fail closed — the bypass-immune guarantee is at
+    // risk) from an AllowedTools-only fault (can only ever narrow access, never widen it). Written
+    // inside the same _stateLock critical section as _boundaryStatus and _stateVersion below, for the
+    // same reason documented on that lock: a reader must never observe the status flip to Faulted
+    // without also observing the violation list that explains it.
+    private readonly ConcurrentDictionary<string, IReadOnlyList<PluginToolBoundaryViolation>> _boundaryViolations =
+        new(StringComparer.OrdinalIgnoreCase);
+
     // #612 grader finding, round 1: writing the dictionary and bumping _stateVersion as two separate
     // Interlocked steps left a window where a reader could observe the dictionary already mutated
     // but StateVersion not yet incremented — a cache keyed on that stale version would then serve
@@ -115,18 +124,24 @@ public sealed class PluginRegistry : IPluginRegistry
     }
 
     /// <inheritdoc />
-    public void MarkBoundaryFaulted(string pluginName, string reason)
+    public void MarkBoundaryFaulted(
+        string pluginName, string reason, IReadOnlyList<PluginToolBoundaryViolation> violations)
     {
         lock (_stateLock)
         {
             // reason is a human-readable summary of facts (plugin/list-kind/tool-name) the caller
             // already surfaces separately at the point of fault — McpToolProvider logs the
             // violation list at Critical, PluginToolBoundaryStartupValidator throws with the same
-            // details — so nothing here needs it back. Deliberately not stored (#524 round-2
-            // code-review: an earlier version kept a _faultReasons dictionary "for diagnostics"
-            // that nothing ever actually read).
+            // details — so nothing here needs reason back. violations IS stored (#608 — unlike
+            // reason, this now has real readers: GetBoundaryViolations lets a consumer distinguish
+            // a DeniedTools fault from an AllowedTools-only one).
             _boundaryStatus[pluginName] = PluginBoundaryStatus.Faulted;
+            _boundaryViolations[pluginName] = violations;
             _stateVersion++;
         }
     }
+
+    /// <inheritdoc />
+    public IReadOnlyList<PluginToolBoundaryViolation> GetBoundaryViolations(string pluginName) =>
+        _boundaryViolations.GetValueOrDefault(pluginName, []);
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -50,6 +50,21 @@ namespace Infrastructure.AI.Plugins;
 /// which the Host guarantees runs after <c>PluginStartupLoader.StartAsync</c> completes, is what
 /// actually sees the merged list.
 /// </para>
+/// <para>
+/// <strong>Deliberately stays list-kind-agnostic even after #608.</strong> #608 taught the two
+/// RUNTIME consequence sites (<c>ToolChainBuilder.ApplyPluginBoundaryIfPluginSkill</c>,
+/// <c>PluginPermissionRuleProvider</c>'s agent-wide fallback) to run normally instead of denying
+/// everything when a <see cref="PluginBoundaryStatus.Faulted"/> boundary's violations are provably
+/// confined to <c>AllowedTools</c> — a typo there can only narrow a plugin's grant, never widen it.
+/// This boot-time check was NOT given the same leniency, on purpose: it fires only in the immediately
+/// decidable case (no MCP server configured anywhere on the host, so a manifest error is provably a
+/// typo right now, not a maybe-real-later name), and the cost of refusing to boot on any such error —
+/// regardless of which list it's in — is a one-time, loud, fixable-before-traffic failure, not an
+/// ongoing degraded runtime. Extending #608's narrower treatment here would trade that for "boot
+/// succeeds with a plugin quietly missing one tool," which is a worse failure mode for something
+/// this cheap to just fix in the manifest and restart. If this validator's severity is ever revisited,
+/// treat that as its own decision — not an oversight inherited from #608's runtime-only scope.
+/// </para>
 /// </remarks>
 public sealed class PluginToolBoundaryStartupValidator : IHostedService
 {

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -58,7 +58,28 @@ public sealed class PluginToolBoundaryTrackerTests
 
         _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+    }
+
+    [Fact]
+    public void Seed_ImmediateViolation_PassesTheActualViolationListToTheRegistry()
+    {
+        // #608: MarkBoundaryFaulted's violations argument must be the real, computed list -- not
+        // discarded -- so a consumer can later distinguish a DeniedTools fault from an
+        // AllowedTools-only one via IPluginRegistry.GetBoundaryViolations.
+        var plugin = MakePlugin("azure", deniedTools: ["file_wrte"]);
+
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
+
+        _registry.Verify(r => r.MarkBoundaryFaulted(
+            "azure",
+            It.IsAny<string>(),
+            It.Is<IReadOnlyList<PluginToolBoundaryViolation>>(v =>
+                v.Count == 1
+                && v[0].PluginName == "azure"
+                && v[0].ListKind == PluginToolBoundaryListKind.DeniedTools
+                && v[0].ToolName == "file_wrte")),
+            Times.Once);
     }
 
     [Fact]
@@ -111,7 +132,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -139,7 +160,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.ReportServerToolsDiscovered("host:github", ["delete_repository", "create_issue"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -194,7 +215,7 @@ public sealed class PluginToolBoundaryTrackerTests
 
         violations.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryVerified("azure"), Times.Once);
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
 
         // The still-unreported "host:jira" server must have nothing left to do for this plugin.
         var laterReport = _sut.ReportServerToolsDiscovered("host:jira", []);
@@ -248,7 +269,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.ReportServerToolsDiscovered("server1", ["unrelated"]);
 
         violations.Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -261,7 +282,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -273,7 +294,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.ReportServerToolsDiscovered("server1", ["real_tool", "other_tool"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -286,7 +307,29 @@ public sealed class PluginToolBoundaryTrackerTests
 
         violations.Should().ContainSingle(v =>
             v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+    }
+
+    [Fact]
+    public void ReportServerToolsDiscovered_LastPendingServerReports_PassesTheActualViolationListToTheRegistry()
+    {
+        // #608: the lazy fault path (unlike Seed's immediate path above) builds its violation list
+        // from PendingEntries at resolution time -- must confirm it's threaded through too, not just
+        // the immediate branch.
+        var plugin = MakePlugin("azure", allowedTools: ["typo_tool"]);
+        _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
+
+        _sut.ReportServerToolsDiscovered("server1", ["unrelated"]);
+
+        _registry.Verify(r => r.MarkBoundaryFaulted(
+            "azure",
+            It.IsAny<string>(),
+            It.Is<IReadOnlyList<PluginToolBoundaryViolation>>(v =>
+                v.Count == 1
+                && v[0].PluginName == "azure"
+                && v[0].ListKind == PluginToolBoundaryListKind.AllowedTools
+                && v[0].ToolName == "typo_tool")),
+            Times.Once);
     }
 
     [Fact]
@@ -297,11 +340,11 @@ public sealed class PluginToolBoundaryTrackerTests
 
         var afterFirst = _sut.ReportServerToolsDiscovered("s1", ["unrelated"]);
         afterFirst.Should().BeEmpty("s2 hasn't reported yet — not provably fake");
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
 
         var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["also_unrelated"]);
         afterSecond.Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -314,7 +357,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["real_tool"]);
 
         afterSecond.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -329,7 +372,7 @@ public sealed class PluginToolBoundaryTrackerTests
             () => results.Add(_sut.ReportServerToolsDiscovered("s2", ["unrelated2"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -348,7 +391,7 @@ public sealed class PluginToolBoundaryTrackerTests
             () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -45,7 +45,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
         violations.Should().ContainSingle(v =>
-            v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
+            v.PluginName == "azure" && v.ListKind == PluginToolBoundaryListKind.DeniedTools && v.ToolName == "file_wrte");
     }
 
     [Fact]
@@ -242,7 +242,7 @@ public sealed class PluginToolBoundaryTrackerTests
 
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
-        violations.Should().ContainSingle(v => v.ListKind == "DeniedTools");
+        violations.Should().ContainSingle(v => v.ListKind == PluginToolBoundaryListKind.DeniedTools);
     }
 
     [Fact]
@@ -305,7 +305,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.ReportServerToolsDiscovered("server1", ["some_other_tool"]);
 
         violations.Should().ContainSingle(v =>
-            v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
+            v.PluginName == "azure" && v.ListKind == PluginToolBoundaryListKind.DeniedTools && v.ToolName == "file_wrte");
         _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryTrackerTests.cs
@@ -58,7 +58,7 @@ public sealed class PluginToolBoundaryTrackerTests
 
         _sut.Seed([plugin], NoFirstPartyToolsKnown, NoServersConfigured);
 
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -73,7 +73,6 @@ public sealed class PluginToolBoundaryTrackerTests
 
         _registry.Verify(r => r.MarkBoundaryFaulted(
             "azure",
-            It.IsAny<string>(),
             It.Is<IReadOnlyList<PluginToolBoundaryViolation>>(v =>
                 v.Count == 1
                 && v[0].PluginName == "azure"
@@ -132,7 +131,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["host:github"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -160,7 +159,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.ReportServerToolsDiscovered("host:github", ["delete_repository", "create_issue"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -215,7 +214,7 @@ public sealed class PluginToolBoundaryTrackerTests
 
         violations.Should().BeEmpty();
         _registry.Verify(r => r.MarkBoundaryVerified("azure"), Times.Once);
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
 
         // The still-unreported "host:jira" server must have nothing left to do for this plugin.
         var laterReport = _sut.ReportServerToolsDiscovered("host:jira", []);
@@ -269,7 +268,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.ReportServerToolsDiscovered("server1", ["unrelated"]);
 
         violations.Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -282,7 +281,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.Seed([plugin], NoFirstPartyToolsKnown, ["server1"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -294,7 +293,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var violations = _sut.ReportServerToolsDiscovered("server1", ["real_tool", "other_tool"]);
 
         violations.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -307,7 +306,7 @@ public sealed class PluginToolBoundaryTrackerTests
 
         violations.Should().ContainSingle(v =>
             v.PluginName == "azure" && v.ListKind == "DeniedTools" && v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -323,7 +322,6 @@ public sealed class PluginToolBoundaryTrackerTests
 
         _registry.Verify(r => r.MarkBoundaryFaulted(
             "azure",
-            It.IsAny<string>(),
             It.Is<IReadOnlyList<PluginToolBoundaryViolation>>(v =>
                 v.Count == 1
                 && v[0].PluginName == "azure"
@@ -340,11 +338,11 @@ public sealed class PluginToolBoundaryTrackerTests
 
         var afterFirst = _sut.ReportServerToolsDiscovered("s1", ["unrelated"]);
         afterFirst.Should().BeEmpty("s2 hasn't reported yet — not provably fake");
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
 
         var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["also_unrelated"]);
         afterSecond.Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -357,7 +355,7 @@ public sealed class PluginToolBoundaryTrackerTests
         var afterSecond = _sut.ReportServerToolsDiscovered("s2", ["real_tool"]);
 
         afterSecond.Should().BeEmpty();
-        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
+        _registry.Verify(r => r.MarkBoundaryFaulted(It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Never);
     }
 
     [Fact]
@@ -372,7 +370,7 @@ public sealed class PluginToolBoundaryTrackerTests
             () => results.Add(_sut.ReportServerToolsDiscovered("s2", ["unrelated2"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]
@@ -391,7 +389,7 @@ public sealed class PluginToolBoundaryTrackerTests
             () => results.Add(_sut.ReportServerToolsDiscovered("s1", ["unrelated"])));
 
         results.SelectMany(r => r).Should().ContainSingle(v => v.ToolName == "file_wrte");
-        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<string>(), It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
+        _registry.Verify(r => r.MarkBoundaryFaulted("azure", It.IsAny<IReadOnlyList<PluginToolBoundaryViolation>>()), Times.Once);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -338,6 +338,106 @@ public class ToolChainBuilderTests
     }
 
     [Fact]
+    public async Task BuildToolsAsync_PluginBoundaryFaultedOnAllowedToolsOnly_StillReturnsOtherValidTools()
+    {
+        // #608: an AllowedTools typo can only ever narrow this plugin's grant, never widen it, and
+        // can never defeat the DeniedTools bypass-immune guarantee — so a fault provably confined to
+        // AllowedTools should run the normal (already-safe) boundary filter instead of denying
+        // everything. ApplyPluginToolBoundary's own positive allow-set match already makes the
+        // faulted name a no-op; no special-casing needed beyond not zeroing the plugin out.
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", AllowedTools = ["safe", "typo_tool"] }));
+        pluginRegistry.Setup(r => r.GetBoundaryStatus("p")).Returns(PluginBoundaryStatus.Faulted);
+        pluginRegistry.Setup(r => r.GetBoundaryViolations("p")).Returns(
+            [new PluginToolBoundaryViolation("p", PluginToolBoundaryListKind.AllowedTools, "typo_tool")]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            Tools =
+            [
+                AIFunctionFactory.Create(() => "r", "safe"),
+                AIFunctionFactory.Create(() => "r", "not_declared_allowed")
+            ]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().ContainSingle(t => t.Name == "safe");
+    }
+
+    [Fact]
+    public async Task BuildToolsAsync_PluginBoundaryFaultedOnBothLists_StillDeniesAllTools()
+    {
+        // A fault touching BOTH lists must still deny everything -- the DeniedTools violation alone
+        // is the hazard, regardless of an AllowedTools violation also being present.
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", DeniedTools = ["dangerous"], AllowedTools = ["safe", "typo_tool"] }));
+        pluginRegistry.Setup(r => r.GetBoundaryStatus("p")).Returns(PluginBoundaryStatus.Faulted);
+        pluginRegistry.Setup(r => r.GetBoundaryViolations("p")).Returns(
+            [
+                new PluginToolBoundaryViolation("p", PluginToolBoundaryListKind.AllowedTools, "typo_tool"),
+                new PluginToolBoundaryViolation("p", PluginToolBoundaryListKind.DeniedTools, "also_typo"),
+            ]);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            Tools = [AIFunctionFactory.Create(() => "r", "safe")]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BuildToolsAsync_PluginBoundaryFaultedWithNoRecordedViolations_StillDeniesAllTools()
+    {
+        // A registry that reports Faulted but has no violation detail (a real implementation
+        // shouldn't do this, but nothing enforces it) must fail closed exactly like an explicit
+        // DeniedTools hit -- never treated as "safe to narrow" on missing information.
+        var pluginRegistry = new Mock<IPluginRegistry>();
+        pluginRegistry.Setup(r => r.GetPlugin("p")).Returns(
+            new LoadedPlugin("p", "1.0", "/plugins/p", new PluginManifest(),
+                PluginLoadStatus.Loaded, [], ["p:server"],
+                new PluginDeclaration { Name = "p", AllowedTools = ["safe"] }));
+        pluginRegistry.Setup(r => r.GetBoundaryStatus("p")).Returns(PluginBoundaryStatus.Faulted);
+        // Deliberately no GetBoundaryViolations setup -- Moq returns null for it.
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pluginRegistry.Object);
+
+        var builder = CreateBuilder(serviceProvider: services.BuildServiceProvider());
+
+        var skill = new SkillDefinition
+        {
+            Id = "p-skill", Name = "p-skill", Instructions = "Test", PluginSource = "p",
+            Tools = [AIFunctionFactory.Create(() => "r", "safe")]
+        };
+
+        var tools = await builder.BuildToolsAsync(skill, new SkillAgentOptions());
+
+        tools.Should().BeEmpty();
+    }
+
+    [Fact]
     public async Task BuildToolsAsync_PluginBoundaryPending_DeniesAllToolsSameAsFaulted()
     {
         // #524 redesign: an entry still awaiting an MCP server's tool list is exactly as unproven as

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpToolProviderBoundaryTrackerTests.cs
@@ -79,7 +79,7 @@ public sealed class McpToolProviderBoundaryTrackerTests
         // IPluginRegistry.IsBoundaryFaulted on the plugin's next tool resolution.
         var tracker = new Mock<IPluginToolBoundaryTracker>();
         tracker.Setup(t => t.ReportServerToolsDiscovered(It.IsAny<string>(), It.IsAny<IReadOnlyCollection<string>>()))
-            .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
+            .Returns([new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
         var (sut, _) = CreateSut(tracker.Object);
 
         var act = () => sut.ReportDiscoveryToBoundaryTracker("azure:server1", ["unrelated"]);

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/PluginPermissionRuleProviderRealRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/PluginPermissionRuleProviderRealRegistryTests.cs
@@ -60,7 +60,9 @@ public sealed class PluginPermissionRuleProviderRealRegistryTests
         var beforeFault = await provider.GetRulesAsync("any-agent");
         beforeFault.Should().BeEmpty("the plugin's boundary is Verified, so no fail-closed rules apply yet");
 
-        registry.MarkBoundaryFaulted("azure", "DeniedTools entry matches no known tool");
+        registry.MarkBoundaryFaulted(
+            "azure", "DeniedTools entry matches no known tool",
+            [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
 
         var afterFault = await provider.GetRulesAsync("any-agent");
         afterFault.Should().Contain(r => r.ToolPattern == "file_system"
@@ -78,7 +80,7 @@ public sealed class PluginPermissionRuleProviderRealRegistryTests
         // return the exact same cached list, not a freshly recomputed equal one.
         var registry = new PluginRegistry();
         registry.Register(MakePlugin("azure"));
-        registry.MarkBoundaryFaulted("azure", "reason");
+        registry.MarkBoundaryFaulted("azure", "reason", []);
 
         var provider = CreateSut(registry, "file_system");
 
@@ -86,5 +88,65 @@ public sealed class PluginPermissionRuleProviderRealRegistryTests
         var second = await provider.GetRulesAsync("any-agent");
 
         ReferenceEquals(first, second).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_RealRegistryFaultedOnAllowedToolsOnly_DoesNotDenyEveryFirstPartyTool()
+    {
+        // #608: a fault confined to AllowedTools can only ever narrow this plugin's own grant -- it
+        // can never widen access, and it can never defeat the DeniedTools bypass-immune guarantee
+        // this agent-wide fallback exists to protect. Regression guard for the OLD behavior (any
+        // non-Verified status denied every known first-party tool, regardless of which list faulted).
+        var registry = new PluginRegistry();
+        registry.Register(MakePlugin("azure"));
+        registry.MarkBoundaryFaulted(
+            "azure", "AllowedTools entry matches no known tool",
+            [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool")]);
+
+        var provider = CreateSut(registry, "file_system", "shell");
+
+        var rules = await provider.GetRulesAsync("any-agent");
+
+        rules.Should().NotContain(r => r.ToolPattern == "file_system" && r.Behavior == PermissionBehaviorType.Deny);
+        rules.Should().NotContain(r => r.ToolPattern == "shell" && r.Behavior == PermissionBehaviorType.Deny);
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_RealRegistryFaultedOnBothLists_StillDeniesEveryFirstPartyTool()
+    {
+        // A plugin whose fault involves BOTH lists must still get the full agent-wide fallback -- the
+        // DeniedTools violation alone is enough, even though an AllowedTools violation is also present.
+        var registry = new PluginRegistry();
+        registry.Register(MakePlugin("azure"));
+        registry.MarkBoundaryFaulted(
+            "azure", "Both lists have unresolved entries",
+            [
+                new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool"),
+                new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte"),
+            ]);
+
+        var provider = CreateSut(registry, "file_system");
+
+        var rules = await provider.GetRulesAsync("any-agent");
+
+        rules.Should().Contain(r => r.ToolPattern == "file_system"
+            && r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
+    }
+
+    [Fact]
+    public async Task GetRulesAsync_RealRegistryPendingRegardlessOfEntryListKind_StillDeniesEveryFirstPartyTool()
+    {
+        // Pending keeps the OLD, list-kind-agnostic treatment even under #608 -- it's transient (about
+        // to resolve to Verified or Faulted), so narrowing it isn't part of this fix's scope.
+        var registry = new PluginRegistry();
+        registry.Register(MakePlugin("azure"));
+        registry.MarkBoundaryPending("azure");
+
+        var provider = CreateSut(registry, "file_system");
+
+        var rules = await provider.GetRulesAsync("any-agent");
+
+        rules.Should().Contain(r => r.ToolPattern == "file_system"
+            && r.Behavior == PermissionBehaviorType.Deny && r.IsBypassImmune);
     }
 }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/PluginPermissionRuleProviderRealRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/PluginPermissionRuleProviderRealRegistryTests.cs
@@ -61,7 +61,7 @@ public sealed class PluginPermissionRuleProviderRealRegistryTests
         beforeFault.Should().BeEmpty("the plugin's boundary is Verified, so no fail-closed rules apply yet");
 
         registry.MarkBoundaryFaulted(
-            "azure", "DeniedTools entry matches no known tool",
+            "azure",
             [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
 
         var afterFault = await provider.GetRulesAsync("any-agent");
@@ -80,7 +80,7 @@ public sealed class PluginPermissionRuleProviderRealRegistryTests
         // return the exact same cached list, not a freshly recomputed equal one.
         var registry = new PluginRegistry();
         registry.Register(MakePlugin("azure"));
-        registry.MarkBoundaryFaulted("azure", "reason", []);
+        registry.MarkBoundaryFaulted("azure", []);
 
         var provider = CreateSut(registry, "file_system");
 
@@ -100,7 +100,7 @@ public sealed class PluginPermissionRuleProviderRealRegistryTests
         var registry = new PluginRegistry();
         registry.Register(MakePlugin("azure"));
         registry.MarkBoundaryFaulted(
-            "azure", "AllowedTools entry matches no known tool",
+            "azure",
             [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool")]);
 
         var provider = CreateSut(registry, "file_system", "shell");
@@ -119,7 +119,7 @@ public sealed class PluginPermissionRuleProviderRealRegistryTests
         var registry = new PluginRegistry();
         registry.Register(MakePlugin("azure"));
         registry.MarkBoundaryFaulted(
-            "azure", "Both lists have unresolved entries",
+            "azure",
             [
                 new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool"),
                 new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte"),

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -125,6 +125,25 @@ public class PluginRegistryTests
     }
 
     [Fact]
+    public void MarkBoundaryFaulted_CalledTwiceForSamePlugin_MergesViolationsRatherThanOverwriting()
+    {
+        // #608 code-review: a second MarkBoundaryFaulted call must only ever ADD to the recorded
+        // danger, never silently narrow it. Mutation guard for the specific failure this closes: a
+        // second call with a narrower (AllowedTools-only) violation set must not erase a previously
+        // recorded DeniedTools violation.
+        _sut.MarkBoundaryFaulted("azure", "first fault",
+            [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
+        _sut.MarkBoundaryFaulted("azure", "second fault",
+            [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool")]);
+
+        var violations = _sut.GetBoundaryViolations("azure");
+
+        violations.Should().HaveCount(2);
+        violations.Should().Contain(v => v.ListKind == PluginToolBoundaryListKind.DeniedTools && v.ToolName == "file_wrte");
+        violations.Should().Contain(v => v.ListKind == PluginToolBoundaryListKind.AllowedTools && v.ToolName == "typo_tool");
+    }
+
+    [Fact]
     public void GetBoundaryViolations_PluginNeverFaulted_ReturnsEmpty()
     {
         _sut.GetBoundaryViolations("never-faulted").Should().BeEmpty();

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -87,7 +87,7 @@ public class PluginRegistryTests
     [Fact]
     public void MarkBoundaryFaulted_ThenGetBoundaryStatus_ReturnsFaulted()
     {
-        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool", []);
+        _sut.MarkBoundaryFaulted("azure", []);
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
     }
@@ -95,7 +95,7 @@ public class PluginRegistryTests
     [Fact]
     public void GetBoundaryStatus_CaseInsensitive_ReturnsFaulted()
     {
-        _sut.MarkBoundaryFaulted("Azure", "reason", []);
+        _sut.MarkBoundaryFaulted("Azure", []);
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
         _sut.GetBoundaryStatus("AZURE").Should().Be(PluginBoundaryStatus.Faulted);
@@ -107,24 +107,27 @@ public class PluginRegistryTests
         IReadOnlyList<PluginToolBoundaryViolation> violations =
             [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")];
 
-        _sut.MarkBoundaryFaulted("azure", "reason", violations);
+        _sut.MarkBoundaryFaulted("azure", violations);
 
         _sut.GetBoundaryViolations("azure").Should().BeEquivalentTo(violations);
     }
 
     [Fact]
-    public void GetBoundaryViolations_CallerMutatesReturnedList_DoesNotCorruptTheRegistry()
+    public void GetBoundaryViolations_ReturnsAReadOnlyWrapper_CannotBeDowncastAndMutated()
     {
-        // #608 code-review round 3: GetBoundaryViolations must hand back a copy, not the registry's
-        // own stored instance -- a caller downcasting and mutating it (e.g. dropping the DeniedTools
-        // entry) would otherwise silently defeat the DeniedTools bypass-immune guarantee for every
-        // later reader.
-        _sut.MarkBoundaryFaulted("azure", "reason",
+        // #608 code-review round 3 / /simplify: GetBoundaryViolations must not hand back a mutable
+        // path to the registry's own stored list -- a caller downcasting and mutating it (e.g.
+        // dropping the DeniedTools entry) would otherwise silently defeat the DeniedTools
+        // bypass-immune guarantee for every later reader. Returning .AsReadOnly() (a
+        // ReadOnlyCollection<T>, a distinct type from List<T>) means the downcast itself throws,
+        // rather than a copy merely making the attempt harmless.
+        _sut.MarkBoundaryFaulted("azure",
             [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
 
-        var returned = (List<PluginToolBoundaryViolation>)_sut.GetBoundaryViolations("azure");
-        returned.Clear();
+        var returned = _sut.GetBoundaryViolations("azure");
+        var attemptDowncast = () => (List<PluginToolBoundaryViolation>)returned;
 
+        attemptDowncast.Should().Throw<InvalidCastException>();
         _sut.GetBoundaryViolations("azure").Should().ContainSingle(v => v.ToolName == "file_wrte");
     }
 
@@ -134,7 +137,7 @@ public class PluginRegistryTests
         IReadOnlyList<PluginToolBoundaryViolation> violations =
             [new PluginToolBoundaryViolation("Azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool")];
 
-        _sut.MarkBoundaryFaulted("Azure", "reason", violations);
+        _sut.MarkBoundaryFaulted("Azure", violations);
 
         _sut.GetBoundaryViolations("azure").Should().BeEquivalentTo(violations);
         _sut.GetBoundaryViolations("AZURE").Should().BeEquivalentTo(violations);
@@ -147,9 +150,9 @@ public class PluginRegistryTests
         // danger, never silently narrow it. Mutation guard for the specific failure this closes: a
         // second call with a narrower (AllowedTools-only) violation set must not erase a previously
         // recorded DeniedTools violation.
-        _sut.MarkBoundaryFaulted("azure", "first fault",
+        _sut.MarkBoundaryFaulted("azure",
             [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
-        _sut.MarkBoundaryFaulted("azure", "second fault",
+        _sut.MarkBoundaryFaulted("azure",
             [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool")]);
 
         var violations = _sut.GetBoundaryViolations("azure");
@@ -194,7 +197,7 @@ public class PluginRegistryTests
         // Faulted is terminal (#524 redesign) — a caller resolving one pending entry has no way to
         // know whether some OTHER entry already faulted this same plugin through a different call,
         // so MarkBoundaryVerified must never be able to downgrade it.
-        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool", []);
+        _sut.MarkBoundaryFaulted("azure", []);
         _sut.MarkBoundaryVerified("azure");
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
@@ -208,7 +211,7 @@ public class PluginRegistryTests
         // reachable via any caller today (Seed calls MarkBoundaryPending at most once per plugin, and
         // never after a fault), but the registry is the shared trust boundary, not any one caller's
         // discipline, so it must hold regardless of how many callers exist in the future.
-        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool", []);
+        _sut.MarkBoundaryFaulted("azure", []);
         _sut.MarkBoundaryPending("azure");
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
@@ -223,7 +226,7 @@ public class PluginRegistryTests
         yield return [new Action<PluginRegistry>(r => r.Register(MakePlugin("azure")))];
         yield return [new Action<PluginRegistry>(r => r.MarkBoundaryPending("azure"))];
         yield return [new Action<PluginRegistry>(r => r.MarkBoundaryVerified("azure"))];
-        yield return [new Action<PluginRegistry>(r => r.MarkBoundaryFaulted("azure", "reason", []))];
+        yield return [new Action<PluginRegistry>(r => r.MarkBoundaryFaulted("azure", []))];
     }
 
     [Theory]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -87,7 +87,7 @@ public class PluginRegistryTests
     [Fact]
     public void MarkBoundaryFaulted_ThenGetBoundaryStatus_ReturnsFaulted()
     {
-        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
+        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool", []);
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
     }
@@ -95,10 +95,45 @@ public class PluginRegistryTests
     [Fact]
     public void GetBoundaryStatus_CaseInsensitive_ReturnsFaulted()
     {
-        _sut.MarkBoundaryFaulted("Azure", "reason");
+        _sut.MarkBoundaryFaulted("Azure", "reason", []);
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
         _sut.GetBoundaryStatus("AZURE").Should().Be(PluginBoundaryStatus.Faulted);
+    }
+
+    [Fact]
+    public void MarkBoundaryFaulted_StoresViolations_GetBoundaryViolationsReturnsThem()
+    {
+        IReadOnlyList<PluginToolBoundaryViolation> violations =
+            [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")];
+
+        _sut.MarkBoundaryFaulted("azure", "reason", violations);
+
+        _sut.GetBoundaryViolations("azure").Should().BeEquivalentTo(violations);
+    }
+
+    [Fact]
+    public void GetBoundaryViolations_CaseInsensitive_ReturnsThem()
+    {
+        IReadOnlyList<PluginToolBoundaryViolation> violations =
+            [new PluginToolBoundaryViolation("Azure", PluginToolBoundaryListKind.AllowedTools, "typo_tool")];
+
+        _sut.MarkBoundaryFaulted("Azure", "reason", violations);
+
+        _sut.GetBoundaryViolations("azure").Should().BeEquivalentTo(violations);
+        _sut.GetBoundaryViolations("AZURE").Should().BeEquivalentTo(violations);
+    }
+
+    [Fact]
+    public void GetBoundaryViolations_PluginNeverFaulted_ReturnsEmpty()
+    {
+        _sut.GetBoundaryViolations("never-faulted").Should().BeEmpty();
+
+        _sut.MarkBoundaryVerified("verified-plugin");
+        _sut.GetBoundaryViolations("verified-plugin").Should().BeEmpty();
+
+        _sut.MarkBoundaryPending("pending-plugin");
+        _sut.GetBoundaryViolations("pending-plugin").Should().BeEmpty();
     }
 
     [Fact]
@@ -124,7 +159,7 @@ public class PluginRegistryTests
         // Faulted is terminal (#524 redesign) — a caller resolving one pending entry has no way to
         // know whether some OTHER entry already faulted this same plugin through a different call,
         // so MarkBoundaryVerified must never be able to downgrade it.
-        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
+        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool", []);
         _sut.MarkBoundaryVerified("azure");
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
@@ -138,7 +173,7 @@ public class PluginRegistryTests
         // reachable via any caller today (Seed calls MarkBoundaryPending at most once per plugin, and
         // never after a fault), but the registry is the shared trust boundary, not any one caller's
         // discipline, so it must hold regardless of how many callers exist in the future.
-        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool");
+        _sut.MarkBoundaryFaulted("azure", "DeniedTools entry 'file_wrte' matches no known tool", []);
         _sut.MarkBoundaryPending("azure");
 
         _sut.GetBoundaryStatus("azure").Should().Be(PluginBoundaryStatus.Faulted);
@@ -153,7 +188,7 @@ public class PluginRegistryTests
         yield return [new Action<PluginRegistry>(r => r.Register(MakePlugin("azure")))];
         yield return [new Action<PluginRegistry>(r => r.MarkBoundaryPending("azure"))];
         yield return [new Action<PluginRegistry>(r => r.MarkBoundaryVerified("azure"))];
-        yield return [new Action<PluginRegistry>(r => r.MarkBoundaryFaulted("azure", "reason"))];
+        yield return [new Action<PluginRegistry>(r => r.MarkBoundaryFaulted("azure", "reason", []))];
     }
 
     [Theory]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginRegistryTests.cs
@@ -113,6 +113,22 @@ public class PluginRegistryTests
     }
 
     [Fact]
+    public void GetBoundaryViolations_CallerMutatesReturnedList_DoesNotCorruptTheRegistry()
+    {
+        // #608 code-review round 3: GetBoundaryViolations must hand back a copy, not the registry's
+        // own stored instance -- a caller downcasting and mutating it (e.g. dropping the DeniedTools
+        // entry) would otherwise silently defeat the DeniedTools bypass-immune guarantee for every
+        // later reader.
+        _sut.MarkBoundaryFaulted("azure", "reason",
+            [new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
+
+        var returned = (List<PluginToolBoundaryViolation>)_sut.GetBoundaryViolations("azure");
+        returned.Clear();
+
+        _sut.GetBoundaryViolations("azure").Should().ContainSingle(v => v.ToolName == "file_wrte");
+    }
+
+    [Fact]
     public void GetBoundaryViolations_CaseInsensitive_ReturnsThem()
     {
         IReadOnlyList<PluginToolBoundaryViolation> violations =

--- a/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Plugins/PluginToolBoundaryStartupValidatorTests.cs
@@ -75,7 +75,7 @@ public sealed class PluginToolBoundaryStartupValidatorTests
         _registry.Setup(r => r.GetLoadedPlugins()).Returns([MakePlugin("azure")]);
         _tracker.Setup(t => t.Seed(
                 It.IsAny<IReadOnlyList<LoadedPlugin>>(), It.IsAny<Func<string, bool>>(), It.IsAny<IReadOnlyCollection<string>>()))
-            .Returns([new PluginToolBoundaryViolation("azure", "DeniedTools", "file_wrte")]);
+            .Returns([new PluginToolBoundaryViolation("azure", PluginToolBoundaryListKind.DeniedTools, "file_wrte")]);
         var sut = MakeSut(_ => false);
 
         var act = async () => await sut.StartAsync(CancellationToken.None);


### PR DESCRIPTION
## Summary

- #524 made an unresolved `AllowedTools`/`DeniedTools` entry deny everything: the whole plugin's tools (`ToolChainBuilder`) and every known first-party tool agent-wide (`PluginPermissionRuleProvider`'s #612 fallback) — regardless of which list the bad entry came from.
- A typo in `AllowedTools` can only ever narrow a plugin's grant, never widen it, and can never defeat the `DeniedTools` bypass-immune guarantee #524 exists to protect. This PR gives a `Faulted` boundary a payload (which specific entries proved it broken, via the existing `PluginToolBoundaryViolation` record) instead of a bare status, so both consequence sites can ask "did any violation involve `DeniedTools`?" and only fail closed on uncertainty or a confirmed `DeniedTools` hit — an `AllowedTools`-only fault now runs the normal boundary filter, which is already a safe no-op for the faulted name (a positive allow-set match never matches a bogus entry).
- `Pending` is deliberately unchanged (still list-kind-agnostic) — it's transient by nature, and narrowing it isn't part of what #608 reported. The boot-time startup validator (`PluginToolBoundaryStartupValidator`) is also deliberately unchanged, with an explicit doc comment explaining why: a one-time loud boot failure is cheaper than an ongoing silently-degraded runtime.

Closes #608.

## Review history

This touches the `DeniedTools` bypass-immune security guarantee, so it got the full cadence: 3 rounds of `/code-review`, one 4-angle `/simplify` pass, and an independent `security-reviewer` pass — each round found something real and fixed it:

1. **Round 1**: a lock race, a missing defensive copy on write, a silent-overwrite bug (a second fault call could narrow away a recorded `DeniedTools` violation), and duplicated logic.
2. **Round 2**: a doc comment that overclaimed cross-call atomicity (confirmed), plus naming/cohesion nits.
3. **Round 3**: the read side (`GetBoundaryViolations`) had no defensive copy even though the write side did in round 1 — real gap, closed and mutation-tested. Also found a round-2 fix was itself partly cosmetic (wrapping single-key `ConcurrentDictionary` reads in a lock that added contention with no real joint-atomicity benefit) — reverted.
4. **`/simplify`**: consolidated the Verified/Pending/Faulted decision branch (independently duplicated across two consumer files — flagged across 3 separate passes) into one shared `RequiresFailClosed` extension; adopted the class's own `AddOrUpdate` idiom instead of a manual check-then-set; dropped a fully-dead `reason` parameter; switched `GetBoundaryViolations` to `.AsReadOnly()` (O(1), and — as a bonus — stronger against the exact downcast-mutation hazard round 1 closed, since `ReadOnlyCollection<T>` can't be cast back to `List<T>`).
5. **`security-reviewer`**: independently verified the core property end-to-end (no path lets a `DeniedTools` violation reach the run-normally branch, including through the merge logic, string comparison, and empty/null fallback — APPROVE-WITH-CHANGES). Found one real MEDIUM (a log message that now stated the opposite of what the new code does) and closed it, plus converted the violation's list-kind field from a raw string to an enum (the sole discriminator for a security decision, now compiler-checked) while every call site was already being touched for this PR's breaking change anyway.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, 0 errors
- [x] Every touched test suite (`Application.AI.Common.Tests`, `Application.Core.Tests`, `Infrastructure.AI.Tests`, `Infrastructure.AI.MCP.Tests` — Plugins/Permissions/ToolChainBuilder/BoundaryTracker filters) run clean after every commit in this PR, re-verified after each review round's fixes
- [x] New regression tests, each mutation-tested (broke the code, confirmed the test fails, reverted): an `AllowedTools`-only fault still returns the plugin's other valid tools; a `DeniedTools`-involving fault (even alongside an `AllowedTools` one) still denies everything; a fault with no recorded violations still fails closed; a second `MarkBoundaryFaulted` call merges rather than overwrites; `GetBoundaryViolations` can't be downcast-mutated; the shared `RequiresFailClosed`/`IsConfinedToAllowedTools` predicates are load-bearing at both consumer sites
- [x] Local test gate: Docker Desktop was unavailable on this machine for this entire PR (confirmed via `docker info`), so the 9 Testcontainers-backed `Presentation.AgentHub.Tests.Telemetry` tests couldn't run locally — same pre-existing, unrelated environmental gap as the prior PR (#630). Every test that actually exercises this PR's diff was run directly and is green; CI has Docker and will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu