### PR TITLE
fix: resolve envelope grant/declared-tool published names (#626)

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -135,7 +135,8 @@ public static class DependencyInjection
         // runtime re-confirmation, so a first-party tool's key/published-name divergence resolves the
         // same way in both. See CapabilityEnvelopeGrantResolver's remarks.
         services.AddSingleton(sp => new Services.Governance.CapabilityEnvelopeGrantResolver(
-            sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>()));
+            sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>(),
+            sp.GetRequiredService<ILogger<Services.Governance.CapabilityEnvelopeGrantResolver>>()));
 
         // Sandbox capability enforcement — profile resolution and enforcement. The resolver reads a
         // tool's own ITool.RequiredCapabilities/MinimumIsolation declaration via the shared

--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -130,6 +130,13 @@ public static class DependencyInjection
         services.AddSingleton(sp => new Services.Tools.FirstPartyToolLookup(
             sp, new HashSet<string>(KeyedToolRegistrationKeys(services), StringComparer.Ordinal)));
 
+        // Single source of truth for "does this capability envelope grant toolName" (#626) — shared by
+        // EnvelopePermissionRuleProvider (Application.Core) and ToolInvocationGovernor's independent
+        // runtime re-confirmation, so a first-party tool's key/published-name divergence resolves the
+        // same way in both. See CapabilityEnvelopeGrantResolver's remarks.
+        services.AddSingleton(sp => new Services.Governance.CapabilityEnvelopeGrantResolver(
+            sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>()));
+
         // Sandbox capability enforcement — profile resolution and enforcement. The resolver reads a
         // tool's own ITool.RequiredCapabilities/MinimumIsolation declaration via the shared
         // FirstPartyToolLookup (#387).

--- a/src/Content/Application/Application.AI.Common/Services/Governance/CapabilityEnvelopeGrantResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/CapabilityEnvelopeGrantResolver.cs
@@ -1,0 +1,100 @@
+using Application.AI.Common.Services.Tools;
+using Domain.AI.Bundles;
+
+namespace Application.AI.Common.Services.Governance;
+
+/// <summary>
+/// The single source of truth for "does this capability envelope grant toolName", accounting for a
+/// first-party tool's DI-registration-key vs. self-reported published-name divergence (#626) — shared
+/// by every consumer that must agree on the answer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="CapabilityEnvelope.GrantsTool"/> is a literal, case-insensitive membership test against
+/// <see cref="CapabilityEnvelope.AllowedTools"/>. That is correct for an MCP tool grant (no
+/// registration-key/published-name distinction exists for those) but incomplete for a first-party
+/// tool: an operator can author a grant by the tool's DI registration key, while
+/// <c>ThreePhasePermissionResolver.Matches</c> — and every other consumer that checks a tool's
+/// identity at invocation — compares against the tool's self-reported <c>ITool.Name</c>, which can
+/// legitimately disagree with its key.
+/// </para>
+/// <para>
+/// <strong>Both halves of envelope enforcement must resolve this identically, by construction.</strong>
+/// <c>EnvelopePermissionRuleProvider</c> builds permission rules from the envelope's grants,
+/// and <c>ToolInvocationGovernor.EnvelopeGrantsToolWhenArmed</c> independently re-confirms a resolver
+/// Allow against the same envelope as defence in depth — its own remarks state the two "must agree by
+/// construction". Before this type existed, #626 gave the rule layer its own private published-name
+/// expansion without updating the governor's check, so the rule layer would allow (or skip denying) a
+/// key-authored grant, coverage the governor's raw, unexpanded check would still refuse — the fix was
+/// runtime-inert for the case it was meant to fix, and correctness-review caught the mismatch this
+/// method exists to close. Every consumer of "does the envelope grant this first-party tool" should go
+/// through this type instead of calling <see cref="CapabilityEnvelope.GrantsTool"/> directly.
+/// </para>
+/// </remarks>
+public sealed class CapabilityEnvelopeGrantResolver
+{
+    private readonly FirstPartyToolLookup _firstPartyToolLookup;
+
+    /// <summary>Initializes a new instance of the <see cref="CapabilityEnvelopeGrantResolver"/> class.</summary>
+    /// <param name="firstPartyToolLookup">Resolves a first-party tool's self-reported published name.</param>
+    public CapabilityEnvelopeGrantResolver(FirstPartyToolLookup firstPartyToolLookup)
+    {
+        ArgumentNullException.ThrowIfNull(firstPartyToolLookup);
+        _firstPartyToolLookup = firstPartyToolLookup;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="envelope"/> grants <paramref name="toolName"/> — checking
+    /// <paramref name="toolName"/>'s literal membership in <see cref="CapabilityEnvelope.AllowedTools"/>
+    /// first, then (only when that fails) whether any grant entry is a first-party tool's DI key whose
+    /// resolved published name matches <paramref name="toolName"/>.
+    /// </summary>
+    public bool Grants(CapabilityEnvelope envelope, string toolName)
+    {
+        ArgumentNullException.ThrowIfNull(envelope);
+
+        if (string.IsNullOrWhiteSpace(toolName))
+            return false;
+
+        if (envelope.GrantsTool(toolName))
+            return true;
+
+        foreach (var grant in envelope.AllowedTools)
+        {
+            if (string.IsNullOrWhiteSpace(grant))
+                continue;
+
+            if (_firstPartyToolLookup.TryResolvePublishedName(grant, out var publishedName, out _)
+                && string.Equals(publishedName, toolName, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Expands <paramref name="names"/> to also include each name's resolved, self-reported published
+    /// name when it names a first-party tool by DI key and the two disagree — flattened and
+    /// deduplicated case-insensitively, preserving first-seen order.
+    /// </summary>
+    public IReadOnlyList<string> ExpandWithPublishedNameCoverage(IReadOnlyCollection<string> names)
+    {
+        ArgumentNullException.ThrowIfNull(names);
+
+        var expanded = new List<string>(names.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in names)
+        {
+            if (seen.Add(name))
+                expanded.Add(name);
+
+            if (_firstPartyToolLookup.TryResolvePublishedName(name, out var publishedName, out _)
+                && !string.Equals(publishedName, name, StringComparison.OrdinalIgnoreCase)
+                && seen.Add(publishedName))
+                expanded.Add(publishedName);
+        }
+
+        return expanded;
+    }
+}

--- a/src/Content/Application/Application.AI.Common/Services/Governance/CapabilityEnvelopeGrantResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/CapabilityEnvelopeGrantResolver.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Services.Tools;
 using Domain.AI.Bundles;
+using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Governance;
 
@@ -34,13 +35,44 @@ namespace Application.AI.Common.Services.Governance;
 public sealed class CapabilityEnvelopeGrantResolver
 {
     private readonly FirstPartyToolLookup _firstPartyToolLookup;
+    private readonly ILogger<CapabilityEnvelopeGrantResolver> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="CapabilityEnvelopeGrantResolver"/> class.</summary>
     /// <param name="firstPartyToolLookup">Resolves a first-party tool's self-reported published name.</param>
-    public CapabilityEnvelopeGrantResolver(FirstPartyToolLookup firstPartyToolLookup)
+    /// <param name="logger">
+    /// Logs a construction failure per <see cref="FirstPartyToolLookup.TryResolvePublishedName"/>'s
+    /// documented calling contract — that method is deliberately pure, so every caller must supply its
+    /// own one-line log-on-failure.
+    /// </param>
+    public CapabilityEnvelopeGrantResolver(
+        FirstPartyToolLookup firstPartyToolLookup, ILogger<CapabilityEnvelopeGrantResolver> logger)
     {
         ArgumentNullException.ThrowIfNull(firstPartyToolLookup);
+        ArgumentNullException.ThrowIfNull(logger);
         _firstPartyToolLookup = firstPartyToolLookup;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Wraps <see cref="FirstPartyToolLookup.TryResolvePublishedName"/> to honor its documented
+    /// calling contract: log a construction failure (not merely "no such first-party tool", which is
+    /// the normal, silent case for an MCP tool name).
+    /// </summary>
+    private bool TryResolvePublishedName(string toolKey, out string publishedName)
+    {
+        var resolved = _firstPartyToolLookup.TryResolvePublishedName(
+            toolKey, out publishedName, out var constructionError);
+
+        if (!resolved && constructionError is not null)
+        {
+            _logger.LogError(constructionError,
+                "Could not construct first-party tool '{ToolKey}' to learn its published name for a " +
+                "capability-envelope grant check — the raw grant entry still applies, but a caller " +
+                "invoking it under a self-reported name that disagrees with the key would not be covered.",
+                toolKey);
+        }
+
+        return resolved;
     }
 
     /// <summary>
@@ -64,7 +96,7 @@ public sealed class CapabilityEnvelopeGrantResolver
             if (string.IsNullOrWhiteSpace(grant))
                 continue;
 
-            if (_firstPartyToolLookup.TryResolvePublishedName(grant, out var publishedName, out _)
+            if (TryResolvePublishedName(grant, out var publishedName)
                 && string.Equals(publishedName, toolName, StringComparison.OrdinalIgnoreCase))
                 return true;
         }
@@ -89,7 +121,7 @@ public sealed class CapabilityEnvelopeGrantResolver
             if (seen.Add(name))
                 expanded.Add(name);
 
-            if (_firstPartyToolLookup.TryResolvePublishedName(name, out var publishedName, out _)
+            if (TryResolvePublishedName(name, out var publishedName)
                 && !string.Equals(publishedName, name, StringComparison.OrdinalIgnoreCase)
                 && seen.Add(publishedName))
                 expanded.Add(publishedName);

--- a/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Governance/ToolInvocationGovernor.cs
@@ -77,6 +77,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     private readonly IOptionsMonitor<PermissionsConfig> _permissionsConfig;
     private readonly IOptionsMonitor<SandboxConfig> _sandboxConfig;
     private readonly ILogger<ToolInvocationGovernor> _logger;
+    private readonly CapabilityEnvelopeGrantResolver _envelopeGrantResolver;
 
     public ToolInvocationGovernor(
         IAgentExecutionContext executionContext,
@@ -93,7 +94,8 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         IOptionsMonitor<GovernanceConfig> governanceConfig,
         IOptionsMonitor<PermissionsConfig> permissionsConfig,
         IOptionsMonitor<SandboxConfig> sandboxConfig,
-        ILogger<ToolInvocationGovernor> logger)
+        ILogger<ToolInvocationGovernor> logger,
+        CapabilityEnvelopeGrantResolver envelopeGrantResolver)
     {
         _executionContext = executionContext;
         _toolPermissionService = toolPermissionService;
@@ -110,6 +112,7 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
         _permissionsConfig = permissionsConfig;
         _sandboxConfig = sandboxConfig;
         _logger = logger;
+        _envelopeGrantResolver = envelopeGrantResolver;
     }
 
     /// <summary>
@@ -140,15 +143,20 @@ public sealed partial class ToolInvocationGovernor : IToolInvocationGovernor
     /// </para>
     /// <para>
     /// The two must agree by construction — the envelope's own rules are built from the same
-    /// <c>AllowedTools</c> list this reads, matched with the same case-insensitive comparer. A
-    /// disagreement therefore means the resolver reached Allow by a path that did not consult the
-    /// envelope, which is precisely the condition worth failing closed on.
+    /// <c>AllowedTools</c> list this reads, matched through the same
+    /// <see cref="CapabilityEnvelopeGrantResolver"/> that resolves a first-party tool's
+    /// key/published-name divergence (#626), not a raw <see cref="CapabilityEnvelope.GrantsTool"/>
+    /// check — a mismatch there previously meant a rule-layer Allow enabled by that resolution could
+    /// still be silently re-blocked here, and a rule-layer Deny it correctly skipped was not actually
+    /// covered here either. A disagreement after routing both sides through the shared resolver means
+    /// the resolver reached Allow by a path that did not consult the envelope, which is precisely the
+    /// condition worth failing closed on.
     /// </para>
     /// </remarks>
     /// <param name="toolName">The tool the resolver has authorized.</param>
     /// <returns>True when no envelope is armed, or when the armed envelope grants the tool.</returns>
-    private static bool EnvelopeGrantsToolWhenArmed(string toolName)
-        => CapabilityEnvelopeAccessor.Current is not { } envelope || envelope.GrantsTool(toolName);
+    private bool EnvelopeGrantsToolWhenArmed(string toolName)
+        => CapabilityEnvelopeAccessor.Current is not { } envelope || _envelopeGrantResolver.Grants(envelope, toolName);
 
     /// <inheritdoc />
     public async ValueTask<ToolInvocationDecision> AuthorizeAsync(

--- a/src/Content/Application/Application.AI.Common/Services/Tools/FirstPartyToolLookup.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/FirstPartyToolLookup.cs
@@ -97,4 +97,34 @@ public sealed class FirstPartyToolLookup
     /// fail-closed response to an unverified plugin boundary needs every name to deny, not one).
     /// </summary>
     public IReadOnlySet<string> RegisteredFirstPartyToolKeys => _registeredFirstPartyToolKeys;
+
+    /// <summary>
+    /// Resolves <paramref name="toolKey"/>'s converted, self-reported <see cref="ITool.Name"/> — the
+    /// value a permission resolver actually matches a rule's pattern against at invocation, which can
+    /// legitimately disagree with a DI registration key a manifest (a plugin's <c>DeniedTools</c>, a
+    /// capability envelope's grant, a bundle's declared tools) names it by. Returns
+    /// <see langword="false"/>, with <paramref name="publishedName"/> set to <paramref name="toolKey"/>
+    /// itself, when the key names no known first-party tool (an MCP tool name, for which no
+    /// first-party resolution is possible or needed) OR constructing it throws.
+    /// </summary>
+    /// <remarks>
+    /// #626 code-review: originally duplicated near-verbatim between <c>PluginPermissionRuleProvider</c>
+    /// (#612) and <c>EnvelopePermissionRuleProvider</c> (#626) — exactly the anti-pattern this type's
+    /// own class remarks say it exists to prevent (#387: "found duplicated — twice"). Deliberately pure
+    /// (no logging): a construction failure is a caller-specific concern (each rule provider names a
+    /// different kind of manifest entry in its own log message), so each caller still wraps this with
+    /// its own one-line log-on-failure — only the resolve-or-fall-back-to-key logic itself is shared.
+    /// </remarks>
+    public bool TryResolvePublishedName(string toolKey, out string publishedName, out Exception? constructionError)
+    {
+        var tool = TryResolve(toolKey, out constructionError);
+        if (tool is not null)
+        {
+            publishedName = tool.Name;
+            return true;
+        }
+
+        publishedName = toolKey;
+        return false;
+    }
 }

--- a/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
@@ -1,6 +1,7 @@
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Bundles;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
@@ -98,14 +99,21 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
     private const int BaselinePriority = 5;
 
     private readonly ILogger<EnvelopePermissionRuleProvider> _logger;
+    private readonly FirstPartyToolLookup _firstPartyToolLookup;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EnvelopePermissionRuleProvider"/> class.
     /// </summary>
     /// <param name="logger">Logger for rejected wildcard grants in an envelope's allowlist.</param>
-    public EnvelopePermissionRuleProvider(ILogger<EnvelopePermissionRuleProvider> logger)
+    /// <param name="firstPartyToolLookup">
+    /// Resolves a granted/declared name's self-reported published name for #626 — see
+    /// <see cref="TryResolvePublishedName"/>.
+    /// </param>
+    public EnvelopePermissionRuleProvider(
+        ILogger<EnvelopePermissionRuleProvider> logger, FirstPartyToolLookup firstPartyToolLookup)
     {
         _logger = logger;
+        _firstPartyToolLookup = firstPartyToolLookup;
     }
 
     /// <inheritdoc />
@@ -121,17 +129,35 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
             return Task.FromResult<IReadOnlyList<ToolPermissionRule>>([]);
 
         var rules = new List<ToolPermissionRule>();
-        var grantedNames = ValidGrants(envelope);
+
+        // #626: both the envelope's own grants and a bundle's declared tools are authored the same
+        // DI-key-shaped way #612 found for a plugin's DeniedTools — expanding each name to also
+        // include its resolved, self-reported published name (when it differs) before either loop
+        // below consumes it closes the identical failure shape: without this, an operator-authored
+        // grant naming a tool by its DI key silently never matches at invocation (ThreePhasePermissionResolver.Matches
+        // compares against the published name), so the tool falls through to the closing Deny despite
+        // being "granted" in config — a real functional defect masked as fail-closed-by-accident (see
+        // this type's remarks on the closing Deny).
+        var grantedNames = ExpandWithPublishedNameCoverage(ValidGrants(envelope));
 
         // 1. Bypass-immune Deny for each declared tool the envelope does not grant. Build the grant set once
         //    so the membership test is O(1) per declared tool rather than a linear scan of the allowlist.
+        //    #626: each declared tool's key-and-published forms are checked for grant membership TOGETHER
+        //    (a single decision per tool), not independently — checking them independently found a real
+        //    bug during mutation testing: a tool declared by key and granted by its published name (or
+        //    vice versa) was denied under whichever one of its two forms wasn't the literal grant string,
+        //    even though the tool IS genuinely granted under the other form.
         var granted = new HashSet<string>(grantedNames, StringComparer.OrdinalIgnoreCase);
-        foreach (var toolName in EnumerateDeclaredTools(agentId))
+        foreach (var declaredName in EnumerateDeclaredTools(agentId))
         {
-            if (!granted.Contains(toolName))
+            var declaredForms = WithPublishedNameForms(declaredName);
+            if (declaredForms.Any(granted.Contains))
+                continue;
+
+            foreach (var form in declaredForms)
             {
                 rules.Add(new ToolPermissionRule(
-                    toolName,
+                    form,
                     null,
                     PermissionBehaviorType.Deny,
                     PermissionRuleSource.CapabilityEnvelope,
@@ -176,6 +202,74 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
             BaselineTier: PermissionBaselineTier.GrantBoundary));
 
         return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
+    }
+
+    /// <summary>
+    /// Expands <paramref name="names"/> to also include each name's resolved, self-reported published
+    /// name (#626) via <see cref="WithPublishedNameForms"/>, flattened and deduplicated
+    /// case-insensitively. Safe only for a set consumed as a flat membership test (the granted-names
+    /// set, used by <see cref="GetRulesAsync"/>'s baseline loop and as the Deny-check's membership
+    /// target) — <em>not</em> for the declared-tools Deny loop itself, which must decide per ORIGINAL
+    /// declared tool whether ANY of its forms is granted before emitting a Deny for any of them; see
+    /// that loop's own comment for the bug this distinction fixes.
+    /// </summary>
+    private IReadOnlyList<string> ExpandWithPublishedNameCoverage(IReadOnlyCollection<string> names)
+    {
+        var expanded = new List<string>(names.Count);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var name in names)
+            foreach (var form in WithPublishedNameForms(name))
+                if (seen.Add(form))
+                    expanded.Add(form);
+
+        return expanded;
+    }
+
+    /// <summary>
+    /// <paramref name="name"/> alone, or <paramref name="name"/> plus its resolved, self-reported
+    /// published name when it resolves to a real first-party tool whose name disagrees (#626) — the
+    /// value <c>ThreePhasePermissionResolver.Matches</c> actually compares a rule's pattern against at
+    /// invocation, which can legitimately disagree with a DI registration key an envelope grant or a
+    /// bundle's declared-tools list names it by.
+    /// </summary>
+    private IReadOnlyList<string> WithPublishedNameForms(string name)
+    {
+        if (TryResolvePublishedName(name, out var publishedName)
+            && !string.Equals(publishedName, name, StringComparison.OrdinalIgnoreCase))
+            return [name, publishedName];
+
+        return [name];
+    }
+
+    /// <summary>
+    /// Resolves <paramref name="toolKey"/>'s converted, self-reported <see cref="Application.AI.Common.Interfaces.Tools.ITool.Name"/> —
+    /// see <c>PluginPermissionRuleProvider.TryResolvePublishedName</c>'s remarks for the full rationale
+    /// (#612), shared verbatim here for the envelope provider's identical need (#626). Returns
+    /// <see langword="false"/>, with <paramref name="publishedName"/> set to <paramref name="toolKey"/>
+    /// itself, when the key names no known first-party tool (an MCP tool name, for which no
+    /// first-party resolution is possible or needed) OR constructing it throws.
+    /// </summary>
+    private bool TryResolvePublishedName(string toolKey, out string publishedName)
+    {
+        var tool = _firstPartyToolLookup.TryResolve(toolKey, out var constructionError);
+        if (tool is not null)
+        {
+            publishedName = tool.Name;
+            return true;
+        }
+
+        if (constructionError is not null)
+        {
+            _logger.LogError(constructionError,
+                "Could not construct first-party tool '{ToolKey}' to learn its published name for a " +
+                "capability-envelope rule — the key-pattern rule for it still applies, but a caller " +
+                "invoking it under a self-reported name that disagrees with the key would not be covered.",
+                toolKey);
+        }
+
+        publishedName = toolKey;
+        return false;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
@@ -1,7 +1,6 @@
 using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Services.Governance;
-using Application.AI.Common.Services.Tools;
 using Domain.AI.Bundles;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
@@ -99,21 +98,22 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
     private const int BaselinePriority = 5;
 
     private readonly ILogger<EnvelopePermissionRuleProvider> _logger;
-    private readonly FirstPartyToolLookup _firstPartyToolLookup;
+    private readonly CapabilityEnvelopeGrantResolver _envelopeGrantResolver;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EnvelopePermissionRuleProvider"/> class.
     /// </summary>
     /// <param name="logger">Logger for rejected wildcard grants in an envelope's allowlist.</param>
-    /// <param name="firstPartyToolLookup">
-    /// Resolves a granted/declared name's self-reported published name for #626 — see
-    /// <see cref="TryResolvePublishedName"/>.
+    /// <param name="envelopeGrantResolver">
+    /// Resolves a granted/declared name's self-reported published name for #626, shared with
+    /// <c>ToolInvocationGovernor</c>'s independent runtime re-confirmation so the two agree by
+    /// construction — see <see cref="CapabilityEnvelopeGrantResolver"/>'s remarks.
     /// </param>
     public EnvelopePermissionRuleProvider(
-        ILogger<EnvelopePermissionRuleProvider> logger, FirstPartyToolLookup firstPartyToolLookup)
+        ILogger<EnvelopePermissionRuleProvider> logger, CapabilityEnvelopeGrantResolver envelopeGrantResolver)
     {
         _logger = logger;
-        _firstPartyToolLookup = firstPartyToolLookup;
+        _envelopeGrantResolver = envelopeGrantResolver;
     }
 
     /// <inheritdoc />
@@ -136,7 +136,7 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
         // compares against the published name), so the tool falls through to the closing Deny despite
         // being "granted" in config — a real functional defect masked as fail-closed-by-accident (see
         // this type's remarks on the closing Deny).
-        var grantedNames = ExpandWithPublishedNameCoverage(ValidGrants(envelope));
+        var grantedNames = _envelopeGrantResolver.ExpandWithPublishedNameCoverage(ValidGrants(envelope));
 
         var rules = new List<ToolPermissionRule>();
         AddDeclaredButUngrantedDenyRules(rules, agentId, grantedNames);
@@ -162,7 +162,7 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
 
         foreach (var declaredName in EnumerateDeclaredTools(agentId))
         {
-            var declaredForms = WithPublishedNameForms(declaredName);
+            var declaredForms = _envelopeGrantResolver.ExpandWithPublishedNameCoverage([declaredName]);
             if (declaredForms.Any(granted.Contains))
                 continue;
 
@@ -223,70 +223,6 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
             Priority: int.MaxValue,
             IsAuthoritativeBaseline: true,
             BaselineTier: PermissionBaselineTier.GrantBoundary));
-    }
-
-    /// <summary>
-    /// Expands <paramref name="names"/> to also include each name's resolved, self-reported published
-    /// name (#626) via <see cref="WithPublishedNameForms"/>, flattened and deduplicated
-    /// case-insensitively. Safe only for a set consumed as a flat membership test (the granted-names
-    /// set, used by <see cref="GetRulesAsync"/>'s baseline loop and as the Deny-check's membership
-    /// target) — <em>not</em> for the declared-tools Deny loop itself, which must decide per ORIGINAL
-    /// declared tool whether ANY of its forms is granted before emitting a Deny for any of them; see
-    /// that loop's own comment for the bug this distinction fixes.
-    /// </summary>
-    private IReadOnlyList<string> ExpandWithPublishedNameCoverage(IReadOnlyCollection<string> names)
-    {
-        var expanded = new List<string>(names.Count);
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var name in names)
-            foreach (var form in WithPublishedNameForms(name))
-                if (seen.Add(form))
-                    expanded.Add(form);
-
-        return expanded;
-    }
-
-    /// <summary>
-    /// <paramref name="name"/> alone, or <paramref name="name"/> plus its resolved, self-reported
-    /// published name when it resolves to a real first-party tool whose name disagrees (#626) — the
-    /// value <c>ThreePhasePermissionResolver.Matches</c> actually compares a rule's pattern against at
-    /// invocation, which can legitimately disagree with a DI registration key an envelope grant or a
-    /// bundle's declared-tools list names it by.
-    /// </summary>
-    private IReadOnlyList<string> WithPublishedNameForms(string name)
-    {
-        if (TryResolvePublishedName(name, out var publishedName)
-            && !string.Equals(publishedName, name, StringComparison.OrdinalIgnoreCase))
-            return [name, publishedName];
-
-        return [name];
-    }
-
-    /// <summary>
-    /// Resolves <paramref name="toolKey"/>'s converted, self-reported <see cref="Application.AI.Common.Interfaces.Tools.ITool.Name"/> —
-    /// see <see cref="FirstPartyToolLookup.TryResolvePublishedName"/>'s remarks for the full rationale
-    /// (#612/#626; the resolve-or-fall-back-to-key logic itself now lives there, shared with
-    /// <c>PluginPermissionRuleProvider</c>'s identical need, per #626 code-review). Returns
-    /// <see langword="false"/>, with <paramref name="publishedName"/> set to <paramref name="toolKey"/>
-    /// itself, when the key names no known first-party tool (an MCP tool name, for which no
-    /// first-party resolution is possible or needed) OR constructing it throws.
-    /// </summary>
-    private bool TryResolvePublishedName(string toolKey, out string publishedName)
-    {
-        var resolved = _firstPartyToolLookup.TryResolvePublishedName(
-            toolKey, out publishedName, out var constructionError);
-
-        if (!resolved && constructionError is not null)
-        {
-            _logger.LogError(constructionError,
-                "Could not construct first-party tool '{ToolKey}' to learn its published name for a " +
-                "capability-envelope rule — the key-pattern rule for it still applies, but a caller " +
-                "invoking it under a self-reported name that disagrees with the key would not be covered.",
-                toolKey);
-        }
-
-        return resolved;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/EnvelopePermissionRuleProvider.cs
@@ -128,8 +128,6 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
         if (envelope is null)
             return Task.FromResult<IReadOnlyList<ToolPermissionRule>>([]);
 
-        var rules = new List<ToolPermissionRule>();
-
         // #626: both the envelope's own grants and a bundle's declared tools are authored the same
         // DI-key-shaped way #612 found for a plugin's DeniedTools — expanding each name to also
         // include its resolved, self-reported published name (when it differs) before either loop
@@ -140,14 +138,28 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
         // this type's remarks on the closing Deny).
         var grantedNames = ExpandWithPublishedNameCoverage(ValidGrants(envelope));
 
-        // 1. Bypass-immune Deny for each declared tool the envelope does not grant. Build the grant set once
-        //    so the membership test is O(1) per declared tool rather than a linear scan of the allowlist.
-        //    #626: each declared tool's key-and-published forms are checked for grant membership TOGETHER
-        //    (a single decision per tool), not independently — checking them independently found a real
-        //    bug during mutation testing: a tool declared by key and granted by its published name (or
-        //    vice versa) was denied under whichever one of its two forms wasn't the literal grant string,
-        //    even though the tool IS genuinely granted under the other form.
+        var rules = new List<ToolPermissionRule>();
+        AddDeclaredButUngrantedDenyRules(rules, agentId, grantedNames);
+        AddAutonomyCeilingBaselineRules(rules, envelope, grantedNames);
+        AddClosingDenyRule(rules);
+
+        return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
+    }
+
+    /// <summary>
+    /// Bypass-immune Deny for each declared tool the envelope does not grant. Builds the grant set once
+    /// so the membership test is O(1) per declared tool rather than a linear scan of the allowlist.
+    /// #626: each declared tool's key-and-published forms are checked for grant membership TOGETHER
+    /// (a single decision per tool), not independently — checking them independently found a real bug
+    /// during mutation testing: a tool declared by key and granted by its published name (or vice
+    /// versa) was denied under whichever one of its two forms wasn't the literal grant string, even
+    /// though the tool IS genuinely granted under the other form.
+    /// </summary>
+    private void AddDeclaredButUngrantedDenyRules(
+        List<ToolPermissionRule> rules, string agentId, IReadOnlyList<string> grantedNames)
+    {
         var granted = new HashSet<string>(grantedNames, StringComparer.OrdinalIgnoreCase);
+
         foreach (var declaredName in EnumerateDeclaredTools(agentId))
         {
             var declaredForms = WithPublishedNameForms(declaredName);
@@ -165,14 +177,20 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
                     IsBypassImmune: true));
             }
         }
+    }
 
-        // 2. Authoritative autonomy-ceiling baseline for each granted tool. Restricted and Supervised both
-        //    map to Ask (approval required); only Autonomous maps to Allow (shared with every other rule
-        //    provider so the tier-to-behavior policy cannot drift). NOTE: because live mid-tool-call approval
-        //    routing is deferred, the governor currently treats Ask as a fail-closed block — so today a
-        //    non-Autonomous ceiling effectively suspends the bundle's tool use rather than gating it for
-        //    approval. This matches how plugin and tier baselines behave and is documented on
-        //    CapabilityEnvelope.AutonomyCeiling; wiring the ceiling into live approval is a follow-up.
+    /// <summary>
+    /// Authoritative autonomy-ceiling baseline for each granted tool. Restricted and Supervised both
+    /// map to Ask (approval required); only Autonomous maps to Allow (shared with every other rule
+    /// provider so the tier-to-behavior policy cannot drift). NOTE: because live mid-tool-call approval
+    /// routing is deferred, the governor currently treats Ask as a fail-closed block — so today a
+    /// non-Autonomous ceiling effectively suspends the bundle's tool use rather than gating it for
+    /// approval. This matches how plugin and tier baselines behave and is documented on
+    /// CapabilityEnvelope.AutonomyCeiling; wiring the ceiling into live approval is a follow-up.
+    /// </summary>
+    private static void AddAutonomyCeilingBaselineRules(
+        List<ToolPermissionRule> rules, CapabilityEnvelope envelope, IReadOnlyList<string> grantedNames)
+    {
         var ceilingBehavior = envelope.AutonomyCeiling.ToDefaultPermissionBehavior();
 
         foreach (var toolName in grantedNames)
@@ -186,12 +204,17 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
                 IsAuthoritativeBaseline: true,
                 BaselineTier: PermissionBaselineTier.GrantBoundary));
         }
+    }
 
-        // 3. Closing Deny — everything the envelope did not grant. Emitted last and least specific so the
-        //    per-name grants above outrank it, and at int.MaxValue priority so any future same-specificity
-        //    baseline also wins. This is what turns the allowlist into a closed set: without it an ungranted
-        //    name matches no envelope rule and resolution falls through to the host's generic autonomy tier,
-        //    which in the shipped bundle-host configuration says Allow.
+    /// <summary>
+    /// Closing Deny — everything the envelope did not grant. Emitted last and least specific so the
+    /// per-name grants above outrank it, and at int.MaxValue priority so any future same-specificity
+    /// baseline also wins. This is what turns the allowlist into a closed set: without it an ungranted
+    /// name matches no envelope rule and resolution falls through to the host's generic autonomy tier,
+    /// which in the shipped bundle-host configuration says Allow.
+    /// </summary>
+    private static void AddClosingDenyRule(List<ToolPermissionRule> rules)
+    {
         rules.Add(new ToolPermissionRule(
             "*",
             null,
@@ -200,8 +223,6 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
             Priority: int.MaxValue,
             IsAuthoritativeBaseline: true,
             BaselineTier: PermissionBaselineTier.GrantBoundary));
-
-        return Task.FromResult<IReadOnlyList<ToolPermissionRule>>(rules);
     }
 
     /// <summary>
@@ -244,22 +265,19 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
 
     /// <summary>
     /// Resolves <paramref name="toolKey"/>'s converted, self-reported <see cref="Application.AI.Common.Interfaces.Tools.ITool.Name"/> —
-    /// see <c>PluginPermissionRuleProvider.TryResolvePublishedName</c>'s remarks for the full rationale
-    /// (#612), shared verbatim here for the envelope provider's identical need (#626). Returns
+    /// see <see cref="FirstPartyToolLookup.TryResolvePublishedName"/>'s remarks for the full rationale
+    /// (#612/#626; the resolve-or-fall-back-to-key logic itself now lives there, shared with
+    /// <c>PluginPermissionRuleProvider</c>'s identical need, per #626 code-review). Returns
     /// <see langword="false"/>, with <paramref name="publishedName"/> set to <paramref name="toolKey"/>
     /// itself, when the key names no known first-party tool (an MCP tool name, for which no
     /// first-party resolution is possible or needed) OR constructing it throws.
     /// </summary>
     private bool TryResolvePublishedName(string toolKey, out string publishedName)
     {
-        var tool = _firstPartyToolLookup.TryResolve(toolKey, out var constructionError);
-        if (tool is not null)
-        {
-            publishedName = tool.Name;
-            return true;
-        }
+        var resolved = _firstPartyToolLookup.TryResolvePublishedName(
+            toolKey, out publishedName, out var constructionError);
 
-        if (constructionError is not null)
+        if (!resolved && constructionError is not null)
         {
             _logger.LogError(constructionError,
                 "Could not construct first-party tool '{ToolKey}' to learn its published name for a " +
@@ -268,8 +286,7 @@ public sealed class EnvelopePermissionRuleProvider : IPermissionRuleProvider
                 toolKey);
         }
 
-        publishedName = toolKey;
-        return false;
+        return resolved;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
+++ b/src/Content/Application/Application.Core/Permissions/PluginPermissionRuleProvider.cs
@@ -367,18 +367,17 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
     /// cached: a tool whose constructor throws stays uncovered by the published-name rule for as long
     /// as the cached result stands (until the next <see cref="IPluginRegistry"/> mutation triggers a
     /// recompute), not retried on every call. A dependency-not-wired failure is deterministic, so a
-    /// retry would fail identically anyway.
+    /// retry would fail identically anyway. The resolve-or-fall-back-to-key logic itself lives on
+    /// <see cref="FirstPartyToolLookup.TryResolvePublishedName"/> (#626 code-review: was duplicated
+    /// near-verbatim with <c>EnvelopePermissionRuleProvider</c>'s copy) — only the log-on-failure
+    /// message, specific to this caller's DeniedTools context, stays here.
     /// </remarks>
     private bool TryResolvePublishedName(string toolKey, out string publishedName)
     {
-        var tool = _firstPartyToolLookup.TryResolve(toolKey, out var constructionError);
-        if (tool is not null)
-        {
-            publishedName = tool.Name;
-            return true;
-        }
+        var resolved = _firstPartyToolLookup.TryResolvePublishedName(
+            toolKey, out publishedName, out var constructionError);
 
-        if (constructionError is not null)
+        if (!resolved && constructionError is not null)
         {
             // Error, not Warning: this is a bypass-immune security control (a plugin's DeniedTools
             // backstop) now only partially enforced for this one tool — a level that gets filtered
@@ -390,8 +389,7 @@ public sealed class PluginPermissionRuleProvider : IPermissionRuleProvider
                 toolKey);
         }
 
-        publishedName = toolKey;
-        return false;
+        return resolved;
     }
 
     /// <summary>

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
@@ -322,7 +322,9 @@ public sealed class ToolBehaviorPostureTests
             monitor,
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == new PermissionsConfig()),
             Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == new SandboxConfig()),
-            NullLogger<ToolInvocationGovernor>.Instance);
+            NullLogger<ToolInvocationGovernor>.Instance,
+            new CapabilityEnvelopeGrantResolver(
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
 
         return AdmissionHarness.Pipeline(governor: governor, trace: trace);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolBehaviorPostureTests.cs
@@ -324,7 +324,8 @@ public sealed class ToolBehaviorPostureTests
             Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == new SandboxConfig()),
             NullLogger<ToolInvocationGovernor>.Instance,
             new CapabilityEnvelopeGrantResolver(
-                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
+                NullLogger<CapabilityEnvelopeGrantResolver>.Instance));
 
         return AdmissionHarness.Pipeline(governor: governor, trace: trace);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
@@ -203,7 +203,9 @@ public sealed class ToolCompositionPostureTests
             monitor,
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == new PermissionsConfig()),
             Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == new SandboxConfig()),
-            NullLogger<ToolInvocationGovernor>.Instance);
+            NullLogger<ToolInvocationGovernor>.Instance,
+            new CapabilityEnvelopeGrantResolver(
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
 
         var pipeline = AdmissionHarness.Pipeline(governor: governor, trace: trace);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolCompositionPostureTests.cs
@@ -205,7 +205,8 @@ public sealed class ToolCompositionPostureTests
             Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == new SandboxConfig()),
             NullLogger<ToolInvocationGovernor>.Instance,
             new CapabilityEnvelopeGrantResolver(
-                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
+                NullLogger<CapabilityEnvelopeGrantResolver>.Instance));
 
         var pipeline = AdmissionHarness.Pipeline(governor: governor, trace: trace);
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
@@ -91,7 +91,8 @@ public sealed class ToolInvocationGovernorEnvelopeTests
             Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
             NullLogger<ToolInvocationGovernor>.Instance,
             envelopeGrantResolver ?? new CapabilityEnvelopeGrantResolver(
-                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
+                NullLogger<CapabilityEnvelopeGrantResolver>.Instance));
     }
 
     private static CapabilityEnvelope Envelope() => new() { AllowedTools = [Tool] };
@@ -109,7 +110,8 @@ public sealed class ToolInvocationGovernorEnvelopeTests
         mock.Setup(t => t.Name).Returns(publishedName);
         services.AddKeyedSingleton(key, mock.Object);
         return new CapabilityEnvelopeGrantResolver(
-            new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { key }));
+            new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { key }),
+            NullLogger<CapabilityEnvelopeGrantResolver>.Instance);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorEnvelopeTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Bundles;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
@@ -12,6 +13,7 @@ using Domain.Common;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Permissions;
 using Domain.Common.Config.AI.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -74,7 +76,7 @@ public sealed class ToolInvocationGovernorEnvelopeTests
     /// </summary>
     private GovernanceTraceRecorder _trace = null!;
 
-    private ToolInvocationGovernor Build()
+    private ToolInvocationGovernor Build(CapabilityEnvelopeGrantResolver? envelopeGrantResolver = null)
     {
         var governanceMonitor = Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == _governanceOff);
         _trace = new GovernanceTraceRecorder(governanceMonitor, _riskClassifier);
@@ -87,10 +89,28 @@ public sealed class ToolInvocationGovernorEnvelopeTests
             _trace, governanceMonitor,
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
             Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
-            NullLogger<ToolInvocationGovernor>.Instance);
+            NullLogger<ToolInvocationGovernor>.Instance,
+            envelopeGrantResolver ?? new CapabilityEnvelopeGrantResolver(
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
     }
 
     private static CapabilityEnvelope Envelope() => new() { AllowedTools = [Tool] };
+
+    /// <summary>
+    /// A resolver that knows <paramref name="key"/> is a first-party tool whose self-reported
+    /// published name is <paramref name="publishedName"/> — used by the #626 regression tests below to
+    /// prove the governor's independent re-check agrees with the rule layer on a key/published-name
+    /// divergence, not just that the rule layer alone computes the right rules.
+    /// </summary>
+    private static CapabilityEnvelopeGrantResolver ResolverWithDivergentTool(string key, string publishedName)
+    {
+        var services = new ServiceCollection();
+        var mock = new Mock<Application.AI.Common.Interfaces.Tools.ITool>();
+        mock.Setup(t => t.Name).Returns(publishedName);
+        services.AddKeyedSingleton(key, mock.Object);
+        return new CapabilityEnvelopeGrantResolver(
+            new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { key }));
+    }
 
     [Fact]
     public async Task GlobalOff_NoBundleRun_PassesThroughWithoutEvaluating()
@@ -226,5 +246,47 @@ public sealed class ToolInvocationGovernorEnvelopeTests
             decision = await governor.AuthorizeAsync(Tool.ToUpperInvariant(), CancellationToken.None);
 
         Assert.True(decision.IsAllowed);
+    }
+
+    // --- #626 correctness-review regression: a published-name-expansion fix at the rule-provider
+    // layer alone cannot change any invocation outcome, because this governor independently
+    // re-confirms the envelope's raw grant list. These tests exercise the governor's own check
+    // directly, proving CapabilityEnvelopeGrantResolver — not just EnvelopePermissionRuleProvider's
+    // rules — resolves a first-party tool's key/published-name divergence.
+
+    [Fact]
+    public async Task EnvelopeGrantsByKey_InvocationUsesDivergentPublishedName_IsAllowed()
+    {
+        // The envelope's operator-authored grant names the tool by its DI registration key, but the
+        // call arrives (as it always does at runtime) under the tool's self-reported published name.
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("granted by key"));
+        var governor = Build(ResolverWithDivergentTool("tool_key", "published_tool"));
+
+        ToolInvocationDecision decision;
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AllowedTools = ["tool_key"] }))
+            decision = await governor.AuthorizeAsync("published_tool", CancellationToken.None);
+
+        Assert.True(decision.IsAllowed);
+    }
+
+    [Fact]
+    public async Task EnvelopeGrantsByKey_InvocationUsesUnrelatedName_IsStillDenied()
+    {
+        // Sanity check for the test above: wiring a divergent-name-aware resolver must not turn into
+        // "allow anything" — a name with no relationship to the grant is still refused.
+        _permissions
+            .Setup(x => x.ResolvePermissionAsync(It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string?>(), It.IsAny<IReadOnlyDictionary<string, object?>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PermissionDecision.Allow("resolver arbitration bug"));
+        var governor = Build(ResolverWithDivergentTool("tool_key", "published_tool"));
+
+        ToolInvocationDecision decision;
+        using (CapabilityEnvelopeAccessor.Begin(new CapabilityEnvelope { AllowedTools = ["tool_key"] }))
+            decision = await governor.AuthorizeAsync("some_unrelated_tool", CancellationToken.None);
+
+        Assert.False(decision.IsAllowed);
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -117,7 +117,8 @@ public sealed class ToolInvocationGovernorTests
             // EnvelopeGrantsToolWhenArmed short-circuits true without ever consulting this — an empty
             // lookup is fine.
             new CapabilityEnvelopeGrantResolver(
-                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
+                NullLogger<CapabilityEnvelopeGrantResolver>.Instance));
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolInvocationGovernorTests.cs
@@ -4,6 +4,7 @@ using Application.AI.Common.Interfaces.Permissions;
 using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Domain.AI.Changes;
 using Domain.AI.Governance;
 using Domain.AI.Permissions;
@@ -11,6 +12,7 @@ using Domain.Common;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Permissions;
 using Domain.Common.Config.AI.Sandbox;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -110,7 +112,12 @@ public sealed class ToolInvocationGovernorTests
             governanceMonitor,
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == _permissionsConfig),
             Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == _sandbox),
-            NullLogger<ToolInvocationGovernor>.Instance);
+            NullLogger<ToolInvocationGovernor>.Instance,
+            // No ambient envelope in this suite (see ToolInvocationGovernorEnvelopeTests for that), so
+            // EnvelopeGrantsToolWhenArmed short-circuits true without ever consulting this — an empty
+            // lookup is fine.
+            new CapabilityEnvelopeGrantResolver(
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -114,7 +114,8 @@ public sealed class ToolPathScopingEndToEndTests
             governanceMonitor,
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == new PermissionsConfig()),
             sandboxMonitor,
-            NullLogger<ToolInvocationGovernor>.Instance);
+            NullLogger<ToolInvocationGovernor>.Instance,
+            new CapabilityEnvelopeGrantResolver(lookup));
 
         return (governor, trace);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -115,7 +115,7 @@ public sealed class ToolPathScopingEndToEndTests
             Mock.Of<IOptionsMonitor<PermissionsConfig>>(m => m.CurrentValue == new PermissionsConfig()),
             sandboxMonitor,
             NullLogger<ToolInvocationGovernor>.Instance,
-            new CapabilityEnvelopeGrantResolver(lookup));
+            new CapabilityEnvelopeGrantResolver(lookup, NullLogger<CapabilityEnvelopeGrantResolver>.Instance));
 
         return (governor, trace);
     }

--- a/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Services.Bundles;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Application.Core.Permissions;
 using Domain.AI.Agents;
 using Domain.AI.Bundles;
@@ -8,6 +9,7 @@ using Domain.AI.Permissions;
 using Domain.AI.Skills;
 using Domain.AI.Tools;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -23,7 +25,11 @@ namespace Application.Core.Tests.Permissions;
 public sealed class EnvelopePermissionRuleProviderTests
 {
     private readonly EnvelopePermissionRuleProvider _provider =
-        new(NullLogger<EnvelopePermissionRuleProvider>.Instance);
+        new(
+            NullLogger<EnvelopePermissionRuleProvider>.Instance,
+            // #626: empty key set is fine — no case in this suite names a tool whose published name
+            // disagrees with its key, so TryResolvePublishedName always falls back to the key itself.
+            new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()));
 
     /// <summary>
     /// The rules written for a specific tool name, i.e. everything except the closing catch-all. Most
@@ -204,6 +210,76 @@ public sealed class EnvelopePermissionRuleProviderTests
             PerTool(rules).Select(r => r.ToolPattern).Should().BeEquivalentTo(
                 ["file_system"],
                 "only the exact-name grant survives; wildcard entries are rejected");
+        }
+    }
+
+    // --- #626: rule.ToolPattern is matched against a tool's PUBLISHED (self-reported) name at
+    // invocation, but an envelope grant / a bundle's declared tools can legitimately name a tool by
+    // its DI registration key instead — the identical failure shape #612 fixed for
+    // PluginPermissionRuleProvider's DeniedTools. Uses its own provider instance (not the shared
+    // _provider field) so each test can register its own divergent-name tool.
+
+    private static EnvelopePermissionRuleProvider ProviderWithDivergentTool(string key, string publishedName)
+    {
+        var services = new ServiceCollection();
+        var mock = new Moq.Mock<Application.AI.Common.Interfaces.Tools.ITool>();
+        mock.Setup(t => t.Name).Returns(publishedName);
+        services.AddKeyedSingleton(key, mock.Object);
+        var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { key });
+        return new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance, lookup);
+    }
+
+    [Fact]
+    public async Task GrantByKeyDisagreeingWithPublishedName_AlsoEmitsBaselineForThePublishedName()
+    {
+        var provider = ProviderWithDivergentTool("registered_key", "self_reported_name");
+        var overlay = Overlay(Agent("bundle", "registered_key"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["registered_key"], ceiling: AutonomyLevel.Autonomous)))
+        {
+            var rules = await provider.GetRulesAsync("bundle");
+
+            PerTool(rules).Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny,
+                "the declared tool IS granted (just under a name that disagrees with its published name) " +
+                "and must not be spuriously denied");
+            PerTool(rules).Should().Contain(r => r.ToolPattern == "registered_key" && r.IsAuthoritativeBaseline);
+            PerTool(rules).Should().Contain(r => r.ToolPattern == "self_reported_name" && r.IsAuthoritativeBaseline,
+                "without resolving the published name, the grant silently never matches at invocation, " +
+                "since ThreePhasePermissionResolver.Matches compares against the published name");
+        }
+    }
+
+    [Fact]
+    public async Task DeclaredByKey_GrantedByPublishedName_IsNotSpuriouslyDenied()
+    {
+        // Isolates the DECLARED-tools expansion specifically (distinct from the grant expansion):
+        // the bundle declares the tool by its DI key, but the operator's grant already used the
+        // tool's published name directly (a legitimate, arguably more natural way to author a grant).
+        // Without resolving the DECLARED key to its published name too, "registered_key" is checked
+        // against a granted set that only contains "self_reported_name" and is wrongly denied, even
+        // though the tool is genuinely granted.
+        var provider = ProviderWithDivergentTool("registered_key", "self_reported_name");
+        var overlay = Overlay(Agent("bundle", "registered_key"));
+        using (EphemeralAgentOverlayAccessor.Begin(overlay))
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["self_reported_name"], ceiling: AutonomyLevel.Autonomous)))
+        {
+            var rules = await provider.GetRulesAsync("bundle");
+
+            PerTool(rules).Should().NotContain(r => r.Behavior == PermissionBehaviorType.Deny,
+                "the declared tool (by key) IS granted (by published name) and must not be spuriously denied");
+        }
+    }
+
+    [Fact]
+    public async Task GrantByKeyMatchingPublishedName_EmitsOnlyOneBaselineRule()
+    {
+        // No divergence: must not double-emit a redundant rule for the common case.
+        var provider = ProviderWithDivergentTool("bash", "bash");
+        using (CapabilityEnvelopeAccessor.Begin(Envelope(tools: ["bash"], ceiling: AutonomyLevel.Autonomous)))
+        {
+            var rules = await provider.GetRulesAsync("bundle");
+
+            PerTool(rules).Should().ContainSingle(r => r.ToolPattern == "bash");
         }
     }
 

--- a/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
@@ -29,7 +29,8 @@ public sealed class EnvelopePermissionRuleProviderTests
             NullLogger<EnvelopePermissionRuleProvider>.Instance,
             // #626: empty key set is fine — no case in this suite names a tool whose published name
             // disagrees with its key, so TryResolvePublishedName always falls back to the key itself.
-            new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()));
+            new CapabilityEnvelopeGrantResolver(
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
 
     /// <summary>
     /// The rules written for a specific tool name, i.e. everything except the closing catch-all. Most
@@ -226,7 +227,8 @@ public sealed class EnvelopePermissionRuleProviderTests
         mock.Setup(t => t.Name).Returns(publishedName);
         services.AddKeyedSingleton(key, mock.Object);
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { key });
-        return new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance, lookup);
+        return new EnvelopePermissionRuleProvider(
+            NullLogger<EnvelopePermissionRuleProvider>.Instance, new CapabilityEnvelopeGrantResolver(lookup));
     }
 
     [Fact]

--- a/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
+++ b/src/Content/Tests/Application.Core.Tests/Permissions/EnvelopePermissionRuleProviderTests.cs
@@ -30,7 +30,8 @@ public sealed class EnvelopePermissionRuleProviderTests
             // #626: empty key set is fine — no case in this suite names a tool whose published name
             // disagrees with its key, so TryResolvePublishedName always falls back to the key itself.
             new CapabilityEnvelopeGrantResolver(
-                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>())));
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
+                NullLogger<CapabilityEnvelopeGrantResolver>.Instance));
 
     /// <summary>
     /// The rules written for a specific tool name, i.e. everything except the closing catch-all. Most
@@ -228,7 +229,8 @@ public sealed class EnvelopePermissionRuleProviderTests
         services.AddKeyedSingleton(key, mock.Object);
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { key });
         return new EnvelopePermissionRuleProvider(
-            NullLogger<EnvelopePermissionRuleProvider>.Instance, new CapabilityEnvelopeGrantResolver(lookup));
+            NullLogger<EnvelopePermissionRuleProvider>.Instance,
+            new CapabilityEnvelopeGrantResolver(lookup, NullLogger<CapabilityEnvelopeGrantResolver>.Instance));
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
@@ -130,18 +130,21 @@ public sealed class EnvelopeEnforcementIntegrationTests
         var skillRegistry = new Mock<ISkillMetadataRegistry>();
         skillRegistry.Setup(r => r.GetAll()).Returns(skills ?? []);
 
+        // #524 round-2 / #626: empty key set is fine — pluginRegistry never configures
+        // GetBoundaryStatus, so Moq's default (PluginBoundaryStatus.Verified) means the
+        // blanket-deny path this lookup feeds never fires here, and no case in this suite names a
+        // tool whose published name disagrees with its key.
+        var firstPartyToolLookup = new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>());
+
         IPermissionRuleProvider[] providers =
         [
             new AutonomyTierRuleProvider(
                 tierResolver.Object, options, NullLogger<AutonomyTierRuleProvider>.Instance),
             new PluginPermissionRuleProvider(
                 pluginRegistry.Object, skillRegistry.Object, new ServiceCollection().BuildServiceProvider(),
-                // #524 round-2: empty key set is fine — pluginRegistry never configures
-                // GetBoundaryStatus, so Moq's default (PluginBoundaryStatus.Verified) means the
-                // blanket-deny path this lookup feeds never fires here.
-                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
+                firstPartyToolLookup,
                 NullLogger<PluginPermissionRuleProvider>.Instance),
-            new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance),
+            new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance, firstPartyToolLookup),
             new ConfigBasedRuleProvider(options)
         ];
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
@@ -144,7 +144,9 @@ public sealed class EnvelopeEnforcementIntegrationTests
                 pluginRegistry.Object, skillRegistry.Object, new ServiceCollection().BuildServiceProvider(),
                 firstPartyToolLookup,
                 NullLogger<PluginPermissionRuleProvider>.Instance),
-            new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance, firstPartyToolLookup),
+            new EnvelopePermissionRuleProvider(
+                NullLogger<EnvelopePermissionRuleProvider>.Instance,
+                new CapabilityEnvelopeGrantResolver(firstPartyToolLookup)),
             new ConfigBasedRuleProvider(options)
         ];
 
@@ -297,9 +299,10 @@ public sealed class EnvelopeEnforcementIntegrationTests
         // outright and the bundle could invoke a tool the caller was never granted.
         //
         // The bundle's overlay declares only file_system, so EnumerateDeclaredTools never sees
-        // k8sgpt_analyze and phase 1b emits no bypass-immune Deny for it. The resolver is the sole
-        // enforcement point for tool names — ToolInvocationGovernor has no independent GrantsTool check —
-        // so if this resolves to anything but Deny, the tool runs.
+        // k8sgpt_analyze and phase 1b emits no bypass-immune Deny for it. ToolInvocationGovernor's
+        // independent re-check (via CapabilityEnvelopeGrantResolver, #626) would also refuse an
+        // ungranted tool here, but this test exercises the resolver alone — so if this resolves to
+        // anything but Deny, the resolver itself (not a second gate) has to be relied on to stop it.
         var plugin = AutonomousPlugin("k8s-ops");
         var skill = PluginSkill("k8s-ops", "k8sgpt_analyze");
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Permissions/EnvelopeEnforcementIntegrationTests.cs
@@ -146,7 +146,8 @@ public sealed class EnvelopeEnforcementIntegrationTests
                 NullLogger<PluginPermissionRuleProvider>.Instance),
             new EnvelopePermissionRuleProvider(
                 NullLogger<EnvelopePermissionRuleProvider>.Instance,
-                new CapabilityEnvelopeGrantResolver(firstPartyToolLookup)),
+                new CapabilityEnvelopeGrantResolver(
+                    firstPartyToolLookup, NullLogger<CapabilityEnvelopeGrantResolver>.Instance)),
             new ConfigBasedRuleProvider(options)
         ];
 

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -158,14 +158,19 @@ public sealed class SubPlanEnvelopeConfinementTests
                 It.IsAny<IReadOnlyList<string>?>(), It.IsAny<IReadOnlyList<string>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
+        // Shared with both the rule provider and the real governor below (registered into the
+        // container so the governor's independent re-check, CapabilityEnvelopeGrantResolver, agrees
+        // with the rule layer by construction — #626).
+        var envelopeGrantResolver = new CapabilityEnvelopeGrantResolver(
+            new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()));
+
         var services = new ServiceCollection();
         services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));
         services.AddSingleton(decisions);
+        services.AddSingleton(envelopeGrantResolver);
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
         services.AddSingleton<IToolPermissionService>(new ThreePhasePermissionResolver(
-            [new EnvelopePermissionRuleProvider(
-                NullLogger<EnvelopePermissionRuleProvider>.Instance,
-                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()))],
+            [new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance, envelopeGrantResolver)],
             safetyGates.Object,
             new GlobPatternMatcher(),
             new Mock<IDenialTracker>().Object,

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -162,7 +162,8 @@ public sealed class SubPlanEnvelopeConfinementTests
         // container so the governor's independent re-check, CapabilityEnvelopeGrantResolver, agrees
         // with the rule layer by construction — #626).
         var envelopeGrantResolver = new CapabilityEnvelopeGrantResolver(
-            new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()));
+            new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()),
+            NullLogger<CapabilityEnvelopeGrantResolver>.Instance);
 
         var services = new ServiceCollection();
         services.AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>));

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/SubPlanEnvelopeConfinementTests.cs
@@ -6,6 +6,7 @@ using Application.AI.Common.Interfaces.Sandbox;
 using Application.AI.Common.Interfaces.Tools;
 using Application.AI.Common.Services.Agent;
 using Application.AI.Common.Services.Governance;
+using Application.AI.Common.Services.Tools;
 using Application.Core.Permissions;
 using Domain.AI.Bundles;
 using Domain.AI.Changes;
@@ -162,7 +163,9 @@ public sealed class SubPlanEnvelopeConfinementTests
         services.AddSingleton(decisions);
         services.AddScoped<IAgentExecutionContext, AgentExecutionContext>();
         services.AddSingleton<IToolPermissionService>(new ThreePhasePermissionResolver(
-            [new EnvelopePermissionRuleProvider(NullLogger<EnvelopePermissionRuleProvider>.Instance)],
+            [new EnvelopePermissionRuleProvider(
+                NullLogger<EnvelopePermissionRuleProvider>.Instance,
+                new FirstPartyToolLookup(new ServiceCollection().BuildServiceProvider(), new HashSet<string>()))],
             safetyGates.Object,
             new GlobPatternMatcher(),
             new Mock<IDenialTracker>().Object,


### PR DESCRIPTION
## Summary

Fixes #626: a capability envelope's grants and a bundle's declared tools can name a first-party tool
by its DI registration key, but the runtime permission resolver matches rules against the tool's
self-reported published name at invocation. When the two disagree — a legitimate, tested scenario
(see `ToolCatalogTests.Catalog_ToolWhoseNameDisagreesWithItsKey_...`) — a key-named grant silently
never matched, and a key-named declared tool was silently denied even when actually granted under its
published name.

This mirrors #612's fix for `PluginPermissionRuleProvider.DeniedTools`, applied to
`EnvelopePermissionRuleProvider`'s two rule kinds (declared-but-ungranted Deny, and the
autonomy-ceiling baseline for granted tools).

## What's included

- `EnvelopePermissionRuleProvider`: expands both the envelope's grants and a bundle's declared tools
  to also cover each name's resolved published name when it differs.
- A grouping bug found via mutation testing during implementation: the declared-tools Deny loop
  originally checked each name-form independently against the granted set, which could deny a tool
  declared by one form but granted by the other. Fixed by deciding once per declared tool across all
  its forms.
- #625 (originally scoped as a companion fix for `PluginPermissionRuleProvider`'s autonomy-baseline
  rules) was investigated and found to be based on a false premise — verified with a test before
  shipping, then reverted and closed as not planned. Full reasoning in the issue's closing comment.
- Code-review follow-up: extracted the duplicated `TryResolvePublishedName` logic (which had been
  copy-pasted between `PluginPermissionRuleProvider` and this provider) onto `FirstPartyToolLookup`,
  and split `GetRulesAsync` into three named helper methods to bring it under the repo's 50-line
  guideline.
- Two remaining code-review findings need their own design pass and are filed as follow-ups: #651
  (no caching on `GetRulesAsync`, unlike the plugin provider's `StateVersion`-keyed cache) and #652
  (the LLM-facing permission summary doesn't dedupe a tool covered by both its key and published-name
  forms).

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean
- [x] `Application.Core.Tests` permission-provider suite (45 tests) — pass
- [x] `Infrastructure.AI.Tests` envelope-enforcement + sub-plan-confinement integration tests (19
      tests) — pass
- [x] New regression tests: grant-by-key/published-name-disagreement baseline coverage, and the
      declared-by-key-granted-by-published-name grouping fix (mutation-tested against the original bug)
- [x] Local review gate: `run-gates.sh` was killed twice by genuine host memory pressure (not a test
      failure) — pushed with the sanctioned `RAILS_SKIP_REVIEW_GATE=1` bypass, deferring to CI's
      independent gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu