### PR TITLE
fix: give CapabilityEnforcer.ValidateHosts a general-purpose validator (#605)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -1,5 +1,6 @@
 using Domain.AI.Sandbox;
 using Domain.Common;
+using Domain.Common.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Sandbox;
@@ -61,16 +62,15 @@ public sealed partial class CapabilityEnforcer
         {
             var normalizedHost = NormalizeHostForMatch(host);
 
-            // Closes only the empty-string case of the gap ValidatePaths' unconditional rejection
-            // closes more broadly for paths (#595 code-review) — an empty host is refused regardless
-            // of whether AllowedHosts is configured, not only when it fails to match an allow entry.
-            // Without this, a deny-list-only configuration (no AllowedHosts, so the allow-check below
-            // never runs) would silently admit an empty host that matches no configured deny pattern.
-            // NOT a full mirror of ValidatePaths: a non-empty but malformed host (embedded control
-            // characters, oversized input) still falls through to ordinary deny/allow matching here,
-            // unlike a path, which SecureInputValidatorHelper.ValidateFilePath rejects outright.
-            // Broadening this to match is tracked separately, not part of what #595 set out to fix.
-            if (string.IsNullOrEmpty(normalizedHost))
+            // Rejects the whole class of malformed input outright — empty, oversized, embedded
+            // NUL/control characters, or anything that isn't syntactically a valid host — mirroring
+            // ValidatePaths' unconditional NormalizeRequestedPath rejection for paths (#605; #595
+            // closed only the narrower empty-string case of this gap). Validated against the
+            // NORMALIZED value, not the raw requested value: a legitimate requested host can arrive
+            // as a full absolute URI, which NormalizeHostForMatch's own job is to reduce to a bare
+            // host — SecureInputValidatorHelper.ValidateHost expects that bare-host shape, so running
+            // it against the raw value would reject every URI-shaped legitimate host.
+            if (!SecureInputValidatorHelper.ValidateHost(normalizedHost))
                 return host;
 
             if (deniedPatterns.Any(pattern => HostPatternMatches(normalizedHost, pattern)))

--- a/src/Content/Domain/Domain.Common/Helpers/SecureInputValidatorHelper.cs
+++ b/src/Content/Domain/Domain.Common/Helpers/SecureInputValidatorHelper.cs
@@ -11,6 +11,9 @@ public static class SecureInputValidatorHelper
     private const int DefaultMaxLength = 1024;
     private const int MaxPathLength = 4096;
 
+    /// <summary>RFC 1035's maximum fully-qualified domain name length (253 octets, excluding the root dot).</summary>
+    private const int MaxHostLength = 253;
+
     // #576: anchored with \A/\z, not ^/$ — $ in .NET regex matches immediately before a trailing '\n'
     // as well as at the true end of the string, so a caller-supplied value ending in a newline would
     // otherwise pass (the same bug class already fixed in StorageSegmentSafety.AllowedCharset; see that
@@ -74,6 +77,32 @@ public static class SecureInputValidatorHelper
             return false;
 
         return true;
+    }
+
+    /// <summary>
+    /// Validates a bare network host value (a hostname or IP literal — <em>not</em> a full URL; a
+    /// caller that may receive an absolute URI must reduce it to a bare host first). Rejects the
+    /// whole class of malformed input a host-scoping comparison must never be allowed to silently
+    /// admit — empty, oversized, embedded NUL/control characters, or anything that is not
+    /// syntactically a valid DNS name or IP literal — mirroring <see cref="ValidateFilePath"/>'s role
+    /// for paths (#605).
+    /// </summary>
+    public static bool ValidateHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return false;
+
+        if (host.Length > MaxHostLength)
+            return false;
+
+        if (host.Contains('\0'))
+            return false;
+
+        // Uri.CheckHostName already rejects control characters, whitespace, and any character
+        // outside DNS-name/IPv4/IPv6 grammar as UriHostNameType.Unknown — the explicit checks above
+        // exist for parity with ValidateFilePath's own explicit NUL check, not because this alone
+        // would miss them.
+        return Uri.CheckHostName(host) != UriHostNameType.Unknown;
     }
 
     /// <summary>

--- a/src/Content/Domain/Domain.Common/Helpers/SecureInputValidatorHelper.cs
+++ b/src/Content/Domain/Domain.Common/Helpers/SecureInputValidatorHelper.cs
@@ -98,10 +98,12 @@ public static class SecureInputValidatorHelper
         if (host.Contains('\0'))
             return false;
 
-        // Uri.CheckHostName already rejects control characters, whitespace, and any character
-        // outside DNS-name/IPv4/IPv6 grammar as UriHostNameType.Unknown — the explicit checks above
-        // exist for parity with ValidateFilePath's own explicit NUL check, not because this alone
-        // would miss them.
+        // Uri.CheckHostName's own MS Learn doc only guarantees the null/empty-string -> Unknown case
+        // in writing; whitespace-only and embedded-NUL are not explicitly documented, only observed
+        // (#605 /simplify review) to behave the same way today. The checks above are deliberate
+        // defense-in-depth on a security gate: they encode this method's actual invariant explicitly,
+        // rather than resting solely on an undocumented corner of a BCL method's behavior that a
+        // future .NET version is free to change without it counting as a breaking change.
         return Uri.CheckHostName(host) != UriHostNameType.Unknown;
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -598,6 +598,27 @@ public sealed class CapabilityEnforcementTests
     }
 
     [Fact]
+    public async Task DeniedHostOnly_RequestedHostIsMalformedButNonEmpty_Refuses()
+    {
+        // #605: #595's fix above closed only the empty-string case of this gap. A non-empty but
+        // malformed host (embedded control character) matched no configured deny pattern and fell
+        // through the allow-check (which never runs in a deny-list-only config) unchecked — silently
+        // admitted. SecureInputValidatorHelper.ValidateHost now rejects the whole class outright,
+        // mirroring ValidatePaths' unconditional rejection of an unparsable path.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["evil\0.com"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task AllowedHostConfigured_ExactMatchWithPortStripped_PassesThrough()
     {
         var config = new SandboxConfig

--- a/src/Content/Tests/Domain.Common.Tests/Helpers/SecureInputValidatorHelperLogicTests.cs
+++ b/src/Content/Tests/Domain.Common.Tests/Helpers/SecureInputValidatorHelperLogicTests.cs
@@ -145,6 +145,65 @@ public class SecureInputValidatorHelperLogicTests
         SecureInputValidatorHelper.ValidateFilePath("src/Content/Tests/file.cs").Should().BeTrue();
     }
 
+    // ── ValidateHost (#605) ──
+
+    [Fact]
+    public void ValidateHost_NullHost_ReturnsFalse()
+    {
+        SecureInputValidatorHelper.ValidateHost(null!).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateHost_EmptyHost_ReturnsFalse()
+    {
+        SecureInputValidatorHelper.ValidateHost("").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateHost_WhitespaceHost_ReturnsFalse()
+    {
+        SecureInputValidatorHelper.ValidateHost("   ").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateHost_ExceedsMaxLength_ReturnsFalse()
+    {
+        var longHost = new string('a', 254);
+        SecureInputValidatorHelper.ValidateHost(longHost).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateHost_NullByte_ReturnsFalse()
+    {
+        SecureInputValidatorHelper.ValidateHost("evil\0.com").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("evil.com")] // BEL control character
+    [InlineData("evil\n.com")]
+    [InlineData("evil\r.com")]
+    [InlineData("evil .com")] // embedded space
+    [InlineData("*.evil.com")] // wildcard glob is never a valid literal host
+    public void ValidateHost_MalformedNonEmptyHost_ReturnsFalse(string host)
+    {
+        // #605: this is the exact class of input #595's empty-string-only fix left admitted in a
+        // deny-list-only configuration — a non-empty but malformed host fell through untouched.
+        SecureInputValidatorHelper.ValidateHost(host).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("example.com")]
+    [InlineData("sub.example.com")]
+    [InlineData("localhost")]
+    [InlineData("internal-server")]
+    [InlineData("192.168.1.1")]
+    [InlineData("::1")]
+    [InlineData("2001:db8::1")]
+    public void ValidateHost_ValidHost_ReturnsTrue(string host)
+    {
+        SecureInputValidatorHelper.ValidateHost(host).Should().BeTrue();
+    }
+
     // ── ValidateIdentifier ──
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #605 — `ValidatePaths` closes its class of malformed-input problem through a real
general-purpose validator: every requested path routes through
`SecureInputValidatorHelper.ValidateFilePath` before any deny/allow matching runs. `ValidateHosts`
had no equivalent; #595 closed only the narrower empty-string case, so a non-empty but malformed host
(embedded NUL/control characters, garbage text) still fell through to plain pattern matching
untouched — silently admitted in a deny-list-only configuration.

- New `SecureInputValidatorHelper.ValidateHost` (`Domain.Common`) — rejects empty, oversized (>253
  chars), NUL/control-character, and anything that isn't syntactically a valid DNS name or IP literal
  (`Uri.CheckHostName(host) != UriHostNameType.Unknown`).
- Wired into `CapabilityEnforcer.HostScoping.cs`'s `ValidateHosts`, replacing the #595 empty-string
  check, run unconditionally against the *normalized* host value — a legitimate requested host can
  arrive as a full absolute URI, which `NormalizeHostForMatch`'s job is to reduce to a bare host
  before this validator ever sees it.
- Explicit empty/NUL guards kept even though `Uri.CheckHostName` already covers them today (verified
  empirically, not just from docs) — deliberate defense-in-depth on a security gate, not resting
  solely on an undocumented corner of a BCL method's behavior.

## Follow-up filed (deliberately out of scope here)

`security-reviewer` confirmed this PR is clean and strictly fail-closed — it cannot admit anything
that was previously refused — but surfaced **#635**: three pre-existing, independently-verified
bypasses in `NormalizeHostForMatch` itself (alternate IPv4 encodings, Unicode label separators /
zero-width characters, and inconsistent IPv6 bracket/zone-id handling) that let a deny-list entry be
evaded by a spelling that resolves to the same host at connect time. Different defect class (semantic
canonicalization vs. syntactic validity) and a different mechanism (`NormalizeHostForMatch`, not the
new `ValidateHost`), so scoped to its own issue per this repo's one-issue-per-PR convention, per the
reviewer's own recommendation to merge #605 as-is.

## Review

- `/code-review`: clean on round 1 — reviewer independently verified `Uri.CheckHostName` edge-case
  behavior via a scratch console app (bare IPv6, empty/NUL, underscore hostnames) rather than just
  reading the code.
- `/simplify`, 4 parallel angles: 3 clean (reuse, efficiency, altitude); simplification correctly
  flagged the explicit empty/NUL guards as redundant with `Uri.CheckHostName` today — kept
  deliberately for defense-in-depth, doc comment rewritten to say so honestly.
- `security-reviewer`: clean verdict on the diff itself (see follow-up above for what it found in the
  surrounding, pre-existing code).

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] `Domain.Common.Tests` (791 tests, incl. new `ValidateHost` boundary/IPv6/malformed cases) — pass
- [x] `Application.AI.Common.Tests` (2684 tests, incl. new deny-list-only regression test) — pass
- [x] Mutation-tested: reverting to #595's empty-string-only check reproduces the exact bypass the
      issue's own "what's needed" section describes
- [ ] CI (full gate suite, including `security-review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu