### PR TITLE
fix: close host-scoping deny-list bypasses via alternate address encodings (#635)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -143,12 +143,16 @@ public sealed partial class CapabilityEnforcer
     /// (<c>notevil.com</c>, <c>xn--vil-9ma.com</c>, a different IP) collides with another. NOT
     /// verified exhaustive — this closes the specific classes above, not every conceivable alternate
     /// host encoding; treat a new one, if found, as its own gap rather than assuming this comment's
-    /// list is complete. Also verified: no tool in this repo issues an outbound network request
-    /// through anything other than <c>Uri</c>/<c>HttpClient</c> today (no raw socket, no shelled
-    /// <c>curl</c>) — the one process-spawning tool
-    /// (<c>Infrastructure.AI.Tools.RestrictedSearchTool</c>) is a read-only, network-incapable local
-    /// shell sandbox — so this canonicalization matches every real consumer that exists, not just the
-    /// one the issue measured.
+    /// list is complete. This <c>Uri</c>-based canonicalization matches every tool that exists TODAY
+    /// — not because every tool connects via <c>Uri</c>/<c>HttpClient</c> (several run subprocesses —
+    /// terraform, npm, kubectl — via <c>ISandboxExecutor</c>, which could resolve a host differently),
+    /// but because grepping every <c>ResourceParametersByOperation</c> declaration in this repo found
+    /// zero production tools that declare a <see cref="Domain.AI.Sandbox.ResourceParameterKind.Host"/>
+    /// parameter — <see cref="EnforceHostScoping"/> never runs with a non-empty <c>requestedHosts</c>
+    /// today regardless of what a given tool's own consumer does with the value. A template consumer
+    /// adding a host-taking tool that resolves the raw value through something other than <c>Uri</c>
+    /// (a raw socket, a DNS lookup, a subprocess) would need this file's normalization to actually
+    /// match — worth re-verifying at that point rather than assuming this comment still holds.
     /// </remarks>
     private static string NormalizeHostForMatch(string value)
     {
@@ -178,7 +182,17 @@ public sealed partial class CapabilityEnforcer
         if (Uri.TryCreate(value, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host))
             return CanonicalizeParsedHost(uri);
 
-        if (value.Contains('/'))
+        // run-gates correctness/security review: not just '/' — a bare value carrying '@' (userinfo),
+        // '#' (fragment), '?' (query), or '\' (a browser/some URI parsers treat this as '/') would
+        // otherwise be silently reduced to just the leading host segment by the synthetic-scheme
+        // parse below, where it was refused outright as malformed before #635. Harmless for a tool
+        // that builds a web request from the result (the real HTTP client resolves the identical
+        // leading host), but a template consumer's future tool that feeds the raw value to a DNS
+        // lookup, a raw socket, or a subprocess would be checked against a different string than it
+        // actually contacts — the same "checked value must match consumed value" hazard #635 exists
+        // to close, just for a shape no tool in this repo produces today. Kept alongside '/' in the
+        // legacy StripPort fallback rather than synthetic-parsed.
+        if (value.IndexOfAny(['/', '@', '#', '?', '\\']) >= 0)
             return StripPort(value).TrimEnd('.');
 
         // Bare IPv6 needs brackets to be syntactically valid inside a URI ("http://::1/" is not a

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -219,7 +219,9 @@ public sealed partial class CapabilityEnforcer
     /// configured pattern it makes that one entry permanently unmatchable, which
     /// <see cref="WarnIfPatternIsInert"/> already logs as an inert-configuration warning. Either way
     /// the failure is observable through the logging this file already has, rather than adding a new
-    /// logging path for an exception verified (empirically, not exhaustively) never to occur.
+    /// logging path for an exception verified (round-2 code review) to actually occur — a mixed
+    /// valid-character-plus-invalid-Unicode label throws <see cref="UriFormatException"/> from
+    /// <see cref="Uri.IdnHost"/>, not merely a hypothetical this sentinel guards against defensively.
     /// </summary>
     private const string UnnormalizableHostSentinel = "\0";
 
@@ -234,11 +236,12 @@ public sealed partial class CapabilityEnforcer
         {
             // Uri.IdnHost, not Uri.Host: Host preserves a Unicode label separator or a bracketed IPv6
             // literal verbatim, which is exactly the class of string a raw compare against a deny
-            // entry misses (#635). Guarded defensively — verified empirically that IdnHost does not
-            // throw across every adversarial shape tried (overlong labels, invalid punycode-looking
-            // input, invalid surrogates, invalid percent-encoding), but a security gate must not
-            // itself become a crash vector on attacker-controlled input regardless. See
-            // UnnormalizableHostSentinel for why the fallback on an actual throw is NOT uri.Host.
+            // entry misses (#635). Round-2 code review found IdnHost DOES throw
+            // UriFormatException for a mixed valid-character-plus-invalid-Unicode label (verified:
+            // "a￿.com" — a pure-invalid label fails earlier, at Uri.TryCreate itself, and never
+            // reaches this property; a mixed one reaches it and throws) — correcting this file's
+            // earlier, narrower empirical claim. See UnnormalizableHostSentinel for why the fallback
+            // on that throw is NOT uri.Host.
             host = uri.IdnHost;
         }
         catch (Exception)
@@ -263,10 +266,55 @@ public sealed partial class CapabilityEnforcer
         // before this. Mirrors the existing normalization in
         // Infrastructure.AI.Hooks.CompositeHookExecutor.IsReservedAddress for the identical address
         // class, rather than inventing a second way to do the same collapse.
-        if (IPAddress.TryParse(host, out var ip) && ip.IsIPv4MappedToIPv6)
-            host = ip.MapToIPv4().ToString();
+        if (IPAddress.TryParse(host, out var ip))
+        {
+            if (ip.IsIPv4MappedToIPv6)
+                host = ip.MapToIPv4().ToString();
+            else if (TryGetDeprecatedIPv4CompatibleForm(ip, out var ipv4))
+                host = ipv4.ToString();
+        }
 
         return host.TrimEnd('.');
+    }
+
+    /// <summary>
+    /// Round-2 code review: the older, RFC 4291-deprecated "IPv4-compatible" IPv6 form
+    /// (<c>::a.b.c.d</c>, no <c>ffff</c> prefix — distinct from the IPv4-<em>mapped</em> form
+    /// <see cref="IPAddress.IsIPv4MappedToIPv6"/> already handles above) still parses successfully
+    /// today and is not covered by that property. Verified: <c>::127.0.0.1</c> and its equivalent
+    /// compressed form <c>::7f00:1</c> both parse to the identical address, with
+    /// <c>IsIPv4MappedToIPv6</c> false for both — so without this, a plain
+    /// <c>DeniedHosts=["127.0.0.1"]</c> entry does not refuse either spelling.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT a blind "first 12 bytes zero → take the last 4" check: <c>::1</c> (loopback)
+    /// and <c>::</c> (unspecified) both have an all-zero first-12-byte prefix too, but are reserved
+    /// addresses with their own distinct meaning, not IPv4-compatible encodings — verified naively
+    /// extracting the last 4 bytes of <c>::1</c> gives <c>0.0.0.1</c>, not <c>127.0.0.1</c>, which
+    /// would be an outright WRONG collapse (misidentifying loopback as an unrelated address), not
+    /// merely an incomplete one. Excluded via the same well-tested <see cref="IPAddress.IsLoopback"/>
+    /// / <see cref="IPAddress.IPv6Any"/> checks the BCL itself uses, rather than a hand-rolled
+    /// special-case list.
+    /// </remarks>
+    private static bool TryGetDeprecatedIPv4CompatibleForm(IPAddress ip, out IPAddress ipv4)
+    {
+        ipv4 = IPAddress.None;
+
+        if (ip.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6)
+            return false;
+
+        if (IPAddress.IsLoopback(ip) || ip.Equals(IPAddress.IPv6Any))
+            return false;
+
+        var bytes = ip.GetAddressBytes();
+        for (var i = 0; i < 12; i++)
+        {
+            if (bytes[i] != 0)
+                return false;
+        }
+
+        ipv4 = new IPAddress(bytes[12..]);
+        return true;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -177,7 +177,39 @@ public sealed partial class CapabilityEnforcer
     /// Normalizes a value with any leading <c>"*."</c> wildcard prefix already stripped — either a
     /// full absolute URI or a bare host[:port]/IP literal, never a wildcard pattern itself.
     /// </summary>
+    /// <remarks>
+    /// CI security-review (post-merge-attempt) found a second-order gap in this normalization: a
+    /// non-ASCII digit (a fullwidth <c>２</c>, U+FF12) defeats <see cref="Uri"/>'s own up-front IPv4-
+    /// literal recognition — <c>Uri.TryCreate("http://２852039166/")</c> classifies this as
+    /// <c>HostNameType.Dns</c>, not <c>IPv4</c>, because the leading character isn't an ASCII digit at
+    /// parse time. <see cref="CanonicalizeParsedHost"/>'s <c>IdnHost</c> step then IDNA/NFKC-folds the
+    /// fullwidth digit to plain ASCII as a side effect of DNS-label normalization — producing
+    /// <c>"2852039166"</c>, a pure-ASCII decimal string that IS a legacy decimal-IPv4 encoding of
+    /// <c>169.254.169.254</c> (the cloud metadata address), but <c>Uri</c> never re-evaluates
+    /// <c>HostNameType</c> against its own normalized output, so the value is never collapsed to the
+    /// dotted-quad form the very first #635 fix already handles for a plain (all-ASCII) decimal
+    /// literal. Verified live: feeding <c>NormalizeBareHostOnce</c>'s own output back into itself a
+    /// second time DOES resolve it correctly — the second pass sees pure ASCII digits up front and
+    /// <c>Uri</c> recognizes them as IPv4 immediately. <see cref="NormalizeBareHost"/> below re-runs
+    /// the single-pass normalization to a fixed point (bounded, not unconditional) specifically to
+    /// catch this class regardless of how many confusable/normalization layers an adversarial value
+    /// stacks — not just the two observed here.
+    /// </remarks>
     private static string NormalizeBareHost(string value)
+    {
+        var current = value;
+        for (var i = 0; i < 4; i++)
+        {
+            var next = NormalizeBareHostOnce(current);
+            if (next == current)
+                return next;
+            current = next;
+        }
+
+        return current;
+    }
+
+    private static string NormalizeBareHostOnce(string value)
     {
         if (Uri.TryCreate(value, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host))
             return CanonicalizeParsedHost(uri);

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/CapabilityEnforcer.HostScoping.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Domain.AI.Sandbox;
 using Domain.Common;
 using Domain.Common.Helpers;
@@ -40,6 +41,15 @@ public sealed partial class CapabilityEnforcer
         // type) is skipped rather than passed to NormalizeHostForMatch, which would NRE on it.
         var deniedPatterns = profile.DeniedHosts.Where(h => h is not null).Select(NormalizeHostForMatch).ToList();
         var allowedPatterns = profile.AllowedHosts.Where(h => h is not null).Select(NormalizeHostForMatch).ToList();
+
+        // #635 LOW: a typo'd or malformed deny/allow entry normalizes to a string ValidateHost
+        // would reject on the requested-host side (SecureInputValidatorHelper.ValidateHost is never
+        // run on the CONFIGURED side, only the requested side, in ValidateHosts below) — silently
+        // becoming a permanent no-op with no signal to the operator that their configuration is
+        // inert. Advisory only: log and keep evaluating, since a malformed pattern is harmless (it
+        // just never matches anything) rather than a reason to fail every call closed.
+        WarnIfPatternIsInert(toolName, "DeniedHosts", deniedPatterns);
+        WarnIfPatternIsInert(toolName, "AllowedHosts", allowedPatterns);
 
         if (ValidateHosts(requestedHosts, deniedPatterns, allowedPatterns) is { } hostViolation)
         {
@@ -89,7 +99,7 @@ public sealed partial class CapabilityEnforcer
     /// </summary>
     private static bool HostPatternMatches(string normalizedHost, string normalizedPattern)
     {
-        if (normalizedPattern.StartsWith("*."))
+        if (HasWildcardPrefix(normalizedPattern))
         {
             var suffix = normalizedPattern[1..];
             return normalizedHost.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
@@ -101,23 +111,169 @@ public sealed partial class CapabilityEnforcer
 
     /// <summary>
     /// Reduces a host value — whether a requested host or a configured deny/allow entry — to a bare,
-    /// comparable host name. A value that parses as an absolute URI is reduced via <see cref="Uri.Host"/>
-    /// itself, which correctly drops a scheme, userinfo (<c>user@</c>), port, and path/query in one
-    /// step — <em>not</em> an ad-hoc scan for <c>"://"</c>, which matches the first occurrence anywhere
-    /// in the string rather than only a leading scheme and so can be pointed at an unrelated embedded
-    /// URL later in the value. A value that isn't itself an absolute URI falls back to a trailing-port
-    /// strip and a root-terminating FQDN dot trim. Applying the identical reduction to both sides of a
-    /// <see cref="HostPatternMatches"/> comparison is what keeps an operator's plain <c>"evil.com"</c>
-    /// entry matching every equivalent spelling of that same host a caller might supply.
+    /// comparable host name, canonicalized the same way the actual network client
+    /// (<c>Uri</c>/<c>SocketsHttpHandler</c>) would resolve it — <em>not</em> an ad-hoc scan for
+    /// <c>"://"</c>, which matches the first occurrence anywhere in the string rather than only a
+    /// leading scheme and so can be pointed at an unrelated embedded URL later in the value. A leading
+    /// <c>"*."</c> wildcard prefix is preserved verbatim around the normalized remainder so
+    /// <see cref="HostPatternMatches"/>'s suffix check keeps working.
     /// </summary>
+    /// <remarks>
+    /// #635: a bare-shape value (no leading scheme, no <c>'/'</c>) is now routed through the same
+    /// <c>Uri</c> host parser via a synthetic <c>http://</c> scheme, then reduced by
+    /// <see cref="CanonicalizeParsedHost"/> to the connect-time form — closing four
+    /// deny-list-evasion classes measured against the real .NET BCL and, for the fourth, against the
+    /// actual compiled <see cref="CapabilityEnforcer.EnforceAsync"/>: a decimal/hex/short-form IPv4
+    /// literal (<c>2130706433</c>, <c>0x7f.0.0.1</c>, <c>127.1</c>) that a raw string compare never
+    /// equated with its dotted-quad deny entry; a Unicode label separator or zero-width character
+    /// (<c>evil。com</c>, a trailing U+200B) that <c>Uri.Host</c> preserves verbatim but
+    /// <c>Uri.IdnHost</c> — what the connecting client actually uses — normalizes to plain ASCII; a
+    /// bracketed/zone-qualified IPv6 literal (<c>[::1]</c>, <c>fe80::1%eth0</c>) that previously had
+    /// up to four spellings that failed to match each other or a bare deny entry; and an IPv4-mapped
+    /// IPv6 literal (<c>::ffff:127.0.0.1</c>), collapsed to its IPv4 form in
+    /// <see cref="CanonicalizeParsedHost"/>. A value containing <c>'/'</c> is deliberately excluded
+    /// from synthetic-scheme parsing and keeps the legacy <see cref="StripPort"/> fallback: forcing a
+    /// path/query-shaped value through a scheme would let its leading segment before the first
+    /// <c>'/'</c> be treated as a host even though it has no leading scheme naming one, which is
+    /// exactly the confusion
+    /// <c>AllowedHost_UrlWithEmbeddedSchemeLaterInString_DoesNotMatchTheEmbeddedHost</c> exists to
+    /// rule out. Verified (throwaway console app against the pinned BCL, 26/26 cases, plus code
+    /// review's own live probe of the compiled enforcer): every existing test pair still normalizes
+    /// identically, every deny-list bypass class named above closes, and no unrelated host
+    /// (<c>notevil.com</c>, <c>xn--vil-9ma.com</c>, a different IP) collides with another. NOT
+    /// verified exhaustive — this closes the specific classes above, not every conceivable alternate
+    /// host encoding; treat a new one, if found, as its own gap rather than assuming this comment's
+    /// list is complete. Also verified: no tool in this repo issues an outbound network request
+    /// through anything other than <c>Uri</c>/<c>HttpClient</c> today (no raw socket, no shelled
+    /// <c>curl</c>) — the one process-spawning tool
+    /// (<c>Infrastructure.AI.Tools.RestrictedSearchTool</c>) is a read-only, network-incapable local
+    /// shell sandbox — so this canonicalization matches every real consumer that exists, not just the
+    /// one the issue measured.
+    /// </remarks>
     private static string NormalizeHostForMatch(string value)
     {
         var trimmed = value.Trim();
 
-        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host))
-            return uri.Host.TrimEnd('.');
+        return HasWildcardPrefix(trimmed)
+            ? "*." + NormalizeBareHost(trimmed[2..])
+            : NormalizeBareHost(trimmed);
+    }
 
-        return StripPort(trimmed).TrimEnd('.');
+    private const string WildcardPrefix = "*.";
+
+    /// <summary>
+    /// Whether <paramref name="value"/> carries the <see cref="WildcardPrefix"/> a
+    /// <see cref="HostPatternMatches"/> suffix pattern uses — the single shared check for all three
+    /// call sites, so an ordinal-vs-culture inconsistency between them can't reopen a mismatch of the
+    /// kind #635 was filed to close.
+    /// </summary>
+    private static bool HasWildcardPrefix(string value) => value.StartsWith(WildcardPrefix, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Normalizes a value with any leading <c>"*."</c> wildcard prefix already stripped — either a
+    /// full absolute URI or a bare host[:port]/IP literal, never a wildcard pattern itself.
+    /// </summary>
+    private static string NormalizeBareHost(string value)
+    {
+        if (Uri.TryCreate(value, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Host))
+            return CanonicalizeParsedHost(uri);
+
+        if (value.Contains('/'))
+            return StripPort(value).TrimEnd('.');
+
+        // Bare IPv6 needs brackets to be syntactically valid inside a URI ("http://::1/" is not a
+        // parseable URI); a lone ':' is a port separator (StripPort's job below), not IPv6, so only
+        // wrap when there's more than one — the same signal StripPort itself uses to leave a bare
+        // IPv6 literal untouched.
+        var candidate = !value.StartsWith('[') && value.Count(c => c == ':') > 1 ? $"[{value}]" : value;
+
+        return Uri.TryCreate($"http://{candidate}/", UriKind.Absolute, out var synthetic) && !string.IsNullOrEmpty(synthetic.Host)
+            ? CanonicalizeParsedHost(synthetic)
+            : StripPort(value).TrimEnd('.');
+    }
+
+    /// <summary>
+    /// A value <see cref="NormalizeBareHost"/> guarantees fails
+    /// <see cref="SecureInputValidatorHelper.ValidateHost"/> (its explicit embedded-NUL check),
+    /// returned when <see cref="Uri.IdnHost"/> throws instead of falling back to the un-normalized
+    /// <see cref="Uri.Host"/>. Falling back to <c>Host</c> would silently reintroduce the exact
+    /// Unicode-label-separator/zero-width-character evasion class #635 exists to close, on precisely
+    /// the adversarial input that triggered the exception — code review (#635) found the original
+    /// silent fallback did exactly this with no signal it had fired. This sentinel instead composes
+    /// with existing, already-logged machinery: on the requested-host side it makes
+    /// <see cref="ValidateHosts"/> refuse the call outright (already logged as "host denied"); on a
+    /// configured pattern it makes that one entry permanently unmatchable, which
+    /// <see cref="WarnIfPatternIsInert"/> already logs as an inert-configuration warning. Either way
+    /// the failure is observable through the logging this file already has, rather than adding a new
+    /// logging path for an exception verified (empirically, not exhaustively) never to occur.
+    /// </summary>
+    private const string UnnormalizableHostSentinel = "\0";
+
+    /// <summary>
+    /// Reduces a successfully-parsed <see cref="Uri"/> to the bracket-free, zone-free, IPv4-collapsed,
+    /// connect-time canonical host <see cref="Uri.IdnHost"/> resolves to.
+    /// </summary>
+    private static string CanonicalizeParsedHost(Uri uri)
+    {
+        string host;
+        try
+        {
+            // Uri.IdnHost, not Uri.Host: Host preserves a Unicode label separator or a bracketed IPv6
+            // literal verbatim, which is exactly the class of string a raw compare against a deny
+            // entry misses (#635). Guarded defensively — verified empirically that IdnHost does not
+            // throw across every adversarial shape tried (overlong labels, invalid punycode-looking
+            // input, invalid surrogates, invalid percent-encoding), but a security gate must not
+            // itself become a crash vector on attacker-controlled input regardless. See
+            // UnnormalizableHostSentinel for why the fallback on an actual throw is NOT uri.Host.
+            host = uri.IdnHost;
+        }
+        catch (Exception)
+        {
+            return UnnormalizableHostSentinel;
+        }
+
+        if (host.StartsWith('[') && host.EndsWith(']'))
+            host = host[1..^1];
+
+        // IdnHost retains an IPv6 zone identifier verbatim, but two spellings of the identical zone
+        // ("%eth0" bare vs. the percent-escaped "%25eth0") do not string-equal each other — truncate
+        // it outright rather than trying to normalize its encoding.
+        var zoneIndex = host.IndexOf('%');
+        if (zoneIndex >= 0)
+            host = host[..zoneIndex];
+
+        // #635 code review: an IPv4-mapped IPv6 literal ("::ffff:127.0.0.1") is well-formed IPv6, and
+        // IdnHost does not collapse it to the equivalent IPv4 form — so it never string-equals a plain
+        // IPv4 deny/allow entry for the identical address. Verified live against the compiled
+        // enforcer: a DeniedHosts=["127.0.0.1"] entry did not refuse a requested "::ffff:127.0.0.1"
+        // before this. Mirrors the existing normalization in
+        // Infrastructure.AI.Hooks.CompositeHookExecutor.IsReservedAddress for the identical address
+        // class, rather than inventing a second way to do the same collapse.
+        if (IPAddress.TryParse(host, out var ip) && ip.IsIPv4MappedToIPv6)
+            host = ip.MapToIPv4().ToString();
+
+        return host.TrimEnd('.');
+    }
+
+    /// <summary>
+    /// Logs one warning per already-normalized <paramref name="patterns"/> entry that
+    /// <see cref="SecureInputValidatorHelper.ValidateHost"/> would reject — #635 LOW: such an entry
+    /// can never match any requested host (every requested host is validated the same way in
+    /// <see cref="ValidateHosts"/>), so it is a silent, permanent no-op in the operator's
+    /// configuration unless something says so.
+    /// </summary>
+    private void WarnIfPatternIsInert(string toolName, string configKey, IReadOnlyList<string> patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            var checkValue = HasWildcardPrefix(pattern) ? pattern[2..] : pattern;
+            if (!SecureInputValidatorHelper.ValidateHost(checkValue))
+            {
+                _logger.LogWarning(
+                    "Tool {ToolName} has a {ConfigKey} entry that normalizes to an invalid host and can never match any requested host: {Pattern}",
+                    toolName, configKey, pattern);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -56,6 +56,11 @@ public sealed class CapabilityEnforcementTests
 
     private static (ToolPermissionProfileResolver Resolver, CapabilityEnforcer Enforcer) Build(
         SandboxConfig? config = null,
+        params (string Name, ITool Tool)[] tools) => Build(config, null, tools);
+
+    private static (ToolPermissionProfileResolver Resolver, CapabilityEnforcer Enforcer) Build(
+        SandboxConfig? config,
+        Mock<ILogger<CapabilityEnforcer>>? logger,
         params (string Name, ITool Tool)[] tools)
     {
         var services = new ServiceCollection();
@@ -68,9 +73,16 @@ public sealed class CapabilityEnforcementTests
         var lookup = new FirstPartyToolLookup(
             services.BuildServiceProvider(), new HashSet<string>(tools.Select(t => t.Name)));
         var resolver = new ToolPermissionProfileResolver(lookup, configMock.Object);
-        var enforcer = new CapabilityEnforcer(resolver, Mock.Of<ILogger<CapabilityEnforcer>>());
+        var enforcer = new CapabilityEnforcer(resolver, (logger ?? new Mock<ILogger<CapabilityEnforcer>>()).Object);
         return (resolver, enforcer);
     }
+
+    private static bool LogsMessageContaining(Mock<ILogger<CapabilityEnforcer>> logger, string substring) =>
+        logger.Invocations.Any(i =>
+            i.Method.Name == nameof(ILogger.Log) &&
+            i.Arguments.Count > 2 &&
+            i.Arguments[2] is not null &&
+            i.Arguments[2]!.ToString()!.Contains(substring, StringComparison.Ordinal));
 
     // --- Capability Checks ---
 
@@ -742,5 +754,238 @@ public sealed class CapabilityEnforcementTests
             "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess, requestedHosts: null);
 
         result.IsSuccess.Should().BeFalse();
+    }
+
+    // --- #635: NormalizeHostForMatch bypasses ---
+
+    [Theory]
+    [InlineData("2130706433")] // decimal IPv4
+    [InlineData("127.1")] // short-form IPv4
+    [InlineData("0x7f.0.0.1")] // hex-octet IPv4
+    public async Task DeniedHost_AlternateIPv4Encoding_StillMatchesDottedQuadDenyEntry(string encodedLoopback)
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["127.0.0.1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: [encodedLoopback]);
+
+        result.IsSuccess.Should().BeFalse(
+            $"'{encodedLoopback}' is the same address as the denied 127.0.0.1 to the real HTTP client");
+    }
+
+    [Theory]
+    [InlineData("evil。com")] // U+3002 ideographic full stop
+    [InlineData("evil．com")] // U+FF0E fullwidth full stop
+    [InlineData("evil.com｡")] // U+FF61 halfwidth ideographic full stop (trailing)
+    [InlineData("evil.com​")] // trailing zero-width space
+    public async Task DeniedHost_UnicodeLabelSeparatorOrZeroWidthChar_StillMatchesAsciiDenyEntry(string spoofedHost)
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: [spoofedHost]);
+
+        result.IsSuccess.Should().BeFalse(
+            "Uri.IdnHost — what the real HTTP client connects with — normalizes this to plain \"evil.com\"");
+    }
+
+    [Fact]
+    public async Task DeniedHost_UnicodeLabelSeparator_StillDefeatsWildcardDenyEntry()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["a.evil。com"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeniedHost_BracketedIPv6Literal_StillMatchesBareDenyEntry()
+    {
+        // Before #635: the absolute-URI branch of NormalizeHostForMatch returned Uri.Host verbatim,
+        // which retains brackets ("[::1]") — a bare deny entry of "::1" never matched a requested
+        // "http://[::1]/".
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["::1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["http://[::1]/"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("fe80::1%eth0")]
+    [InlineData("[fe80::1%25eth0]")]
+    public async Task DeniedHost_IPv6ZoneIdentifier_StillMatchesBareDenyEntryWithoutZone(string zoneQualifiedHost)
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["fe80::1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: [zoneQualifiedHost]);
+
+        result.IsSuccess.Should().BeFalse(
+            "a bare vs. percent-escaped zone id spelling of the same interface must normalize identically");
+    }
+
+    [Fact]
+    public async Task AllowedHost_UnrelatedPrefixCollisionHost_StillRefused()
+    {
+        // Guard case: the #635 fix must not become OVER-broad — "notevil.com" must never be treated
+        // as if it were "evil.com" just because #635's synthetic-scheme parsing now runs on more
+        // bare-shaped values than before.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { AllowedHosts = ["evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["notevil.com"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AllowedHost_PunycodeLookalike_DoesNotCollideWithUnicodeDenyEntry()
+    {
+        // Guard case: a value that is ALREADY in ASCII/punycode form must not be treated as if
+        // IdnHost-canonicalizing it could make it collide with an unrelated Unicode-derived host.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { AllowedHosts = ["evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["xn--vil-9ma.com"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeniedHost_MalformedConfiguredEntry_LogsInertConfigurationWarning()
+    {
+        // #635 LOW: a typo'd deny entry that can never match any requested host previously failed
+        // silently, with no signal to the operator that their configuration does nothing.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["evil.com/*"] }
+            }
+        };
+        var loggerMock = new Mock<ILogger<CapabilityEnforcer>>();
+        var (_, enforcer) = Build(config, loggerMock, ("http_tool", NetworkFileTool()));
+
+        await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["example.com"]);
+
+        LogsMessageContaining(loggerMock, "can never match any requested host").Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DeniedHost_WellFormedConfiguredEntry_DoesNotLogInertConfigurationWarning()
+    {
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new()
+            {
+                ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["evil.com"] } // well-formed
+            }
+        };
+        var loggerMock = new Mock<ILogger<CapabilityEnforcer>>();
+        var (_, enforcer) = Build(config, loggerMock, ("http_tool", NetworkFileTool()));
+
+        await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["example.com"]);
+
+        LogsMessageContaining(loggerMock, "can never match any requested host").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("::ffff:127.0.0.1")] // IPv4-mapped IPv6, colon-hex form
+    [InlineData("[::ffff:127.0.0.1]")] // same, bracketed as a URI would carry it
+    public async Task DeniedHost_Ipv4MappedIpv6Literal_StillMatchesPlainIPv4DenyEntry(string mappedForm)
+    {
+        // #635 code-review (round 2): a well-formed IPv6 literal encoding the SAME address as a
+        // plain IPv4 deny entry — Uri.IdnHost does not collapse this form, so it needs its own
+        // explicit normalization step (mirrors CompositeHookExecutor.IsReservedAddress).
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["127.0.0.1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: [mappedForm]);
+
+        result.IsSuccess.Should().BeFalse(
+            $"'{mappedForm}' is the same address as the denied 127.0.0.1 to the real HTTP client");
+    }
+
+    [Fact]
+    public async Task DeniedHost_Ipv4MappedIpv6CloudMetadataAddress_StillMatchesDenyEntry()
+    {
+        // The concrete exploit shape from #635's own issue text, restated for the IPv6-mapped form.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["169.254.169.254"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["::ffff:169.254.169.254"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AllowedHost_UnrelatedIpv6_DoesNotCollideWithIpv4MappedNormalization()
+    {
+        // Guard case: IPv4-mapped-IPv6 normalization must not over-fire on an ordinary IPv6 address
+        // that is NOT an IPv4-mapped literal.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { AllowedHosts = ["127.0.0.1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["2001:db8::1"]);
+
+        result.IsSuccess.Should().BeFalse("an unrelated IPv6 address must not be treated as 127.0.0.1");
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -1077,4 +1077,27 @@ public sealed class CapabilityEnforcementTests
 
         result.IsSuccess.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task DeniedHost_FullwidthDigitEncodedDecimalIPv4_StillMatchesDenyEntry()
+    {
+        // CI security-review (post-push, before merge): a fullwidth digit ("２", U+FF12) defeats
+        // Uri's own up-front IPv4-literal recognition ("２852039166" classifies as HostNameType.Dns,
+        // not IPv4), so a single normalization pass only IDNA/NFKC-folds it to the plain-ASCII
+        // decimal string "2852039166" — which IS a legacy decimal encoding of 169.254.169.254 (the
+        // cloud metadata address) but is never re-evaluated as an IP literal. Verified live: the
+        // exact concrete exploit from #635's own issue text, restated with a fullwidth leading digit.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["169.254.169.254"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["２852039166"]);
+
+        result.IsSuccess.Should().BeFalse(
+            "the fullwidth leading digit must not survive normalization as a way to hide a decimal-IPv4-encoded deny entry");
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -1013,4 +1013,68 @@ public sealed class CapabilityEnforcementTests
 
         result.IsSuccess.Should().BeFalse($"'{ambiguousValue}' must stay refused as malformed, not silently reduced to a bare host");
     }
+
+    [Theory]
+    [InlineData("::127.0.0.1")] // deprecated IPv4-compatible form, expanded
+    [InlineData("::7f00:1")] // same address, compressed hex form
+    public async Task DeniedHost_DeprecatedIpv4CompatibleIpv6Literal_StillMatchesPlainIPv4DenyEntry(string compatibleForm)
+    {
+        // #635 round-2 code-review: distinct from the IPv4-MAPPED form ("::ffff:a.b.c.d") already
+        // covered above — this is the older, RFC 4291-deprecated "IPv4-compatible" form (no "ffff"),
+        // which IPAddress.IsIPv4MappedToIPv6 does NOT recognize.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["127.0.0.1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: [compatibleForm]);
+
+        result.IsSuccess.Should().BeFalse(
+            $"'{compatibleForm}' is the same address as the denied 127.0.0.1 to the real HTTP client");
+    }
+
+    [Fact]
+    public async Task AllowedHost_Ipv6Loopback_IsNotMisidentifiedAsAnUnrelatedIPv4Address()
+    {
+        // Guard case: naively taking the last 4 bytes of "::1" (loopback) gives "0.0.0.1", NOT
+        // "127.0.0.1" — the IPv4-compatible-form collapse must exclude loopback/unspecified rather
+        // than blindly treating any all-zero-prefixed IPv6 address as IPv4-compatible. Configuring
+        // the WRONG value ("0.0.0.1") the naive bug would produce, rather than the correct one
+        // ("127.0.0.1"), so this test actually discriminates: refusing "::1" against a
+        // "127.0.0.1" allow entry is ALSO the correct outcome, just for a different reason,
+        // so that pairing can't tell a fixed collapse from a differently-broken one.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { AllowedHosts = ["0.0.0.1"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["::1"]);
+
+        result.IsSuccess.Should().BeFalse("\"::1\" (loopback) must not be collapsed into an unrelated \"0.0.0.1\"");
+    }
+
+    [Fact]
+    public async Task DeniedHostOnly_RequestedHostTriggersIdnHostException_StillRefused()
+    {
+        // #635 round-2 code-review: verified live that Uri.IdnHost throws UriFormatException for a
+        // mixed valid-character-plus-invalid-Unicode label — the fail-closed sentinel path
+        // (CanonicalizeParsedHost's catch block) must refuse the call, not silently admit it.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: ["a￿.com"]);
+
+        result.IsSuccess.Should().BeFalse();
+    }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -988,4 +988,29 @@ public sealed class CapabilityEnforcementTests
 
         result.IsSuccess.Should().BeFalse("an unrelated IPv6 address must not be treated as 127.0.0.1");
     }
+
+    [Theory]
+    [InlineData("evil.com@allowed.com")] // userinfo
+    [InlineData("allowed.com#evil.com")] // fragment
+    [InlineData("allowed.com?evil.com")] // query
+    [InlineData("allowed.com\\evil.com")] // backslash
+    public async Task DeniedHostOnly_BareValueWithUserinfoFragmentQueryOrBackslash_StillRefused(string ambiguousValue)
+    {
+        // run-gates correctness/security review: these shapes were refused outright as malformed
+        // before #635 (Uri.CheckHostName rejects them). #635's synthetic-scheme parsing must not
+        // start silently reducing them to just the leading host segment — kept excluded alongside
+        // '/' so this file's own normalization never disagrees with a consumer that isn't Uri/
+        // HttpClient (a raw socket, a DNS lookup, a subprocess) about which host a value names.
+        var config = new SandboxConfig
+        {
+            ToolOverrides = new() { ["http_tool"] = new ToolOverrideConfig { DeniedHosts = ["*.evil.com"] } }
+        };
+        var (_, enforcer) = Build(config, ("http_tool", NetworkFileTool()));
+
+        var result = await enforcer.EnforceAsync(
+            "http_tool", ToolCapability.FileRead | ToolCapability.NetworkAccess,
+            requestedHosts: [ambiguousValue]);
+
+        result.IsSuccess.Should().BeFalse($"'{ambiguousValue}' must stay refused as malformed, not silently reduced to a bare host");
+    }
 }


### PR DESCRIPTION
## Summary

Closes #635. `CapabilityEnforcer`'s network-host allow/deny check compared a requested host and
a configured deny/allow entry as raw strings — so a blocked address (e.g. a cloud metadata
endpoint) could be reached by spelling it a different but equivalent way. This PR canonicalizes
both sides of the comparison through the same host resolution the real HTTP client uses, closing
six distinct alternate-encoding bypass classes:

- Decimal/hex/short-form IPv4 (`2130706433`, `0x7f.0.0.1`, `127.1`)
- Unicode label separators / zero-width characters (`evil。com`, a trailing zero-width space)
- Bracketed / zone-qualified IPv6 (`[::1]`, `fe80::1%eth0`)
- IPv4-mapped IPv6 (`::ffff:127.0.0.1`) — found during code review, verified live against the
  compiled enforcer
- The older, RFC 4291-deprecated IPv4-compatible IPv6 form (`::127.0.0.1`, no `ffff`) — found in a
  second review round, fixed with an explicit loopback/unspecified-address exclusion (naively
  taking the last 4 bytes of `::1` gives `0.0.0.1`, not `127.0.0.1` — verified and guarded against)
- Bare values carrying `@`/`#`/`?`/`\` silently reducing to just their leading host segment where
  they were previously refused outright as malformed

Also adds an advisory warning when a configured deny/allow entry can never match anything (a
typo'd pattern previously became a silent, permanent no-op).

## Review history

Two full `/code-review` rounds plus a nudge-nudge-verified coordinator pass, `run-gates.sh`'s
grader/correctness/security/owasp gates clean 5/5 runs (opus-tier automated review independently
found the IPv4-mapped-IPv6 bypass and the ambiguous-character gap before I'd finished my own
second pass). Every fix mutation-tested (temporarily reverted, confirmed the new test fails,
restored). 62/62 `CapabilityEnforcementTests` pass.

Local `test` gate failed 5 consecutive times on the same unrelated, pre-existing flaky test class
(`ProcessSandboxExecutorTests`/`SandboxAttestationBindingTests` — sandbox process execution,
unrelated to this diff, confirmed clean in isolation every time) — pushed via the sanctioned
`RAILS_SKIP_REVIEW_GATE=1` bypass, deferring to CI's independent (non-contended) run.

## Follow-ups filed (out of scope for this PR)

- #647 — move inert-pattern detection from per-call warning to startup validation
- #648 — `OwnerOnlyDirectoryHelper.Create` TOCTOU race (different file, not touched here)
- Added findings to existing #640 — audit-chain and conversation-store directories not yet on the
  owner-only helper

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx`
- [x] `CapabilityEnforcementTests`: 62/62 pass
- [x] Every fix mutation-tested (revert → confirm test fails → restore → confirm passes)
- [x] `run-gates.sh`: build/owasp/grader/correctness/security/docs-drift clean 5/5; `test` gate's
      failure isolated and confirmed as pre-existing, unrelated flakiness
- [x] Verified empirically against the real .NET BCL and the compiled enforcer at every step
      (throwaway console apps + live temp tests), not asserted from documentation alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu