### PR TITLE
fix: create trace/tool-result directories with owner-only permissions (#527)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/Context/FileSystemToolResultStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Context/FileSystemToolResultStore.cs
@@ -6,6 +6,7 @@ using Domain.AI.Context;
 using Domain.AI.Telemetry.Redaction;
 using Domain.Common.Config;
 using Domain.Common.Helpers;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -287,7 +288,9 @@ public sealed class FileSystemToolResultStore : IToolResultStore
 
         var storagePath = Path.Combine(config.StoragePath, safeSessionId, "tool-results", $"{resultId}.txt");
         var directory = Path.GetDirectoryName(storagePath)!;
-        CreateDirectoryOwnerOnly(directory);
+        // Owner-only (#559, pairs with #527): this is the directory a spilled result's raw,
+        // unredacted-since-#563 output lands in.
+        OwnerOnlyDirectoryHelper.Create(directory);
 
         await File.WriteAllTextAsync(storagePath, spillable, cancellationToken);
 
@@ -549,25 +552,6 @@ public sealed class FileSystemToolResultStore : IToolResultStore
                 return;
             directory = parent;
         }
-    }
-
-    /// <summary>
-    /// Creates <paramref name="directory"/> (and any missing parents) with owner-only access on POSIX
-    /// (#559, pairs with #527) — the directory a spilled result's raw, unredacted-since-#563 output
-    /// lands in. Windows is left to its inherited ACL, matching the only other place in this codebase
-    /// that restricts filesystem permissions (<c>SandboxWorkspace</c>) rather than inventing a second,
-    /// untested ACL-setting path.
-    /// </summary>
-    private static void CreateDirectoryOwnerOnly(string directory)
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            Directory.CreateDirectory(directory);
-            return;
-        }
-
-        Directory.CreateDirectory(
-            directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }
 
     /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI/Helpers/OwnerOnlyDirectoryHelper.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Helpers/OwnerOnlyDirectoryHelper.cs
@@ -1,0 +1,36 @@
+namespace Infrastructure.AI.Helpers;
+
+/// <summary>
+/// Creates a directory (and any missing parents) with owner-only access on POSIX, for storage roots
+/// that hold sensitive content — tool-call payloads, execution traces — and were never meant to be
+/// readable by anything beyond the process's own user (#527).
+/// </summary>
+/// <remarks>
+/// Windows is left to its inherited ACL, matching the one other place in this codebase that restricts
+/// filesystem permissions for this reason (<c>FileSystemToolResultStore.CreateDirectoryOwnerOnly</c>,
+/// #559) — extracted here as a shared helper now that a third consumer
+/// (<c>FileSystemExecutionTraceStore</c>) needs the identical behavior, rather than a third
+/// hand-copied private method. Deliberately NOT reused by <c>SandboxWorkspace</c>, which grants
+/// broader access on purpose (a workspace mounted into a container running as a different UID needs
+/// <c>Other</c> permissions) — that is a different security posture for a different reason, not the
+/// same gap.
+/// </remarks>
+internal static class OwnerOnlyDirectoryHelper
+{
+    /// <summary>
+    /// Creates <paramref name="directory"/> (and any missing parents) with owner-only read/write/execute
+    /// access on POSIX. A no-op permission-wise if the directory already exists — <see cref="Directory.CreateDirectory(string, UnixFileMode)"/>
+    /// only applies the mode to directories it actually creates.
+    /// </summary>
+    public static void Create(string directory)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Directory.CreateDirectory(directory);
+            return;
+        }
+
+        Directory.CreateDirectory(
+            directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+}

--- a/src/Content/Infrastructure/Infrastructure.AI/Helpers/OwnerOnlyDirectoryHelper.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Helpers/OwnerOnlyDirectoryHelper.cs
@@ -10,6 +10,14 @@ namespace Infrastructure.AI.Helpers;
 /// grants broader access on purpose (a workspace mounted into a container running as a different UID
 /// needs <c>Other</c> permissions) — that is a different security posture for a different reason, not
 /// the same gap.
+/// <para>
+/// <strong>Does not remediate a directory that already exists</strong> (/code-review, round 2) — this
+/// only tightens permissions on the create path. A host upgraded in place, whose storage root was
+/// already created by pre-#527 code with looser default permissions, keeps that root's old mode
+/// indefinitely; only the NEW leaf directories created under it after the upgrade get owner-only.
+/// Closing that gap needs a one-time startup remediation pass, tracked separately rather than folded
+/// into this create-time fix.
+/// </para>
 /// </remarks>
 internal static class OwnerOnlyDirectoryHelper
 {

--- a/src/Content/Infrastructure/Infrastructure.AI/Helpers/OwnerOnlyDirectoryHelper.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Helpers/OwnerOnlyDirectoryHelper.cs
@@ -6,22 +6,36 @@ namespace Infrastructure.AI.Helpers;
 /// readable by anything beyond the process's own user (#527).
 /// </summary>
 /// <remarks>
-/// Windows is left to its inherited ACL, matching the one other place in this codebase that restricts
-/// filesystem permissions for this reason (<c>FileSystemToolResultStore.CreateDirectoryOwnerOnly</c>,
-/// #559) — extracted here as a shared helper now that a third consumer
-/// (<c>FileSystemExecutionTraceStore</c>) needs the identical behavior, rather than a third
-/// hand-copied private method. Deliberately NOT reused by <c>SandboxWorkspace</c>, which grants
-/// broader access on purpose (a workspace mounted into a container running as a different UID needs
-/// <c>Other</c> permissions) — that is a different security posture for a different reason, not the
-/// same gap.
+/// Windows is left to its inherited ACL. Deliberately NOT reused by <c>SandboxWorkspace</c>, which
+/// grants broader access on purpose (a workspace mounted into a container running as a different UID
+/// needs <c>Other</c> permissions) — that is a different security posture for a different reason, not
+/// the same gap.
 /// </remarks>
 internal static class OwnerOnlyDirectoryHelper
 {
+    private const UnixFileMode OwnerOnlyMode =
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
     /// <summary>
     /// Creates <paramref name="directory"/> (and any missing parents) with owner-only read/write/execute
-    /// access on POSIX. A no-op permission-wise if the directory already exists — <see cref="Directory.CreateDirectory(string, UnixFileMode)"/>
-    /// only applies the mode to directories it actually creates.
+    /// access on POSIX, applied to <em>every</em> directory this call actually creates — not just the
+    /// leaf. A no-op permission-wise for any segment that already exists.
     /// </summary>
+    /// <remarks>
+    /// <c>Directory.CreateDirectory(path, mode)</c>'s single-call overload does NOT do this
+    /// (/code-review finding, verified against <c>dotnet/runtime</c>'s <c>FileSystem.Unix.cs</c>):
+    /// its internal <c>CreateParentsAndDirectory</c> only applies the caller's requested mode to the
+    /// final path segment — every missing intermediate directory it creates along the way gets the
+    /// BCL's loose default (0777 minus umask, typically 0755). On a first-ever call for a not-yet-
+    /// existing storage root, that would leave every intermediate segment (e.g. the trace root, an
+    /// "executions" folder, an execution-run-id folder) world-readable/executable — permanently, since
+    /// nothing revisits their permissions once created — even though the leaf directory this method
+    /// was actually asked to protect ends up correctly restricted. Walking the path manually and
+    /// creating each missing segment with its own single-directory call (root-to-leaf, so a segment's
+    /// parent always already exists by the time that segment's own call runs) is what closes this: each
+    /// such call's "final path segment" is always the one directory it is responsible for, so the
+    /// requested mode lands on every level, not just the last one.
+    /// </remarks>
     public static void Create(string directory)
     {
         if (OperatingSystem.IsWindows())
@@ -30,7 +44,19 @@ internal static class OwnerOnlyDirectoryHelper
             return;
         }
 
-        Directory.CreateDirectory(
-            directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        var fullPath = Path.GetFullPath(directory);
+        var missingSegments = new Stack<string>();
+        var current = fullPath;
+        while (!Directory.Exists(current))
+        {
+            missingSegments.Push(current);
+            var parent = Path.GetDirectoryName(current);
+            if (parent is null || parent == current)
+                break;
+            current = parent;
+        }
+
+        while (missingSegments.Count > 0)
+            Directory.CreateDirectory(missingSegments.Pop(), OwnerOnlyMode);
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Traces/FileSystemExecutionTraceStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Traces/FileSystemExecutionTraceStore.cs
@@ -5,6 +5,7 @@ using Application.AI.Common.Interfaces.Traces;
 using Domain.Common.Config;
 using Domain.Common.Config.MetaHarness;
 using Domain.Common.MetaHarness;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -45,7 +46,9 @@ public sealed class FileSystemExecutionTraceStore : IExecutionTraceStore
     {
         var config = _appConfig.CurrentValue.MetaHarness;
         var dir = scope.ResolveDirectory(config.TraceDirectoryRoot);
-        Directory.CreateDirectory(dir);
+        // Owner-only (#527): this directory (and its turns/tool_results subdirectories) holds
+        // redacted-but-still-substantive tool-result payloads once ExecutionTracingEnabled is on.
+        OwnerOnlyDirectoryHelper.Create(dir);
 
         var manifest = new
         {
@@ -113,7 +116,7 @@ public sealed class FileSystemExecutionTraceStore : IExecutionTraceStore
             ArgumentOutOfRangeException.ThrowIfNegativeOrZero(turnNumber);
 
             var turnDir = Path.Combine(RunDirectory, "turns", turnNumber.ToString());
-            Directory.CreateDirectory(turnDir);
+            OwnerOnlyDirectoryHelper.Create(turnDir);
 
             if (artifacts.SystemPrompt is { } prompt)
             {
@@ -151,7 +154,7 @@ public sealed class FileSystemExecutionTraceStore : IExecutionTraceStore
                         continue;
                     }
 
-                    Directory.CreateDirectory(toolResultsDir);
+                    OwnerOnlyDirectoryHelper.Create(toolResultsDir);
                     await File.WriteAllTextAsync(targetPath, result, ct);
                 }
             }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Context/FileSystemToolResultStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Context/FileSystemToolResultStoreTests.cs
@@ -527,7 +527,7 @@ public sealed class FileSystemToolResultStoreTests : IDisposable
     public async Task StoreIfLargeAsync_SessionIdWithinTheAllowedCharset_DoesNotThrow(string sessionId)
     {
         // Correctness-review finding: content must exceed this fixture's 100-char PerResultCharLimit
-        // so StoreIfLargeAsync actually reaches CreateDirectoryOwnerOnly/Path.Combine. A short "data"
+        // so StoreIfLargeAsync actually reaches OwnerOnlyDirectoryHelper.Create/Path.Combine. A short "data"
         // payload stays inline and never touches the filesystem, so a colon-in-the-charset id would
         // pass this test even on a build where Directory.CreateDirectory("conv-1:step-5") throws
         // IOException on Windows — which the pre-fix code did.

--- a/src/Content/Tests/Infrastructure.AI.Tests/Helpers/OwnerOnlyDirectoryHelperTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Helpers/OwnerOnlyDirectoryHelperTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Infrastructure.AI.Helpers;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Helpers;
+
+/// <summary>
+/// Tests for <see cref="OwnerOnlyDirectoryHelper"/>.
+/// </summary>
+public sealed class OwnerOnlyDirectoryHelperTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "owner-only-dir-tests-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+                Directory.Delete(_root, recursive: true);
+        }
+        catch
+        {
+            // Best-effort test cleanup
+        }
+    }
+
+    [Fact]
+    public void Create_MultiLevelPathWithNoExistingSegments_AppliesOwnerOnlyModeToEveryCreatedLevel()
+    {
+        // /code-review finding: Directory.CreateDirectory(path, mode)'s single-call overload only
+        // applies the mode to the FINAL path segment — every missing intermediate directory it
+        // creates gets the loose BCL default instead. This asserts the fix closes that gap for every
+        // level this call creates, not just the leaf.
+        var leaf = Path.Combine(_root, "a", "b", "c");
+
+        OwnerOnlyDirectoryHelper.Create(leaf);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Directory.Exists(leaf).Should().BeTrue();
+            return;
+        }
+
+        const UnixFileMode expected = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+        File.GetUnixFileMode(_root).Should().Be(expected, "the root segment this call newly created must be owner-only too");
+        File.GetUnixFileMode(Path.Combine(_root, "a")).Should().Be(expected);
+        File.GetUnixFileMode(Path.Combine(_root, "a", "b")).Should().Be(expected);
+        File.GetUnixFileMode(leaf).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Create_DirectoryAlreadyExists_IsANoOpAndDoesNotThrow()
+    {
+        Directory.CreateDirectory(_root);
+
+        var act = () => OwnerOnlyDirectoryHelper.Create(_root);
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Create_SomeParentSegmentsAlreadyExist_OnlyAppliesModeToTheNewlyCreatedOnes()
+    {
+        var existingParent = Path.Combine(_root, "existing");
+        Directory.CreateDirectory(existingParent); // created with the default (non-restricted) mode
+        var leaf = Path.Combine(existingParent, "new-a", "new-b");
+
+        var act = () => OwnerOnlyDirectoryHelper.Create(leaf);
+
+        act.Should().NotThrow();
+        Directory.Exists(leaf).Should().BeTrue();
+
+        if (!OperatingSystem.IsWindows())
+        {
+            const UnixFileMode expected = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+            File.GetUnixFileMode(Path.Combine(existingParent, "new-a")).Should().Be(expected);
+            File.GetUnixFileMode(leaf).Should().Be(expected);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Helpers/OwnerOnlyDirectoryHelperTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Helpers/OwnerOnlyDirectoryHelperTests.cs
@@ -62,7 +62,14 @@ public sealed class OwnerOnlyDirectoryHelperTests : IDisposable
     public void Create_SomeParentSegmentsAlreadyExist_OnlyAppliesModeToTheNewlyCreatedOnes()
     {
         var existingParent = Path.Combine(_root, "existing");
-        Directory.CreateDirectory(existingParent); // created with the default (non-restricted) mode
+        Directory.CreateDirectory(existingParent);
+        // A deliberately WIDE mode, distinguishable from owner-only, and set explicitly rather than
+        // relying on whatever the ambient umask happens to produce — the assertion below must prove
+        // this segment was left untouched, not coincide with owner-only by chance.
+        const UnixFileMode wideMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+            | UnixFileMode.GroupRead | UnixFileMode.GroupExecute | UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(existingParent, wideMode);
         var leaf = Path.Combine(existingParent, "new-a", "new-b");
 
         var act = () => OwnerOnlyDirectoryHelper.Create(leaf);
@@ -73,6 +80,8 @@ public sealed class OwnerOnlyDirectoryHelperTests : IDisposable
         if (!OperatingSystem.IsWindows())
         {
             const UnixFileMode expected = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+            File.GetUnixFileMode(existingParent).Should().Be(wideMode,
+                "a pre-existing segment's permissions must never be touched by a call that only needs to create its children");
             File.GetUnixFileMode(Path.Combine(existingParent, "new-a")).Should().Be(expected);
             File.GetUnixFileMode(leaf).Should().Be(expected);
         }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Traces/FileSystemExecutionTraceStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Traces/FileSystemExecutionTraceStoreTests.cs
@@ -61,6 +61,52 @@ public sealed class FileSystemExecutionTraceStoreTests : IDisposable
         StartedAt = DateTimeOffset.UtcNow
     };
 
+    // --- Directory permissions (#527) ---
+
+    [Fact]
+    public async Task StartRunAsync_RunDirectoryIsCreatedOwnerOnly()
+    {
+        // #527: the run directory (and, transitively, its turns/tool_results subdirectories) holds
+        // redacted-but-still-substantive tool-result payloads once tracing is on — it must never be
+        // created with whatever the process umask/inherited ACL happens to grant.
+        var scope = TraceScope.ForExecution(Guid.NewGuid());
+
+        var writer = await _sut.StartRunAsync(scope, DefaultMetadata());
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var mode = File.GetUnixFileMode(writer.RunDirectory);
+            mode.Should().Be(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute,
+                "the run directory must be readable/writable/executable by the owner only");
+        }
+    }
+
+    [Fact]
+    public async Task WriteTurnAsync_TurnAndToolResultsDirectoriesAreCreatedOwnerOnly()
+    {
+        var scope = TraceScope.ForExecution(Guid.NewGuid());
+        var writer = await _sut.StartRunAsync(scope, DefaultMetadata());
+
+        // MaxFullPayloadKB is 1 KB in this fixture (see constructor) — a result over that spills to
+        // tool_results/<callId>.json, exercising the second, nested owner-only directory creation.
+        var oversizedResult = new string('x', 2048);
+        await writer.WriteTurnAsync(1, new TurnArtifacts
+        {
+            ToolResults = new Dictionary<string, string> { ["call-1"] = oversizedResult }
+        });
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var turnDir = Path.Combine(writer.RunDirectory, "turns", "1");
+            File.GetUnixFileMode(turnDir).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+            var toolResultsDir = Path.Combine(turnDir, "tool_results");
+            File.GetUnixFileMode(toolResultsDir).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     // --- Directory creation ---
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #527 — `FileSystemExecutionTraceStore` created each run's directory (and its `turns`/
`tool_results` subdirectories) with whatever the process umask or inherited ACL gave it. Since #505
connected this writer to `ToolDiagnosticsMiddleware`, those files hold real (redacted, capped)
tool-result payloads whenever `ExecutionTracingEnabled` is on — "whatever the umask gave it" is not a
decision anyone made, on a shared host or a widely-mounted container volume.

- `FileSystemToolResultStore` already had this exact fix (#559, filed pairing with #527) via a private
  `CreateDirectoryOwnerOnly` method. Extracted it into a shared `OwnerOnlyDirectoryHelper` now that a
  third consumer needs the identical behavior, and refactored `FileSystemToolResultStore` to delegate
  to it too, rather than hand-copying a third private method.
- Deliberately **not** reused by `SandboxWorkspace`, which grants broader access on purpose (a
  workspace mounted into a container running as a different UID needs `Other` permissions) — a
  different security posture for a different reason, not the same gap.
- Retention policy (nothing prunes `traces.jsonl`) is explicitly out of scope per the issue's own text.

## Review found and fixed a real bug in the fix itself

Round 1 `/code-review` found — verified against `dotnet/runtime`'s actual `FileSystem.Unix.cs` source,
not assumed — that `Directory.CreateDirectory(path, mode)`'s single-call overload only applies the
requested mode to the **final** path segment; every missing intermediate directory it creates gets the
BCL's loose default (0777 minus umask). On a fresh deployment, only the innermost leaf directory would
have ended up correctly restricted — every ancestor (the storage root, an `executions` folder, an
execution-run-id folder) would have stayed permanently world-readable/executable. Fixed by walking the
path manually and creating each missing segment with its own single-directory call, so every level
gets the owner-only mode, not just the leaf.

Round 2 found two more real things (both fixed) and two real residual gaps, both confirmed out of
#527's own stated scope and filed as **#640**: other filesystem-backed stores in the same assembly
(notably the audit hash-chain log) have the identical unrestricted-`CreateDirectory` pattern, and a
host upgraded in place never gets its pre-existing, already-loose ancestor directories remediated
(this fix only tightens permissions on the create path, documented explicitly).

## Review

- `/code-review`: 2 full rounds, each found something real (see above) — at the round cap.
- `/simplify` + a security read-through done directly (parallel `Agent` launches remain blocked by
  the auto-mode classifier since #619): no reuse/simplification/efficiency/altitude issues beyond
  what the two code-review rounds already surfaced and fixed. Considered a TOCTOU angle on the
  manual existence-check-then-create walk — not a new gap: it's the same class of risk any
  check-then-create filesystem code has (including the original single-call BCL overload this
  replaces), and an attacker who could exploit it would already need write access to the parent
  directory, at which point they have worse options available regardless.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] `Infrastructure.AI.Tests` (72 tests, incl. 3 new for `OwnerOnlyDirectoryHelper` proving
      every path level gets the mode, a pre-existing segment is left untouched, and a no-op on an
      already-existing directory) — pass
- [x] Local mutation test (revert to plain `Directory.CreateDirectory`) confirmed the run-directory
      assertion is real on this machine's OS-gated path; the POSIX-specific `GetUnixFileMode`
      assertions only execute on Linux — this dev machine is Windows, so CI is the first real
      execution of those assertions
- [ ] CI (full gate suite, including `security-review`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu