### PR TITLE
fix: create owner-only directories for 7 sensitive storage roots (#640)

### DIFF
--- a/src/Content/Infrastructure/Infrastructure.AI/Agents/JsonlDelegationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Agents/JsonlDelegationStore.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Application.AI.Common.Interfaces.Agents;
 using Domain.AI.Orchestration;
 using Domain.Common.Config;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -175,7 +176,7 @@ public sealed class JsonlDelegationStore : IDelegationStore, IDisposable
         return _sessionFiles.GetOrAdd(supervisorId, id =>
         {
             var dir = Path.Combine(_basePath, SanitizeSupervisorId(id));
-            Directory.CreateDirectory(dir);
+            OwnerOnlyDirectoryHelper.Create(dir); // #640
 
             var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddTHHmmss'Z'");
             var filePath = Path.Combine(dir, $"{timestamp}.jsonl");
@@ -328,6 +329,6 @@ public sealed class JsonlDelegationStore : IDelegationStore, IDisposable
     {
         var dir = Path.GetDirectoryName(filePath);
         if (dir is not null)
-            Directory.CreateDirectory(dir);
+            OwnerOnlyDirectoryHelper.Create(dir); // #640
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/Audit/HashChainedJsonlWriter.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Audit/HashChainedJsonlWriter.cs
@@ -4,6 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Domain.AI.Audit;
 using Domain.Common;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.Logging;
 
 namespace Infrastructure.AI.Audit;
@@ -168,7 +169,11 @@ public sealed class HashChainedJsonlWriter : IDisposable
                 sequence.ToString(CultureInfo.InvariantCulture), "\n");
 
             var segmentPath = _currentSegment();
-            Directory.CreateDirectory(Path.GetDirectoryName(segmentPath)!);
+            // Owner-only (#640, following #527's precedent): this is the tamper-evident audit log
+            // covering governance/escalation/drift/change/egress events -- the most security-relevant
+            // of the stores #640 migrated, since its tamper-evidence hash chain protects integrity but
+            // says nothing about confidentiality on a shared host.
+            OwnerOnlyDirectoryHelper.Create(Path.GetDirectoryName(segmentPath)!);
 
             await using (var stream = new FileStream(
                 segmentPath, FileMode.Append, FileAccess.Write, FileShare.ReadWrite))

--- a/src/Content/Infrastructure/Infrastructure.AI/Changes/FileSystemEvidenceStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Changes/FileSystemEvidenceStore.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using Application.AI.Common.Interfaces.Changes;
 using Domain.Common.Config;
 using Domain.Common.Helpers;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -58,7 +59,7 @@ public sealed class FileSystemEvidenceStore : IEvidenceStore
         var path = PathFor(hash);
 
         var dir = Path.GetDirectoryName(path)!;
-        Directory.CreateDirectory(dir);
+        OwnerOnlyDirectoryHelper.Create(dir); // #640
 
         // Already present: content addressing makes the write pure, so an
         // existing blob is byte-identical. Skip rewriting to avoid needless I/O

--- a/src/Content/Infrastructure/Infrastructure.AI/Conversations/FileSystemConversationStore.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Conversations/FileSystemConversationStore.cs
@@ -3,6 +3,7 @@ using Application.AI.Common.Interfaces.AI;
 using Application.AI.Common.Services;
 using Application.AI.Common.Models.Conversations;
 using Domain.Common.Config.AI.Conversations;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -59,7 +60,7 @@ public sealed class FileSystemConversationStore : IConversationStore
         _basePath = Path.GetFullPath(config.Value.ConversationsPath);
         _timeProvider = timeProvider;
         _logger = logger;
-        Directory.CreateDirectory(_basePath);
+        OwnerOnlyDirectoryHelper.Create(_basePath); // #640: full conversation transcripts
     }
 
     /// <inheritdoc/>

--- a/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePaths.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Persistence/GovernanceStatePaths.cs
@@ -1,4 +1,5 @@
 using Domain.Common.Helpers;
+using Infrastructure.AI.Helpers;
 
 namespace Infrastructure.AI.Persistence;
 
@@ -81,6 +82,6 @@ public static class GovernanceStatePaths
                 nameof(resolvedDatabasePath));
         }
 
-        Directory.CreateDirectory(directory);
+        OwnerOnlyDirectoryHelper.Create(directory); // #640: holds the approval-verdicts database
     }
 }

--- a/src/Content/Infrastructure/Infrastructure.AI/StateManagement/Checkpoints/JsonCheckpointStateManager.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/StateManagement/Checkpoints/JsonCheckpointStateManager.cs
@@ -1,5 +1,6 @@
 using Domain.Common.Config.Infrastructure;
 using Domain.Common.Workflow;
+using Infrastructure.AI.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Text.Json;
@@ -57,9 +58,8 @@ public class JsonCheckpointStateManager : IStateManager
             DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
         };
 
-        // Ensure base path exists
-        if (!Directory.Exists(_settings.BasePath))
-            Directory.CreateDirectory(_settings.BasePath);
+        // Ensure base path exists, owner-only (#640) -- Create is already a no-op for an existing path.
+        OwnerOnlyDirectoryHelper.Create(_settings.BasePath);
     }
 
     public async Task<WorkflowState?> LoadAsync(string workflowId, CancellationToken cancellationToken = default)
@@ -89,8 +89,8 @@ public class JsonCheckpointStateManager : IStateManager
         var stateFilePath = GetStateFilePath(state.WorkflowId);
         var directory = Path.GetDirectoryName(stateFilePath);
 
-        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-            Directory.CreateDirectory(directory);
+        if (!string.IsNullOrEmpty(directory))
+            OwnerOnlyDirectoryHelper.Create(directory); // #640
 
         // Write to temp file first for atomic operation
         var tempFilePath = stateFilePath + ".tmp";

--- a/src/Content/Infrastructure/Infrastructure.AI/StateManagement/MarkdownCheckpointDecorator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/StateManagement/MarkdownCheckpointDecorator.cs
@@ -1,6 +1,7 @@
 using Domain.Common.Config.Infrastructure;
 using Domain.Common.Workflow;
 using Infrastructure.AI.Generators;
+using Infrastructure.AI.Helpers;
 using Infrastructure.AI.StateManagement.Checkpoints;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -57,9 +58,8 @@ public class MarkdownCheckpointDecorator : IStateManager
         _markdownGenerator = markdownGenerator;
         _settings = infraConfig.CurrentValue.StateManagement;
 
-        // Ensure base path exists
-        if (!Directory.Exists(_settings.BasePath))
-            Directory.CreateDirectory(_settings.BasePath);
+        // Ensure base path exists, owner-only (#640) -- Create is already a no-op for an existing path.
+        OwnerOnlyDirectoryHelper.Create(_settings.BasePath);
     }
 
     public async Task<WorkflowState?> LoadAsync(string workflowId, CancellationToken cancellationToken = default)
@@ -169,8 +169,8 @@ public class MarkdownCheckpointDecorator : IStateManager
         var markdownPath = GetMarkdownFilePath(state.WorkflowId);
         var directory = Path.GetDirectoryName(markdownPath);
 
-        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
-            Directory.CreateDirectory(directory);
+        if (!string.IsNullOrEmpty(directory))
+            OwnerOnlyDirectoryHelper.Create(directory); // #640
 
         // Write to temp file first for atomic operation
         var tempFilePath = markdownPath + ".tmp";

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/JsonlDelegationStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/JsonlDelegationStoreTests.cs
@@ -63,6 +63,24 @@ public sealed class JsonlDelegationStoreTests : IDisposable
             ParentDelegationId = parentDelegationId
         };
 
+    // --- Directory permissions (#640, following #527's precedent) ---
+
+    [Fact]
+    public async Task AppendAsync_SupervisorDirectoryIsCreatedOwnerOnly()
+    {
+        // #640: delegation records hold task descriptions and required capabilities for subagent
+        // delegations -- the supervisor subdirectory must never inherit whatever the process
+        // umask/ACL happens to grant.
+        await _store.AppendAsync(BuildRecord());
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var supervisorDir = Path.Combine(_tempDir, "supervisor-1");
+            File.GetUnixFileMode(supervisorDir).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     [Fact]
     public async Task AppendAsync_ThenGetByIdAsync_ReturnsRecord()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Agents/JsonlDelegationStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Agents/JsonlDelegationStoreTests.cs
@@ -73,12 +73,7 @@ public sealed class JsonlDelegationStoreTests : IDisposable
         // umask/ACL happens to grant.
         await _store.AppendAsync(BuildRecord());
 
-        if (!OperatingSystem.IsWindows())
-        {
-            var supervisorDir = Path.Combine(_tempDir, "supervisor-1");
-            File.GetUnixFileMode(supervisorDir).Should().Be(
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
+        Path.Combine(_tempDir, "supervisor-1").ShouldBeOwnerOnlyDirectory();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Audit/HashChainedJsonlWriterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Audit/HashChainedJsonlWriterTests.cs
@@ -40,12 +40,7 @@ public sealed class HashChainedJsonlWriterTests : IDisposable
 
         (await sut.AppendAsync("{\"a\":1}", CancellationToken.None)).IsSuccess.Should().BeTrue();
 
-        if (!OperatingSystem.IsWindows())
-        {
-            var segmentDir = Path.Combine(_tempDir, "nested");
-            File.GetUnixFileMode(segmentDir).Should().Be(
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
+        Path.Combine(_tempDir, "nested").ShouldBeOwnerOnlyDirectory();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Audit/HashChainedJsonlWriterTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Audit/HashChainedJsonlWriterTests.cs
@@ -26,6 +26,28 @@ public sealed class HashChainedJsonlWriterTests : IDisposable
     private HashChainedJsonlWriter NewWriter() =>
         new(_filePath, NullLogger.Instance);
 
+    // --- Directory permissions (#640, following #527's precedent) ---
+
+    [Fact]
+    public async Task AppendAsync_SegmentDirectoryIsCreatedOwnerOnly()
+    {
+        // #640: this is the tamper-evident audit log covering governance/escalation/drift/change/
+        // egress events -- the segment directory (not pre-created by this fixture, unlike _tempDir
+        // above; nested one level deeper so the create actually exercises a new directory) must never
+        // inherit whatever the process umask/ACL happens to grant.
+        var nestedFilePath = Path.Combine(_tempDir, "nested", "audit.jsonl");
+        using var sut = new HashChainedJsonlWriter(nestedFilePath, NullLogger.Instance);
+
+        (await sut.AppendAsync("{\"a\":1}", CancellationToken.None)).IsSuccess.Should().BeTrue();
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var segmentDir = Path.Combine(_tempDir, "nested");
+            File.GetUnixFileMode(segmentDir).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     [Fact]
     public async Task Append_PersistsOneFramedLinePerRecord()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/FileSystemEvidenceStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/FileSystemEvidenceStoreTests.cs
@@ -25,6 +25,27 @@ public sealed class FileSystemEvidenceStoreTests : IDisposable
         catch { /* best effort */ }
     }
 
+    // --- Directory permissions (#640, following #527's precedent) ---
+
+    [Fact]
+    public async Task StoreAsync_EvidenceDirectoryIsCreatedOwnerOnly()
+    {
+        // #640: evidence blobs are content-addressed copies of whatever content the store was asked
+        // to preserve -- neither the evidence root nor its hash-prefix fan-out subdirectory exist
+        // before this call, so both must be created owner-only rather than inheriting whatever the
+        // process umask/ACL happens to grant.
+        var bytes = Encoding.UTF8.GetBytes("permission check payload");
+        var hash = await _sut.StoreAsync(bytes, "text/plain", CancellationToken.None);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var prefix = hash["sha256:".Length..][..2];
+            var evidenceDir = Path.Combine(_tempDir, "evidence", prefix);
+            File.GetUnixFileMode(evidenceDir).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     [Fact]
     public async Task Store_ProducesShaPrefixedHash()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Changes/FileSystemEvidenceStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Changes/FileSystemEvidenceStoreTests.cs
@@ -37,13 +37,8 @@ public sealed class FileSystemEvidenceStoreTests : IDisposable
         var bytes = Encoding.UTF8.GetBytes("permission check payload");
         var hash = await _sut.StoreAsync(bytes, "text/plain", CancellationToken.None);
 
-        if (!OperatingSystem.IsWindows())
-        {
-            var prefix = hash["sha256:".Length..][..2];
-            var evidenceDir = Path.Combine(_tempDir, "evidence", prefix);
-            File.GetUnixFileMode(evidenceDir).Should().Be(
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
+        var prefix = hash["sha256:".Length..][..2];
+        Path.Combine(_tempDir, "evidence", prefix).ShouldBeOwnerOnlyDirectory();
     }
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/FileSystemConversationStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/FileSystemConversationStoreTests.cs
@@ -41,6 +41,36 @@ public sealed class FileSystemConversationStoreTests : ConversationStoreContract
             Directory.Delete(_tempDir, recursive: true);
     }
 
+    // --- Directory permissions (#640, following #527's precedent) ---
+
+    [Fact]
+    public void Constructor_CreatesConversationsDirectoryOwnerOnly()
+    {
+        // #640: this store holds full conversation transcripts -- must never inherit whatever the
+        // process umask/ACL happens to grant. Uses its own fresh, not-yet-existing directory (unlike
+        // this fixture's own _tempDir, pre-created above for every other test here) since
+        // OwnerOnlyDirectoryHelper.Create is a documented no-op for a directory that already exists.
+        var freshDir = Path.Combine(Path.GetTempPath(), $"convstore-permcheck-{Guid.NewGuid():N}");
+        try
+        {
+            _ = new FileSystemConversationStore(
+                Options.Create(new ConversationsConfig { ConversationsPath = freshDir }),
+                Clock,
+                NullLogger<FileSystemConversationStore>.Instance);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                File.GetUnixFileMode(freshDir).Should().Be(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(freshDir))
+                Directory.Delete(freshDir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task CreateAsync_WritesJsonFileAtExpectedPath()
     {

--- a/src/Content/Tests/Infrastructure.AI.Tests/Conversations/FileSystemConversationStoreTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Conversations/FileSystemConversationStoreTests.cs
@@ -58,11 +58,7 @@ public sealed class FileSystemConversationStoreTests : ConversationStoreContract
                 Clock,
                 NullLogger<FileSystemConversationStore>.Instance);
 
-            if (!OperatingSystem.IsWindows())
-            {
-                File.GetUnixFileMode(freshDir).Should().Be(
-                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-            }
+            freshDir.ShouldBeOwnerOnlyDirectory();
         }
         finally
         {

--- a/src/Content/Tests/Infrastructure.AI.Tests/OwnerOnlyDirectoryAssertions.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/OwnerOnlyDirectoryAssertions.cs
@@ -1,0 +1,24 @@
+using FluentAssertions;
+
+namespace Infrastructure.AI.Tests;
+
+/// <summary>
+/// Shared assertion for the owner-only (#640, following #527's precedent) directory-permission tests
+/// scattered across this assembly — one per migrated storage root.
+/// </summary>
+internal static class OwnerOnlyDirectoryAssertions
+{
+    /// <summary>
+    /// Asserts <paramref name="directory"/> was created with owner-only read/write/execute
+    /// permissions. A no-op on Windows, where <see cref="Infrastructure.AI.Helpers.OwnerOnlyDirectoryHelper"/>
+    /// itself is a no-op and there is nothing to assert.
+    /// </summary>
+    internal static void ShouldBeOwnerOnlyDirectory(this string directory)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        File.GetUnixFileMode(directory).Should().Be(
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Persistence/GovernanceStatePathsTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Persistence/GovernanceStatePathsTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Infrastructure.AI.Persistence;
+using Xunit;
+
+namespace Infrastructure.AI.Tests.Persistence;
+
+/// <summary>
+/// Tests for <see cref="GovernanceStatePaths.EnsureDirectory"/> — path resolution/containment
+/// (<see cref="GovernanceStatePaths.Resolve"/>) is covered separately in
+/// <c>DurableEscalationHardeningTests</c>.
+/// </summary>
+public sealed class GovernanceStatePathsTests
+{
+    // --- Directory permissions (#640, following #527's precedent) ---
+
+    [Fact]
+    public void EnsureDirectory_CreatesContainingDirectoryOwnerOnly()
+    {
+        // #640: this directory holds the approval-verdicts database -- must never inherit whatever
+        // the process umask/ACL happens to grant.
+        var root = Path.Combine(Path.GetTempPath(), $"gov-perm-check-{Guid.NewGuid():N}");
+        var resolved = GovernanceStatePaths.Resolve(".agent-state/governance-state.db", root);
+
+        try
+        {
+            GovernanceStatePaths.EnsureDirectory(resolved);
+
+            if (!OperatingSystem.IsWindows())
+            {
+                var directory = Path.GetDirectoryName(resolved)!;
+                File.GetUnixFileMode(directory).Should().Be(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/src/Content/Tests/Infrastructure.AI.Tests/Persistence/GovernanceStatePathsTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/Persistence/GovernanceStatePathsTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions;
 using Infrastructure.AI.Persistence;
 using Xunit;
 
@@ -25,12 +24,7 @@ public sealed class GovernanceStatePathsTests
         {
             GovernanceStatePaths.EnsureDirectory(resolved);
 
-            if (!OperatingSystem.IsWindows())
-            {
-                var directory = Path.GetDirectoryName(resolved)!;
-                File.GetUnixFileMode(directory).Should().Be(
-                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-            }
+            Path.GetDirectoryName(resolved)!.ShouldBeOwnerOnlyDirectory();
         }
         finally
         {

--- a/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/JsonCheckpointStateManagerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/JsonCheckpointStateManagerTests.cs
@@ -42,6 +42,24 @@ public sealed class JsonCheckpointStateManagerTests : IDisposable
             Directory.Delete(_basePath, recursive: true);
     }
 
+    // ── Directory permissions (#640, following #527's precedent) ──────────────
+
+    [Fact]
+    public async Task CreateAsync_CheckpointsDirectoryIsCreatedOwnerOnly()
+    {
+        // #640: checkpoint state can carry intermediate tool arguments/outputs -- the per-workflow
+        // checkpoints directory (not pre-created by this fixture, unlike _basePath above) must never
+        // inherit whatever the process umask/ACL happens to grant.
+        await _sut.CreateAsync("wf-perm-check");
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var checkpointsDir = Path.Combine(_basePath, "wf-perm-check", "checkpoints");
+            File.GetUnixFileMode(checkpointsDir).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     // ── CreateAsync ──────────────────────────────────────────────────────────
 
     [Fact]

--- a/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/JsonCheckpointStateManagerTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/JsonCheckpointStateManagerTests.cs
@@ -52,12 +52,7 @@ public sealed class JsonCheckpointStateManagerTests : IDisposable
         // inherit whatever the process umask/ACL happens to grant.
         await _sut.CreateAsync("wf-perm-check");
 
-        if (!OperatingSystem.IsWindows())
-        {
-            var checkpointsDir = Path.Combine(_basePath, "wf-perm-check", "checkpoints");
-            File.GetUnixFileMode(checkpointsDir).Should().Be(
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
+        Path.Combine(_basePath, "wf-perm-check", "checkpoints").ShouldBeOwnerOnlyDirectory();
     }
 
     // ── CreateAsync ──────────────────────────────────────────────────────────

--- a/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/MarkdownCheckpointDecoratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/MarkdownCheckpointDecoratorTests.cs
@@ -81,12 +81,7 @@ public sealed class MarkdownCheckpointDecoratorTests : IDisposable
 
         await _sut.SaveAsync(state);
 
-        if (!OperatingSystem.IsWindows())
-        {
-            var inputsDir = Path.Combine(_basePath, "wf-md-perm-check", "inputs");
-            File.GetUnixFileMode(inputsDir).Should().Be(
-                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
-        }
+        Path.Combine(_basePath, "wf-md-perm-check", "inputs").ShouldBeOwnerOnlyDirectory();
     }
 
     // ── SaveAsync: markdown generation ───────────────────────────────────────

--- a/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/MarkdownCheckpointDecoratorTests.cs
+++ b/src/Content/Tests/Infrastructure.AI.Tests/StateManagement/MarkdownCheckpointDecoratorTests.cs
@@ -62,6 +62,33 @@ public sealed class MarkdownCheckpointDecoratorTests : IDisposable
     private string GetMarkdownPath(string workflowId) =>
         Path.Combine(_basePath, workflowId, "inputs", "workflow-state.md");
 
+    // ── Directory permissions (#640, following #527's precedent) ──────────────
+
+    [Fact]
+    public async Task SaveAsync_MarkdownInputsDirectoryIsCreatedOwnerOnly()
+    {
+        // #640: the markdown checkpoint is a human-readable rendering of the same workflow state the
+        // JSON checkpoint holds -- the per-workflow "inputs" directory (not pre-created by this
+        // fixture, unlike _basePath above) must never inherit whatever the process umask/ACL happens
+        // to grant.
+        var state = new WorkflowState
+        {
+            WorkflowId = "wf-md-perm-check",
+            WorkflowStatus = "in_progress",
+            CurrentNodeId = "phase-1",
+            WorkflowStarted = DateTime.UtcNow
+        };
+
+        await _sut.SaveAsync(state);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var inputsDir = Path.Combine(_basePath, "wf-md-perm-check", "inputs");
+            File.GetUnixFileMode(inputsDir).Should().Be(
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
     // ── SaveAsync: markdown generation ───────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

- Routes 7 storage-root directory-creation call sites — audit log, delegation store, conversation store, checkpoint state (JSON + Markdown), governance state, and evidence store — through the existing `OwnerOnlyDirectoryHelper` (#527's precedent) instead of plain `Directory.CreateDirectory`, so these directories are created owner-only (0700) on POSIX from the moment they exist rather than inheriting whatever the process umask/ACL happens to grant.
- Adds one regression test per migrated site, each asserting `UnixFileMode` on a genuinely-fresh directory (not vacuously passing against a fixture's pre-created path).
- Follow-up commit extracts a shared `ShouldBeOwnerOnlyDirectory()` assertion helper, deduping the identical 4-line permission-check block that was repeated across all 7 new tests.

## Scope

Stays scoped to #640's own explicit 7-file list. A completeness sweep (`grep -rn "Directory.CreateDirectory(" src/Content/Infrastructure/Infrastructure.AI`) found additional call sites outside that list — filed as #660, with the 3 sandbox-workspace sites and one agent-directed file-I/O site explicitly excluded there (documented, by-design reasons, not gaps).

Closes #640.

## Test plan

- [x] Full solution build clean
- [x] Full unfiltered `Infrastructure.AI.Tests` suite: 3525 passed, 0 failed, 6 skipped
- [x] Mutation-tested one new test (reverted `OwnerOnlyDirectoryHelper.Create` back to plain `Directory.CreateDirectory` in `HashChainedJsonlWriter.cs`) — confirmed the corresponding test's Windows-guarded assertion body doesn't execute on this dev machine (same platform-conditional shape as #527's precedent; the assertion only runs on POSIX, which is where CI executes it)
- [x] `run-gates.sh` clean: build, test, owasp, grader, correctness, docs-drift (advisory) all pass
- [x] 2 `/code-review` rounds (initial pass + re-review after the simplify commit) — no correctness bugs found
- [x] `/simplify` pass — extracted shared test assertion helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu