### PR TITLE
fix: migrate FirstPartyToolLookup's unguarded Resolve callers to TryResolve (#627)

### DIFF
--- a/src/Content/Application/Application.AI.Common/DependencyInjection.cs
+++ b/src/Content/Application/Application.AI.Common/DependencyInjection.cs
@@ -145,6 +145,7 @@ public static class DependencyInjection
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
             sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>(),
             sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>(),
+            sp.GetRequiredService<ILogger<ToolPermissionProfileResolver>>(),
             // Both optional (#419): a composition root that never calls AddGovernance still
             // constructs this widely-used singleton — it just gets no durable audit trail for an
             // ungoverned-dispatch refusal, and (absent an EnableAudit toggle to read) defaults to
@@ -184,7 +185,8 @@ public static class DependencyInjection
         // bounded; this call site was missed by the original #387 sweep and probed keyed DI directly
         // (found during a later code-review pass on this same diff).
         services.AddSingleton<Interfaces.Tools.IToolRiskClassifier>(sp => new Services.Tools.ToolRiskClassifier(
-            sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>()));
+            sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>(),
+            sp.GetRequiredService<ILogger<Services.Tools.ToolRiskClassifier>>()));
 
         // Tool behaviour registry — what each tool declared it does, and who declared it. Singleton
         // because an external MCP server's declaration arrives on a discovery call and must still be
@@ -202,7 +204,8 @@ public static class DependencyInjection
         services.AddSingleton<Interfaces.Tools.IToolCapabilityResolver>(sp => new Services.Tools.ToolCapabilityResolver(
             sp.GetRequiredService<Services.Tools.FirstPartyToolLookup>(),
             sp.GetRequiredService<Interfaces.Tools.IToolBehaviorRegistry>(),
-            sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.GovernanceConfig>>()));
+            sp.GetRequiredService<IOptionsMonitor<Domain.Common.Config.AI.GovernanceConfig>>(),
+            sp.GetRequiredService<ILogger<Services.Tools.ToolCapabilityResolver>>()));
 
         // Tool composition analyzer + reporter — flags an agent's assembled tool set for an
         // untrusted-input/credential-reading tool co-resident with a file-write/code-exec/outbound-send

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -226,20 +226,16 @@ public sealed class ToolPermissionProfileResolver
         SandboxIsolationLevel defaultIsolationLevel = SandboxIsolationLevel.Process,
         string? agentId = null)
     {
-        // Single FirstPartyToolLookup.TryResolve call, reused for the under-declaration check below and
-        // as ResolveOverride's isolation floor — this used to call Resolve(toolName) (itself a lookup,
+        // Single FirstPartyToolLookup lookup, reused for the under-declaration check below and as
+        // ResolveOverride's isolation floor — this used to call Resolve(toolName) (itself a lookup,
         // via ResolveBase) AND a second direct lookup just for RequiredCapabilities (a security-review
         // finding: real keyed-DI resolution, not a dictionary read, paid twice on this dispatch path).
         // A construction failure (#627) takes the same path as "not first-party" below — logged, since
         // that's a host misconfiguration rather than an ordinary external-tool answer.
-        var firstPartyTool = _firstPartyLookup.TryResolve(toolName, out var dispatchConstructionError);
-        if (firstPartyTool is null && dispatchConstructionError is not null)
-        {
-            _logger.LogError(dispatchConstructionError,
-                "Could not construct first-party tool '{ToolName}' to resolve its sandbox permission " +
-                "profile for ungoverned dispatch — treating it as outside the bounded first-party set.",
-                toolName);
-        }
+        var firstPartyTool = _firstPartyLookup.TryResolveLogged(
+            toolName, _logger,
+            "to resolve its sandbox permission profile for ungoverned dispatch — treating it as " +
+            "outside the bounded first-party set");
 
         if (firstPartyTool is not null)
         {
@@ -343,14 +339,10 @@ public sealed class ToolPermissionProfileResolver
     /// </summary>
     private (ToolCapability Capabilities, SandboxIsolationLevel Isolation) ResolveBase(string toolName)
     {
-        var firstParty = _firstPartyLookup.TryResolve(toolName, out var constructionError);
-        if (firstParty is null && constructionError is not null)
-        {
-            _logger.LogError(constructionError,
-                "Could not construct first-party tool '{ToolName}' to resolve its sandbox permission " +
-                "profile — treating it as outside the bounded first-party set.",
-                toolName);
-        }
+        var firstParty = _firstPartyLookup.TryResolveLogged(
+            toolName, _logger,
+            "to resolve its sandbox permission profile — treating it as outside the bounded " +
+            "first-party set");
 
         return firstParty is not null
             ? (firstParty.RequiredCapabilities, firstParty.MinimumIsolation)

--- a/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Sandbox/ToolPermissionProfileResolver.cs
@@ -10,6 +10,7 @@ using Domain.Common.Helpers;
 using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Sandbox;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Application.AI.Common.Services.Sandbox;
@@ -34,6 +35,7 @@ public sealed class ToolPermissionProfileResolver
     private readonly IOptionsMonitor<SandboxConfig> _config;
     private readonly IGovernanceAuditService? _auditService;
     private readonly IOptionsMonitor<GovernanceConfig>? _governanceConfig;
+    private readonly ILogger<ToolPermissionProfileResolver> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="ToolPermissionProfileResolver"/> class.</summary>
     /// <param name="firstPartyLookup">
@@ -61,17 +63,30 @@ public sealed class ToolPermissionProfileResolver
     /// composition root that doesn't wire this still gets the historically-correct "audit on" behavior
     /// rather than silently losing the trail.
     /// </param>
+    /// <param name="logger">
+    /// Logs a construction failure (#627: both call sites into <see cref="FirstPartyToolLookup"/> used
+    /// the unguarded <c>Resolve</c>, which propagates a keyed tool's constructor exception instead of
+    /// catching it). The resolved profile still degrades to the same
+    /// <see cref="ToolCapability.None"/>/<see cref="SandboxIsolationLevel.None"/> base a name outside
+    /// the bounded first-party set already gets — this only extends that existing, accepted fallback to
+    /// cover a construction failure too, rather than crashing the caller — the log is what makes a
+    /// genuine host misconfiguration visible instead of silently indistinguishable from an ordinary
+    /// external tool.
+    /// </param>
     public ToolPermissionProfileResolver(
         FirstPartyToolLookup firstPartyLookup,
         IOptionsMonitor<SandboxConfig> config,
+        ILogger<ToolPermissionProfileResolver> logger,
         IGovernanceAuditService? auditService = null,
         IOptionsMonitor<GovernanceConfig>? governanceConfig = null)
     {
         ArgumentNullException.ThrowIfNull(firstPartyLookup);
         ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
 
         _firstPartyLookup = firstPartyLookup;
         _config = config;
+        _logger = logger;
         _auditService = auditService;
         _governanceConfig = governanceConfig;
     }
@@ -211,11 +226,20 @@ public sealed class ToolPermissionProfileResolver
         SandboxIsolationLevel defaultIsolationLevel = SandboxIsolationLevel.Process,
         string? agentId = null)
     {
-        // Single FirstPartyToolLookup.Resolve call, reused for the under-declaration check below and
+        // Single FirstPartyToolLookup.TryResolve call, reused for the under-declaration check below and
         // as ResolveOverride's isolation floor — this used to call Resolve(toolName) (itself a lookup,
         // via ResolveBase) AND a second direct lookup just for RequiredCapabilities (a security-review
         // finding: real keyed-DI resolution, not a dictionary read, paid twice on this dispatch path).
-        var firstPartyTool = _firstPartyLookup.Resolve(toolName);
+        // A construction failure (#627) takes the same path as "not first-party" below — logged, since
+        // that's a host misconfiguration rather than an ordinary external-tool answer.
+        var firstPartyTool = _firstPartyLookup.TryResolve(toolName, out var dispatchConstructionError);
+        if (firstPartyTool is null && dispatchConstructionError is not null)
+        {
+            _logger.LogError(dispatchConstructionError,
+                "Could not construct first-party tool '{ToolName}' to resolve its sandbox permission " +
+                "profile for ungoverned dispatch — treating it as outside the bounded first-party set.",
+                toolName);
+        }
 
         if (firstPartyTool is not null)
         {
@@ -314,11 +338,19 @@ public sealed class ToolPermissionProfileResolver
     /// <see cref="ITool.RequiredCapabilities"/>/<see cref="ITool.MinimumIsolation"/>, or
     /// <see cref="ToolCapability.None"/>/<see cref="SandboxIsolationLevel.None"/> for a name outside
     /// the bounded registered-key set (MCP or bundle-owned tools — never covered by capability
-    /// declarations either way).
+    /// declarations either way) — the same fallback a registered tool whose constructor throws (#627)
+    /// now also takes, logged since that case is a host misconfiguration, not an ordinary external tool.
     /// </summary>
     private (ToolCapability Capabilities, SandboxIsolationLevel Isolation) ResolveBase(string toolName)
     {
-        var firstParty = _firstPartyLookup.Resolve(toolName);
+        var firstParty = _firstPartyLookup.TryResolve(toolName, out var constructionError);
+        if (firstParty is null && constructionError is not null)
+        {
+            _logger.LogError(constructionError,
+                "Could not construct first-party tool '{ToolName}' to resolve its sandbox permission " +
+                "profile — treating it as outside the bounded first-party set.",
+                toolName);
+        }
 
         return firstParty is not null
             ? (firstParty.RequiredCapabilities, firstParty.MinimumIsolation)

--- a/src/Content/Application/Application.AI.Common/Services/Tools/FirstPartyToolLookup.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/FirstPartyToolLookup.cs
@@ -1,5 +1,6 @@
 using Application.AI.Common.Interfaces.Tools;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Tools;
 
@@ -52,22 +53,30 @@ public sealed class FirstPartyToolLookup
     /// <see langword="null"/> when the name is outside the bounded key set or the keyed registration
     /// itself resolves to null.
     /// </summary>
+    /// <remarks>
+    /// Private deliberately (#627 code-review): this propagates a keyed tool's constructor exception
+    /// instead of catching it, which is exactly the footgun #627 closed out the last five production
+    /// callers of. Keeping it private, with <see cref="TryResolve"/>/<see cref="TryResolveLogged"/> as
+    /// the only way in or out of the class, makes that bug class structurally impossible to
+    /// reintroduce rather than relying on every future caller remembering the safe overload.
+    /// </remarks>
     /// <param name="toolName">The tool's published name.</param>
-    public ITool? Resolve(string toolName) =>
+    private ITool? Resolve(string toolName) =>
         _registeredFirstPartyToolKeys.Contains(toolName)
             ? _serviceProvider.GetKeyedService<ITool>(toolName)
             : null;
 
     /// <summary>
-    /// Same bounded resolution as <see cref="Resolve"/>, but catches and reports a construction
+    /// Same bounded resolution as the private <c>Resolve</c>, but catches and reports a construction
     /// failure instead of propagating it.
     /// </summary>
     /// <remarks>
     /// A keyed tool's constructor can require a dependency this particular host never wired — the
     /// exact failure mode that broke host boot when an earlier existence-check attempt (#524)
-    /// unconditionally constructed every registered tool. <see cref="Resolve"/> does not guard
-    /// against that; use this overload whenever a caller can't afford one broken tool's constructor
-    /// to take down whatever loop or request it's part of (#612).
+    /// unconditionally constructed every registered tool. Prefer <see cref="TryResolveLogged"/> over
+    /// this overload directly when the caller can log the failure through an <see cref="ILogger"/> —
+    /// it owns the "resolve, then log on failure" shape once instead of each caller repeating it
+    /// (#627 code-review: found independently duplicated across five call sites).
     /// </remarks>
     /// <param name="toolName">The tool's registration key.</param>
     /// <param name="constructionError">
@@ -88,6 +97,32 @@ public sealed class FirstPartyToolLookup
             constructionError = ex;
             return null;
         }
+    }
+
+    /// <summary>
+    /// As <see cref="TryResolve"/>, but also logs a construction failure — the "resolve, then log if
+    /// it threw" shape (#627 code-review) previously repeated by hand at every call site instead of
+    /// living once here.
+    /// </summary>
+    /// <param name="toolName">The tool's registration key.</param>
+    /// <param name="logger">The caller's own logger, so the error is attributed to the right category.</param>
+    /// <param name="context">
+    /// A caller-specific phrase completing "Could not construct first-party tool '{toolName}' …" —
+    /// e.g. "to classify its risk; falling back to the conservative default". Should name both what
+    /// the caller was trying to do and what it does instead, since the fallback itself is silent.
+    /// </param>
+    /// <returns>The resolved tool, or <see langword="null"/> when unresolved for any reason.</returns>
+    public ITool? TryResolveLogged(string toolName, ILogger logger, string context)
+    {
+        var tool = TryResolve(toolName, out var constructionError);
+
+        if (tool is null && constructionError is not null)
+        {
+            logger.LogError(constructionError,
+                "Could not construct first-party tool '{ToolName}' {Context}.", toolName, context);
+        }
+
+        return tool;
     }
 
     /// <summary>

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityResolver.cs
@@ -2,6 +2,7 @@ using Application.AI.Common.Interfaces.Tools;
 using Domain.AI.Governance;
 using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Governance;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Application.AI.Common.Services.Tools;
@@ -23,24 +24,34 @@ public sealed class ToolCapabilityResolver : IToolCapabilityResolver
     private readonly FirstPartyToolLookup _firstPartyLookup;
     private readonly IToolBehaviorRegistry _behaviorRegistry;
     private readonly IOptionsMonitor<GovernanceConfig> _governanceConfig;
+    private readonly ILogger<ToolCapabilityResolver> _logger;
 
     /// <summary>Initializes a new instance of the <see cref="ToolCapabilityResolver"/> class.</summary>
     /// <param name="firstPartyLookup">
     /// The shared bounded-key-set-gated first-party tool lookup — see its remarks for why probing
     /// keyed DI outside its bounded key set is unsafe.
     /// </param>
+    /// <param name="logger">
+    /// Logs a construction failure (#627: this used <see cref="FirstPartyToolLookup.Resolve"/>, which
+    /// propagates a keyed tool's constructor exception instead of catching it). Classification still
+    /// degrades safely to the keyword heuristic either way — the same path an MCP/bundle tool outside
+    /// the bounded first-party set already takes — the log is what makes the anomaly visible.
+    /// </param>
     public ToolCapabilityResolver(
         FirstPartyToolLookup firstPartyLookup,
         IToolBehaviorRegistry behaviorRegistry,
-        IOptionsMonitor<GovernanceConfig> governanceConfig)
+        IOptionsMonitor<GovernanceConfig> governanceConfig,
+        ILogger<ToolCapabilityResolver> logger)
     {
         ArgumentNullException.ThrowIfNull(firstPartyLookup);
         ArgumentNullException.ThrowIfNull(behaviorRegistry);
         ArgumentNullException.ThrowIfNull(governanceConfig);
+        ArgumentNullException.ThrowIfNull(logger);
 
         _firstPartyLookup = firstPartyLookup;
         _behaviorRegistry = behaviorRegistry;
         _governanceConfig = governanceConfig;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -126,8 +137,19 @@ public sealed class ToolCapabilityResolver : IToolCapabilityResolver
     private (ToolCompositionCapability Capabilities, ToolCapabilityOrigin Origin) ResolveBase(string publishedToolName)
     {
         // Bounded-key-set-gated — see FirstPartyToolLookup's remarks. An MCP or bundle-owned name that
-        // is not a registration key resolves to null and skips straight to the keyword heuristic below.
-        var firstParty = _firstPartyLookup.Resolve(publishedToolName);
+        // is not a registration key resolves to null and skips straight to the keyword heuristic below
+        // — as does a registered tool whose constructor throws (#627), logged since that case is a
+        // host misconfiguration rather than an expected "not first-party" answer.
+        var firstParty = _firstPartyLookup.TryResolve(publishedToolName, out var constructionError);
+        if (firstParty is null && constructionError is not null)
+        {
+            _logger.LogError(constructionError,
+                "Could not construct first-party tool '{ToolName}' to classify its composition " +
+                "capabilities — falling back to the keyword heuristic, the same path taken for a tool " +
+                "outside the bounded first-party set.",
+                publishedToolName);
+        }
+
         if (firstParty is not null)
         {
             return firstParty.Capabilities != ToolCompositionCapability.None

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityResolver.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolCapabilityResolver.cs
@@ -140,15 +140,10 @@ public sealed class ToolCapabilityResolver : IToolCapabilityResolver
         // is not a registration key resolves to null and skips straight to the keyword heuristic below
         // — as does a registered tool whose constructor throws (#627), logged since that case is a
         // host misconfiguration rather than an expected "not first-party" answer.
-        var firstParty = _firstPartyLookup.TryResolve(publishedToolName, out var constructionError);
-        if (firstParty is null && constructionError is not null)
-        {
-            _logger.LogError(constructionError,
-                "Could not construct first-party tool '{ToolName}' to classify its composition " +
-                "capabilities — falling back to the keyword heuristic, the same path taken for a tool " +
-                "outside the bounded first-party set.",
-                publishedToolName);
-        }
+        var firstParty = _firstPartyLookup.TryResolveLogged(
+            publishedToolName, _logger,
+            "to classify its composition capabilities — falling back to the keyword heuristic, the " +
+            "same path taken for a tool outside the bounded first-party set");
 
         if (firstParty is not null)
         {

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolRiskClassifier.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolRiskClassifier.cs
@@ -1,4 +1,5 @@
 using Application.AI.Common.Interfaces.Tools;
+using Microsoft.Extensions.Logging;
 
 namespace Application.AI.Common.Services.Tools;
 
@@ -6,11 +7,13 @@ namespace Application.AI.Common.Services.Tools;
 /// Default <see cref="IToolRiskClassifier"/>: resolves the registered <see cref="ITool"/> for
 /// a name via <see cref="FirstPartyToolLookup"/> and reads its declared risk. Returns
 /// <see cref="ToolRiskProfile.Default"/> for names that do not resolve (external MCP tools,
-/// unregistered names) so an unknown tool is never treated as lower-risk than it is.
+/// unregistered names, or a registered tool whose constructor throws) so an unknown tool is never
+/// treated as lower-risk than it is.
 /// </summary>
 public sealed class ToolRiskClassifier : IToolRiskClassifier
 {
     private readonly FirstPartyToolLookup _firstPartyLookup;
+    private readonly ILogger<ToolRiskClassifier> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ToolRiskClassifier"/> class.
@@ -20,10 +23,18 @@ public sealed class ToolRiskClassifier : IToolRiskClassifier
     /// probe (this type's original implementation) leaks process-lifetime memory once MCP/bundle
     /// tool calls, whose names are unbounded, reach this classifier on every governed invocation.
     /// </param>
-    public ToolRiskClassifier(FirstPartyToolLookup firstPartyLookup)
+    /// <param name="logger">
+    /// Logs a construction failure (#627: this used <see cref="FirstPartyToolLookup.Resolve"/>, which
+    /// propagates a keyed tool's constructor exception instead of catching it — the same host-boot
+    /// failure mode #612 fixed for a permission-rule provider). Classification still degrades safely
+    /// to <see cref="ToolRiskProfile.Default"/> either way; the log is what makes the anomaly visible.
+    /// </param>
+    public ToolRiskClassifier(FirstPartyToolLookup firstPartyLookup, ILogger<ToolRiskClassifier> logger)
     {
         ArgumentNullException.ThrowIfNull(firstPartyLookup);
+        ArgumentNullException.ThrowIfNull(logger);
         _firstPartyLookup = firstPartyLookup;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -32,7 +43,15 @@ public sealed class ToolRiskClassifier : IToolRiskClassifier
         if (string.IsNullOrWhiteSpace(toolName))
             return ToolRiskProfile.Default;
 
-        var tool = _firstPartyLookup.Resolve(toolName);
+        var tool = _firstPartyLookup.TryResolve(toolName, out var constructionError);
+
+        if (tool is null && constructionError is not null)
+        {
+            _logger.LogError(constructionError,
+                "Could not construct first-party tool '{ToolName}' to classify its risk — treating it " +
+                "as {DefaultProfile} (the same conservative answer used for an unrecognized tool).",
+                toolName, ToolRiskProfile.Default);
+        }
 
         return tool is null
             ? ToolRiskProfile.Default

--- a/src/Content/Application/Application.AI.Common/Services/Tools/ToolRiskClassifier.cs
+++ b/src/Content/Application/Application.AI.Common/Services/Tools/ToolRiskClassifier.cs
@@ -24,10 +24,11 @@ public sealed class ToolRiskClassifier : IToolRiskClassifier
     /// tool calls, whose names are unbounded, reach this classifier on every governed invocation.
     /// </param>
     /// <param name="logger">
-    /// Logs a construction failure (#627: this used <see cref="FirstPartyToolLookup.Resolve"/>, which
-    /// propagates a keyed tool's constructor exception instead of catching it — the same host-boot
-    /// failure mode #612 fixed for a permission-rule provider). Classification still degrades safely
-    /// to <see cref="ToolRiskProfile.Default"/> either way; the log is what makes the anomaly visible.
+    /// Logs a construction failure via <see cref="FirstPartyToolLookup.TryResolveLogged"/> (#627: this
+    /// used to call the unguarded resolve overload directly, propagating a keyed tool's constructor
+    /// exception instead of catching it — the same host-boot failure mode #612 fixed for a
+    /// permission-rule provider). Classification still degrades safely to
+    /// <see cref="ToolRiskProfile.Default"/> either way; the log is what makes the anomaly visible.
     /// </param>
     public ToolRiskClassifier(FirstPartyToolLookup firstPartyLookup, ILogger<ToolRiskClassifier> logger)
     {
@@ -43,15 +44,10 @@ public sealed class ToolRiskClassifier : IToolRiskClassifier
         if (string.IsNullOrWhiteSpace(toolName))
             return ToolRiskProfile.Default;
 
-        var tool = _firstPartyLookup.TryResolve(toolName, out var constructionError);
-
-        if (tool is null && constructionError is not null)
-        {
-            _logger.LogError(constructionError,
-                "Could not construct first-party tool '{ToolName}' to classify its risk — treating it " +
-                "as {DefaultProfile} (the same conservative answer used for an unrecognized tool).",
-                toolName, ToolRiskProfile.Default);
-        }
+        var tool = _firstPartyLookup.TryResolveLogged(
+            toolName, _logger,
+            $"to classify its risk — treating it as {ToolRiskProfile.Default} (the same conservative " +
+            "answer used for an unrecognized tool)");
 
         return tool is null
             ? ToolRiskProfile.Default

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -408,7 +408,20 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
     {
         // Resolved first so a tool with no resource-parameter declaration (or one outside the bounded
         // first-party set) skips the normalization pass below entirely — Extract would return null anyway.
-        var tool = _firstPartyToolLookup.Resolve(toolName);
+        // A tool whose constructor throws (#627) takes the identical null path: CapabilityEnforcer's
+        // fail-closed design (see this method's own remarks) refuses a scoped tool when the resource
+        // request stays unset, so treating "could not construct" like "no declaration" here still
+        // fails closed rather than silently bypassing scoping.
+        var tool = _firstPartyToolLookup.TryResolve(toolName, out var constructionError);
+        if (constructionError is not null)
+        {
+            _logger.LogError(constructionError,
+                "Could not construct first-party tool '{ToolName}' to resolve its resource-parameter " +
+                "declaration — treating it as undeclared, which CapabilityEnforcer refuses if the tool " +
+                "has path/host scoping configured.",
+                toolName);
+        }
+
         if (tool?.ResourceParametersByOperation is not { Count: > 0 } declared)
             return null;
 

--- a/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Planner/StepExecutors/ToolUseStepExecutor.cs
@@ -412,15 +412,10 @@ public sealed class ToolUseStepExecutor : IPlanStepExecutor
         // fail-closed design (see this method's own remarks) refuses a scoped tool when the resource
         // request stays unset, so treating "could not construct" like "no declaration" here still
         // fails closed rather than silently bypassing scoping.
-        var tool = _firstPartyToolLookup.TryResolve(toolName, out var constructionError);
-        if (constructionError is not null)
-        {
-            _logger.LogError(constructionError,
-                "Could not construct first-party tool '{ToolName}' to resolve its resource-parameter " +
-                "declaration — treating it as undeclared, which CapabilityEnforcer refuses if the tool " +
-                "has path/host scoping configured.",
-                toolName);
-        }
+        var tool = _firstPartyToolLookup.TryResolveLogged(
+            toolName, _logger,
+            "to resolve its resource-parameter declaration — treating it as undeclared, which " +
+            "CapabilityEnforcer refuses if the tool has path/host scoping configured");
 
         if (tool?.ResourceParametersByOperation is not { Count: > 0 } declared)
             return null;

--- a/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Behaviors/CapabilityEnforcementTests.cs
@@ -8,6 +8,7 @@ using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -72,7 +73,8 @@ public sealed class CapabilityEnforcementTests
 
         var lookup = new FirstPartyToolLookup(
             services.BuildServiceProvider(), new HashSet<string>(tools.Select(t => t.Name)));
-        var resolver = new ToolPermissionProfileResolver(lookup, configMock.Object);
+        var resolver = new ToolPermissionProfileResolver(
+            lookup, configMock.Object, NullLogger<ToolPermissionProfileResolver>.Instance);
         var enforcer = new CapabilityEnforcer(resolver, (logger ?? new Mock<ILogger<CapabilityEnforcer>>()).Object);
         return (resolver, enforcer);
     }

--- a/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Governance/ToolPathScopingEndToEndTests.cs
@@ -79,7 +79,8 @@ public sealed class ToolPathScopingEndToEndTests
     {
         var sandboxMonitor = Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == sandboxConfig);
         var lookup = new FirstPartyToolLookup(toolProvider, toolNames ?? new HashSet<string> { "file_system" });
-        var resolver = new ToolPermissionProfileResolver(lookup, sandboxMonitor);
+        var resolver = new ToolPermissionProfileResolver(
+            lookup, sandboxMonitor, NullLogger<ToolPermissionProfileResolver>.Instance);
         var enforcer = new CapabilityEnforcer(resolver, NullLogger<CapabilityEnforcer>.Instance);
 
         var governance = new GovernanceConfig { EnforceToolInvocation = true, Enabled = false, EnableAudit = true };
@@ -361,7 +362,8 @@ public sealed class ToolPathScopingEndToEndTests
     {
         var lookup = new FirstPartyToolLookup(toolProvider, new HashSet<string> { "file_system" });
         var resolver = new ToolPermissionProfileResolver(
-            lookup, Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == sandboxConfig));
+            lookup, Mock.Of<IOptionsMonitor<SandboxConfig>>(m => m.CurrentValue == sandboxConfig),
+            NullLogger<ToolPermissionProfileResolver>.Instance);
         return new CapabilityEnforcer(resolver, NullLogger<CapabilityEnforcer>.Instance);
     }
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
@@ -9,6 +9,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -88,15 +89,26 @@ public sealed class ToolPermissionProfileResolverTests
         var configMock = new Mock<IOptionsMonitor<SandboxConfig>>();
         configMock.Setup(m => m.CurrentValue).Returns(new SandboxConfig());
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { "unbuildable" });
-        var resolver = new ToolPermissionProfileResolver(
-            lookup, configMock.Object, NullLogger<ToolPermissionProfileResolver>.Instance);
+        var logger = new Mock<ILogger<ToolPermissionProfileResolver>>();
+        var resolver = new ToolPermissionProfileResolver(lookup, configMock.Object, logger.Object);
 
         var profile = resolver.Resolve("unbuildable");
 
         profile.RequiredCapabilities.Should().Be(ToolCapability.None);
         profile.DeniedCapabilities.Should().Be(ToolCapability.None);
         profile.MinimumIsolation.Should().Be(SandboxIsolationLevel.None);
+        // The log is the point of the fix (#627 code-review) — see ToolRiskClassifierTests's sibling
+        // assertion for why a silent fallback defeats the purpose of catching the failure at all.
+        LogsErrorMentioning(logger, "unbuildable").Should().BeTrue();
     }
+
+    private static bool LogsErrorMentioning(Mock<ILogger<ToolPermissionProfileResolver>> logger, string substring) =>
+        logger.Invocations.Any(i =>
+            i.Method.Name == nameof(ILogger.Log) &&
+            i.Arguments.Count > 2 &&
+            (LogLevel)i.Arguments[0]! == LogLevel.Error &&
+            i.Arguments[2] is not null &&
+            i.Arguments[2]!.ToString()!.Contains(substring, StringComparison.Ordinal));
 
     [Fact]
     public void ResolveForUngovernedDispatch_ToolConstructorThrows_DoesNotPropagate()
@@ -109,12 +121,13 @@ public sealed class ToolPermissionProfileResolverTests
         var configMock = new Mock<IOptionsMonitor<SandboxConfig>>();
         configMock.Setup(m => m.CurrentValue).Returns(new SandboxConfig());
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { "unbuildable" });
-        var resolver = new ToolPermissionProfileResolver(
-            lookup, configMock.Object, NullLogger<ToolPermissionProfileResolver>.Instance);
+        var logger = new Mock<ILogger<ToolPermissionProfileResolver>>();
+        var resolver = new ToolPermissionProfileResolver(lookup, configMock.Object, logger.Object);
 
         var result = resolver.ResolveForUngovernedDispatch("unbuildable", ToolCapability.None, []);
 
         result.IsSuccess.Should().BeTrue();
+        LogsErrorMentioning(logger, "unbuildable").Should().BeTrue();
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Sandbox/ToolPermissionProfileResolverTests.cs
@@ -9,6 +9,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Sandbox;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -47,7 +48,9 @@ public sealed class ToolPermissionProfileResolverTests
 
         var lookup = new FirstPartyToolLookup(
             services.BuildServiceProvider(), new HashSet<string>(tools.Select(t => t.Name)));
-        return new ToolPermissionProfileResolver(lookup, configMock.Object, auditService, governanceConfig);
+        return new ToolPermissionProfileResolver(
+            lookup, configMock.Object, NullLogger<ToolPermissionProfileResolver>.Instance,
+            auditService, governanceConfig);
     }
 
     private static ITool FileTool() => Mock.Of<ITool>(t =>
@@ -70,6 +73,48 @@ public sealed class ToolPermissionProfileResolverTests
         profile.RequiredCapabilities.Should().Be(ToolCapability.None);
         profile.DeniedCapabilities.Should().Be(ToolCapability.None);
         profile.MinimumIsolation.Should().Be(SandboxIsolationLevel.None);
+    }
+
+    [Fact]
+    public void Resolve_ToolConstructorThrows_FallsBackToTheSameProfileAsUnregistered()
+    {
+        // #627: ResolveBase used FirstPartyToolLookup.Resolve, which propagates a keyed tool's
+        // constructor exception instead of catching it. A construction failure now takes the same
+        // path as a name outside the bounded first-party set — proven by asserting an identical
+        // result to Resolve_UnregisteredName_NoOverride_ReturnsDefaultProfile above.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("unbuildable", (_, _) =>
+            throw new InvalidOperationException("dependency not registered in this host"));
+        var configMock = new Mock<IOptionsMonitor<SandboxConfig>>();
+        configMock.Setup(m => m.CurrentValue).Returns(new SandboxConfig());
+        var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { "unbuildable" });
+        var resolver = new ToolPermissionProfileResolver(
+            lookup, configMock.Object, NullLogger<ToolPermissionProfileResolver>.Instance);
+
+        var profile = resolver.Resolve("unbuildable");
+
+        profile.RequiredCapabilities.Should().Be(ToolCapability.None);
+        profile.DeniedCapabilities.Should().Be(ToolCapability.None);
+        profile.MinimumIsolation.Should().Be(SandboxIsolationLevel.None);
+    }
+
+    [Fact]
+    public void ResolveForUngovernedDispatch_ToolConstructorThrows_DoesNotPropagate()
+    {
+        // Same failure mode as above, exercised through the ungoverned-dispatch entry point — the
+        // live tool-dispatch path code-review flagged as more consequential than a permission check.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("unbuildable", (_, _) =>
+            throw new InvalidOperationException("dependency not registered in this host"));
+        var configMock = new Mock<IOptionsMonitor<SandboxConfig>>();
+        configMock.Setup(m => m.CurrentValue).Returns(new SandboxConfig());
+        var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { "unbuildable" });
+        var resolver = new ToolPermissionProfileResolver(
+            lookup, configMock.Object, NullLogger<ToolPermissionProfileResolver>.Instance);
+
+        var result = resolver.ResolveForUngovernedDispatch("unbuildable", ToolCapability.None, []);
+
+        result.IsSuccess.Should().BeTrue();
     }
 
     [Fact]
@@ -162,7 +207,8 @@ public sealed class ToolPermissionProfileResolverTests
         var configMock = new Mock<IOptionsMonitor<SandboxConfig>>();
         configMock.Setup(m => m.CurrentValue).Returns(new SandboxConfig());
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string>());
-        var resolver = new ToolPermissionProfileResolver(lookup, configMock.Object);
+        var resolver = new ToolPermissionProfileResolver(
+            lookup, configMock.Object, NullLogger<ToolPermissionProfileResolver>.Instance);
 
         var profile = resolver.Resolve("mcp_tool");
 

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/FirstPartyToolLookupTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/FirstPartyToolLookupTests.cs
@@ -23,7 +23,7 @@ public sealed class FirstPartyToolLookupTests
         var lookup = new FirstPartyToolLookup(
             services.BuildServiceProvider(), new HashSet<string> { "file_system" });
 
-        lookup.Resolve("file_system").Should().BeSameAs(tool);
+        lookup.TryResolve("file_system", out _).Should().BeSameAs(tool);
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public sealed class FirstPartyToolLookupTests
         services.AddKeyedSingleton<ITool>("mcp_tool", (_, _) => Mock.Of<ITool>());
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string>());
 
-        lookup.Resolve("mcp_tool").Should().BeNull();
+        lookup.TryResolve("mcp_tool", out _).Should().BeNull();
     }
 
     [Fact]
@@ -45,6 +45,6 @@ public sealed class FirstPartyToolLookupTests
         var lookup = new FirstPartyToolLookup(
             services.BuildServiceProvider(), new HashSet<string> { "unregistered_tool" });
 
-        lookup.Resolve("unregistered_tool").Should().BeNull();
+        lookup.TryResolve("unregistered_tool", out _).Should().BeNull();
     }
 }

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolCapabilityResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolCapabilityResolverTests.cs
@@ -5,6 +5,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Governance;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
@@ -163,6 +164,25 @@ public sealed class ToolCapabilityResolverTests
         profile.Origin.Should().Be(ToolCapabilityOrigin.McpAnnotation);
     }
 
+    [Fact]
+    public void Resolve_ToolConstructorThrows_FallsBackToKeywordHeuristicInsteadOfPropagating()
+    {
+        // #627: this used FirstPartyToolLookup.Resolve, which propagates a keyed tool's constructor
+        // exception instead of catching it. "run_shell" also keyword-matches, so this proves the
+        // fallback is the SAME path an out-of-bounded-set name already takes, not a special case.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("run_shell", (_, _) =>
+            throw new InvalidOperationException("dependency not registered in this host"));
+        var resolver = BuildResolver(
+            serviceProvider: services.BuildServiceProvider(),
+            registeredKeys: new HashSet<string> { "run_shell" });
+
+        var profile = resolver.Resolve("run_shell");
+
+        profile.Capabilities.Should().HaveFlag(ToolCompositionCapability.ExecutesCode);
+        profile.Origin.Should().Be(ToolCapabilityOrigin.KeywordHeuristic);
+    }
+
     private static ToolCapabilityResolver BuildResolver(
         IServiceProvider? serviceProvider = null,
         GovernanceConfig? governance = null,
@@ -173,7 +193,8 @@ public sealed class ToolCapabilityResolverTests
                 serviceProvider ?? new ServiceCollection().BuildServiceProvider(),
                 registeredKeys ?? new HashSet<string>()),
             behaviorRegistry ?? new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider()),
-            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == (governance ?? new GovernanceConfig())));
+            Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == (governance ?? new GovernanceConfig())),
+            NullLogger<ToolCapabilityResolver>.Instance);
 
     private static GovernanceConfig Governance(ToolCompositionGatingConfig gating) =>
         new() { ToolCompositionGating = gating };

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolCapabilityResolverTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolCapabilityResolverTests.cs
@@ -5,6 +5,7 @@ using Domain.Common.Config.AI;
 using Domain.Common.Config.AI.Governance;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -173,28 +174,40 @@ public sealed class ToolCapabilityResolverTests
         var services = new ServiceCollection();
         services.AddKeyedSingleton<ITool>("run_shell", (_, _) =>
             throw new InvalidOperationException("dependency not registered in this host"));
+        var logger = new Mock<ILogger<ToolCapabilityResolver>>();
         var resolver = BuildResolver(
             serviceProvider: services.BuildServiceProvider(),
-            registeredKeys: new HashSet<string> { "run_shell" });
+            registeredKeys: new HashSet<string> { "run_shell" },
+            logger: logger.Object);
 
         var profile = resolver.Resolve("run_shell");
 
         profile.Capabilities.Should().HaveFlag(ToolCompositionCapability.ExecutesCode);
         profile.Origin.Should().Be(ToolCapabilityOrigin.KeywordHeuristic);
+        // The log is the point of the fix (#627 code-review) — see ToolRiskClassifierTests's sibling
+        // assertion for why a silent fallback defeats the purpose of catching the failure at all.
+        logger.Invocations.Any(i =>
+            i.Method.Name == nameof(ILogger.Log) &&
+            i.Arguments.Count > 2 &&
+            (LogLevel)i.Arguments[0]! == LogLevel.Error &&
+            i.Arguments[2] is not null &&
+            i.Arguments[2]!.ToString()!.Contains("run_shell", StringComparison.Ordinal))
+            .Should().BeTrue();
     }
 
     private static ToolCapabilityResolver BuildResolver(
         IServiceProvider? serviceProvider = null,
         GovernanceConfig? governance = null,
         IToolBehaviorRegistry? behaviorRegistry = null,
-        IReadOnlySet<string>? registeredKeys = null) =>
+        IReadOnlySet<string>? registeredKeys = null,
+        ILogger<ToolCapabilityResolver>? logger = null) =>
         new(
             new FirstPartyToolLookup(
                 serviceProvider ?? new ServiceCollection().BuildServiceProvider(),
                 registeredKeys ?? new HashSet<string>()),
             behaviorRegistry ?? new ToolBehaviorRegistry(new ServiceCollection().BuildServiceProvider()),
             Mock.Of<IOptionsMonitor<GovernanceConfig>>(m => m.CurrentValue == (governance ?? new GovernanceConfig())),
-            NullLogger<ToolCapabilityResolver>.Instance);
+            logger ?? NullLogger<ToolCapabilityResolver>.Instance);
 
     private static GovernanceConfig Governance(ToolCompositionGatingConfig gating) =>
         new() { ToolCompositionGating = gating };

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolRiskClassifierTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolRiskClassifierTests.cs
@@ -4,7 +4,9 @@ using Domain.AI.Changes;
 using Domain.AI.Models;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Services.Tools;
@@ -80,12 +82,25 @@ public sealed class ToolRiskClassifierTests
         services.AddKeyedSingleton<ITool>("unbuildable", (_, _) =>
             throw new InvalidOperationException("dependency not registered in this host"));
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { "unbuildable" });
-        var sut = new ToolRiskClassifier(lookup, NullLogger<ToolRiskClassifier>.Instance);
+        var logger = new Mock<ILogger<ToolRiskClassifier>>();
+        var sut = new ToolRiskClassifier(lookup, logger.Object);
 
         var profile = sut.Classify("unbuildable");
 
         profile.Should().Be(ToolRiskProfile.Default);
+        // The log is the point of the fix (#627 code-review) — a silent fallback with no error
+        // signal is indistinguishable from an ordinary unrecognized tool, which defeats the whole
+        // purpose of catching the construction failure instead of propagating it.
+        LogsErrorMentioning(logger, "unbuildable").Should().BeTrue();
     }
+
+    private static bool LogsErrorMentioning(Mock<ILogger<ToolRiskClassifier>> logger, string substring) =>
+        logger.Invocations.Any(i =>
+            i.Method.Name == nameof(ILogger.Log) &&
+            i.Arguments.Count > 2 &&
+            (LogLevel)i.Arguments[0]! == LogLevel.Error &&
+            i.Arguments[2] is not null &&
+            i.Arguments[2]!.ToString()!.Contains(substring, StringComparison.Ordinal));
 
     private sealed class FakeTool(string name, BlastRadius risk, bool isReadOnly) : ITool
     {

--- a/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolRiskClassifierTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Services/Tools/ToolRiskClassifierTests.cs
@@ -4,6 +4,7 @@ using Domain.AI.Changes;
 using Domain.AI.Models;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Application.AI.Common.Tests.Services.Tools;
@@ -23,7 +24,7 @@ public sealed class ToolRiskClassifierTests
         var toolNames = new HashSet<string>(tools.Select(t => t.Name), StringComparer.Ordinal);
         var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), toolNames);
 
-        return new ToolRiskClassifier(lookup);
+        return new ToolRiskClassifier(lookup, NullLogger<ToolRiskClassifier>.Instance);
     }
 
     [Fact]
@@ -68,6 +69,22 @@ public sealed class ToolRiskClassifierTests
         var sut = CreateClassifier(new FakeTool("known", BlastRadius.High, isReadOnly: false));
 
         sut.Classify(name).Should().Be(ToolRiskProfile.Default);
+    }
+
+    [Fact]
+    public void Classify_ToolConstructorThrows_ReturnsFailSafeDefaultInsteadOfPropagating()
+    {
+        // #627: this used FirstPartyToolLookup.Resolve, which propagates a keyed tool's constructor
+        // exception instead of catching it — the same host-boot failure mode #612 fixed elsewhere.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ITool>("unbuildable", (_, _) =>
+            throw new InvalidOperationException("dependency not registered in this host"));
+        var lookup = new FirstPartyToolLookup(services.BuildServiceProvider(), new HashSet<string> { "unbuildable" });
+        var sut = new ToolRiskClassifier(lookup, NullLogger<ToolRiskClassifier>.Instance);
+
+        var profile = sut.Classify("unbuildable");
+
+        profile.Should().Be(ToolRiskProfile.Default);
     }
 
     private sealed class FakeTool(string name, BlastRadius risk, bool isReadOnly) : ITool

--- a/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
+++ b/src/Content/Tests/Infrastructure.AI.MCP.Tests/Services/McpConnectionManagerBundleEgressSupport.cs
@@ -116,8 +116,10 @@ internal static class McpConnectionManagerBundleEgressSupport
         // a real sandbox path via this shared provider.
         services.AddOptions<AppConfig>();
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>(StringComparer.Ordinal)));
+        services.AddSingleton<ILogger<ToolPermissionProfileResolver>>(NullLogger<ToolPermissionProfileResolver>.Instance);
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
-            sp.GetRequiredService<FirstPartyToolLookup>(), sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>()));
+            sp.GetRequiredService<FirstPartyToolLookup>(), sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>(),
+            sp.GetRequiredService<ILogger<ToolPermissionProfileResolver>>()));
         extra?.Invoke(services);
         return services.BuildServiceProvider();
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacSandboxRunnerSolutionReviewFixTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/IacSandboxRunnerSolutionReviewFixTests.cs
@@ -11,6 +11,7 @@ using Infrastructure.AI.Iac;
 using Infrastructure.AI.Tests.Support;
 using Infrastructure.AI.Tools.Iac;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -59,6 +60,7 @@ public sealed class IacSandboxRunnerSolutionReviewFixTests
                 c.ToolOverrides[overrideToolName] = overrideConfig;
         });
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
+        services.AddSingleton<ILogger<ToolPermissionProfileResolver>>(NullLogger<ToolPermissionProfileResolver>.Instance);
         services.AddSingleton<ToolPermissionProfileResolver>();
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Iac/TerraformGeneratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Iac/TerraformGeneratorTests.cs
@@ -82,7 +82,8 @@ public sealed class TerraformGeneratorTests
         var services = new ServiceCollection().AddKeyedSingleton(SandboxIsolationLevel.Process, sandbox);
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
-            sp.GetRequiredService<FirstPartyToolLookup>(), configMock.Object));
+            sp.GetRequiredService<FirstPartyToolLookup>(), configMock.Object,
+            NullLogger<ToolPermissionProfileResolver>.Instance));
         var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
 
         return new TerraformGenerator(

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -14,6 +14,7 @@ using Domain.AI.Sandbox;
 using Infrastructure.AI.Planner.StepExecutors;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -135,6 +136,7 @@ public sealed class ToolUseStepExecutorTests
         services.AddKeyedSingleton<Application.AI.Common.Interfaces.Tools.ITool>("file_system", (_, _) =>
             throw new InvalidOperationException("dependency not registered in this host"));
         var sp = services.BuildServiceProvider();
+        var logger = new Mock<ILogger<ToolUseStepExecutor>>();
 
         var sut = new ToolUseStepExecutor(
             _capabilityEnforcer.Object,
@@ -143,7 +145,7 @@ public sealed class ToolUseStepExecutorTests
             _attestationService.Object,
             _notifier.Object,
             _context,
-            NullLogger<ToolUseStepExecutor>.Instance,
+            logger.Object,
             new FirstPartyToolLookup(sp, new HashSet<string> { "file_system" }));
 
         var config = new ToolUseConfig { ToolName = "file_system" };
@@ -160,6 +162,15 @@ public sealed class ToolUseStepExecutorTests
         var result = await sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
 
         Assert.Equal(StepExecutionStatus.Completed, result.Status);
+        // The log is the point of the fix (#627 code-review) — a silent fallback with no error
+        // signal is indistinguishable from an ordinary unrecognized tool, which defeats the whole
+        // purpose of catching the construction failure instead of propagating it.
+        Assert.Contains(logger.Invocations, i =>
+            i.Method.Name == nameof(ILogger.Log) &&
+            i.Arguments.Count > 2 &&
+            (LogLevel)i.Arguments[0]! == LogLevel.Error &&
+            i.Arguments[2] is not null &&
+            i.Arguments[2]!.ToString()!.Contains("file_system", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Planner/StepExecutors/ToolUseStepExecutorTests.cs
@@ -123,6 +123,46 @@ public sealed class ToolUseStepExecutorTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ResourceParameterToolConstructorThrows_StillCompletesInsteadOfPropagating()
+    {
+        // #627: ExtractResourceRequest used FirstPartyToolLookup.Resolve, which propagates a keyed
+        // tool's constructor exception instead of catching it. A construction failure now takes the
+        // same "no resource-parameter declaration" path a name outside the bounded first-party set
+        // already takes — this step must still complete, not fail with an unhandled exception.
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Process, _sandboxExecutor.Object);
+        services.AddKeyedSingleton<ISandboxExecutor>(SandboxIsolationLevel.Container, _sandboxExecutor.Object);
+        services.AddKeyedSingleton<Application.AI.Common.Interfaces.Tools.ITool>("file_system", (_, _) =>
+            throw new InvalidOperationException("dependency not registered in this host"));
+        var sp = services.BuildServiceProvider();
+
+        var sut = new ToolUseStepExecutor(
+            _capabilityEnforcer.Object,
+            BuildAdmissionPipeline(Mock.Of<IToolCallObserverChain>()),
+            sp,
+            _attestationService.Object,
+            _notifier.Object,
+            _context,
+            NullLogger<ToolUseStepExecutor>.Instance,
+            new FirstPartyToolLookup(sp, new HashSet<string> { "file_system" }));
+
+        var config = new ToolUseConfig { ToolName = "file_system" };
+        var step = CreateStep(config);
+
+        _sandboxExecutor.Setup(s => s.ExecuteAsync(It.IsAny<SandboxExecutionRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SandboxExecutionResult
+            {
+                Success = true,
+                Output = "{}",
+                ResourceUsage = new ResourceUsage()
+            });
+
+        var result = await sut.ExecuteAsync(step, new Dictionary<PlanStepId, string>(), CancellationToken.None);
+
+        Assert.Equal(StepExecutionStatus.Completed, result.Status);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_FailedExecution_ReturnsFailed()
     {
         var config = new ToolUseConfig { ToolName = "file_system" };

--- a/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
@@ -5,6 +5,7 @@ using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Sandbox;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -90,6 +91,7 @@ internal static class TestScopeFactory
         var services = new ServiceCollection();
         services.AddOptions<SandboxConfig>();
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
+        services.AddSingleton<ILogger<ToolPermissionProfileResolver>>(NullLogger<ToolPermissionProfileResolver>.Instance);
         services.AddSingleton<ToolPermissionProfileResolver>();
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Support/TestScopeFactory.cs
@@ -5,6 +5,7 @@ using Domain.AI.Sandbox;
 using Domain.Common.Config.AI.Sandbox;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure.AI.Tests.Support;
@@ -71,7 +72,8 @@ internal static class TestScopeFactory
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
             sp.GetRequiredService<FirstPartyToolLookup>(),
-            sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>()));
+            sp.GetRequiredService<IOptionsMonitor<SandboxConfig>>(),
+            NullLogger<ToolPermissionProfileResolver>.Instance));
 
         return services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
     }

--- a/src/Content/Tests/Infrastructure.AI.Tests/Tools/CaptiveDependencyRegressionTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Tools/CaptiveDependencyRegressionTests.cs
@@ -16,6 +16,7 @@ using Infrastructure.AI.Tools.Iac;
 using Infrastructure.AI.Tools.Workspace;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -66,7 +67,8 @@ public sealed class CaptiveDependencyRegressionTests
         services.AddSingleton(sp => new FirstPartyToolLookup(sp, new HashSet<string>()));
         services.AddSingleton(sp => new ToolPermissionProfileResolver(
             sp.GetRequiredService<FirstPartyToolLookup>(),
-            sp.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<SandboxConfig>>()));
+            sp.GetRequiredService<Microsoft.Extensions.Options.IOptionsMonitor<SandboxConfig>>(),
+            NullLogger<ToolPermissionProfileResolver>.Instance));
 
         return services.BuildServiceProvider(new ServiceProviderOptions
         {


### PR DESCRIPTION
## Summary

Fixes #627: #612 added `FirstPartyToolLookup.TryResolve` (try/catch-wrapped) for the one call site it
touched, but four pre-existing callers still used the unguarded `Resolve` — each one misconfigured/
unwired first-party tool dependency away from an uncaught exception at lookup time, the same failure
mode that broke host boot before #612 (#524).

## What's included

- Migrated all four remaining unguarded callers, with each site's own fallback decision reasoned
  through individually rather than copy-pasted:
  - `ToolRiskClassifier.Classify` — falls back to `ToolRiskProfile.Default`, already the conservative
    answer for an unknown tool.
  - `ToolCapabilityResolver.ResolveBase` — falls back to the keyword heuristic, the same path a
    non-first-party tool already takes.
  - `ToolUseStepExecutor.ExtractResourceRequest` (the live tool-dispatch path) — falls back to "no
    resource declaration", which `CapabilityEnforcer`'s own fail-closed design already refuses for a
    scoped tool — verified by reading that design directly, not assumed.
  - `ToolPermissionProfileResolver` (two call sites) — the one that needed real scrutiny: traced the
    fallback through `CapabilityEnforcer.EnforceAsync` and confirmed reusing the existing
    "not first-party" (`None`/`None`) answer for a construction failure is the SAME vacuous-check state
    already accepted for every external tool, not a new permissive one.
- Two independent review rounds on the fix itself found real follow-up issues, both addressed:
  - `FirstPartyToolLookup.Resolve` stayed public and unguarded right after this PR closed its last
    callers — made it `private`; `TryResolve`/`TryResolveLogged` are now the only way in, so the bug
    class is structurally impossible to reintroduce rather than relying on the next caller remembering.
  - The "resolve, then log on failure" shape was independently duplicated across all 5 call sites —
    extracted into one shared `FirstPartyToolLookup.TryResolveLogged(toolName, logger, context)`.
  - A third pass found the regression tests only asserted the fallback *value*, never that the error
    actually got logged (the whole point of the fix). Added a log assertion to all 5 tests,
    mutation-tested by temporarily disabling the logging condition and confirming all 4 affected tests
    fail without it.
- Deliberately out of scope (per the issue's own "needs its own design pass" carve-out): unifying with
  `ToolCatalog.TryDescribe`'s independent copy of the same safe-construct pattern.

## Test plan

- [x] `dotnet build src/AgenticHarness.slnx` — clean, every round
- [x] `Application.AI.Common.Tests` — 2720/2720 pass
- [x] `Infrastructure.AI.Tests` (filtered: ToolUseStepExecutor, TerraformGenerator, CaptiveDependency) —
      56/56 pass
- [x] `Infrastructure.AI.MCP.Tests` — 156/156 pass
- [x] New regression tests for all 5 construction-failure paths, each mutation-tested against the fix
- [x] Local review gate: `run-gates.sh` was killed by genuine host memory pressure (not a test
      failure) — pushed with the sanctioned `RAILS_SKIP_REVIEW_GATE=1` bypass, deferring to CI's
      independent gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu