### PR TITLE
docs: close #447's audit throw-safety gap via interface contract

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Governance/IGovernanceAuditService.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Governance/IGovernanceAuditService.cs
@@ -10,6 +10,20 @@ public interface IGovernanceAuditService
     /// <summary>
     /// Logs a governance decision to the tamper-evident audit chain.
     /// </summary>
+    /// <remarks>
+    /// <strong>Must never throw (#447).</strong> Every caller treats the audit write as a side effect
+    /// of a decision already made — the tool call is already being allowed, denied, or refused before
+    /// this runs — and none of this interface's 15+ production call sites expect or handle an
+    /// exception from it. Several of those call sites sit inside a <c>try</c> block whose own
+    /// legitimate failure return (e.g. a governance refusal, <c>Result.Fail</c>) would otherwise be
+    /// silently replaced by this call's own unrelated I/O exception, turning a clean refusal into a
+    /// propagating crash. A disk failure or similar here must degrade the audit trail's completeness,
+    /// never the tool-call decision it is recording — "the audit is the record, not the control." An
+    /// implementation should catch broadly, surface the failure through its own logging/metrics (never
+    /// silently), and return normally regardless. See <c>JsonlGovernanceAuditWriter.Log</c>'s own
+    /// remarks for the reference implementation of this contract, including why a write failure must
+    /// still be visible to an operator even though it never throws.
+    /// </remarks>
     /// <param name="agentId">The agent whose action was evaluated.</param>
     /// <param name="action">The action that was evaluated (e.g., tool name).</param>
     /// <param name="decision">The governance decision (allow, deny, warn, etc.).</param>


### PR DESCRIPTION
## Summary

Closes #447 — all three items resolved: item 1 with a code change, items 2 and 3 with documented
design conclusions and no code change (per the issue's own framing).

### Item 1 — the in-try audit calls could, in principle, turn a refusal into a crash

Investigated the concrete implementation before wrapping call sites. `JsonlGovernanceAuditWriter.Log`
— the only production `IGovernanceAuditService` implementation — already never throws: it catches
broadly, degrades to a logged error + `GovernanceMetrics.AuditWriteFailures` metric, and always
returns normally. This is already covered by an existing, passing regression test
(`Log_WriteFailure_DoesNotThrow`).

The actual gap: this guarantee lived only in `JsonlGovernanceAuditWriter`'s own remarks — invisible to
the `IGovernanceAuditService` interface itself, so a future alternate implementation or hand-rolled
test double had no documented reason to honor it. Promoted the "must never throw" contract to the
interface's own XML doc, citing the reference implementation. No behavior change; the production
implementation was already correct — this closes the gap at the right altitude (the contract, not
nine scattered call-site wrappers) rather than adding redundant try/catch around already-safe code.

### Item 2 — throwing pre-dispatch paths (`GetRequiredKeyedService`, `profileResolver.Resolve`) leave no audit record

Design conclusion, no code change: these are pre-dispatch **wiring/configuration failures**
(a host that never registered the sandbox factory for this isolation tier), not governance
**decisions**. No allow/deny/refuse evaluation was ever reached — the system failed to even attempt
one. The tamper-evident audit chain exists to record decisions an operator or auditor needs to trust
were made correctly; a startup/wiring bug belongs in ordinary exception propagation, logging, and
alerting instead, where it's visible as the infrastructure failure it actually is, not diluted into
the decision audit trail as if it were a governance outcome.

### Item 3 — inconsistent overload usage across the three audit call sites

No action, per the issue's own text: "Nothing to fix... unless/until a second monitor-holding
`Func<string>` caller appears." Still true — tracked, not touched.

## Review

- `/code-review`: clean — independently re-verified every factual claim the new doc text makes
  (that `JsonlGovernanceAuditWriter.Log` never throws, that the cited regression test exists, that the
  two `McpConnectionManager` call sites are real, that `JsonlGovernanceAuditWriter` is the only
  production implementation) rather than trusting the comment.
- `/simplify`: skipped the 4-agent pass — a pure `<remarks>` addition with zero logic surface has
  nothing to simplify.
- `security-reviewer`: not run — no runtime behavior changed, so there's nothing new to assess.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] `JsonlGovernanceAuditWriterTests` (10 tests, incl. the pre-existing `Log_WriteFailure_DoesNotThrow`) — pass
- [ ] CI (full gate suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu