### PR TITLE
fix: consolidate the 2 remaining plugin boundary-violation formatters (#611)

### DIFF
--- a/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
+++ b/src/Content/Application/Application.AI.Common/Interfaces/Plugins/IPluginToolBoundaryTracker.cs
@@ -98,6 +98,24 @@ public static class PluginToolBoundaryViolationExtensions
 
         return status.RequiresFailClosed(violations);
     }
+
+    /// <summary>
+    /// The "which list, which name" fragment of a violation — <c>"DeniedTools entry 'foo'"</c> — shared
+    /// by every caller that reports one (#611: previously two independently hand-written formats that
+    /// had already drifted in tone; a wording fix or added detail meant editing both instead of one).
+    /// Omits the plugin name — a caller reporting several violations already grouped by plugin (e.g.
+    /// <c>McpToolProvider.ReportDiscoveryToBoundaryTracker</c>) states it once, not per entry.
+    /// </summary>
+    public static string DescribeEntry(this PluginToolBoundaryViolation violation) =>
+        $"{violation.ListKind} entry '{violation.ToolName}'";
+
+    /// <summary>
+    /// <see cref="DescribeEntry"/> prefixed with the owning plugin's name — for a caller reporting
+    /// violations that are NOT already grouped by plugin (e.g.
+    /// <c>PluginToolBoundaryStartupValidator</c>'s boot-refusal message, one line per violation).
+    /// </summary>
+    public static string DescribeWithPlugin(this PluginToolBoundaryViolation violation) =>
+        $"Plugin '{violation.PluginName}': {violation.DescribeEntry()}";
 }
 
 /// <summary>

--- a/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI.MCP/Services/McpToolProvider.cs
@@ -333,7 +333,7 @@ public sealed class McpToolProvider : IMcpToolProvider
         // happens, not just what used to always happen.
         foreach (var group in violations.GroupBy(v => v.PluginName))
         {
-            var entries = string.Join(", ", group.Select(v => $"{v.ListKind}:'{v.ToolName}'"));
+            var entries = string.Join(", ", group.Select(v => v.DescribeEntry()));
             var confined = group.ToList().IsConfinedToAllowedTools();
             _logger.LogCritical(
                 "Plugin '{Plugin}': boundary entries match no known tool (first-party or MCP) and are " +

--- a/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
+++ b/src/Content/Infrastructure/Infrastructure.AI/Plugins/PluginToolBoundaryStartupValidator.cs
@@ -170,7 +170,7 @@ public sealed class PluginToolBoundaryStartupValidator : IHostedService
         // server no longer collapses this to the zero-server case, so this message is now accurate
         // exactly as worded: it fires only when literally nothing is configured, period.
         var lines = immediateViolations.Select(v =>
-            $"Plugin '{v.PluginName}': {v.ListKind} entry '{v.ToolName}' matches no first-party tool, " +
+            $"{v.DescribeWithPlugin()} matches no first-party tool, " +
             "and no MCP server is configured anywhere on this host that could ever supply it either.");
 
         throw new InvalidOperationException(

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryViolationExtensionsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryViolationExtensionsTests.cs
@@ -13,20 +13,15 @@ namespace Application.AI.Common.Tests.Plugins;
 /// </summary>
 public sealed class PluginToolBoundaryViolationExtensionsTests
 {
-    [Fact]
-    public void DescribeEntry_FormatsListKindAndToolNameWithoutPluginName()
+    [Theory]
+    [InlineData(PluginToolBoundaryListKind.DeniedTools, "some_tool", "DeniedTools entry 'some_tool'")]
+    [InlineData(PluginToolBoundaryListKind.AllowedTools, "other_tool", "AllowedTools entry 'other_tool'")]
+    public void DescribeEntry_FormatsListKindAndToolNameWithoutPluginName(
+        PluginToolBoundaryListKind listKind, string toolName, string expected)
     {
-        var violation = new PluginToolBoundaryViolation("my-plugin", PluginToolBoundaryListKind.DeniedTools, "some_tool");
+        var violation = new PluginToolBoundaryViolation("my-plugin", listKind, toolName);
 
-        violation.DescribeEntry().Should().Be("DeniedTools entry 'some_tool'");
-    }
-
-    [Fact]
-    public void DescribeEntry_AllowedToolsListKind_IsReflectedInOutput()
-    {
-        var violation = new PluginToolBoundaryViolation("my-plugin", PluginToolBoundaryListKind.AllowedTools, "other_tool");
-
-        violation.DescribeEntry().Should().Be("AllowedTools entry 'other_tool'");
+        violation.DescribeEntry().Should().Be(expected);
     }
 
     [Fact]

--- a/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryViolationExtensionsTests.cs
+++ b/src/Content/Tests/Application.AI.Common.Tests/Plugins/PluginToolBoundaryViolationExtensionsTests.cs
@@ -1,0 +1,39 @@
+using Application.AI.Common.Interfaces.Plugins;
+using FluentAssertions;
+using Xunit;
+
+namespace Application.AI.Common.Tests.Plugins;
+
+/// <summary>
+/// #611: <see cref="PluginToolBoundaryViolationExtensions.DescribeEntry"/> and
+/// <see cref="PluginToolBoundaryViolationExtensions.DescribeWithPlugin"/> are the shared formatters
+/// that replaced two independently hand-written strings in <c>McpToolProvider</c> and
+/// <c>PluginToolBoundaryStartupValidator</c>, which had already drifted in tone/detail from each
+/// other.
+/// </summary>
+public sealed class PluginToolBoundaryViolationExtensionsTests
+{
+    [Fact]
+    public void DescribeEntry_FormatsListKindAndToolNameWithoutPluginName()
+    {
+        var violation = new PluginToolBoundaryViolation("my-plugin", PluginToolBoundaryListKind.DeniedTools, "some_tool");
+
+        violation.DescribeEntry().Should().Be("DeniedTools entry 'some_tool'");
+    }
+
+    [Fact]
+    public void DescribeEntry_AllowedToolsListKind_IsReflectedInOutput()
+    {
+        var violation = new PluginToolBoundaryViolation("my-plugin", PluginToolBoundaryListKind.AllowedTools, "other_tool");
+
+        violation.DescribeEntry().Should().Be("AllowedTools entry 'other_tool'");
+    }
+
+    [Fact]
+    public void DescribeWithPlugin_PrefixesDescribeEntryWithThePluginName()
+    {
+        var violation = new PluginToolBoundaryViolation("my-plugin", PluginToolBoundaryListKind.DeniedTools, "some_tool");
+
+        violation.DescribeWithPlugin().Should().Be("Plugin 'my-plugin': DeniedTools entry 'some_tool'");
+    }
+}


### PR DESCRIPTION
## Summary

- **Finding 1 of #611** (caching `PluginPermissionRuleProvider`'s unverified-boundary deny list) was **already fixed** by a later PR — verified `GetRulesAsync` already has a version-checked cache keyed on `IPluginRegistry.StateVersion`, live on `main`, with its own comment referencing #611.
- **Finding 2**: 3 hand-written formatters for the same `PluginToolBoundaryViolation` triple had shrunk to 2 by the time of this PR (the third, on `PluginToolBoundaryTracker`, was removed by an unrelated #608 refactor to structured violation objects). Extracted `DescribeEntry()`/`DescribeWithPlugin()` onto `PluginToolBoundaryViolationExtensions` so a wording fix or added detail means editing one place instead of two.

**Intentional wording change** (flagged by code review, not a bug): `McpToolProvider`'s Critical log line changes from `DeniedTools:'foo'` (colon-separated) to `DeniedTools entry 'foo'` (matching `PluginToolBoundaryStartupValidator`'s existing phrasing). No test pinned the old string. If any external log-scraping/alerting rule keys on the old substring, it should be updated to match the new wording.

## Verification

- [x] Mutation-tested the new `DescribeWithPlugin` extension (confirmed its test fails if the method stops delegating to `DescribeEntry`)
- [x] Full test runs: `Application.AI.Common.Tests` 2723/2723, `Infrastructure.AI.MCP.Tests` 156/156, `Infrastructure.AI.Tests` — 3 independent confirmations of a pre-existing `Sandbox`-area test flake under full-suite resource contention (different test each time, always clears on isolated retry, no sandbox files touched by this diff)
- [x] 2 `/code-review` rounds + 1 `/simplify` round — design confirmed correct (two single-expression extensions, since the two call sites need different output shapes)
- [x] Local `run-gates.sh` test gate hit the same diagnosed flake twice; pushed via the sanctioned `RAILS_SKIP_REVIEW_GATE=1` bypass, deferring to CI's isolated test run

Closes #611.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aao7Y3hU22v6VH1RdiSxYu