### PR TITLE
fix: forward SkillIdFromArguments across GovernedAIFunction rewraps (#619)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/GovernedAIFunction.cs
@@ -132,6 +132,16 @@ internal sealed class GovernedAIFunction : DelegatingAIFunction
     /// </summary>
     internal ICurrentSkillAccessor? CurrentSkillAccessor => _currentSkillAccessor;
 
+    /// <summary>
+    /// The per-call skill resolver supplied at construction (#589), for the same re-wrap-forwarding
+    /// reason as <see cref="SkillIds"/> — currently unused by either production rewrap site
+    /// (<c>ToolChainBuilder.ApplyCompositionTaint</c>, <c>ToolChainBuilder.ProjectSurvivors.ResolveUnion</c>),
+    /// since no tool built through <c>ToolChainBuilder</c>'s pipeline supplies a per-call resolver
+    /// today (#619) — added defensively so a future tool that does adopt this pattern through that
+    /// pipeline can't have it silently dropped by a rewrap with no compiler or test signal.
+    /// </summary>
+    internal Func<AIFunctionArguments, string?>? SkillIdFromArguments => _skillIdFromArguments;
+
     protected override async ValueTask<object?> InvokeCoreAsync(
         AIFunctionArguments arguments,
         CancellationToken cancellationToken)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.Surface.cs
@@ -278,7 +278,8 @@ public partial class ToolChainBuilder
             .ToList();
 
         return new GovernedAIFunction(
-            publishedGoverned.Inner, compositionTaint: null, publishedGoverned.CurrentSkillAccessor, union);
+            publishedGoverned.Inner, compositionTaint: null, publishedGoverned.CurrentSkillAccessor, union,
+            publishedGoverned.SkillIdFromArguments);
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolChainBuilder.cs
@@ -565,12 +565,12 @@ public partial class ToolChainBuilder : IToolChainBuilder
             // rewrapping — never double-governing, since InnerFunction always points at the real tool.
             // governed.Inner already carries any McpFailureNormalizingAIFunction wrapping intact —
             // there is no separate provenance flag left to forward. governed.CurrentSkillAccessor/
-            // SkillIds (#531/#589) DO need forwarding explicitly — unlike Inner, they are not implicit
-            // in the wrapped function, so a re-wrap that forgot them would silently drop the tool's
-            // skill scope the moment a composition finding implicates it.
+            // SkillIds/SkillIdFromArguments (#531/#589/#619) DO need forwarding explicitly — unlike
+            // Inner, they are not implicit in the wrapped function, so a re-wrap that forgot them
+            // would silently drop the tool's skill scope the moment a composition finding implicates it.
             return (AITool)new GovernedAIFunction(
                 governed.Inner, new ToolCompositionTaint(findings),
-                governed.CurrentSkillAccessor, governed.SkillIds);
+                governed.CurrentSkillAccessor, governed.SkillIds, governed.SkillIdFromArguments);
         }).ToList();
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolChainBuilderTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Plugins;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
 using Application.AI.Common.Services.Tools;
+using Domain.AI.Governance;
 using Domain.AI.Sandbox;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
@@ -17,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
+using System.Reflection;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Services.Tools;
@@ -696,6 +698,60 @@ public class ToolChainBuilderTests
             .Which.Should().BeOfType<GovernedAIFunction>().Subject;
         governed.SkillIds.Should().BeEquivalentTo(["skill-a", "skill-b"],
             "both skills declared this MCP tool, so the published instance must carry both skills' scope");
+    }
+
+    // ── #619: SkillIdFromArguments must survive both rewrap sites, same as CurrentSkillAccessor/SkillIds ──
+
+    [Fact]
+    public void ApplyCompositionTaint_RewrapsAToolWithSkillIdFromArguments_ForwardsItUnchanged()
+    {
+        // #619: no production caller supplies both a composition finding AND a per-call skill
+        // resolver on the same tool today, so this exercises the private rewrap method directly
+        // (reflection) rather than end-to-end — the only way to prove this specific forwarding
+        // without waiting for a future tool to combine the two mechanisms.
+        Func<AIFunctionArguments, string?> resolver = _ => "resolved-skill";
+        var inner = AIFunctionFactory.Create(() => "result", "sink_tool");
+        var governed = new GovernedAIFunction(inner, skillIdFromArguments: resolver);
+
+        var analyzer = new Mock<IToolCompositionAnalyzer>();
+        analyzer.Setup(a => a.Analyze(It.IsAny<IReadOnlyList<AITool>>())).Returns(
+            new ToolCompositionAssessment(
+                [new ToolCompositionFinding(
+                    "source_tool", ToolCompositionCapability.IngestsUntrustedInput,
+                    "sink_tool", ToolCompositionCapability.ExecutesCode,
+                    ToolCapabilityOrigin.FirstParty, ToolCapabilityOrigin.FirstParty)],
+                UnclassifiedTools: []));
+
+        var builder = CreateBuilder();
+        typeof(ToolChainBuilder)
+            .GetField("_compositionAnalyzer", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .SetValue(builder, analyzer.Object);
+
+        var method = typeof(ToolChainBuilder).GetMethod("ApplyCompositionTaint", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var result = (List<AITool>)method.Invoke(builder, [new List<AITool> { governed }, "test-agent"])!;
+
+        var rewrapped = result.Should().ContainSingle().Which.Should().BeOfType<GovernedAIFunction>().Subject;
+        rewrapped.Should().NotBeSameAs(governed, "a composition finding must trigger a rewrap");
+        rewrapped.SkillIdFromArguments.Should().BeSameAs(resolver,
+            "the re-wrap must forward the per-call skill resolver exactly like CurrentSkillAccessor/SkillIds, or a future tool combining both mechanisms would silently lose its scope");
+    }
+
+    [Fact]
+    public void ResolveUnion_PublishedToolHasSkillIdFromArguments_ForwardsItIntoTheRewrappedInstance()
+    {
+        // #619: mirrors the ApplyCompositionTaint test above for the other rewrap site.
+        Func<AIFunctionArguments, string?> resolver = _ => "resolved-skill";
+        var inner = AIFunctionFactory.Create(() => "result", "shared_tool");
+        var published = new GovernedAIFunction(inner, skillIds: ["skill-a"], skillIdFromArguments: resolver);
+        var candidate = new GovernedAIFunction(inner, skillIds: ["skill-b"]);
+
+        var method = typeof(ToolChainBuilder).GetMethod("ResolveUnion", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = (AITool)method.Invoke(null, [published, candidate])!;
+
+        var rewrapped = result.Should().BeOfType<GovernedAIFunction>().Subject;
+        rewrapped.SkillIds.Should().BeEquivalentTo(["skill-a", "skill-b"]);
+        rewrapped.SkillIdFromArguments.Should().BeSameAs(resolver,
+            "the union rewrap must forward the published side's per-call skill resolver, not just its SkillIds/CurrentSkillAccessor");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes item 1 of #619 — `GovernedAIFunction` already exposed internal `SkillIds`/`CurrentSkillAccessor`
accessors so `ToolChainBuilder.ApplyCompositionTaint` and `ToolChainBuilder.Surface.ResolveUnion` can
forward them across an unwrap-and-rewrap. There was no equivalent accessor for `_skillIdFromArguments`
(#589's per-call skill resolver, currently only used by `run_skill_script`), so a rewrap on a tool using
it would silently drop the delegate with no compiler or test signal.

Currently latent — no production tool combines a per-call resolver with either rewrap path today (traced
every `new GovernedAIFunction(...)` call site in the repo: `WrapGoverned` and `GoverningToolContextProvider`
are original-construction sites, not rewraps, so neither had this gap) — but added defensively before
anything depends on its absence, per the issue's own suggested fix.

- New `internal SkillIdFromArguments` accessor on `GovernedAIFunction`, mirroring the existing two.
- Threaded through both rewrap sites.
- Two reflection-based regression tests (the only way to exercise this combination without waiting for
  a production tool to adopt the pattern), mutation-tested: reverting either forwarding call reproduces
  the exact silent-drop the fix prevents.

## Deliberately not in scope

Item 2 of #619 (the union fix being a post-hoc repair on the dedup layer rather than computed before
wrapping) is explicitly marked "not scoped here" by the issue's own text — a design-direction note for
whoever next touches this wrapping/rewrap machinery, not part of this fix.

## Review

- `/code-review`: clean. 4 parallel finder agents + traced all 5 production `GovernedAIFunction`
  construction sites, confirmed no rewrap site missed. One low-severity note (reflection-based tests
  couple to private method names) — accepted, since it's the only way to test this defensive fix before
  a real caller combines both mechanisms, and the tests are already mutation-proven.
- `/simplify`: reviewed directly (parallel subagent launches were rate-limited this turn) — clean, pure
  mirror of the existing accessor pattern, no reuse/efficiency/altitude issues; the fix's scope matches
  the issue's own explicit item-1/item-2 split.
- Security assessment (also done directly, same rate-limit): confirmed no new escalation path — the
  accessor is `internal`-only, mirrors an already-internal pattern, and exposes no new information (the
  delegate was already captured by the constructor before this PR, just not readable back out).

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] `Application.AI.Common.Tests` (2686 tests, incl. 2 new reflection-based forwarding tests) — pass
- [x] Both new tests mutation-tested (revert fix → confirm test fails → restore → confirm passes)
- [ ] CI (full gate suite, including `security-review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu